### PR TITLE
feat: include new anthropic model in docs and recommended config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -23,11 +23,11 @@ default:
 
 Provider of LLM. LLM providers that currently are supported by Goose:
 
-| Provider | Required environment variable(s) to access provider |
-| ----- | ------------------------------ |
-| openai | `OPENAI_API_KEY` |
-| anthropic  | `ANTHROPIC_API_KEY` |
-| databricks | `DATABRICKS_HOST` and `DATABRICKS_TOKEN` |
+| Provider   | Required environment variable(s) to access provider |
+| ---------- | --------------------------------------------------- |
+| openai     | `OPENAI_API_KEY`                                    |
+| anthropic  | `ANTHROPIC_API_KEY`                                 |
+| databricks | `DATABRICKS_HOST` and `DATABRICKS_TOKEN`            |
 
 #### processor
 
@@ -52,8 +52,8 @@ Rules designed to control or manage the output of the model. Moderators that cur
 
 default:
   provider: anthropic
-  processor: claude-3-5-sonnet-20240620
-  accelerator: claude-3-5-sonnet-20240620
+  processor: claude-3-5-sonnet-20241022-v2
+  accelerator: claude-3-5-sonnet-20241022-v2
 ```
 
 #### provider as `databricks`
@@ -74,8 +74,8 @@ You can tell it to use another provider for example for Anthropic:
 ```yaml
 default:
   provider: anthropic
-  processor: claude-3-5-sonnet-20240620
-  accelerator: claude-3-5-sonnet-20240620
+  processor: claude-3-5-sonnet-20241022-v2
+  accelerator: claude-3-5-sonnet-20241022-v2
   moderator: passive
   toolkits:
     - name: developer

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,8 +52,8 @@ Rules designed to control or manage the output of the model. Moderators that cur
 
 default:
   provider: anthropic
-  processor: claude-3-5-sonnet-20241022-v2
-  accelerator: claude-3-5-sonnet-20241022-v2
+  processor: claude-3-5-sonnet-20241022
+  accelerator: claude-3-5-sonnet-20241022
 ```
 
 #### provider as `databricks`
@@ -74,8 +74,8 @@ You can tell it to use another provider for example for Anthropic:
 ```yaml
 default:
   provider: anthropic
-  processor: claude-3-5-sonnet-20241022-v2
-  accelerator: claude-3-5-sonnet-20241022-v2
+  processor: claude-3-5-sonnet-20241022
+  accelerator: claude-3-5-sonnet-20241022
   moderator: passive
   toolkits:
     - name: developer

--- a/src/goose/cli/config.py
+++ b/src/goose/cli/config.py
@@ -94,8 +94,8 @@ def default_model_configuration() -> tuple[str, str, str]:
         "ollama": (OLLAMA_MODEL, OLLAMA_MODEL),
         "openai": ("gpt-4o", "gpt-4o-mini"),
         "anthropic": (
-            "claude-3-5-sonnet-20240620",
-            "claude-3-5-sonnet-20240620",
+            "claude-3-5-sonnet-20241022",
+            "claude-3-5-sonnet-20241022",
         ),
         "databricks": (
             # TODO when function calling is first rec should be: "databricks-meta-llama-3-1-405b-instruct"

--- a/src/goose/utils/_cost_calculator.py
+++ b/src/goose/utils/_cost_calculator.py
@@ -10,6 +10,7 @@ PRICES = {
     "o1-preview": (15.00, 60.00),
     "o1-mini": (3.00, 12.00),
     "claude-3-5-sonnet-20240620": (3.00, 15.00),
+    "claude-3-5-sonnet-20241022": (3.00, 15.00),
     "anthropic.claude-3-5-sonnet-20240620-v1:0": (3.00, 15.00),
     "claude-3-opus-20240229": (15.00, 75.00),
     "anthropic.claude-3-opus-20240229-v1:0": (15.00, 75.00),


### PR DESCRIPTION
# Summary
This PR includes `claude-3-5-sonnet-20241022` where model versions are mentioned.

Feel free to close this PR if it's too early for this or if I accidentally borked something. 

# Changes
* updated configuration docs to mention `claude-3-5-sonnet-20241022` instead of `claude-3-5-sonnet-20240620`
* added `claude-3-5-sonnet-20241022` to `_cost_calculator` using pricing data from [here](https://docs.anthropic.com/en/docs/about-claude/models#model-comparison-table)
* updated recommended anthropic model from `claude-3-5-sonnet-20240620` -> `claude-3-5-sonnet-20241022`