### PR TITLE
[cli] Use clearer Esc -> Enter prompt for sending messages

### DIFF
--- a/crates/goose-cli/src/prompt/cliclack.rs
+++ b/crates/goose-cli/src/prompt/cliclack.rs
@@ -2,7 +2,7 @@ use std::io::{self, Write};
 
 use anyhow::Result;
 use bat::WrappingMode;
-use cliclack::{input, spinner};
+use cliclack::{input, set_theme, spinner, Theme as CliclackTheme, ThemeState};
 use goose::models::message::{Message, MessageContent};
 
 use super::prompt::{Input, InputType, Prompt, Theme};
@@ -34,6 +34,8 @@ impl CliclackPrompt {
         // for syntax in syntax_set {
         //     println!("{}", syntax.name);
         // }
+
+        set_theme(PromptTheme);
 
         CliclackPrompt {
             spinner: spinner(),
@@ -195,5 +197,41 @@ impl Prompt for CliclackPrompt {
 
     fn close(&self) {
         // No cleanup required
+    }
+}
+
+//////
+/// Custom theme for the prompt
+//////
+struct PromptTheme;
+
+const EDIT_MODE_STR: &str = "[Esc](Preview)";
+const PREVIEW_MODE_STR: &str = "[Enter](Submit)";
+
+// We need a wrapper to be able to call the trait default implementation with the same name.
+struct Wrapper<'a, T>(&'a T);
+
+impl<'a, T: CliclackTheme> CliclackTheme for Wrapper<'a, T> {}
+
+impl CliclackTheme for PromptTheme {
+    /// The original logic for teaching the user how to submit in multiline mode.
+    /// https://github.com/fadeevab/cliclack/blob/main/src/input.rs#L250
+    /// We are replacing it to be more explicit.
+    ///
+    fn format_footer_with_message(&self, state: &ThemeState, message: &str) -> String {
+        let new_message = match state {
+            ThemeState::Active => {
+                if EDIT_MODE_STR == message {
+                    "Send [Esc -> Enter]"
+                } else if PREVIEW_MODE_STR == message {
+                    "Send [Enter]"
+                } else {
+                    message
+                }
+            }
+            _ => message,
+        };
+
+        Wrapper(self).format_footer_with_message(state, &new_message)
     }
 }

--- a/crates/goose-cli/src/prompt/cliclack.rs
+++ b/crates/goose-cli/src/prompt/cliclack.rs
@@ -209,8 +209,8 @@ const EDIT_MODE_STR: &str = "[Esc](Preview)";
 const PREVIEW_MODE_STR: &str = "[Enter](Submit)";
 
 // We need a wrapper to be able to call the trait default implementation with the same name.
+#[allow(dead_code)]
 struct Wrapper<'a, T>(&'a T);
-
 impl<'a, T: CliclackTheme> CliclackTheme for Wrapper<'a, T> {}
 
 impl CliclackTheme for PromptTheme {


### PR DESCRIPTION
Changed default cliclack multiline hint text.

Starting state

| Original | New |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/1c4c4e55-6d11-4c38-96c8-f4b3675fc1d7) | ![image](https://github.com/user-attachments/assets/73f87b01-dbbd-4926-a126-00617656153a) |

Press 'Esc'

| Original | New |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/86a6421b-29d5-47fd-a519-6604aaddea4b) | ![image](https://github.com/user-attachments/assets/04de3302-1726-4c06-b73d-67ead11ad1c7) |

