### PR TITLE
Downgrade libc and tracing-core

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -37,6 +37,8 @@ tower-http = { version = "0.5", features = ["cors"] }
 webbrowser = "0.8"
 dotenv = "0.15"
 xcap = "0.0.14"
+libc = "=0.2.164"
+tracing-core = "=0.1.32"
 
 [dev-dependencies]
 wiremock = "0.6.0"


### PR DESCRIPTION
Downgrading deps due to the following error when running `cargo build`:

```
error[E0599]: no method named `len` found for type `i8` in the current scope
   --> /Users/zaki/.cargo/registry/src/index.crates.io-6f17d22bba15001f/sysinfo-0.32.0/src/unix/apple/macos/process.rs:436:53
    |
436 |         Some(node.vip_path.len() * node.vip_path[0].len()),
    |                                                     ^^^
    |
help: there is a method `le` with a similar name, but with different arguments
   --> /rustc/f6e511eec7342f59a25f7c0534f1dbea00d01b14/library/core/src/cmp.rs:1196:5
```

`libc` and `tracing-core` had updated versions today that broke something. Not quite sure how these deps cause that error in sysinfo, but they are deps of it.