### PR TITLE
Interrupt running shell tool commands

### DIFF
--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -176,10 +176,6 @@ impl ProtocolFormatter {
         });
         format!("d:{}\n", finish)
     }
-
-    fn heartbeat() -> String {
-        "2:[]\n".to_string()
-    }
 }
 
 async fn stream_message(
@@ -317,17 +313,8 @@ async fn handler(
                             break;
                         }
                         Err(_) => { // Heartbeat, used to detect disconnected clients and then end running tools.
-                            if let Err(e) = tx.try_send(ProtocolFormatter::heartbeat()) {
-                                match e {
-                                    mpsc::error::TrySendError::Closed(_) => {
-                                        // Client has disconnected, end the stream and close running tools (works by ending this process).
-                                        break;
-                                    }
-                                    mpsc::error::TrySendError::Full(_) => {
-                                        tracing::warn!("Error sending heartbeat message through channel: {}", e);
-                                        continue;
-                                    }
-                                }
+                            if tx.is_closed() {
+                                break;
                             }
                             continue;
                         }

--- a/crates/goose/src/developer.rs
+++ b/crates/goose/src/developer.rs
@@ -8,8 +8,8 @@ use serde_json::{json, Value};
 use std::collections::{HashMap, HashSet};
 use std::io::Cursor;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Mutex;
+use tokio::process::Command;
 use xcap::Monitor;
 
 use crate::errors::{AgentError, AgentResult};
@@ -192,9 +192,11 @@ impl DeveloperSystem {
 
         // Execute the command
         let output = Command::new("bash")
+            .kill_on_drop(true) // Critical so that the command is killed when the agent.reply stream is interrupted.
             .arg("-c")
             .arg(cmd_with_redirect)
             .output()
+            .await
             .map_err(|e| AgentError::ExecutionError(e.to_string()))?;
 
         let output_str = format!(


### PR DESCRIPTION
This PR makes it so that interrupts to the `agent.reply` stream kills the running the bash process if there is one. Essentially it is relying on resources being cleaned up when the stream is cleaned up (leaves scope). So its a shortish term solution that is ok given the majority of systems will be network calls in the future and the shell commands are the most important to be killing atm. To make this work required 2 changes:

- Switch from std::process::Command to tokio::process::Command for running bash commands as this has an option to [kill_on_drop](https://docs.rs/tokio/latest/tokio/process/struct.Command.html#method.kill_on_drop) which allows it to be killed when the parent scope is cleaned up.
- In the goose server use a timeout every 500ms on the stream to detect when the client has closed the stream connection. When the server detects the closed connection it drops the streams which cleans up the process. This works with the existing 'Stop current Goose' button from the GUI or Ctrl+C on CLI.

Tested via checking if a running shell command was halted part way through on interrupt. Eg. `run a shell command for 15 seconds that every seconds writes its current iteration number to test.md`


_Note I have **not** included an updated ui/desktop/src/bin/goosed so this will be required for people to see the difference. Let me know if I should be including it_