### PR TITLE
feat: Add new navigation tools to the web browser toolkit

### DIFF
--- a/src/goose/toolkit/web_browser.py
+++ b/src/goose/toolkit/web_browser.py
@@ -286,8 +286,8 @@ class BrowserToolkit(Toolkit):
                 else:
                     raise
     @tool
-    def click_element_by_link_text(self, link_text: str, exact_match=True) -> None:
-        """Click on a page element using the text visible on the page. 
+    def click_element_by_link_text(self, link_text: str, exact_match: bool = True) -> None:
+        """Click on a page element using the text visible on the page.
         Useful when the page has multiple links or buttons, and you want to click on a specific one.
 
         Args:
@@ -298,7 +298,7 @@ class BrowserToolkit(Toolkit):
         match_type = By.LINK_TEXT if exact_match else By.PARTIAL_LINK_TEXT
         element = self.driver.find_element(match_type, link_text)
         element.click()
-    
+
     @tool
     def find_element_by_text_soup(self, text: str, filename: str) -> str:
         """Find an element containing the specified text using BeautifulSoup on HTML content stored in a file.

--- a/src/goose/toolkit/web_browser.py
+++ b/src/goose/toolkit/web_browser.py
@@ -285,6 +285,7 @@ class BrowserToolkit(Toolkit):
                     time.sleep(2)
                 else:
                     raise
+
     @tool
     def click_element_by_link_text(self, link_text: str, exact_match: bool = True) -> None:
         """Click on a page element using the text visible on the page.

--- a/src/goose/toolkit/web_browser.py
+++ b/src/goose/toolkit/web_browser.py
@@ -20,6 +20,8 @@ from pyshadow.main import Shadow
 from selenium import webdriver
 from selenium.common.exceptions import InvalidSessionIdException, NoSuchElementException, TimeoutException
 from selenium.webdriver.common.by import By
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as ec
 from selenium.webdriver.support.ui import WebDriverWait
 
@@ -120,6 +122,21 @@ class BrowserToolkit(Toolkit):
             return f"image:{path}"
         except Exception as e:
             self.notifier.notify(f"Error taking screenshot: {str(e)}")
+
+    @tool
+    def scroll_page(self, direction: str = "down") -> None:
+        """Scroll the current page up or down.
+
+        Args:
+            direction (str): The direction to scroll the page. Either 'up' or 'down'.
+        """
+        actions = ActionChains(self.driver)
+        if direction == "up":
+            actions.send_keys(Keys.PAGE_UP).perform()
+        elif direction == "down":
+            actions.send_keys(Keys.PAGE_DOWN).perform()
+        else:
+            self.notifier.notify(f"Invalid scroll direction: {direction}")
 
     @tool
     def open_new_tab(self, url: str) -> None:
@@ -268,7 +285,20 @@ class BrowserToolkit(Toolkit):
                     time.sleep(2)
                 else:
                     raise
+    @tool
+    def click_element_by_link_text(self, link_text: str, exact_match=True) -> None:
+        """Click on a page element using the text visible on the page. 
+        Useful when the page has multiple links or buttons, and you want to click on a specific one.
 
+        Args:
+            link_text (str): The visible text of the button or link.
+            exact_match (bool): Whether to match the exact link text or any partial match.
+        """
+        self.notifier.notify(f"Clicking element with text: {link_text}")
+        match_type = By.LINK_TEXT if exact_match else By.PARTIAL_LINK_TEXT
+        element = self.driver.find_element(match_type, link_text)
+        element.click()
+    
     @tool
     def find_element_by_text_soup(self, text: str, filename: str) -> str:
         """Find an element containing the specified text using BeautifulSoup on HTML content stored in a file.


### PR DESCRIPTION
This pull request includes two enhancements to the web browser toolkit. 

The browser extension occasionally has issues clicking on the correct element on the page while navigating a website. This pull request help address the issue by allowing goose to easily scroll through a page and click on links and buttons using the visible text content. 

New functionalities:
* Introduced a new method `scroll_page` to scroll the current page up or down using the `PAGE_UP` and `PAGE_DOWN` keys.
* Added a method `click_element_by_link_text` to click on a page element by its visible text, with an option for exact or partial text match.

