### PR TITLE
fix: Session:single_pass isn't plan aware

### DIFF
--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -77,6 +77,7 @@ class Session:
         self.prompt_session = GoosePromptSession()
         self.status_indicator = Status("", spinner="dots")
         self.notifier = SessionNotifier(self.status_indicator)
+        self.has_plan = plan is not None
         if not tracing:
             logging.getLogger("langfuse").setLevel(logging.ERROR)
         else:
@@ -140,23 +141,30 @@ class Session:
             return Message.user(text=user_input.text)
         return self.exchange.messages.pop()
 
-    def single_pass(self, initial_message: str) -> None:
+    def single_pass(self, initial_message: Optional[str]) -> None:
         """
         Handles a single input message and processes a reply
         without entering a loop for additional inputs.
 
         Args:
-            initial_message (str): The initial user message to process.
+            initial_message (Optional[str]): The initial user message to process.
         """
         profile = self.profile_name or "default"
         print(f"[dim]starting session | name: [cyan]{self.name}[/]  profile: [cyan]{profile}[/]")
         print(f"[dim]saving to {self.session_file_path}")
 
-        # Process initial message
-        message = Message.user(initial_message)
+        # Check to see if there is a planned operation to perform prior to the bespoke prompt
+        if self.has_plan and len(self.exchange.messages) > 0:
+            # Process the plan prompt
+            self.exchange.add(self.exchange.messages.pop())
+            self.reply()  
 
-        self.exchange.add(message)
-        self.reply()  # Process the user message
+        if initial_message:
+            # Process initial message
+            message = Message.user(initial_message)
+
+            self.exchange.add(message)
+            self.reply()  # Process the user message
 
         print(f"[dim]ended run | name: [cyan]{self.name}[/]  profile: [cyan]{profile}[/]")
         print(f"[dim]to resume: [magenta]goose session resume {self.name} --profile {profile}[/][/]")

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -157,7 +157,7 @@ class Session:
         if self.has_plan and len(self.exchange.messages) > 0:
             # Process the plan prompt
             self.exchange.add(self.exchange.messages.pop())
-            self.reply()  
+            self.reply()
 
         if initial_message:
             # Process initial message


### PR DESCRIPTION
## Description
This PR fixes a minor oversight in the `single_pass` function where if a plan was provided to the session it would not be processed by the single_pass function.

This issue has been addressed by implementing a global "has_plan" check to maintain if there was originally a plan for the session. We also check the current length of the exchange message stack to ensure we perform this action in the event there was a plan added and it's not yet been processed.

Additionally, the initial_message variable has been changed to optional to allow CLI tools to take advantage of only leveraging session plans as prompts from Goose plugins.