### PR TITLE
feat: allow synopsis moderator to show progress

### DIFF
--- a/packages/exchange/src/exchange/moderators/base.py
+++ b/packages/exchange/src/exchange/moderators/base.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from goose.notifier import Notifier
 
+
 class Moderator(ABC):
     def __init__(self, notifier: Notifier | None = None) -> None:
         self.notifier = notifier

--- a/packages/exchange/src/exchange/moderators/base.py
+++ b/packages/exchange/src/exchange/moderators/base.py
@@ -1,7 +1,10 @@
 from abc import ABC, abstractmethod
-
+from goose.notifier import Notifier
 
 class Moderator(ABC):
+    def __init__(self, notifier: Notifier | None = None) -> None:
+        self.notifier = notifier
+
     @abstractmethod
     def rewrite(self, exchange: type["exchange.exchange.Exchange"]) -> None:  # noqa: F821
         pass

--- a/src/goose/build.py
+++ b/src/goose/build.py
@@ -53,7 +53,7 @@ def build_exchange(profile: Profile, notifier: Notifier) -> Exchange:
         provider=provider,
         system=system,
         tools=tools,
-        moderator=get_moderator(profile.moderator)(),
+        moderator=get_moderator(profile.moderator)(notifier=notifier),
         model=profile.processor,
     )
 

--- a/src/goose/synopsis/moderator.py
+++ b/src/goose/synopsis/moderator.py
@@ -110,12 +110,12 @@ class Synopsis(Moderator):
                 self.notifier.status("Updating action plan...")
             self.current_plan = self.plan(exchange)
 
-        if self.notifier:
-            self.notifier.status("Creating synopsis message...")
         return Message.load("synopsis.md", synopsis=self, system=system)
 
     def summarize(self, exchange: Exchange) -> str:
         message = Message.load("summarize.md", synopsis=self, messages=self.originals, exchange=exchange, system=system)
+        if len(self.originals) < 5:
+            return "\n".join([message.summary for message in self.originals])
         model = os.environ.get("SUMMARIZER", exchange.model)
         new_exchange = exchange.replace(moderator=ContextTruncate(), tools=(), system="", messages=[], model=model)
         new_exchange.add(message)


### PR DESCRIPTION
This adds status reporting to synopsis and moderators (gives better visual feedback) - does make it seem wierd to have that initial summary (and this also will only summarize after a few iterations of rewrite - to stop the initial slowstart)