### PR TITLE
feat [cli]: Add keyring management for OpenAI API keys

### DIFF
--- a/crates/goose-cli/src/profile/provider_helper.rs
+++ b/crates/goose-cli/src/profile/provider_helper.rs
@@ -90,6 +90,6 @@ pub fn set_provider_config(provider_name: &str, model: String) -> ProviderConfig
             temperature: None,
             max_tokens: None,
         }),
-        _ => panic!("Invalid provider name: {}", provider_name),
+        _ => panic!("Invalid provider name"),
     }
 }

--- a/crates/goose-cli/src/profile/provider_helper.rs
+++ b/crates/goose-cli/src/profile/provider_helper.rs
@@ -1,9 +1,10 @@
-use crate::inputs::inputs::get_env_value_or_input;
+use crate::inputs::inputs::{get_user_input, get_env_value_or_input};
 use goose::providers::configs::{
     DatabricksAuth, DatabricksProviderConfig, OpenAiProviderConfig, OllamaProviderConfig, ProviderConfig
 };
 use goose::providers::factory::ProviderType;
 use goose::providers::ollama::OLLAMA_HOST;
+use goose::key_manager::{get_api_key_default, save_to_keyring, KeyRetrievalStrategy};
 use strum::IntoEnumIterator;
 
 pub const PROVIDER_OPEN_AI: &str = "openai";
@@ -24,19 +25,48 @@ pub fn select_provider_lists() -> Vec<(&'static str, String, &'static str)> {
         .collect()
 }
 
+pub fn get_or_set_api_key(provider_name: &str, api_key_name: &str) -> Result<String, Box<dyn std::error::Error>> {
+    // Try to get existing key first from keyring or environment
+    if let Ok(key) = get_api_key_default(api_key_name, KeyRetrievalStrategy::Both) {
+        return Ok(key);
+    }
+
+    // If no key found or error occurred, prompt user for input
+    let prompt = format!("Please enter your {} key:", provider_name);
+    let api_key = get_env_value_or_input(
+        api_key_name,
+        &prompt,
+        false,
+    );
+    
+    // Check if user wants to save to the system keyring
+    let resp = get_user_input("Would you like to save this key to the system keyring? (y/n):", "y")?;
+    if resp.eq_ignore_ascii_case("y") {
+        match save_to_keyring(api_key_name, &api_key) {
+            Ok(_) => println!("Successfully saved key to system keyring"),
+            Err(e) => {
+                // Log the error but don't fail - the API key is still usable
+                println!("Warning: Failed to save key to system keyring: {}", e);
+            }
+        }
+    }
+    
+    Ok(api_key)
+}
+
 pub fn set_provider_config(provider_name: &str, model: String) -> ProviderConfig {
     match provider_name.to_lowercase().as_str() {
-        PROVIDER_OPEN_AI => ProviderConfig::OpenAi(OpenAiProviderConfig {
-            host: "https://api.openai.com".to_string(),
-            api_key: get_env_value_or_input(
-                "OPENAI_API_KEY",
-                "Please enter your OpenAI API key:",
-                true,
-            ),
-            model,
-            temperature: None,
-            max_tokens: None,
-        }),
+        PROVIDER_OPEN_AI => {
+            let api_key = get_or_set_api_key(provider_name, "OPENAI_API_KEY")
+                .expect("Failed to get OpenAI API key");
+            ProviderConfig::OpenAi(OpenAiProviderConfig {
+                host: "https://api.openai.com".to_string(),
+                api_key,
+                model,
+                temperature: None,
+                max_tokens: None,
+            })
+        },
         PROVIDER_DATABRICKS => {
             let host = get_env_value_or_input(
                 "DATABRICKS_HOST",
@@ -60,6 +90,6 @@ pub fn set_provider_config(provider_name: &str, model: String) -> ProviderConfig
             temperature: None,
             max_tokens: None,
         }),
-        _ => panic!("Invalid provider name"),
+        _ => panic!("Invalid provider name: {}", provider_name),
     }
 }

--- a/crates/goose-server/src/configuration.rs
+++ b/crates/goose-server/src/configuration.rs
@@ -249,7 +249,7 @@ mod tests {
         } = settings.provider
         {
             assert_eq!(host, "https://api.openai.com");
-            assert_eq!(api_key, "test-key");
+            assert_eq!(api_key, "test-key".to_string());
             assert_eq!(model, "gpt-4o");
             assert_eq!(temperature, None);
             assert_eq!(max_tokens, None);

--- a/crates/goose-server/src/configuration.rs
+++ b/crates/goose-server/src/configuration.rs
@@ -249,7 +249,7 @@ mod tests {
         } = settings.provider
         {
             assert_eq!(host, "https://api.openai.com");
-            assert_eq!(api_key, "test-key".to_string());
+            assert_eq!(api_key, "test-key");
             assert_eq!(model, "gpt-4o");
             assert_eq!(temperature, None);
             assert_eq!(max_tokens, None);

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -43,7 +43,6 @@ keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sy
 wiremock = "0.6.0"
 mockito = "1.2"
 tempfile = "3.8"
-dotenv = "0.15"
 mockall = "0.11"
 
 [[example]]

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -37,12 +37,16 @@ tower-http = { version = "0.5", features = ["cors"] }
 webbrowser = "0.8"
 dotenv = "0.15"
 xcap = "0.0.14"
+keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service"] }
 
 [dev-dependencies]
 wiremock = "0.6.0"
 mockito = "1.2"
 tempfile = "3.8"
+dotenv = "0.15"
+mockall = "0.11"
 
 [[example]]
 name = "databricks_oauth"
 path = "examples/databricks_oauth.rs"
+

--- a/crates/goose/src/key_manager.rs
+++ b/crates/goose/src/key_manager.rs
@@ -1,0 +1,327 @@
+use std::env;
+use keyring::Entry;
+use thiserror::Error;
+#[cfg(test)]
+use mockall::automock;
+#[cfg(test)]
+use mockall::predicate::*;
+
+const KEYRING_SERVICE: &str = "goose";
+
+#[derive(Error, Debug)]
+pub enum KeyManagerError {
+    #[error("Failed to access keyring: {0}")]
+    KeyringAccess(String),
+
+    #[error("Failed to save to keyring: {0}")]
+    KeyringSave(String),
+
+    #[error("Failed to access environment variable: {0}")]
+    EnvVarAccess(String)
+}
+
+impl From<keyring::Error> for KeyManagerError {
+    fn from(err: keyring::Error) -> Self {
+        KeyManagerError::KeyringAccess(err.to_string())
+    }
+}
+
+impl From<env::VarError> for KeyManagerError {
+    fn from(err: env::VarError) -> Self {
+        KeyManagerError::EnvVarAccess(err.to_string())
+    }
+}
+
+// Define a trait for the keyring operations
+#[cfg_attr(test, automock)]
+pub trait Keyring: Send + Sync {
+    fn get_password(&self) -> std::result::Result<String, KeyManagerError>;
+    fn set_password(&self, password: &str) -> std::result::Result<(), KeyManagerError>;
+}
+
+#[cfg_attr(test, automock)]
+pub trait Environment: Send + Sync {
+    fn get_var(&self, key: &str) -> std::result::Result<String, env::VarError>;
+    fn set_var(&self, key: &str, value: &str);
+}
+
+// Implement the trait for the actual environment
+pub struct RealEnvironment;
+
+impl Environment for RealEnvironment {
+    fn get_var(&self, key: &str) -> std::result::Result<String, env::VarError> {
+        env::var(key)
+    }
+
+    fn set_var(&self, key: &str, value: &str) {
+        env::set_var(key, value)
+    }
+}
+
+// Implement the trait for the actual keyring
+impl Keyring for Entry {
+    fn get_password(&self) -> std::result::Result<String, KeyManagerError> {
+        self.get_password().map_err(KeyManagerError::from)
+    }
+
+    fn set_password(&self, password: &str) -> std::result::Result<(), KeyManagerError> {
+        self.set_password(password).map_err(KeyManagerError::from)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum KeyRetrievalStrategy {
+    /// Only look in environment variables
+    EnvironmentOnly,
+    /// Only look in system keyring
+    KeyringOnly,
+    /// Try keyring first, then environment variables (default behavior)
+    Both,
+}
+
+impl Default for KeyRetrievalStrategy {
+    fn default() -> Self {
+        Self::Both
+    }
+}
+
+pub fn get_api_key_default(
+    api_key_name: &str,
+    strategy: KeyRetrievalStrategy,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let env = RealEnvironment;
+    let kr = Entry::new(KEYRING_SERVICE, api_key_name)?;
+    get_api_key(api_key_name, strategy, &kr, &env)
+}
+
+pub fn get_api_key(
+    api_key_name: &str,
+    strategy: KeyRetrievalStrategy,
+    keyring: &impl Keyring,
+    env: &impl Environment,
+) -> Result<String, Box<dyn std::error::Error>> {
+    match strategy {
+        KeyRetrievalStrategy::EnvironmentOnly => {
+            env.get_var(api_key_name)
+                .map_err(|e| Box::new(KeyManagerError::from(e)) as Box<dyn std::error::Error>)
+        }
+        KeyRetrievalStrategy::KeyringOnly => {
+            keyring.get_password()
+                .map_err(|e| Box::new(e) as Box<dyn std::error::Error>)
+        }
+        KeyRetrievalStrategy::Both => {
+            match keyring.get_password() {
+                Ok(key) => Ok(key),
+                Err(e) => {
+                    println!("Note: Could not retrieve key from keyring: {}", e);
+                    env.get_var(api_key_name).map_err(|_| {
+                        Box::new(KeyManagerError::EnvVarAccess(format!(
+                            "Could not find {} key in keyring or environment variables",
+                            api_key_name
+                        ))) as Box<dyn std::error::Error>
+                    })
+                }
+            }
+        }
+    }
+}
+
+pub fn save_to_keyring(
+    key_name: &str,
+    api_key: &str,
+) -> std::result::Result<(), KeyManagerError> {
+    let kr = Entry::new(KEYRING_SERVICE, key_name)?;
+    kr.set_password(api_key)
+        .map_err(|e| KeyManagerError::KeyringSave(format!("Failed to save key {}: {}", key_name, e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_KEY: &str = "TEST_KEY";
+
+    #[test]
+    fn test_get_api_key_environment_only() {
+        let mut mock_env = MockEnvironment::new();
+        let mut mock_keyring = MockKeyring::new();
+        
+        mock_env.expect_get_var()
+            .with(eq(TEST_KEY))
+            .times(1)
+            .return_once(|_| Ok("env_value".to_string()));
+        
+        mock_keyring.expect_get_password()
+            .times(0);
+
+        let result = get_api_key(
+            TEST_KEY,
+            KeyRetrievalStrategy::EnvironmentOnly,
+            &mock_keyring,
+            &mock_env,
+        );
+        
+        assert!(matches!(result.as_deref(), Ok("env_value")));
+    }
+
+    #[test]
+    fn test_get_api_key_environment_only_missing() {
+        let mut mock_env = MockEnvironment::new();
+        let mut mock_keyring = MockKeyring::new();
+        
+        mock_env.expect_get_var()
+            .with(eq(TEST_KEY))
+            .times(1)
+            .return_once(|_| Err(env::VarError::NotPresent));
+        
+        mock_keyring.expect_get_password()
+            .times(0);
+
+        let result = get_api_key(
+            TEST_KEY,
+            KeyRetrievalStrategy::EnvironmentOnly,
+            &mock_keyring,
+            &mock_env,
+        );
+        
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_api_key_keyring_only() {
+        let mut mock_env = MockEnvironment::new();
+        let mut mock_keyring = MockKeyring::new();
+        
+        mock_keyring.expect_get_password()
+            .times(1)
+            .return_once(|| Ok("keyring_value".to_string()));
+            
+        mock_env.expect_get_var()
+            .times(0);
+
+        let result = get_api_key(
+            TEST_KEY,
+            KeyRetrievalStrategy::KeyringOnly,
+            &mock_keyring,
+            &mock_env,
+        );
+        
+        assert!(matches!(result.as_deref(), Ok("keyring_value")));
+    }
+
+    #[test]
+    fn test_get_api_key_keyring_only_missing() {
+        let mut mock_env = MockEnvironment::new();
+        let mut mock_keyring = MockKeyring::new();
+        
+        mock_keyring.expect_get_password()
+            .times(1)
+            .return_once(|| Err(KeyManagerError::KeyringAccess("Not found".to_string())));
+            
+        mock_env.expect_get_var()
+            .times(0);
+
+        let result = get_api_key(
+            TEST_KEY,
+            KeyRetrievalStrategy::KeyringOnly,
+            &mock_keyring,
+            &mock_env,
+        );
+        
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_api_key_both_keyring_succeeds() {
+        let mut mock_env = MockEnvironment::new();
+        let mut mock_keyring = MockKeyring::new();
+        
+        mock_keyring.expect_get_password()
+            .times(1)
+            .return_once(|| Ok("keyring_value".to_string()));
+            
+        mock_env.expect_get_var()
+            .times(0);
+
+        let result = get_api_key(
+            TEST_KEY,
+            KeyRetrievalStrategy::Both,
+            &mock_keyring,
+            &mock_env,
+        );
+        
+        assert!(matches!(result.as_deref(), Ok("keyring_value")));
+    }
+
+    #[test]
+    fn test_get_api_key_both_keyring_fails_env_succeeds() {
+        let mut mock_env = MockEnvironment::new();
+        let mut mock_keyring = MockKeyring::new();
+        
+        mock_keyring.expect_get_password()
+            .times(1)
+            .return_once(|| Err(KeyManagerError::KeyringAccess("Failed".to_string())));
+            
+        mock_env.expect_get_var()
+            .with(eq(TEST_KEY))
+            .times(1)
+            .return_once(|_| Ok("env_value".to_string()));
+
+        let result = get_api_key(
+            TEST_KEY,
+            KeyRetrievalStrategy::Both,
+            &mock_keyring,
+            &mock_env,
+        );
+        
+        assert!(matches!(result.as_deref(), Ok("env_value")));
+    }
+
+    #[test]
+    fn test_get_api_key_both_all_fail() {
+        let mut mock_env = MockEnvironment::new();
+        let mut mock_keyring = MockKeyring::new();
+        
+        mock_keyring.expect_get_password()
+            .times(1)
+            .return_once(|| Err(KeyManagerError::KeyringAccess("Failed".to_string())));
+            
+        mock_env.expect_get_var()
+            .with(eq(TEST_KEY))
+            .times(1)
+            .return_once(|_| Err(env::VarError::NotPresent));
+
+        let result = get_api_key(
+            TEST_KEY,
+            KeyRetrievalStrategy::Both,
+            &mock_keyring,
+            &mock_env,
+        );
+        
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_save_to_keyring() {
+        let mut mock_keyring = MockKeyring::new();
+        mock_keyring.expect_set_password()
+            .with(eq("test_value"))
+            .times(1)
+            .return_once(|_| Ok(()));
+
+        let result = save_to_keyring(TEST_KEY, "test_value");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_save_to_keyring_fails() {
+        let mut mock_keyring = MockKeyring::new();
+        mock_keyring.expect_set_password()
+            .with(eq("test_value"))
+            .times(1)
+            .return_once(|_| Err(KeyManagerError::KeyringSave("Failed to save".to_string())));
+
+        let result = save_to_keyring(TEST_KEY, "test_value");
+        assert!(matches!(result.unwrap_err(), KeyManagerError::KeyringSave(_)));
+    }
+}

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -6,3 +6,4 @@ pub mod prompt_template;
 pub mod providers;
 pub mod systems;
 pub mod token_counter;
+pub mod key_manager;


### PR DESCRIPTION

Remove API key handling from client for OpenAI provider. Instead, core goose will check the keyring, then the env variable for the API key and finally ask the user to input it if in neither of those locations, after which it will be set in the environment.