### PR TITLE
fix: only run summarize when there is something to summarize vs up front

### DIFF
--- a/src/goose/synopsis/moderator.py
+++ b/src/goose/synopsis/moderator.py
@@ -90,6 +90,8 @@ class Synopsis(Moderator):
 
     def summarize(self, exchange: Exchange) -> str:
         message = Message.load("summarize.md", synopsis=self, messages=self.originals, exchange=exchange, system=system)
+        if len(self.originals) < 5:
+            return "\n".join([message.summary for message in self.originals])
         model = os.environ.get("SUMMARIZER", exchange.model)
         new_exchange = exchange.replace(moderator=ContextTruncate(), tools=(), system="", messages=[], model=model)
         new_exchange.add(message)


### PR DESCRIPTION
This makes it a lot less chatty especially at first