### PR TITLE
feat [ui]: ensure chat tab index ordering

### DIFF
--- a/ui/desktop/src/components/Tabs.tsx
+++ b/ui/desktop/src/components/Tabs.tsx
@@ -141,8 +141,19 @@ export default function Tabs({ chats, selectedChatId, setSelectedChatId, setChat
 
   const removeChat = (chatId: number) => {
     const updatedChats = chats.filter((chat: any) => chat.id !== chatId);
-    setChats(updatedChats);
-    navigateChat(updatedChats[0].id);
+    // Reassign titles based on the new order
+    const reorderedChats = updatedChats.map((chat, index) => ({
+      ...chat,
+      title: `Chat ${index + 1}`,
+    }));
+
+    // Update the chats state
+    setChats(reorderedChats);
+
+    // Navigate to the first remaining chat (if any)
+    if (reorderedChats.length > 0) {
+      navigateChat(reorderedChats[0].id);
+    }
   };
 
   return (

--- a/ui/desktop/src/components/Tabs.tsx
+++ b/ui/desktop/src/components/Tabs.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { useNavigate } from 'react-router-dom'
+import { Chat } from '../ChatWindow';
 
 import Plus from './ui/Plus';
 import X from './ui/X';
@@ -129,10 +130,10 @@ export default function Tabs({ chats, selectedChatId, setSelectedChatId, setChat
 
   // Tab management functions
   const addChat = () => {
-    const newChatId = chats[chats.length-1].id + 1;
+    const newChatId = chats.length > 0 ? Math.max(...chats.map(chat => chat.id)) + 1 : 1;
     const newChat = {
       id: newChatId,
-      title: `Chat ${newChatId}`,
+      title: `Chat ${chats.length + 1}`,
       messages: [],
     };
     setChats([...chats, newChat]);
@@ -142,7 +143,7 @@ export default function Tabs({ chats, selectedChatId, setSelectedChatId, setChat
   const removeChat = (chatId: number) => {
     const updatedChats = chats.filter((chat: any) => chat.id !== chatId);
     // Reassign titles based on the new order
-    const reorderedChats = updatedChats.map((chat, index) => ({
+    const reorderedChats = updatedChats.map((chat: Chat, index: number) => ({
       ...chat,
       title: `Chat ${index + 1}`,
     }));


### PR DESCRIPTION
before:
Chat ordering will depend on latest index as you add and delete tabs
![image](https://github.com/user-attachments/assets/d87cde4e-27e4-4361-a3f7-55eba841cda9)

after:
Chat tab ordering will always be sequential
![image](https://github.com/user-attachments/assets/35e26f61-c080-47d8-a796-9144e5925a35)
