### PR TITLE
fix: prompt rendering

### DIFF
--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -148,7 +148,7 @@ class Session:
             initial_message (str): The initial user message to process.
         """
         profile = self.profile_name or "default"
-        print(f"[dim]starting session | name:[cyan]{self.name}[/]  profile:[cyan]{profile}[/]")
+        print(f"[dim]starting session | name: [cyan]{self.name}[/]  profile: [cyan]{profile}[/]")
         print(f"[dim]saving to {self.session_file_path}")
 
         # Process initial message
@@ -157,7 +157,7 @@ class Session:
         self.exchange.add(message)
         self.reply()  # Process the user message
 
-        print(f"[dim]ended run | name:[cyan]{self.name}[/]  profile:[cyan]{profile}[/]")
+        print(f"[dim]ended run | name: [cyan]{self.name}[/]  profile: [cyan]{profile}[/]")
         print(f"[dim]to resume: [magenta]goose session resume {self.name} --profile {profile}[/][/]")
 
     def run(self, new_session: bool = True) -> None:


### PR DESCRIPTION
quick fix for prompt rendering, this occurs because of how the color parses in `rich` 

#### Before
![image](https://github.com/user-attachments/assets/54aca70b-30ba-4303-91e3-5d806f828f51)

#### After
![image](https://github.com/user-attachments/assets/71ea5f72-9d87-419c-91fd-36447a9af550)

