### PR TITLE
[cli] On interrupt repair messages

### DIFF
--- a/crates/goose-cli/src/agents/mock_agent.rs
+++ b/crates/goose-cli/src/agents/mock_agent.rs
@@ -9,9 +9,7 @@ pub struct MockAgent;
 
 #[async_trait]
 impl Agent for MockAgent {
-    fn add_system(&mut self, _system: Box<dyn System>) {
-        
-    }
+    fn add_system(&mut self, _system: Box<dyn System>) {}
 
     async fn reply(&self, _messages: &[Message]) -> Result<BoxStream<'_, Result<Message>>> {
         Ok(Box::pin(futures::stream::empty()))

--- a/crates/goose-cli/src/prompt.rs
+++ b/crates/goose-cli/src/prompt.rs
@@ -16,6 +16,9 @@ pub trait Prompt {
         println!("Goose is running! Enter your instructions, or try asking what goose can do.");
         println!("\n");
     }
+    // Used for testing. Allows us to downcast to any type.
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any;
 }
 
 pub struct Input {

--- a/crates/goose-cli/src/prompt/cliclack.rs
+++ b/crates/goose-cli/src/prompt/cliclack.rs
@@ -271,6 +271,11 @@ impl Prompt for CliclackPrompt {
     fn close(&self) {
         // No cleanup required
     }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        panic!("Not implemented");
+    }
 }
 
 //////

--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -360,4 +360,9 @@ impl Prompt for RustylinePrompt {
     fn close(&self) {
         // No cleanup required
     }
+
+    #[cfg(test)]
+    fn as_any(&self) -> &dyn std::any::Any {
+        panic!("Not implemented");
+    }
 }

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -284,7 +284,7 @@ mod tests {
     use crate::prompt::{self, Input};
 
     use super::*;
-    use goose::models::content::{Content, TextContent};
+    use goose::models::content::Content;
     use goose::models::tool;
     use goose::{errors::AgentResult, models::tool::ToolCall};
     use tempfile::NamedTempFile;
@@ -524,5 +524,40 @@ mod tests {
         // Check the follow-up assistant message
         assert_eq!(session.messages[6].role, Role::Assistant);
         assert_eq!(session.messages[6].content[0], MessageContent::text(format!("We interrupted the existing call to {}. How would you like to proceed?", tool_name2)));
+    }
+
+    #[test]
+    fn test_interrupted_tool_use_interrupts_multiple_tools() {
+        let tool_name1 = "test";
+        let tool_call1 = tool::ToolCall::new(tool_name1, "test".into());
+
+        let tool_name2 = "test2";
+        let tool_call2 = tool::ToolCall::new(tool_name2, "test2".into());
+        let mut session = create_test_session_with_prompt(Box::new(MockPrompt::new()));
+        session.messages.push(Message::user().with_text("Do something"));
+        session.messages.push(Message::assistant().with_text("Doing it")
+            .with_tool_request("1", Ok(tool_call1.clone()))
+            .with_tool_request("2", Ok(tool_call2.clone())));
+
+
+        session.handle_interrupted_messages();
+        
+        assert_eq!(session.messages.len(), 4);
+        assert_eq!(session.messages[0].role, Role::User);
+        assert_eq!(session.messages[0].content[0], MessageContent::text("Do something"));
+        assert_eq!(session.messages[1].role, Role::Assistant);
+        assert_eq!(session.messages[1].content[0], MessageContent::text("Doing it"));
+        assert_eq!(session.messages[1].content[1], MessageContent::tool_request("1", Ok(tool_call1)));
+        assert_eq!(session.messages[1].content[2], MessageContent::tool_request("2", Ok(tool_call2)));
+
+        // Check the interrupted tool response message
+        assert_eq!(session.messages[2].role, Role::User);
+        let tool_result = Err(goose::errors::AgentError::ExecutionError("Interrupted by the user to make a correction".to_string()));
+        assert_eq!(session.messages[2].content[0], MessageContent::tool_response("1", tool_result.clone()));
+        assert_eq!(session.messages[2].content[1], MessageContent::tool_response("2", tool_result));
+
+        // Check the follow-up assistant message
+        assert_eq!(session.messages[3].role, Role::Assistant);
+        assert_eq!(session.messages[3].content[0], MessageContent::text(format!("We interrupted the existing call to {}. How would you like to proceed?", tool_name2)));
     }
 }

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -158,8 +158,14 @@ impl<'a> Session<'a> {
                             self.prompt.show_busy();
                         }
                         Some(Err(e)) => {
-                            // TODO: Handle error display through prompt
                             eprintln!("Error: {}", e);
+                            drop(stream);
+                            self.rewind_messages();
+                            self.prompt.render(raw_message(&format!("{}",
+                                "\x1b[31mThe error above was an exception we were not able to handle.\n\n\x1b[0m".to_string()
+                                + "These errors are often related to connection or authentication\n"
+                                + "We've removed the conversation up to the most recent user message"
+                                + " - \x1b[33mdepending on the error you may be able to continue\x1b[0m")));
                             break;
                         }
                         None => break,
@@ -176,7 +182,7 @@ impl<'a> Session<'a> {
     }
 
     /// Rewind the messages to before the last user message (they have cancelled it).
-    pub fn rewind_messages(&mut self) {
+    fn rewind_messages(&mut self) {
         if self.messages.is_empty() {
             return;
         }

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -161,11 +161,11 @@ impl<'a> Session<'a> {
                             eprintln!("Error: {}", e);
                             drop(stream);
                             self.rewind_messages();
-                            self.prompt.render(raw_message(&format!("{}",
-                                "\x1b[31mThe error above was an exception we were not able to handle.\n\n\x1b[0m".to_string()
-                                + "These errors are often related to connection or authentication\n"
-                                + "We've removed the conversation up to the most recent user message"
-                                + " - \x1b[33mdepending on the error you may be able to continue\x1b[0m")));
+                            self.prompt.render(raw_message(r#"
+\x1b[31mThe error above was an exception we were not able to handle.\n\n\x1b[0m
+These errors are often related to connection or authentication\n
+We've removed the conversation up to the most recent user message
+ - \x1b[33mdepending on the error you may be able to continue\x1b[0m"#));
                             break;
                         }
                         None => break,


### PR DESCRIPTION
Implemented based on the [old python version](https://github.com/block/goose/blob/main/src/goose/cli/session.py#L248).

Behavior on interrupt:
- If last message is a user message then remove it and inform the user
- If there were tool requests in the last message, then add 'interrupted' tool response messages as a new message

Other changes:
- a bit of plumbing to enable mocking of the prompt to test what messages were being shown to the user.