### PR TITLE
docs: correct intellij link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -166,7 +166,7 @@ Learn how to modify your Goose profiles.yaml file to add and remove functionalit
 
 We have some experimental IDE integrations for VSCode and JetBrains IDEs:
 * https://github.com/square/goose-vscode
-* https://github.com/block-open-source/goose-intellij
+* https://github.com/Kvadratni/goose-intellij
 
 **Goose as a Github Action**
 


### PR DESCRIPTION
```
Issues found in 1 input. Find details below.

[./docs/index.md]:
     [404] https://github.com/block-open-source/goose-intellij

🔍 116 Total (in 0s) ✅ 115 OK 🚫 1 Error
   [WARN ] There were issues with GitHub URLs. You could try setting a GitHub token and running lychee again.
```