### PR TITLE
poc for being able to terminate a running shell command via cli or goosed

### DIFF
--- a/crates/goose-cli/src/agents/agent.rs
+++ b/crates/goose-cli/src/agents/agent.rs
@@ -2,11 +2,12 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use goose::{agent::Agent as GooseAgent, models::message::Message, systems::System};
+use tokio::sync::watch;
 
 #[async_trait]
 pub trait Agent {
     fn add_system(&mut self, system: Box<dyn System>);
-    async fn reply(&self, messages: &[Message]) -> Result<BoxStream<'_, Result<Message>>>;
+    async fn reply(&self, messages: &[Message], cancel_rx: watch::Receiver<bool>) -> Result<BoxStream<'_, Result<Message>>>;
 }
 
 #[async_trait]
@@ -15,7 +16,7 @@ impl Agent for GooseAgent {
         self.add_system(system);
     }
 
-    async fn reply(&self, messages: &[Message]) -> Result<BoxStream<'_, Result<Message>>> {
-        self.reply(messages).await
+    async fn reply(&self, messages: &[Message], cancel_rx: watch::Receiver<bool>) -> Result<BoxStream<'_, Result<Message>>> {
+        self.reply(messages, cancel_rx).await
     }
 }

--- a/crates/goose-cli/src/agents/mock_agent.rs
+++ b/crates/goose-cli/src/agents/mock_agent.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use goose::{models::message::Message, systems::System};
+use tokio::sync::watch;
 
 use crate::agents::agent::Agent;
 
@@ -13,7 +14,7 @@ impl Agent for MockAgent {
         ()
     }
 
-    async fn reply(&self, _messages: &[Message]) -> Result<BoxStream<'_, Result<Message>>> {
+    async fn reply(&self, _messages: &[Message], _cancel_rx: watch::Receiver<bool>) -> Result<BoxStream<'_, Result<Message>>> {
         Ok(Box::pin(futures::stream::empty()))
     }
 }

--- a/crates/goose-cli/src/systems/goose_hints.rs
+++ b/crates/goose-cli/src/systems/goose_hints.rs
@@ -10,6 +10,7 @@ use goose::models::tool::Tool;
 use goose::models::tool::ToolCall;
 use goose::systems::System;
 
+#[derive(Clone)]
 pub struct GooseHintsSystem {
     instructions: String,
 }

--- a/crates/goose/src/agent.rs
+++ b/crates/goose/src/agent.rs
@@ -283,6 +283,7 @@ mod tests {
     use serde_json::json;
     use std::collections::HashMap;
 
+    #[derive(Clone)]
     // Mock system for testing
     struct MockSystem {
         name: String,

--- a/crates/goose/src/developer.rs
+++ b/crates/goose/src/developer.rs
@@ -9,7 +9,7 @@ use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use xcap::Monitor;
 
 use crate::errors::{AgentError, AgentResult};
@@ -18,11 +18,12 @@ use crate::models::role::Role;
 use crate::models::tool::{Tool, ToolCall};
 use crate::systems::System;
 
+#[derive(Clone)]
 pub struct DeveloperSystem {
     tools: Vec<Tool>,
-    cwd: Mutex<PathBuf>,
-    active_files: Mutex<HashSet<PathBuf>>,
-    file_history: Mutex<HashMap<PathBuf, Vec<String>>>,
+    cwd: Arc<Mutex<PathBuf>>,
+    active_files: Arc<Mutex<HashSet<PathBuf>>>,
+    file_history: Arc<Mutex<HashMap<PathBuf, Vec<String>>>>,
     instructions: String,
 }
 
@@ -148,9 +149,9 @@ impl DeveloperSystem {
         };
         Self {
             tools: vec![bash_tool, text_editor_tool, screen_capture_tool],
-            cwd: Mutex::new(std::env::current_dir().unwrap()),
-            active_files: Mutex::new(HashSet::new()),
-            file_history: Mutex::new(HashMap::new()),
+            cwd: Arc::new(Mutex::new(std::env::current_dir().unwrap())),
+            active_files: Arc::new(Mutex::new(HashSet::new())),
+            file_history: Arc::new(Mutex::new(HashMap::new())),
             instructions,
         }
     }

--- a/crates/goose/src/memory.rs
+++ b/crates/goose/src/memory.rs
@@ -266,6 +266,7 @@ pub fn execute_tool_call(tool_call: ToolCall) -> Result<String, io::Error> {
     }
 }
 
+#[derive(Clone)]
 // MemorySystem implementation
 
 pub struct MemorySystem {

--- a/crates/goose/src/systems.rs
+++ b/crates/goose/src/systems.rs
@@ -1,11 +1,38 @@
 use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
+use futures::future::BoxFuture;
 use serde_json::Value;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::errors::AgentResult;
 use crate::models::content::Content;
 use crate::models::tool::{Tool, ToolCall};
+
+/// Type alias for a cancellation function that can be called to terminate a running operation
+pub type CancelFn = Arc<dyn Fn() + Send + Sync>;
+
+/// Represents a cancellable future that will eventually produce an AgentResult<Vec<Content>>
+pub struct CancellableOperation {
+    /// Function to call to cancel the operation
+    pub cancel: CancelFn,
+    /// Future that will resolve to the operation result
+    pub future: BoxFuture<'static, AgentResult<Vec<Content>>>,
+}
+
+impl CancellableOperation {
+    /// Helper method for tests - executes the operation and unwraps the result
+    #[cfg(test)]
+    pub async fn unwrap(self) -> Vec<Content> {
+        self.future.await.unwrap()
+    }
+
+    /// Helper method for tests - executes the operation and unwraps the error
+    #[cfg(test)]
+    pub async fn unwrap_err(self) -> crate::errors::AgentError {
+        self.future.await.unwrap_err()
+    }
+}
 
 /// Core trait that defines a system that can be operated by an AI agent
 #[async_trait]
@@ -25,8 +52,9 @@ pub trait System: Send + Sync + ClonableSystem {
     /// Get current system status
     async fn status(&self) -> AnyhowResult<HashMap<String, Value>>;
 
-    /// Call a tool with the given parameters
-    async fn call(&self, tool_call: ToolCall) -> AgentResult<Vec<Content>>;
+    /// Call a tool with the given parameters, returning a CancellableOperation that contains
+    /// both a cancellation function and a future that will resolve to the operation result
+    async fn call(&self, tool_call: ToolCall) -> CancellableOperation;
 }
 
 pub trait ClonableSystem {

--- a/crates/goose/src/systems.rs
+++ b/crates/goose/src/systems.rs
@@ -9,7 +9,7 @@ use crate::models::tool::{Tool, ToolCall};
 
 /// Core trait that defines a system that can be operated by an AI agent
 #[async_trait]
-pub trait System: Send + Sync {
+pub trait System: Send + Sync + ClonableSystem {
     /// Get the name of the system
     fn name(&self) -> &str;
 
@@ -27,4 +27,23 @@ pub trait System: Send + Sync {
 
     /// Call a tool with the given parameters
     async fn call(&self, tool_call: ToolCall) -> AgentResult<Vec<Content>>;
+}
+
+pub trait ClonableSystem {
+    fn clone_box(&self) -> Box<dyn System>;
+}
+
+impl<T> ClonableSystem for T
+where
+    T: 'static + System + Clone,
+{
+    fn clone_box(&self) -> Box<dyn System> {
+        Box::new(self.clone())
+    }
+}
+
+impl Clone for Box<dyn System> {
+    fn clone(&self) -> Box<dyn System> {
+        self.clone_box()
+    }
 }

--- a/crates/goose/tests/systems.rs
+++ b/crates/goose/tests/systems.rs
@@ -8,6 +8,7 @@ use goose::models::content::Content;
 use goose::models::tool::{Tool, ToolCall};
 use goose::systems::System;
 
+#[derive(Clone)]
 /// A simple system that echoes input back to the caller
 pub struct EchoSystem {
     tools: Vec<Tool>,


### PR DESCRIPTION
This PR just shows how its possible to do this, I took a lot of shortcuts to prove it out so will need to rewrite using this.

Essentially there are 3 parts:
- The reply process of the agent runs in a spawned process and is fed a cancel channel so the caller can signal it to stop.
- At any time the caller can 'drop' the stream resulting in closing the message channel backing the stream which breaks the spawned processes loop. Note this is sufficient to stop the process via ctrl+c using the cli but when running goosed server the shell process continues running even after the stream is interrupted.
- To stop the shell process when goosed server is running we need the tool call to return a future to run the tool and a cancellation function. Then we use tokio::select! to run all the tools (futures) and at the same time monitor for the cancel channel signal. If we get cancel channel signal then we call the 'cancel' function for all running tools which for relevant tools like bash kills the process.

I tested this by having a bash tool writing to a file every second and when interrupted checking if the file kept getting written to. "run a shell command for 15 seconds that every seconds writes its current iteration number to test.md"