### PR TITLE
fix: Mark kill related commands as dangerous

### DIFF
--- a/src/goose/utils/shell.py
+++ b/src/goose/utils/shell.py
@@ -34,6 +34,9 @@ def is_dangerous_command(command: str) -> bool:
         r"\bsystemctl\b",  # systemctl command
         r"\breboot\b",  # reboot command
         r"\bshutdown\b",  # shutdown command
+        # Commands that kill processes
+        r"\b(kill|pkill|killall|xkill|skill)\b",
+        r"\bfuser\b\s*-[kK]",  # fuser -k command
         # Target files that are unsafe
         r"\b~\/\.|\/\.\w+",  # commands that point to files or dirs in home that start with a dot (dotfiles)
     ]

--- a/tests/utils/test_check_shell_command.py
+++ b/tests/utils/test_check_shell_command.py
@@ -17,6 +17,8 @@ from goose.utils.shell import is_dangerous_command
         "shutdown now",
         "cat ~/.hello.txt",
         "cat ~/.config/example.txt",
+        "pkill -f gradle",
+        "fuser -k -n tcp 80",
     ],
 )
 def test_dangerous_commands(command):


### PR DESCRIPTION
We should have the user confirm any commands related to killing processes.