### PR TITLE
feat: create a text editor tool with multiple commands

### DIFF
--- a/packages/exchange/src/exchange/utils.py
+++ b/packages/exchange/src/exchange/utils.py
@@ -1,7 +1,7 @@
 import inspect
 import uuid
 from importlib.metadata import entry_points
-from typing import Literal, get_args, get_origin, Any, List, Tuple, Dict, Union
+from typing import Literal, get_args, get_origin, Any, Union
 
 from griffe import (
     Docstring,
@@ -122,9 +122,9 @@ def _map_type_to_schema(py_type: type) -> dict[str, Any]:
             return {"anyOf": [_map_type_to_schema(arg) for arg in non_none_args]}
     elif origin is Literal:
         return {"enum": list(args)}
-    elif origin in (list, List, tuple, Tuple):
+    elif origin in (list, tuple):
         return {"type": "array", "items": _map_type_to_schema(args[0] if args else Any)}
-    elif origin in (dict, Dict):
+    elif origin is dict:
         return {
             "type": "object",
             "additionalProperties": _map_type_to_schema(args[1] if len(args) > 1 else Any),

--- a/packages/exchange/src/exchange/utils.py
+++ b/packages/exchange/src/exchange/utils.py
@@ -1,7 +1,7 @@
 import inspect
 import uuid
 from importlib.metadata import entry_points
-from typing import get_args, get_origin, Any, List, Tuple, Dict, Union
+from typing import Literal, get_args, get_origin, Any, List, Tuple, Dict, Union
 
 from griffe import (
     Docstring,
@@ -120,6 +120,8 @@ def _map_type_to_schema(py_type: type) -> dict[str, Any]:
         else:
             # General Union
             return {"anyOf": [_map_type_to_schema(arg) for arg in non_none_args]}
+    elif origin is Literal:
+        return {"enum": list(args)}
     elif origin in (list, List, tuple, Tuple):
         return {"type": "array", "items": _map_type_to_schema(args[0] if args else Any)}
     elif origin in (dict, Dict):

--- a/packages/exchange/src/exchange/utils.py
+++ b/packages/exchange/src/exchange/utils.py
@@ -1,7 +1,7 @@
 import inspect
 import uuid
 from importlib.metadata import entry_points
-from typing import get_args, get_origin
+from typing import get_args, get_origin, Any, List, Tuple, Dict, Union
 
 from griffe import (
     Docstring,
@@ -107,16 +107,25 @@ def json_schema(func: any) -> dict[str, any]:  # noqa: ANN401
     return schema
 
 
-def _map_type_to_schema(py_type: type) -> dict[str, any]:  # noqa: ANN401
+def _map_type_to_schema(py_type: type) -> dict[str, Any]:
     origin = get_origin(py_type)
     args = get_args(py_type)
 
-    if origin is list or origin is tuple:
-        return {"type": "array", "items": _map_type_to_schema(args[0] if args else any)}
-    elif origin is dict:
+    if origin is Union:
+        # Handle Optional[X], which is Union[X, NoneType]
+        non_none_args = [arg for arg in args if arg is not type(None)]
+        if len(non_none_args) == 1:
+            # This is Optional[X]
+            return _map_type_to_schema(non_none_args[0])
+        else:
+            # General Union
+            return {"anyOf": [_map_type_to_schema(arg) for arg in non_none_args]}
+    elif origin in (list, List, tuple, Tuple):
+        return {"type": "array", "items": _map_type_to_schema(args[0] if args else Any)}
+    elif origin in (dict, Dict):
         return {
             "type": "object",
-            "additionalProperties": _map_type_to_schema(args[1] if len(args) > 1 else any),
+            "additionalProperties": _map_type_to_schema(args[1] if len(args) > 1 else Any),
         }
     elif py_type is int:
         return {"type": "integer"}

--- a/packages/exchange/tests/test_utils.py
+++ b/packages/exchange/tests/test_utils.py
@@ -65,6 +65,28 @@ def test_parse_docstring_no_description() -> None:
     assert "Attempted to load from a function" in str(e.value)
 
 
+def test_parse_docstring_with_optional_params() -> None:
+    from typing import Optional
+
+    def dummy_func(a: int, b: Optional[str] = None, c: int = 1) -> None:
+        """This function does something.
+
+        Args:
+            a (int): The first required parameter.
+            b (Optional[str], optional): Optional second parameter. Defaults to None.
+            c (int, optional): The third parameter with default value. Defaults to 1.
+        """
+        pass
+
+    description, parameters = utils.parse_docstring(dummy_func)
+    assert description == "This function does something."
+    assert parameters == [
+        {"name": "a", "annotation": "int", "description": "The first required parameter."},
+        {"name": "b", "annotation": "Optional[str]", "description": "Optional second parameter. Defaults to None."},
+        {"name": "c", "annotation": "int", "description": "The third parameter with default value. Defaults to 1."},
+    ]
+
+
 def test_json_schema() -> None:
     def dummy_func(a: int, b: str, c: list) -> None:
         pass
@@ -79,6 +101,31 @@ def test_json_schema() -> None:
             "c": {"type": "string"},
         },
         "required": ["a", "b", "c"],
+    }
+
+
+def test_json_schema_with_optional_params() -> None:
+    from typing import Optional, List
+
+    def dummy_func(
+        a: int,
+        b: str = "hello",
+        c: Optional[List[int]] = None,
+        d: Optional[str] = None,
+    ) -> None:
+        pass
+
+    schema = utils.json_schema(dummy_func)
+
+    assert schema == {
+        "type": "object",
+        "properties": {
+            "a": {"type": "integer"},
+            "b": {"type": "string", "default": "hello"},
+            "c": {"type": "array", "items": {"type": "integer"}, "default": None},
+            "d": {"type": "string", "default": None},
+        },
+        "required": ["a"],
     }
 
 

--- a/packages/exchange/tests/test_utils.py
+++ b/packages/exchange/tests/test_utils.py
@@ -1,3 +1,4 @@
+from typing import Literal
 import pytest
 from exchange import utils
 from unittest.mock import patch
@@ -68,13 +69,13 @@ def test_parse_docstring_no_description() -> None:
 def test_parse_docstring_with_optional_params() -> None:
     from typing import Optional
 
-    def dummy_func(a: int, b: Optional[str] = None, c: int = 1) -> None:
+    def dummy_func(a: int, b: Optional[str] = None, c: Literal["foo", "bar"] = "foo") -> None:
         """This function does something.
 
         Args:
             a (int): The first required parameter.
             b (Optional[str], optional): Optional second parameter. Defaults to None.
-            c (int, optional): The third parameter with default value. Defaults to 1.
+            c (Literal["foo", "bar"], optional): A parameter with a literal default value. Defaults to "foo".
         """
         pass
 
@@ -83,7 +84,11 @@ def test_parse_docstring_with_optional_params() -> None:
     assert parameters == [
         {"name": "a", "annotation": "int", "description": "The first required parameter."},
         {"name": "b", "annotation": "Optional[str]", "description": "Optional second parameter. Defaults to None."},
-        {"name": "c", "annotation": "int", "description": "The third parameter with default value. Defaults to 1."},
+        {
+            "name": "c",
+            "annotation": 'Literal["foo", "bar"]',
+            "description": 'A parameter with a literal default value. Defaults to "foo".',
+        },
     ]
 
 
@@ -109,7 +114,7 @@ def test_json_schema_with_optional_params() -> None:
 
     def dummy_func(
         a: int,
-        b: str = "hello",
+        b: Literal["foo", "bar"] = "foo",
         c: Optional[List[int]] = None,
         d: Optional[str] = None,
     ) -> None:
@@ -121,7 +126,7 @@ def test_json_schema_with_optional_params() -> None:
         "type": "object",
         "properties": {
             "a": {"type": "integer"},
-            "b": {"type": "string", "default": "hello"},
+            "b": {"enum": ["foo", "bar"], "default": "foo"},
             "c": {"type": "array", "items": {"type": "integer"}, "default": None},
             "d": {"type": "string", "default": None},
         },

--- a/packages/exchange/tests/test_utils.py
+++ b/packages/exchange/tests/test_utils.py
@@ -67,15 +67,16 @@ def test_parse_docstring_no_description() -> None:
 
 
 def test_parse_docstring_with_optional_params() -> None:
-    from typing import Optional
+    from typing import Optional, List
 
-    def dummy_func(a: int, b: Optional[str] = None, c: Literal["foo", "bar"] = "foo") -> None:
+    def dummy_func(a: int, b: List[int], c: Literal["foo", "bar"] = "foo", d: Optional[str] = None) -> None:
         """This function does something.
 
         Args:
             a (int): The first required parameter.
-            b (Optional[str], optional): Optional second parameter. Defaults to None.
+            b (List[int]): The second parameter.
             c (Literal["foo", "bar"], optional): A parameter with a literal default value. Defaults to "foo".
+            d (Optional[str], optional): Optional fourth parameter. Defaults to None.
         """
         pass
 
@@ -83,12 +84,13 @@ def test_parse_docstring_with_optional_params() -> None:
     assert description == "This function does something."
     assert parameters == [
         {"name": "a", "annotation": "int", "description": "The first required parameter."},
-        {"name": "b", "annotation": "Optional[str]", "description": "Optional second parameter. Defaults to None."},
+        {"name": "b", "annotation": "List[int]", "description": "The second parameter."},
         {
             "name": "c",
             "annotation": 'Literal["foo", "bar"]',
             "description": 'A parameter with a literal default value. Defaults to "foo".',
         },
+        {"name": "d", "annotation": "Optional[str]", "description": "Optional fourth parameter. Defaults to None."},
     ]
 
 

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -138,7 +138,7 @@ class SynopsisDeveloper(Toolkit):
 
     def _save_file_history(self, patho: Path) -> None:
         """Save the current content of the file to history for undo functionality."""
-        content = patho.read_text()
+        content = patho.read_text() if patho.exists() else ""
         self._file_history[str(patho)] = content
 
     def _undo_edit(self, path: str) -> str:

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -6,7 +6,6 @@ import os
 from pathlib import Path
 import tempfile
 from typing import Dict, Literal, Optional
-import shutil
 
 from exchange import Message
 import httpx
@@ -159,7 +158,7 @@ class SynopsisDeveloper(Toolkit):
         # Remember the file in system
         system.remember_file(path)
 
-        language = get_language(path)
+        get_language(path)
         md_content = f"Undo edit for {path}."
 
         self.notifier.log("")
@@ -191,13 +190,23 @@ class SynopsisDeveloper(Toolkit):
         - `undo_edit`: Undo the last edit made to a file.
 
         Args:
-            command (str): The commands to run. Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.
-            path (str): Absolute path (or relative path against cwd) to file or directory, e.g. `/repo/file.py` or `/repo` or `curr_dir_file.py`.
-            file_text (str, optional): Required parameter of `create` command, with the content of the file to be created.
-            insert_line (int, optional): Required parameter of `insert` command. The `new_str` will be inserted AFTER the line `insert_line` of `path`.
-            new_str (str, optional): Optional parameter of `str_replace` command containing the new string (if not given, no string will be added). Required parameter of `insert` command containing the string to insert.
-            old_str (str, optional): Required parameter of `str_replace` command containing the string in `path` to replace.
-            view_range (list, optional): Optional parameter of `view` command when `path` points to a file. If none is given, the full file is shown. If provided, the file will be shown in the indicated line number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.
+            command (str): The commands to run.
+                Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.
+            path (str): Absolute path (or relative path against cwd) to file or directory,
+                e.g. `/repo/file.py` or `/repo` or `curr_dir_file.py`.
+            file_text (str, optional): Required parameter of `create` command, with the content
+                of the file to be created.
+            insert_line (int, optional): Required parameter of `insert` command.
+                The `new_str` will be inserted AFTER the line `insert_line` of `path`.
+            new_str (str, optional): Optional parameter of `str_replace` command
+                containing the new string (if not given, no string will be added).
+                Required parameter of `insert` command containing the string to insert.
+            old_str (str, optional): Required parameter of `str_replace` command containing the
+                string in `path` to replace.
+            view_range (list, optional): Optional parameter of `view` command when `path` points to a file.
+                If none is given, the full file is shown. If provided, the file will be shown in the indicated line
+                number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start.
+                Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.
         """
         # Ensure 'command' is provided
         if not command:

--- a/tests/synopsis/test_toolkit.py
+++ b/tests/synopsis/test_toolkit.py
@@ -34,24 +34,24 @@ def test_shell(toolkit, tmpdir):
     assert "Hello, World!" in result
 
 
-def test_read_write_file(toolkit, tmpdir):
+def test_text_editor_read_write_file(toolkit, tmpdir):
     test_file = tmpdir.join("test_file.txt")
     content = "Test content"
 
-    toolkit.write_file(str(test_file), content)
+    toolkit.text_editor(command="create", path=str(test_file), file_text=content)
     assert test_file.read() == content
 
-    result = toolkit.read_file(str(test_file))
-    assert "The file content at" in result
+    result = toolkit.text_editor(command="view", path=str(test_file))
+    assert "Displayed content of" in result
     assert system.is_active(str(test_file))
 
 
-def test_patch_file(toolkit, tmpdir):
+def test_text_editor_patch_file(toolkit, tmpdir):
     test_file = tmpdir.join("test_file.txt")
     test_file.write("Hello, World!")
 
-    toolkit.read_file(str(test_file))  # Remember the file
-    result = toolkit.patch_file(str(test_file), "World", "Universe")
+    toolkit.text_editor(command="view", path=str(test_file))  # Remember the file
+    result = toolkit.text_editor(command="str_replace", path=str(test_file), old_str="World", new_str="Universe")
     assert "Succesfully replaced before with after" in result
     assert test_file.read() == "Hello, Universe!"
 


### PR DESCRIPTION
Changes:
- support optional params, literals in docstring -> jsonschema: https://github.com/block/goose/pull/188
- create a tool that calls out to different commands

Anthropic is using this text editor tool for Computer Use. It might be useful to try this in goose - [docs](https://docs.anthropic.com/en/docs/build-with-claude/computer-use#text-editor-tool), [code](https://github.com/anthropics/anthropic-quickstarts/blob/main/computer-use-demo/computer_use_demo/tools/edit.py#L41). It seems like they prefer to have fewer tools, but each tool has more optional args which are used for specific actions. For example, in goose we have separate tools for read_file, write_file, patch_file but in this case, its a single EditorTool with command as an Enum that routes to the editor action (view, create, insert).


Test:

tool descriptions are correctly passed
![tool-descriptions](https://github.com/user-attachments/assets/a3b36a47-bf96-4520-8409-15044b581eaf)
