### PR TITLE
feat: Cleanup serialization of content

### DIFF
--- a/crates/goose/src/models/content.rs
+++ b/crates/goose/src/models/content.rs
@@ -1,17 +1,20 @@
 use serde::Serialize;
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all="camelCase")]
 pub struct TextContent {
     pub text: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all="camelCase")]
 pub struct ImageContent {
     pub data: String,
     pub mime_type: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all="camelCase")]
 /// Content passed to or from an LLM
 pub enum Content {
     Text(TextContent),


### PR DESCRIPTION
This better aligns with client expectations

```json
{"result":[{"Text":{"text":"example"}}],"toolCallId":"call_HZM0sraJtEL0znZd4xaSbckj"}
```

becomes

```json
{"result":[{"text":"example","type":"text"}],"toolCallId":"call_AFJtX3C1mJdzRov6qt72iVZB"}
```