### PR TITLE
[cli] Runs agent as an async spawned task

### DIFF
--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -1,9 +1,7 @@
 use rand::{distributions::Alphanumeric, Rng};
 use std::path::{Path, PathBuf};
 
-use goose::agent::Agent;
 use goose::models::message::Message;
-use goose::providers::factory;
 
 use crate::commands::expected_config::get_recommended_models;
 use crate::profile::profile::Profile;
@@ -47,9 +45,6 @@ pub fn build_session<'a>(
     let provider_config =
         set_provider_config(&loaded_profile.provider, loaded_profile.model.clone());
 
-    // TODO: Odd to be prepping the provider rather than having that done in the agent?
-    let provider = factory::get_provider(provider_config).unwrap();
-    let agent = Box::new(Agent::new(provider));
     let mut prompt = match std::env::var("GOOSE_INPUT") {
         Ok(val) => match val.as_str() {
             "cliclack" => Box::new(CliclackPrompt::new()) as Box<dyn Prompt>,
@@ -70,7 +65,7 @@ pub fn build_session<'a>(
         session_file.display()
     ))));
 
-    Box::new(Session::new(agent, prompt, session_file))
+    Box::new(Session::new(provider_config.clone(), prompt, session_file))
 }
 
 fn session_path(


### PR DESCRIPTION
We have a problem with the existing cli in that if the user presses Ctrl+c it will interrupt the agents action (with a tool result error) but then leave the agent running to respond to the error.

The user is trying to interrupt the process.

This PR is a **POC** that shows if we run the agent as a spawned async task then when the ctrl+c is pressed it is handled by the cli code (`tokio::signal::ctrl_c`) rather than the agent. This signals the spawned agent to break via a channel which results in the underlying process being terminated without further interaction. This is obviously a pretty ungraceful shutdown for the agent but required to stop processing immediately.

How do we know it actually stops any underlying tools under the hood? I had it run a shell command loop that wrote a line for every second. When interrupting I was able to assert that the shell command stopped writing rather than completing the loop.

The downside is that we spinning up the agent from scratch for each user message. This can be avoided but requires making the agent and its attributes cloneable so they can survive the async move. An alternative would be to explore if we can push this async interaction deeper into the agent. At that stage we should probably consider having the cli interact with the goose-server rather than the agent directly and just solve that interaction.