### PR TITLE
fix: add escaped characters in goosehint docs

### DIFF
--- a/docs/guidance/using-goosehints.md
+++ b/docs/guidance/using-goosehints.md
@@ -40,7 +40,7 @@ Go through the README.md for information on how to build and test it as needed.
 Make sure to confirm all changes with me before applying.
 
 Use the following custom values when needed:
-{% include custom-config.js %}
+&#123;% include custom-config.js %&#125;
 
 Run tests with `npm run test` ideally after each change.
 ```


### PR DESCRIPTION
This pull request includes a small change to the `docs/guidance/using-goosehints.md` file. The change involves escaping the curly braces in the include directive to ensure proper rendering.

* [`docs/guidance/using-goosehints.md`](diffhunk://#diff-da23e59bb493adae010b24d49c44a73fe715f2afb0582a4c1dd947246c412696L43-R43): Escaped curly braces in the include directive to ensure proper rendering.