### PR TITLE
Always render bash commands

### DIFF
--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -88,7 +88,7 @@ fn load_profile(profile_name: Option<String>) -> Box<Profile> {
                     "No '{}' profile found. Run configure to create a profile.",
                     PROFILE_DEFAULT_NAME
                 ),
-            }, // Default to the first profile. TODO: Define a constant name for the default profile.
+            },
         }
     };
     loaded_profile

--- a/crates/goose-cli/src/prompt/cliclack.rs
+++ b/crates/goose-cli/src/prompt/cliclack.rs
@@ -8,7 +8,10 @@ use bat::WrappingMode;
 use cliclack::{input, set_theme, spinner, Theme as CliclackTheme, ThemeState};
 use goose::models::message::{Message, MessageContent, ToolRequest, ToolResponse};
 
-use super::{prompt::{Input, InputType, Prompt, Theme}, thinking::get_random_thinking_message};
+use super::{
+    prompt::{Input, InputType, Prompt, Theme},
+    thinking::get_random_thinking_message,
+};
 
 pub struct CliclackPrompt {
     spinner: cliclack::ProgressBar,
@@ -186,7 +189,8 @@ impl Prompt for CliclackPrompt {
 
     fn show_busy(&mut self) {
         self.spinner = spinner();
-        self.spinner.start(format!("{}...", get_random_thinking_message()));
+        self.spinner
+            .start(format!("{}...", get_random_thinking_message()));
     }
 
     fn hide_busy(&self) {

--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -7,12 +7,15 @@ use anyhow::Result;
 use bat::WrappingMode;
 use cliclack::spinner;
 use console::style;
-use goose::models::content::Content;
 use goose::models::message::{Message, MessageContent, ToolRequest, ToolResponse};
 use goose::models::role::Role;
+use goose::models::{content::Content, tool::ToolCall};
 use serde_json::Value;
 
-use super::{prompt::{Input, InputType, Prompt, Theme}, thinking::get_random_thinking_message};
+use super::{
+    prompt::{Input, InputType, Prompt, Theme},
+    thinking::get_random_thinking_message,
+};
 
 const PROMPT: &str = "\x1b[1m\x1b[38;5;30m( O)> \x1b[0m";
 const MAX_STRING_LENGTH: usize = 40;
@@ -44,6 +47,11 @@ impl RustylinePrompt {
         let mut renderers: HashMap<String, Box<dyn ToolRenderer>> = HashMap::new();
         let default_renderer = DefaultRenderer;
         renderers.insert(default_renderer.tool_name(), Box::new(default_renderer));
+        let bash_dev_system_renderer = BashDeveloperSystemRenderer;
+        renderers.insert(
+            bash_dev_system_renderer.tool_name(),
+            Box::new(bash_dev_system_renderer),
+        );
 
         RustylinePrompt {
             spinner: spinner(),
@@ -70,16 +78,7 @@ impl ToolRenderer for DefaultRenderer {
     fn request(&self, tool_request: &ToolRequest, theme: &str) {
         match &tool_request.tool_call {
             Ok(call) => {
-                // Print the tool name with an emoji
-                let parts: Vec<_> = call.name.split("__").collect();
-
-                let tool_header = format!(
-                    "─── {} | {} ──────────────────────────",
-                    style(parts.get(1).unwrap_or(&"unknown")),
-                    style(parts.get(0).unwrap_or(&"unknown")).magenta().dim(),
-                );
-                print_newline();
-                println!("{}", tool_header);
+                default_print_request_header(call);
 
                 // Format and print the parameters
                 print_params(&call.arguments, 0);
@@ -90,23 +89,68 @@ impl ToolRenderer for DefaultRenderer {
     }
 
     fn response(&self, tool_response: &ToolResponse, theme: &str) {
-        match &tool_response.tool_result {
-            Ok(contents) => {
-                for content in contents {
-                    if content
-                        .audience()
-                        .is_some_and(|audience| !audience.contains(&Role::User))
-                    {
-                        continue;
-                    }
+        default_response_renderer(tool_response, theme);
+    }
+}
 
-                    if let Content::Text(text) = content {
-                        print_markdown(&text.text, theme);
-                    }
+fn default_response_renderer(tool_response: &ToolResponse, theme: &str) {
+    match &tool_response.tool_result {
+        Ok(contents) => {
+            for content in contents {
+                if content
+                    .audience()
+                    .is_some_and(|audience| !audience.contains(&Role::User))
+                {
+                    continue;
                 }
+
+                if let Content::Text(text) = content {
+                    print_markdown(&text.text, theme);
+                }
+            }
+        }
+        Err(e) => print(&e.to_string(), theme),
+    }
+}
+
+fn default_print_request_header(call: &ToolCall) {
+    // Print the tool name with an emoji
+    let parts: Vec<_> = call.name.split("__").collect();
+
+    let tool_header = format!(
+        "─── {} | {} ──────────────────────────",
+        style(parts.get(1).unwrap_or(&"unknown")),
+        style(parts.first().unwrap_or(&"unknown")).magenta().dim(),
+    );
+    print_newline();
+    println!("{}", tool_header);
+}
+struct BashDeveloperSystemRenderer;
+
+impl ToolRenderer for BashDeveloperSystemRenderer {
+    fn tool_name(&self) -> String {
+        "DeveloperSystem__bash".to_string()
+    }
+
+    fn request(&self, tool_request: &ToolRequest, theme: &str) {
+        match &tool_request.tool_call {
+            Ok(call) => {
+                default_print_request_header(call);
+
+                match call.arguments.get("command") {
+                    Some(Value::String(s)) => {
+                        println!("{}: {}", style("command").dim(), style(s).green());
+                    }
+                    _ => print_params(&call.arguments, 0),
+                }
+                print_newline();
             }
             Err(e) => print(&e.to_string(), theme),
         }
+    }
+
+    fn response(&self, tool_response: &ToolResponse, theme: &str) {
+        default_response_renderer(tool_response, theme);
     }
 }
 
@@ -245,7 +289,8 @@ impl Prompt for RustylinePrompt {
 
     fn show_busy(&mut self) {
         self.spinner = spinner();
-        self.spinner.start(format!("{}...", get_random_thinking_message()));
+        self.spinner
+            .start(format!("{}...", get_random_thinking_message()));
     }
 
     fn hide_busy(&self) {

--- a/crates/goose-cli/src/prompt/thinking.rs
+++ b/crates/goose-cli/src/prompt/thinking.rs
@@ -91,7 +91,6 @@ pub const THINKING_MESSAGES: &[&str] = &[
     "Honking success signals",
     "Waddling through workflows",
     "Nesting in neural networks",
-    
     // AI thinking actions
     "Consulting the digital oracle",
     "Summoning binary spirits",
@@ -260,15 +259,19 @@ pub const THINKING_MESSAGES: &[&str] = &[
     "Processing memory streams",
     "Evaluating logical paths",
     "Building thought graphs",
-    "Scanning neural pathways"
+    "Scanning neural pathways",
 ];
 
 /// Returns a random thinking message from the extended list
 pub fn get_random_thinking_message() -> &'static str {
-    THINKING_MESSAGES.choose(&mut rand::thread_rng()).unwrap_or(&THINKING_MESSAGES[0])
+    THINKING_MESSAGES
+        .choose(&mut rand::thread_rng())
+        .unwrap_or(&THINKING_MESSAGES[0])
 }
 
 /// Returns a random goose-specific action
 pub fn get_random_goose_action() -> &'static str {
-    GOOSE_ACTIONS.choose(&mut rand::thread_rng()).unwrap_or(&GOOSE_ACTIONS[0])
+    GOOSE_ACTIONS
+        .choose(&mut rand::thread_rng())
+        .unwrap_or(&GOOSE_ACTIONS[0])
 }


### PR DESCRIPTION
It's important users can always see the full bash command being run in order to know what it happening and have a chance to abort. To do this I added a custom renderer for the bash developer system tool that does not truncate the shell command.

Old
![image](https://github.com/user-attachments/assets/b6506668-ed9f-434e-9fcf-cb13ff67f229)

New
![image](https://github.com/user-attachments/assets/a34bbd9d-53f3-4281-9d0e-d8f01a62033b)

There are a few other minor changes in this PR as a result of running `cargo fmt` and `cargo clippy --fix`.