### PR TITLE
added confirm mode

### DIFF
--- a/packages/exchange/src/exchange/content.py
+++ b/packages/exchange/src/exchange/content.py
@@ -45,6 +45,7 @@ class ToolResult(Content):
     tool_use_id: str
     output: str
     is_error: bool = False
+    is_cancelled_by_user: bool = False
 
     @property
     def summary(self) -> str:

--- a/src/goose/build.py
+++ b/src/goose/build.py
@@ -11,7 +11,7 @@ from goose.toolkit.base import Requirements
 from goose.view import ExchangeView
 
 
-def build_exchange(profile: Profile, notifier: Notifier) -> Exchange:
+def build_exchange(profile: Profile, notifier: Notifier, ask_confirmation: bool) -> Exchange:
     """Build an exchange configured through the profile
 
     This will setup any toolkits and use that to build the exchange's collection
@@ -55,6 +55,7 @@ def build_exchange(profile: Profile, notifier: Notifier) -> Exchange:
         tools=tools,
         moderator=get_moderator(profile.moderator)(),
         model=profile.processor,
+        ask_confirmation=ask_confirmation,
     )
 
     # This is a bit awkward, but we have to set this after the fact because building

--- a/src/goose/cli/main.py
+++ b/src/goose/cli/main.py
@@ -160,8 +160,14 @@ def get_session_files() -> dict[str, Path]:
 @click.option("--plan", type=click.Path(exists=True))
 @click.option("--log-level", type=click.Choice(["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]), default="INFO")
 @click.option("--tracing", is_flag=True, required=False)
+@click.option("--confirm", is_flag=True, help="Prompt before executing potentially unsafe commands", default=False)
 def session_start(
-    name: Optional[str], profile: str, log_level: str, plan: Optional[str] = None, tracing: bool = False
+    name: Optional[str],
+    profile: str,
+    log_level: str,
+    plan: Optional[str] = None,
+    tracing: bool = False,
+    confirm: bool = False,
 ) -> None:
     """Start a new goose session"""
     if plan:
@@ -172,7 +178,9 @@ def session_start(
         _plan = None
 
     try:
-        session = Session(name=name, profile=profile, plan=_plan, log_level=log_level, tracing=tracing)
+        session = Session(
+            name=name, profile=profile, plan=_plan, log_level=log_level, tracing=tracing, ask_confirmation=confirm
+        )
         session.run()
     except RuntimeError as e:
         print(f"[red]Error: {e}")

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -67,6 +67,7 @@ class Session:
         plan: Optional[dict] = None,
         log_level: Optional[str] = "INFO",
         tracing: bool = False,
+        ask_confirmation: bool = False,
         **kwargs: dict[str, any],
     ) -> None:
         if name is None:
@@ -90,7 +91,9 @@ class Session:
                 )
         langfuse_context.configure(enabled=tracing)
 
-        self.exchange = create_exchange(profile=load_profile(profile), notifier=self.notifier)
+        self.exchange = create_exchange(
+            profile=load_profile(profile), notifier=self.notifier, ask_confirmation=ask_confirmation
+        )
         setup_logging(log_file_directory=LOG_PATH, log_level=log_level)
 
         self.exchange.messages.extend(self._get_initial_messages())

--- a/src/goose/synopsis/bash.py
+++ b/src/goose/synopsis/bash.py
@@ -1,25 +1,36 @@
 import os
 from pathlib import Path
 
+from rich.markdown import Markdown
+from rich.rule import Rule
 from goose.notifier import Notifier
+from goose.utils.confirm_execute import cancel_confirmation, confirm_execute
 from goose.view import ExchangeView
+from goose.toolkit.utils import RULEPREFIX, RULESTYLE
 from goose.synopsis.system import system
 from goose.utils.shell import shell
 from goose.synopsis.util import log_command
 
 
 class Bash:
-    def __init__(self, notifier: Notifier, exchange_view: ExchangeView) -> None:
+    def __init__(self, notifier: Notifier, exchange_view: ExchangeView, 
+                 explanation: str, ask_confirmation: bool) -> None:
         self.notifier = notifier
         self.exchange_view = exchange_view
+        self.explanation = explanation
+        self.ask_confirmation = ask_confirmation
 
     def _logshell(self, command: str, title: str = "shell") -> None:
         log_command(self.notifier, command, path=os.path.abspath(system.cwd), title=title)
+        if self.explanation:
+            self.notifier.log(self.explanation)
 
     def _source(self, path: str) -> str:
         """Source the file at path."""
         source_command = f"source {path} && env"
         self._logshell(f"source {path}")
+        if not confirm_execute(self.ask_confirmation, self.notifier, "source this file"):
+            return cancel_confirmation("Sourcing file")
         result = shell(source_command, self.notifier, self.exchange_view, cwd=system.cwd, env=system.env)
         env_vars = dict(line.split("=", 1) for line in result.splitlines() if "=" in line)
         system.env.update(env_vars)
@@ -35,7 +46,9 @@ class Bash:
             raise ValueError("You must source files through the bash tool with 'source' command.")
 
         self._logshell(command)
-        return shell(command, self.notifier, self.exchange_view, cwd=system.cwd, env=system.env)
+        if confirm_execute(self.ask_confirmation, self.notifier, "execute this command"):
+            return shell(command, self.notifier, self.exchange_view, cwd=system.cwd, env=system.env)
+        return cancel_confirmation("Command execution")
 
     def _change_dir(self, path: str) -> str:
         """Change the directory to the specified path."""

--- a/src/goose/synopsis/moderator.py
+++ b/src/goose/synopsis/moderator.py
@@ -85,8 +85,7 @@ class Synopsis(Moderator):
 
         if plan:
             self.current_plan = self.plan(exchange)
-
-        return Message.load("synopsis.md", synopsis=self, system=system)
+        return Message.load("synopsis.md", synopsis=self, system=system, ask_confirmation=exchange.ask_confirmation)
 
     def summarize(self, exchange: Exchange) -> str:
         message = Message.load("summarize.md", synopsis=self, messages=self.originals, exchange=exchange, system=system)

--- a/src/goose/synopsis/synopsis.md
+++ b/src/goose/synopsis/synopsis.md
@@ -2,6 +2,13 @@
 
 {{system.info()}}
 
+{% if ask_confirmation %}
+# Ask to confirm function tool execution
+For function tool "bash" with parameter ask_confirmation, if you are 100% sure the suggested function with the parameters won't add, change or delete any resources, states or environment on the computer, please set the parameter ask_confirmation to false.
+Otherwise set to true.
+For other function tool with parameter ask_confirmation, always set true
+{% endif %}
+
 # Hints
 
 {{synopsis.hints}}

--- a/src/goose/synopsis/toolkit.py
+++ b/src/goose/synopsis/toolkit.py
@@ -27,6 +27,8 @@ class SynopsisDeveloper(Toolkit):
     @tool
     def bash(
         self,
+        explanation: str,
+        ask_confirmation: bool,
         command: Optional[str] = None,
         working_dir: Optional[str] = None,
         source_path: Optional[str] = None,
@@ -42,6 +44,8 @@ class SynopsisDeveloper(Toolkit):
         At least one of the parameters must be provided.
 
         Args:
+            explanation (str): The explanations of the bash commands.
+            ask_confirmation (boolean): Whether to ask for confirmation before running the command.
             command (str, optional):The bash shell command to run.
             working_dir (str, optional): The directory to change to.
             source_path (str, optional): The file to source before running the command.
@@ -50,7 +54,8 @@ class SynopsisDeveloper(Toolkit):
             [command, working_dir, source_path]
         ), "At least one of the parameters for bash shell must be provided."
 
-        bash_tool = Bash(notifier=self.notifier, exchange_view=self.exchange_view)
+        bash_tool = Bash(notifier=self.notifier, exchange_view=self.exchange_view, explanation=explanation,
+            ask_confirmation=ask_confirmation)
         outputs = []
 
         if working_dir:
@@ -72,6 +77,7 @@ class SynopsisDeveloper(Toolkit):
         self,
         command: TextEditorCommand,
         path: str,
+        ask_confirmation: bool,
         file_text: Optional[str] = None,
         insert_line: Optional[int] = None,
         new_str: Optional[str] = None,
@@ -93,6 +99,8 @@ class SynopsisDeveloper(Toolkit):
                 Allowed options are: `view`, `create`, `str_replace`, `insert`, `undo_edit`.
             path (str): Absolute path (or relative path against cwd) to file or directory,
                 e.g. `/repo/file.py` or `/repo` or `curr_dir_file.py`.
+            ask_confirmation (boolean): whether to ask for confirmation before creating or modifying any file.
+                Any command except `view` will require confirmation.
             file_text (str, optional): Required parameter of `create` command, with the content
                 of the file to be created.
             insert_line (int, optional): Required parameter of `insert` command.
@@ -107,7 +115,7 @@ class SynopsisDeveloper(Toolkit):
                 number range, e.g. [11, 12] will show lines 11 and 12. Indexing at 1 to start.
                 Setting `[start_line, -1]` shows all lines from `start_line` to the end of the file.
         """
-        text_editor_instance = TextEditor(notifier=self.notifier)
+        text_editor_instance = TextEditor(notifier=self.notifier, ask_confirmation=ask_confirmation)
         return text_editor_instance.run_command(
             command=command,
             path=path,

--- a/src/goose/utils/_create_exchange.py
+++ b/src/goose/utils/_create_exchange.py
@@ -17,9 +17,9 @@ from exchange.invalid_choice_error import InvalidChoiceError
 from exchange.providers.base import MissingProviderEnvVariableError
 
 
-def create_exchange(profile: Profile, notifier: SessionNotifier) -> Exchange:
+def create_exchange(profile: Profile, notifier: SessionNotifier, ask_confirmation: bool) -> Exchange:
     try:
-        return build_exchange(profile, notifier=notifier)
+        return build_exchange(profile, notifier=notifier, ask_confirmation=ask_confirmation)
     except InvalidChoiceError as e:
         error_message = (
             f"[bold red]{e.message}[/bold red].\nPlease check your configuration file at {PROFILES_CONFIG_PATH}.\n"

--- a/src/goose/utils/confirm_execute.py
+++ b/src/goose/utils/confirm_execute.py
@@ -1,0 +1,19 @@
+from goose.notifier import Notifier
+from rich.prompt import Confirm
+
+
+def confirm_execute(ask_confirmation: bool, notifier: Notifier, change: str) -> bool:
+    if ask_confirmation:
+        notifier.stop()
+        confirmation_result = Confirm.ask(f"Would like to continue to {change}?")
+        notifier.start()
+        return confirmation_result
+    return True
+
+
+def cancel_confirmation(change: str) -> str:
+    return f"{change} cancelled by the user."
+
+
+def is_cancelled_by_user(content: str | None) -> bool:
+    return content.endswith("cancelled by the user.") if content else False

--- a/src/goose/utils/file_changes.py
+++ b/src/goose/utils/file_changes.py
@@ -1,0 +1,28 @@
+import difflib
+from rich.text import Text
+from rich import print
+
+
+def show_diff(file_name: str, before: str, after: str) -> str:
+    before_lines = before.splitlines()
+    after_lines = after.splitlines()
+
+    diff = difflib.unified_diff(
+        before_lines, after_lines, fromfile=f"{file_name} (before)", tofile=f"{file_name} (after)", lineterm=""
+    )
+    for line in diff:
+        if line.startswith("---") or line.startswith("+++"):
+            # Style the file changes
+            print(Text(line, style="bold blue"))
+        elif line.startswith("@@"):
+            # Style the diff position
+            print(Text(line, style="bold yellow"))
+        elif line.startswith("-"):
+            # Style removed lines
+            print(Text(line, style="red"))
+        elif line.startswith("+"):
+            # Style added lines
+            print(Text(line, style="green"))
+        else:
+            # Style unchanged lines
+            print(Text(line, style="dim"))


### PR DESCRIPTION
**Why**
At the moment, when the plan is kicked off, the tasks are executed automatically. Users do not have much control to review potential changes that the task will make. It is hard for user to make the decision whether they want to proceed, skip the task or cancel the plan except using `CTRL-C`


**What**
- Enable a `confirm` option to provide some control for the user to decide whether to continue before running the tools of

  - `bash`
  - `text_editor`

- Make the diff change more readable

With `--confirm` option,

***bash***
Before the `source` and `shell` is executed, the user is shown with the **explanation of the command**.  The ai will also **determine whether the command will do any changes** on the users' computer(via prompt in `synopsis.md`).  If it does, the user is will be **prompted whether they want to continue to execute the command**.  If yes, command will be executed.  If no, the subsequent toolkits won't be

***text_editor***
Before changing the file, user are **show the diff of the changes in the similar way of `git diff`**.  The user will be **prompted whether they want to change the file**. If yes, file will be changed.  If no, file won't be changed and will move to the next task. 

TODO:
- I am going to add `yes to all` option, so goose can remember the user decision in the plan