### PR TITLE
docs: Fixed providers link in Quickstart.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ goose session start
 ```
 
 #### Set up a provider
-Goose works with your [preferred LLM][https://block.github.io/goose/plugins/providers.html]. By default, it uses `openai` as the LLM provider. You'll be prompted to set an [API key][openai-key] if you haven't set one previously.
+Goose works with your [preferred LLM](https://block.github.io/goose/plugins/providers.html). By default, it uses `openai` as the LLM provider. You'll be prompted to set an [API key][openai-key] if you haven't set one previously.
 
 >[!TIP]
 > **Billing:**

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -30,7 +30,7 @@ goose session start
 ```
 
 #### Set up a provider
-Goose works with your [preferred LLM][providers]. By default, it uses `openai` as the LLM provider. You'll be prompted to set an [API key][openai-key] if you haven't set one previously.
+Goose works with your [preferred LLM](https://block.github.io/goose/plugins/providers.html). By default, it uses `openai` as the LLM provider. You'll be prompted to set an [API key][openai-key] if you haven't set one previously.
 
 >[!TIP]
 > **Billing:**


### PR DESCRIPTION
This pull request fixes a broken link to [LLM providers](https://block.github.io/goose/plugins/providers.html) I additionally found in our Quickstart guide.

Links fixed:
- Under `Set up a provider` section, in Quickstart.md, fixed the [preferred LLM](https://block.github.io/goose/plugins/providers.html) link. ([Previous link is outdated](https://block.github.io/goose/providers.html))
- Fixed typo in previous README.md push using [] vs ().