### PR TITLE
feat: support stdin and text input in cli

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -153,14 +153,11 @@ async fn main() -> Result<()> {
             resume,
         }) => {
             let contents = if let Some(file_name) = instructions {
-                // Read from file if instructions provided
                 let file_path = std::path::Path::new(&file_name);
                 std::fs::read_to_string(file_path).expect("Failed to read the instruction file")
             } else if let Some(input_text) = input_text {
-                // Use text directly if provided
                 input_text
             } else {
-                // Piped input mode (default to stdin if no instructions or text is provided)
                 use std::io::{self, Read};
                 let mut stdin = String::new();
                 io::stdin().read_to_string(&mut stdin).expect("Failed to read from stdin");

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -14,12 +14,12 @@ mod systems;
 
 use anyhow::Result;
 use clap::{Parser, Subcommand};
+use commands::configure::handle_configure;
 use commands::session::build_session;
+use commands::version::print_version;
+use std::io::{self, Read};
 
 use crate::systems::system_handler::{add_system, remove_system};
-use commands::configure::handle_configure;
-
-use commands::version::print_version;
 
 #[derive(Parser)]
 #[command(author, about, long_about = None)]
@@ -158,9 +158,10 @@ async fn main() -> Result<()> {
             } else if let Some(input_text) = input_text {
                 input_text
             } else {
-                use std::io::{self, Read};
                 let mut stdin = String::new();
-                io::stdin().read_to_string(&mut stdin).expect("Failed to read from stdin");
+                io::stdin()
+                    .read_to_string(&mut stdin)
+                    .expect("Failed to read from stdin");
                 stdin
             };
             let mut session = build_session(session, profile, resume);


### PR DESCRIPTION
Support pipes and/or text input. Usage:

```
echo "say whats for dinner in japanese" | cargo run --bin goose -- run
```

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/137c2f73-22cd-44cf-af23-0c2d5850b925">

--- 

```
cargo run --bin goose -- run -t "say hello in japanese"  
```
<img width="972" alt="image" src="https://github.com/user-attachments/assets/801724eb-0ee0-4674-9ea0-9b30e02f2ca8">
