### PR TITLE
ci: Add CI to main pushes

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches:
+      - main # Trigger CI on PRs to main
+
+  push:
+    branches:
+      - main # Trigger CI on pushes to main
 
 jobs:
   exchange:

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -1,9 +1,17 @@
 ---
 name: License Check
 
-"on":
-  pull_request:
+on:
+  pull_request: # Trigger license check on any PRs
     paths:
+      - '**/pyproject.toml'
+      - '.github/workflows/license-check.yml'
+      - '.github/workflows/scripts/check_licenses.py'
+
+  push: # Trigger license check on pushes to main
+    branches:
+      - main
+    paths: # TODO: can't DRY unless https://github.com/actions/runner/issues/1182
       - '**/pyproject.toml'
       - '.github/workflows/license-check.yml'
       - '.github/workflows/scripts/check_licenses.py'


### PR DESCRIPTION
With these changes the CI and license check workflows will also run when PRs are merged on the main branch, this way we can ensure the main branch is also covered.