### PR TITLE
fix: During configure remove 'recommended' from provider descriptions

### DIFF
--- a/crates/goose-cli/src/commands/expected_config.rs
+++ b/crates/goose-cli/src/commands/expected_config.rs
@@ -1,5 +1,3 @@
-// This is a temporary file to simulate some configuration data from the backend
-
 use crate::profile::{PROVIDER_DATABRICKS, PROVIDER_OLLAMA, PROVIDER_OPEN_AI};
 use goose::providers::ollama::OLLAMA_MODEL;
 

--- a/crates/goose-cli/src/profile.rs
+++ b/crates/goose-cli/src/profile.rs
@@ -43,11 +43,7 @@ pub const PROFILE_DEFAULT_NAME: &str = "default";
 pub fn select_provider_lists() -> Vec<(&'static str, String, &'static str)> {
     ProviderType::iter()
         .map(|provider| match provider {
-            ProviderType::OpenAi => (
-                PROVIDER_OPEN_AI,
-                PROVIDER_OPEN_AI.to_string(),
-                "Recommended",
-            ),
+            ProviderType::OpenAi => (PROVIDER_OPEN_AI, PROVIDER_OPEN_AI.to_string(), ""),
             ProviderType::Databricks => (PROVIDER_DATABRICKS, PROVIDER_DATABRICKS.to_string(), ""),
             ProviderType::Ollama => (PROVIDER_OLLAMA, PROVIDER_OLLAMA.to_string(), ""),
         })


### PR DESCRIPTION
The concept of 'recommended' provider doesn't make sense as the decision is based on use case and a collection of tradeoffs (cost, speed, access) etc.

Before
![image](https://github.com/user-attachments/assets/ff09b2da-b151-4ba5-b8ee-c9113eb3118e)

After
![image](https://github.com/user-attachments/assets/a0098e79-331b-4624-8306-ae0641e8ddf9)
