### PR TITLE
Skip ollama intergration test if no ollama env set

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -15,7 +15,6 @@ mod systems;
 use anyhow::Result;
 use clap::{Parser, Subcommand};
 use commands::session::build_session;
-use futures::StreamExt;
 
 use crate::systems::system_handler::{add_system, remove_system};
 use commands::configure::handle_configure;

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -183,6 +183,12 @@ async fn test_databricks_provider_oauth() -> Result<()> {
 async fn test_ollama_provider() -> Result<()> {
     load_env();
 
+    // Skip if model isin't set (specified in ci)
+    if std::env::var("OLLAMA_MODEL").is_err() {
+        println!("Skipping Ollama tests - model not configured");
+        return Ok(());
+    }
+
    let config = ProviderConfig::Ollama(OllamaProviderConfig {
         host: std::env::var("OLLAMA_HOST")
             .unwrap_or_else(|_| String::from(OLLAMA_HOST)),


### PR DESCRIPTION
Following the same pattern as other provider integration tests so that we can run `cargo test` completely locally even if we don't have ollama installed.