### PR TITLE
Replace all processor/accelerator with model including in profile

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -22,15 +22,13 @@ pub async fn handle_configure(provided_profile_name: Option<String>) -> Result<(
 
     let provider_name = select_provider(existing_profile);
     let recommended_models = get_recommended_models(provider_name);
-    let processor = set_processor(existing_profile, &recommended_models)?;
-    let accelerator = set_accelerator(existing_profile, &recommended_models)?;
-    let provider_config = set_provider_config(provider_name, processor.clone());
+    let model = set_model(existing_profile, &recommended_models)?;
+    let provider_config = set_provider_config(provider_name, model.clone());
     let additional_systems =
         existing_profile.map_or(Vec::new(), |profile| profile.additional_systems.clone());
     let profile = Profile {
         provider: provider_name.to_string(),
-        processor: processor.clone(),
-        accelerator,
+        model: model.clone(),
         additional_systems,
     };
     match save_profile(profile_name.as_str(), profile) {
@@ -70,28 +68,14 @@ fn get_existing_profile(profile_name: &String) -> Option<Profile> {
     existing_profile_result
 }
 
-fn set_processor(
+fn set_model(
     existing_profile: Option<&Profile>,
     recommended_models: &RecommendedModels,
 ) -> Result<String, Box<dyn Error>> {
-    let default_processor_value = existing_profile
-        .map_or(recommended_models.processor, |profile| {
-            profile.processor.as_str()
-        });
-    let processor = get_user_input("Enter processor:", default_processor_value)?;
-    Ok(processor)
-}
-
-fn set_accelerator(
-    existing_profile: Option<&Profile>,
-    recommended_models: &RecommendedModels,
-) -> Result<String, Box<dyn Error>> {
-    let default_accelerator_value = existing_profile
-        .map_or(recommended_models.accelerator, |profile| {
-            profile.accelerator.as_str()
-        });
-    let processor = get_user_input("Enter accelerator:", default_accelerator_value)?;
-    Ok(processor)
+    let default_model_value =
+        existing_profile.map_or(recommended_models.model, |profile| profile.model.as_str());
+    let model = get_user_input("Enter model:", default_model_value)?;
+    Ok(model)
 }
 
 fn select_provider(existing_profile: Option<&Profile>) -> &str {

--- a/crates/goose-cli/src/commands/expected_config.rs
+++ b/crates/goose-cli/src/commands/expected_config.rs
@@ -3,19 +3,14 @@
 use crate::profile::provider_helper::PROVIDER_OPEN_AI;
 
 pub struct RecommendedModels {
-    pub processor: &'static str,
-    pub accelerator: &'static str,
+    pub model: &'static str,
 }
 pub fn get_recommended_models(provider_name: &str) -> RecommendedModels {
     if provider_name == PROVIDER_OPEN_AI {
-        RecommendedModels {
-            processor: "gpt-4o",
-            accelerator: "gpt-4o-mini",
-        }
+        RecommendedModels { model: "gpt-4o" }
     } else {
         RecommendedModels {
-            processor: "claude-3-5-sonnet-2",
-            accelerator: "claude-3-5-sonnet-2",
+            model: "claude-3-5-sonnet-2",
         }
     }
 }

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -23,7 +23,7 @@ pub fn build_session<'a>(session: Option<String>, profile: Option<String>) -> Bo
 
     // TODO: Reconsider fn name as we are just using the fn to ask the user if env vars are not set
     let provider_config =
-        set_provider_config(&loaded_profile.provider, loaded_profile.processor.clone());
+        set_provider_config(&loaded_profile.provider, loaded_profile.model.clone());
 
     // TODO: Odd to be prepping the provider rather than having that done in the agent?
     let provider = factory::get_provider(provider_config).unwrap();
@@ -51,8 +51,7 @@ fn load_profile(profile_name: Option<String>) -> Box<Profile> {
         let recommended_models = get_recommended_models(PROVIDER_OPEN_AI);
         Box::new(Profile {
             provider: PROVIDER_OPEN_AI.to_string(),
-            processor: recommended_models.processor.to_string(),
-            accelerator: recommended_models.accelerator.to_string(),
+            model: recommended_models.model.to_string(),
             additional_systems: Vec::new(),
         })
     } else {

--- a/crates/goose-cli/src/profile/profile.rs
+++ b/crates/goose-cli/src/profile/profile.rs
@@ -3,8 +3,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct Profile {
     pub provider: String,
-    pub processor: String,
-    pub accelerator: String,
+    pub model: String,
     #[serde(default)]
     pub additional_systems: Vec<AdditionalSystem>,
 }

--- a/crates/goose-cli/src/profile/profile_handler.rs
+++ b/crates/goose-cli/src/profile/profile_handler.rs
@@ -44,14 +44,13 @@ pub fn load_profiles() -> Result<HashMap<String, Profile>, Box<dyn Error>> {
         return Ok(HashMap::new());
     }
     let file = File::open(&path)?;
-    let profiles: HashMap<String, Profile> = match serde_yaml::from_reader(file) {
-        Ok(profiles) => profiles,
+    match serde_yaml::from_reader(file) {
+        Ok(profiles) => Ok(profiles),
         Err(e) => {
-            eprintln!("\x1b[31mFailed to parse profile file: {}\n\nAbort or we will create a new empty profile file.\n\x1b[0m", e);
-            HashMap::new()
+            eprintln!("\x1b[31mFailed to parse profile file: {}\n\nPlease delete {} and recreate it.\n\x1b[0m", e, path.display());
+            Err(Box::new(e))
         }
-    };
-    Ok(profiles)
+    }
 }
 
 pub fn find_existing_profile(profile_name: &str) -> Option<Profile> {

--- a/crates/goose-cli/src/profile/profile_handler.rs
+++ b/crates/goose-cli/src/profile/profile_handler.rs
@@ -44,7 +44,13 @@ pub fn load_profiles() -> Result<HashMap<String, Profile>, Box<dyn Error>> {
         return Ok(HashMap::new());
     }
     let file = File::open(&path)?;
-    let profiles: HashMap<String, Profile> = serde_yaml::from_reader(file)?;
+    let profiles: HashMap<String, Profile> = match serde_yaml::from_reader(file) {
+        Ok(profiles) => profiles,
+        Err(e) => {
+            eprintln!("\x1b[31mFailed to parse profile file: {}\n\nAbort or we will create a new empty profile file.\n\x1b[0m", e);
+            HashMap::new()
+        }
+    };
     Ok(profiles)
 }
 

--- a/crates/goose-cli/src/profile/provider_helper.rs
+++ b/crates/goose-cli/src/profile/provider_helper.rs
@@ -19,7 +19,7 @@ pub fn select_provider_lists() -> Vec<(&'static str, String, &'static str)> {
         .collect()
 }
 
-pub fn set_provider_config(provider_name: &str, processor: String) -> ProviderConfig {
+pub fn set_provider_config(provider_name: &str, model: String) -> ProviderConfig {
     match provider_name.to_lowercase().as_str() {
         PROVIDER_OPEN_AI => ProviderConfig::OpenAi(OpenAiProviderConfig {
             host: "https://api.openai.com".to_string(),
@@ -28,7 +28,7 @@ pub fn set_provider_config(provider_name: &str, processor: String) -> ProviderCo
                 "Please enter your OpenAI API key:",
                 true,
             ),
-            model: processor,
+            model,
             temperature: None,
             max_tokens: None,
         }),
@@ -43,7 +43,7 @@ pub fn set_provider_config(provider_name: &str, processor: String) -> ProviderCo
                 "Please enter your Databricks token:",
                 true,
             ),
-            model: processor,
+            model,
             temperature: None,
             max_tokens: None,
         }),


### PR DESCRIPTION
We no longer use processor and accelerator models, we just use one `model`. The cli and profiles had not been updated with this so this PR fixes that, replacing all references to them.

**Incompatibilty**
Existing profiles that do not have `model` in them will cause an error and require deleting the file (or fixing) and recreating using /configure.

![image](https://github.com/user-attachments/assets/280c2ffe-da7e-4dac-8bc3-040976620f6b)

If no profile exists, no errors appear.

