### PR TITLE
refactor: used recommended_models function  as default model

### DIFF
--- a/packages/exchange/src/exchange/providers/anthropic.py
+++ b/packages/exchange/src/exchange/providers/anthropic.py
@@ -1,4 +1,5 @@
 import os
+from typing import Tuple
 
 import httpx
 
@@ -156,6 +157,11 @@ class AnthropicProvider(Provider):
         usage = self.get_usage(response)
 
         return message, usage
+
+    @staticmethod
+    def recommended_models() -> Tuple[str, str]:
+        """Return the recommended model and processor for this provider"""
+        return "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022"
 
     @retry_procedure
     def _post(self, payload: dict) -> httpx.Response:

--- a/packages/exchange/src/exchange/providers/anthropic.py
+++ b/packages/exchange/src/exchange/providers/anthropic.py
@@ -1,5 +1,4 @@
 import os
-from typing import Tuple
 
 import httpx
 
@@ -159,7 +158,7 @@ class AnthropicProvider(Provider):
         return message, usage
 
     @staticmethod
-    def recommended_models() -> Tuple[str, str]:
+    def recommended_models() -> tuple[str, str]:
         """Return the recommended model and processor for this provider"""
         return "claude-3-5-sonnet-20241022", "claude-3-5-sonnet-20241022"
 

--- a/packages/exchange/src/exchange/providers/base.py
+++ b/packages/exchange/src/exchange/providers/base.py
@@ -1,7 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from attrs import define, field
-from typing import Optional, Tuple
+from typing import Optional
 
 from exchange.message import Message
 from exchange.tool import Tool
@@ -51,7 +51,7 @@ class Provider(ABC):
         pass
 
     @staticmethod
-    def recommended_models() -> Tuple[str, str]:
+    def recommended_models() -> tuple[str, str]:
         """Return the recommended model and processor for this provider"""
         return "gpt-4o", "gpt-4o-mini"
 

--- a/packages/exchange/src/exchange/providers/base.py
+++ b/packages/exchange/src/exchange/providers/base.py
@@ -1,7 +1,7 @@
 import os
 from abc import ABC, abstractmethod
 from attrs import define, field
-from typing import Optional
+from typing import Optional, Tuple
 
 from exchange.message import Message
 from exchange.tool import Tool
@@ -49,6 +49,11 @@ class Provider(ABC):
     ) -> tuple[Message, Usage]:
         """Generate the next message using the specified model"""
         pass
+
+    @staticmethod
+    def recommended_models() -> Tuple[str, str]:
+        """Return the recommended model and processor for this provider"""
+        return "gpt-4o", "gpt-4o-mini"
 
 
 class MissingProviderEnvVariableError(Exception):

--- a/packages/exchange/src/exchange/providers/databricks.py
+++ b/packages/exchange/src/exchange/providers/databricks.py
@@ -1,3 +1,4 @@
+from typing import Tuple
 import httpx
 import os
 
@@ -89,6 +90,11 @@ class DatabricksProvider(Provider):
         message = openai_response_to_message(response)
         usage = self.get_usage(response)
         return message, usage
+
+    @staticmethod
+    def recommended_models() -> Tuple[str, str]:
+        """Return the recommended model and processor for this provider"""
+        return "databricks-meta-llama-3-1-70b-instruct", "databricks-meta-llama-3-1-70b-instruct"
 
     @retry_procedure
     def _post(self, model: str, payload: dict) -> httpx.Response:

--- a/packages/exchange/src/exchange/providers/databricks.py
+++ b/packages/exchange/src/exchange/providers/databricks.py
@@ -1,4 +1,3 @@
-from typing import Tuple
 import httpx
 import os
 
@@ -92,7 +91,7 @@ class DatabricksProvider(Provider):
         return message, usage
 
     @staticmethod
-    def recommended_models() -> Tuple[str, str]:
+    def recommended_models() -> tuple[str, str]:
         """Return the recommended model and processor for this provider"""
         return "databricks-meta-llama-3-1-70b-instruct", "databricks-meta-llama-3-1-70b-instruct"
 

--- a/packages/exchange/src/exchange/providers/google.py
+++ b/packages/exchange/src/exchange/providers/google.py
@@ -1,5 +1,4 @@
 import os
-from typing import Tuple
 
 import httpx
 
@@ -168,6 +167,6 @@ class GoogleProvider(Provider):
         return raise_for_status(response).json()
 
     @staticmethod
-    def recommended_models() -> Tuple[str, str]:
+    def recommended_models() -> tuple[str, str]:
         """Return the recommended model and processor for this provider"""
         return "gemini-1.5-flash", "gemini-1.5-flash"

--- a/packages/exchange/src/exchange/providers/google.py
+++ b/packages/exchange/src/exchange/providers/google.py
@@ -1,4 +1,5 @@
 import os
+from typing import Tuple
 
 import httpx
 
@@ -165,3 +166,8 @@ class GoogleProvider(Provider):
     def _post(self, payload: dict, model: str) -> httpx.Response:
         response = self.client.post("models/" + model + ":generateContent", json=payload)
         return raise_for_status(response).json()
+
+    @staticmethod
+    def recommended_models() -> Tuple[str, str]:
+        """Return the recommended model and processor for this provider"""
+        return "gemini-1.5-flash", "gemini-1.5-flash"

--- a/packages/exchange/src/exchange/providers/ollama.py
+++ b/packages/exchange/src/exchange/providers/ollama.py
@@ -1,4 +1,5 @@
 import os
+from typing import Tuple
 
 import httpx
 
@@ -43,3 +44,8 @@ ollama:
         # When served by Ollama, the OpenAI API is available at the path "v1/".
         client = httpx.Client(base_url=ollama_url + "v1/", timeout=timeout)
         return cls(client)
+
+    @staticmethod
+    def recommended_models() -> Tuple[str, str]:
+        """Return the recommended model and processor for this provider"""
+        return OLLAMA_MODEL, OLLAMA_MODEL

--- a/packages/exchange/src/exchange/providers/ollama.py
+++ b/packages/exchange/src/exchange/providers/ollama.py
@@ -1,5 +1,4 @@
 import os
-from typing import Tuple
 
 import httpx
 
@@ -46,6 +45,6 @@ ollama:
         return cls(client)
 
     @staticmethod
-    def recommended_models() -> Tuple[str, str]:
+    def recommended_models() -> tuple[str, str]:
         """Return the recommended model and processor for this provider"""
         return OLLAMA_MODEL, OLLAMA_MODEL

--- a/src/goose/cli/config.py
+++ b/src/goose/cli/config.py
@@ -6,7 +6,6 @@ from rich import print
 from rich.panel import Panel
 from ruamel.yaml import YAML
 
-from exchange.providers.ollama import OLLAMA_MODEL
 
 from goose.profile import Profile
 from goose.utils import load_plugins
@@ -90,19 +89,5 @@ def default_model_configuration() -> tuple[str, str, str]:
             pass
     else:
         provider = RECOMMENDED_DEFAULT_PROVIDER
-    recommended = {
-        "ollama": (OLLAMA_MODEL, OLLAMA_MODEL),
-        "openai": ("gpt-4o", "gpt-4o-mini"),
-        "anthropic": (
-            "claude-3-5-sonnet-20241022",
-            "claude-3-5-sonnet-20241022",
-        ),
-        "databricks": (
-            # TODO when function calling is first rec should be: "databricks-meta-llama-3-1-405b-instruct"
-            "databricks-meta-llama-3-1-70b-instruct",
-            "databricks-meta-llama-3-1-70b-instruct",
-        ),
-        "google": ("gemini-1.5-flash", "gemini-1.5-flash"),
-    }
-    processor, accelerator = recommended.get(provider, ("gpt-4o", "gpt-4o-mini"))
+    processor, accelerator = providers.get(provider).recommended_models()
     return provider, processor, accelerator


### PR DESCRIPTION
**Why**

In each provider, define the recommended_models function.  It can be used when we setting the default models for the providers, and the providers in the plugin can override the function to use their recommended models