### PR TITLE
fix: logging production builds + reading env

### DIFF
--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -23,6 +23,7 @@
         "clsx": "^2.1.1",
         "cors": "^2.8.5",
         "dotenv": "^16.4.5",
+        "electron-log": "^5.2.2",
         "electron-squirrel-startup": "^1.0.1",
         "express": "^4.21.1",
         "framer-motion": "^11.11.11",
@@ -5344,6 +5345,15 @@
       "optional": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.2.2.tgz",
+      "integrity": "sha512-fgvx6srjIHDowJD8WAAjoAXmiTyOz6JnGQoxOtk1mXw7o4S+HutuPHLCsk24xTXqWZgy4uO63NbedG+oEvldLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-squirrel-startup": {

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -48,6 +48,7 @@
     "clsx": "^2.1.1",
     "cors": "^2.8.5",
     "dotenv": "^16.4.5",
+    "electron-log": "^5.2.2",
     "electron-squirrel-startup": "^1.0.1",
     "express": "^4.21.1",
     "framer-motion": "^11.11.11",

--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -44,15 +44,6 @@ export const start = (app) => {
     log.error('Failed to start goosed:', err);
   });
 
-  // Wait a bit to ensure the server is up
-  setTimeout(() => {
-    // Test if server is responding
-    fetch('http://127.0.0.1:3000/health')
-      .then(response => response.text())
-      .then(text => log.info('Server health check successful:', text))
-      .catch(err => log.error('Server health check failed:', err));
-  }, 1000);
-
   // Ensure goosed is terminated when the app quits
   app.on('will-quit', () => {
     log.info('App quitting, terminating goosed server');

--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
 import { spawn } from 'child_process';
+import { existsSync } from 'fs';
+import log from './utils/logger';
 
 // Start the goosed binary
 export const start = (app) => {
@@ -16,28 +18,44 @@ export const start = (app) => {
     goosedPath = path.join(process.resourcesPath, 'bin', process.platform === 'win32' ? 'goosed.exe' : 'goosed');
   }
 
-  console.log(`Starting goosed from: ${goosedPath}`);
+  log.info(`Starting goosed from: ${goosedPath}`);
+  
+  // Check if the binary exists
+  if (!existsSync(goosedPath)) {
+    log.error(`goosed binary not found at path: ${goosedPath}`);
+    return;
+  }
 
   const goosedProcess = spawn(goosedPath);
 
   goosedProcess.stdout.on('data', (data) => {
-    console.log(`goosed stdout: ${data}`);
+    log.info(`goosed stdout: ${data.toString()}`);
   });
 
   goosedProcess.stderr.on('data', (data) => {
-    console.error(`goosed stderr: ${data}`);
+    log.error(`goosed stderr: ${data.toString()}`);
   });
 
   goosedProcess.on('close', (code) => {
-    console.log(`goosed process exited with code ${code}`);
+    log.info(`goosed process exited with code ${code}`);
   });
 
   goosedProcess.on('error', (err) => {
-    console.error('Failed to start goosed:', err);
+    log.error('Failed to start goosed:', err);
   });
+
+  // Wait a bit to ensure the server is up
+  setTimeout(() => {
+    // Test if server is responding
+    fetch('http://127.0.0.1:3000/health')
+      .then(response => response.text())
+      .then(text => log.info('Server health check successful:', text))
+      .catch(err => log.error('Server health check failed:', err));
+  }, 1000);
 
   // Ensure goosed is terminated when the app quits
   app.on('will-quit', () => {
+    log.info('App quitting, terminating goosed server');
     goosedProcess.kill();
   });
 };

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -3,6 +3,7 @@ import { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain } from 'electro
 import path from 'node:path';
 import { start as startGoosed } from './goosed';
 import started from "electron-squirrel-startup";
+import log from './utils/logger';
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (started) app.quit();
@@ -159,7 +160,7 @@ const showWindow = () => {
   const windows = BrowserWindow.getAllWindows();
 
   if (windows.length === 0) {
-    console.log("No windows are currently open.");
+    log.info("No windows are currently open.");
     return;
   }
 
@@ -196,10 +197,10 @@ app.whenReady().then(() => {
   const shouldStartServer = (process.env.VITE_START_EMBEDDED_SERVER || 'yes').toLowerCase() === 'yes';
   
   if (shouldStartServer) {
-    console.log('Starting embedded goosed server');
+    log.info('Starting embedded goosed server');
     startGoosed(app);
   } else {
-    console.log('Skipping embedded server startup (disabled by configuration)');
+    log.info('Skipping embedded server startup (disabled by configuration)');
   }
 
   createTray();

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1,4 +1,5 @@
 import 'dotenv/config';
+import { loadZshEnv } from './utils/loadEnv';
 import { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain } from 'electron';
 import path from 'node:path';
 import { start as startGoosed } from './goosed';
@@ -193,6 +194,8 @@ const showWindow = () => {
 };
 
 app.whenReady().then(() => {
+  // Load zsh environment variables
+  loadZshEnv();
   // Get the server startup configuration
   const shouldStartServer = (process.env.VITE_START_EMBEDDED_SERVER || 'yes').toLowerCase() === 'yes';
   

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -194,8 +194,9 @@ const showWindow = () => {
 };
 
 app.whenReady().then(() => {
-  // Load zsh environment variables
-  loadZshEnv();
+  // Load zsh environment variables in production mode only
+  const isProduction = app.isPackaged;
+  loadZshEnv(isProduction);
   // Get the server startup configuration
   const shouldStartServer = (process.env.VITE_START_EMBEDDED_SERVER || 'yes').toLowerCase() === 'yes';
   

--- a/ui/desktop/src/utils/loadEnv.ts
+++ b/ui/desktop/src/utils/loadEnv.ts
@@ -2,7 +2,15 @@ import { execSync } from 'child_process';
 import path from 'path';
 import log from './logger';
 
-export function loadZshEnv(): void {
+export function loadZshEnv(isProduction: boolean = false): void {
+  // Only proceed if running on macOS and in production mode
+  if (process.platform !== 'darwin' || !isProduction) {
+    log.info(`Skipping zsh environment loading: ${
+      process.platform !== 'darwin' ? 'Not running on macOS' : 'Not in production mode'
+    }`);
+    return;
+  }
+
   try {
     // Execute zsh and source the zshrc file, then export all environment variables
     const zshrcPath = path.join(process.env.HOME || '', '.zshrc');

--- a/ui/desktop/src/utils/loadEnv.ts
+++ b/ui/desktop/src/utils/loadEnv.ts
@@ -1,0 +1,28 @@
+import { execSync } from 'child_process';
+import path from 'path';
+import log from './logger';
+
+export function loadZshEnv(): void {
+  try {
+    // Execute zsh and source the zshrc file, then export all environment variables
+    const zshrcPath = path.join(process.env.HOME || '', '.zshrc');
+    const envStr = execSync(`/bin/zsh -c 'source ${zshrcPath} && env'`, {
+      encoding: 'utf-8'
+    });
+
+    // Parse and set environment variables
+    envStr.split('\n').forEach(line => {
+      const matches = line.match(/^([^=]+)=(.*)$/);
+      if (matches) {
+        const [, key, value] = matches;
+        if (!process.env[key]) {
+          process.env[key] = value;
+        }
+      }
+    });
+
+    log.info('Successfully loaded zsh environment variables');
+  } catch (error) {
+    log.error('Failed to load zsh environment variables:', error);
+  }
+}

--- a/ui/desktop/src/utils/logger.ts
+++ b/ui/desktop/src/utils/logger.ts
@@ -1,0 +1,22 @@
+import log from 'electron-log';
+import path from 'node:path';
+import { app } from 'electron';
+
+// Configure electron-log
+// In development: ~/Library/Logs/goose/main.log
+// In production: ~/Library/Application Support/goose/logs/main.log
+log.transports.file.resolvePathFn = () => {
+  const isDev = process.env.NODE_ENV === 'development';
+  if (isDev) {
+    return path.join(app.getPath('home'), 'Library/Logs/goose/main.log');
+  }
+  return path.join(app.getPath('userData'), 'logs/main.log');
+};
+
+// Configure log level based on environment
+log.transports.file.level = process.env.NODE_ENV === 'development' ? 'debug' : 'info';
+
+// Also log to console in development
+log.transports.console.level = process.env.NODE_ENV === 'development' ? 'debug' : false;
+
+export default log;


### PR DESCRIPTION
For v1.0 will on macos read env - needed for Goose.app to work.