### PR TITLE
fix: Log costs during `run` the same as we do during interactive sessions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "goose-ai"
 description = "a programming agent that runs on your machine"
-version = "0.9.11"
+version = "0.9.12"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "goose-ai"
 description = "a programming agent that runs on your machine"
-version = "0.9.12"
+version = "0.9.11"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/goose/cli/session.py
+++ b/src/goose/cli/session.py
@@ -150,6 +150,7 @@ class Session:
         Args:
             initial_message (str): The initial user message to process.
         """
+        time_start = datetime.now()
         profile = self.profile_name or "default"
         print(f"[dim]starting session | name: [cyan]{self.name}[/]  profile: [cyan]{profile}[/]")
         print(f"[dim]saving to {self.session_file_path}")
@@ -159,6 +160,9 @@ class Session:
 
         self.exchange.add(message)
         self.reply()  # Process the user message
+
+        time_end = datetime.now()
+        self._log_cost(start_time=time_start, end_time=time_end)
 
         print(f"[dim]ended run | name: [cyan]{self.name}[/]  profile: [cyan]{profile}[/]")
         print(f"[dim]to resume: [magenta]goose session resume {self.name} --profile {profile}[/][/]")


### PR DESCRIPTION
During an interactive session we will write the cost of the session to the goose log but atm we don't write the costs if its a `goose run file.md`. It's important for me to see the cost of autonomous runs as I work on autonomous use cases.