### PR TITLE
[cli] Adds rustyline as the default input method. Configurable via GOOSE_INPUT env.

### DIFF
--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -32,6 +32,7 @@ strum_macros = "0.26"
 reqwest = "0.11.27"
 rand = "0.8.5"
 async-trait = "0.1"
+rustyline = "15.0.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -11,8 +11,8 @@ use crate::profile::profile_handler::{load_profiles, PROFILE_DEFAULT_NAME};
 use crate::profile::provider_helper::set_provider_config;
 use crate::profile::provider_helper::PROVIDER_OPEN_AI;
 use crate::prompt::cliclack::CliclackPrompt;
-use crate::prompt::rustyline::RustylinePrompt;
 use crate::prompt::prompt::Prompt;
+use crate::prompt::rustyline::RustylinePrompt;
 use crate::session::session::Session;
 use crate::session::session_file::ensure_session_dir;
 

--- a/crates/goose-cli/src/prompt/mod.rs
+++ b/crates/goose-cli/src/prompt/mod.rs
@@ -1,2 +1,3 @@
 pub mod cliclack;
 pub mod prompt;
+pub mod rustyline;

--- a/crates/goose-cli/src/prompt/prompt.rs
+++ b/crates/goose-cli/src/prompt/prompt.rs
@@ -4,7 +4,7 @@ use goose::models::message::Message;
 pub trait Prompt {
     fn render(&mut self, message: Box<Message>);
     fn get_input(&mut self) -> Result<Input>;
-    fn show_busy(&self);
+    fn show_busy(&mut self);
     fn hide_busy(&self);
     fn close(&self);
     fn goose_ready(&self) {

--- a/crates/goose-cli/src/session/session.rs
+++ b/crates/goose-cli/src/session/session.rs
@@ -16,7 +16,7 @@ pub struct Session<'a> {
 }
 
 impl<'a> Session<'a> {
-    pub fn new(agent: Box<Agent>, prompt: Box<impl Prompt + 'a>, session_file: PathBuf) -> Self {
+    pub fn new(agent: Box<Agent>, prompt: Box<dyn Prompt + 'a>, session_file: PathBuf) -> Self {
         Session {
             agent,
             prompt,


### PR DESCRIPTION
Rustyline single line prompt survives pasting content much like the original python version.

I've made it possible to use GOOSE_INPUT env to specify either the cliclack or rustyline prompt version for people testing.

![image](https://github.com/user-attachments/assets/e5cb85b1-18ee-4d08-b505-1861588eaa97)
