### PR TITLE
chore: license-checker improvements

### DIFF
--- a/.github/workflows/scripts/check_licenses.py
+++ b/.github/workflows/scripts/check_licenses.py
@@ -271,11 +271,16 @@ class LicenseChecker:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Check package licenses in TOML files")
-    parser.add_argument("toml_files", type=Path, nargs="+", help="Paths to TOML files")
-    args = parser.parse_args()
+    parser.add_argument("toml_files", type=Path, nargs="*", help="Paths to TOML files")
 
     checker = LicenseChecker()
     all_results: dict[str, LicenseInfo] = {}
+
+    args = parser.parse_args()
+    if not args.toml_files:
+        print("Error: No TOML files specified", file=sys.stderr)
+        parser.print_help()
+        sys.exit(1)
 
     for toml_file in args.toml_files:
         results = checker.check_licenses(toml_file)

--- a/.github/workflows/scripts/check_licenses.py
+++ b/.github/workflows/scripts/check_licenses.py
@@ -272,11 +272,17 @@ class LicenseChecker:
 def main() -> None:
     parser = argparse.ArgumentParser(description="Check package licenses in TOML files")
     parser.add_argument("toml_files", type=Path, nargs="*", help="Paths to TOML files")
+    parser.add_argument("--supported-licenses", action="store_true", help="Print supported licenses")
 
     checker = LicenseChecker()
     all_results: dict[str, LicenseInfo] = {}
 
     args = parser.parse_args()
+    if args.supported_licenses:
+        for license in sorted(checker.config.allowed_licenses, key=str.casefold):
+            print(f" - {license}")
+        sys.exit(0)
+
     if not args.toml_files:
         print("Error: No TOML files specified", file=sys.stderr)
         parser.print_help()

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ integration *FLAGS:
 check-licenses:
     @uv run .github/workflows/scripts/check_licenses.py pyproject.toml packages/exchange/pyproject.toml
 
+# list supported licenses
+list-licenses:
+    @uv run .github/workflows/scripts/check_licenses.py --supported-licenses
+
 # format code
 format:
     #!/usr/bin/env bash

--- a/justfile
+++ b/justfile
@@ -11,8 +11,24 @@ integration *FLAGS:
     @uv run pytest tests/ -m integration {{ FLAGS }}
 
 # check licenses
-check-licenses:
-    @uv run .github/workflows/scripts/check_licenses.py pyproject.toml packages/exchange/pyproject.toml
+check-licenses force="":
+    #!/usr/bin/env bash
+    mapfile -t license_files < <(find . -type f -name 'pyproject.toml')
+    total=${#license_files[@]}
+
+    for ((i=0; i<total; i++)); do
+        license="${license_files[i]}"
+        remaining=$((total - i - 1))
+
+        if ! git diff --quiet "$license" || [ "{{ force }}" == "--force" ]; then
+            echo "checking licenses for: $license"
+            uv run .github/workflows/scripts/check_licenses.py "$license"
+
+            if [ $remaining -gt 0 ]; then
+                echo ""
+            fi
+        fi
+    done
 
 # list supported licenses
 list-licenses:


### PR DESCRIPTION
this PR refines the approach introduced in #208 to consistently check licenses. i forgot it is used with `pre-commit` hooks which can overwhelm the ui output. especially it's sequenced _after_ `just format` because formatting runs faster and happens more frequently.

 * [new] `just list-licenses` - added as a convenience to view allowed licenses before adding dependencies.
  * license check phased implementation:
     * `pre-commit`: runs license checks only if `pyproject.toml` is modified and `just install-hooks`, but now we avoid the unnecessary noise/speed on every commit
     * `just check-license`: for contributors not using `pre-commit` hooks
     * [new] `just check-license --force` requiring an explicit check (skips `git staging`, useful during iteration)
     * ci enforcement: in the event all of these checks get missed we have one last check before merging

lastly, instead of explicitly checking the licenses we look for any `pyproject.toml` files for packages that are added
