### PR TITLE
feat: [gui] cancel manipulates message history

### DIFF
--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -147,7 +147,7 @@ function ChatContent({
       // TODO: Using setInput seems to change the ongoing request message and prevents stop from stopping.
       // It would be nice to find a way to populate the input field with the last message when interrupted.
       // setInput("stop");
-      
+
       // Remove the last user message.
       if (messages.length > 1) {
         setMessages(messages.slice(0, -1));
@@ -156,9 +156,7 @@ function ChatContent({
       }
     } else if (lastMessage.role === 'assistant' && lastMessage.toolInvocations !== undefined) {
       // Add messaging about interrupted ongoing tool invocations.
-      let newLastMessage = lastMessage;
-      if (lastMessage.toolInvocations) {
-        newLastMessage = {
+      const newLastMessage = {
           ...lastMessage,
           toolInvocations: lastMessage.toolInvocations.map((invocation) => {
             if (invocation.state !== 'result') {
@@ -186,8 +184,7 @@ function ChatContent({
             return invocation;
           }
         }),
-        };
-      }
+      };
         
       const updatedMessages = messages.slice(0, -1).concat(newLastMessage);
       setMessages(updatedMessages);

--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useChat } from './ai-sdk-fork/useChat';
+import { Message, useChat } from './ai-sdk-fork/useChat';
 import { Route, Routes, Navigate } from 'react-router-dom';
 import { getApiUrl } from './config';
 import { Card } from './components/ui/card';
@@ -155,7 +155,7 @@ function ChatContent({
         }),
       };
         
-      const updatedMessages = messages.slice(0, -1).concat(newLastMessage);
+      const updatedMessages = [...messages.slice(0, -1), newLastMessage as Message];
       setMessages(updatedMessages);
     }
     

--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -111,7 +111,7 @@ function ChatContent({
   const onStopGoose = () => {
     stop();
 
-    const lastMessage = messages[messages.length - 1];
+    const lastMessage: Message = messages[messages.length - 1];
     if (lastMessage.role === 'user' && lastMessage.toolInvocations === undefined) {
       // TODO: Using setInput seems to change the ongoing request message and prevents stop from stopping.
       // It would be nice to find a way to populate the input field with the last message when interrupted.
@@ -125,7 +125,7 @@ function ChatContent({
       }
     } else if (lastMessage.role === 'assistant' && lastMessage.toolInvocations !== undefined) {
       // Add messaging about interrupted ongoing tool invocations.
-      const newLastMessage = {
+      const newLastMessage: Message = {
           ...lastMessage,
           toolInvocations: lastMessage.toolInvocations.map((invocation) => {
             if (invocation.state !== 'result') {
@@ -155,7 +155,7 @@ function ChatContent({
         }),
       };
         
-      const updatedMessages = [...messages.slice(0, -1), newLastMessage as Message];
+      const updatedMessages = [...messages.slice(0, -1), newLastMessage];
       setMessages(updatedMessages);
     }
     


### PR DESCRIPTION
When the user clicks cancel while goose is working:

# Scenario: The last message in the ui is a user message

The user message will be removed. Ideally we put the content back into the input box but calling `setInput` was breaking everything so I've deferred that aspect.

# Scenario: Ongoing tool calls

Each tool call gets marked as interrupted, providing context to the user and ai

<img width="836" alt="image" src="https://github.com/user-attachments/assets/78407d9b-560d-4ee7-aed4-d61f194bd80e">
