### PR TITLE
ci: Lock CI uv version to 0.5.4 and fix file test_session.py format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.3"
+          version: "0.5.4"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -40,8 +40,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install UV
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.5.4"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -73,8 +75,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install UV
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.5.4"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.2"
+          version: "0.5.1"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.2"
+          version: "0.5.1"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -78,7 +78,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.2"
+          version: "0.5.1"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.1"
+          version: "0.5.4"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.1"
+          version: "0.5.4"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -78,7 +78,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.1"
+          version: "0.5.4"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,8 +16,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install UV
-        run: curl -LsSf https://astral.sh/uv/install.sh | sh
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          version: "0.5.4"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.4"
+          version: "0.5.3"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.4"
+          version: "0.5.3"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -78,7 +78,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.4"
+          version: "0.5.3"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.3"
+          version: "0.5.2"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.3"
+          version: "0.5.2"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env
@@ -78,7 +78,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.3"
+          version: "0.5.2"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v3
         with:
-          version: "0.5.4"
+          version: "0.5.3"
 
       - name: Source Cargo Environment
         run: source $HOME/.cargo/env

--- a/tests/cli/test_session.py
+++ b/tests/cli/test_session.py
@@ -271,8 +271,9 @@ def test_observer_plugin_called(create_session_with_mock_configs):
     observer_manager_mock = MagicMock(spec=ObserverManager)
     observer_manager_mock._observers = [observer_mock]
 
-    with patch("exchange.observers.ObserverManager.get_instance", return_value=observer_manager_mock), patch(
-        "exchange.Exchange.generate", return_value=Message.assistant("test response")
+    with (
+        patch("exchange.observers.ObserverManager.get_instance", return_value=observer_manager_mock),
+        patch("exchange.Exchange.generate", return_value=Message.assistant("test response")),
     ):
         session = create_session_with_mock_configs({"name": SESSION_NAME})
 


### PR DESCRIPTION
- Locks the UV version according to [their docs](https://docs.astral.sh/uv/guides/integration/github/#installation)
- Fixes the lint complain in the `test_session.py` file