### PR TITLE
feat: After goose response focusses input box to enable immediate typing

### DIFF
--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -7,7 +7,7 @@ import { ScrollArea } from './components/ui/scroll-area';
 import Splash from './components/Splash';
 import GooseMessage from './components/GooseMessage';
 import UserMessage from './components/UserMessage';
-import Input from './components/Input';
+import Input, { getInputElement } from './components/Input';
 import MoreMenu from './components/MoreMenu';
 import LoadingGoose from './components/LoadingGoose';
 import { ApiKeyWarning } from './components/ApiKeyWarning';
@@ -85,6 +85,12 @@ function ChatContent({
       const fetchResponses = await askAi(promptTemplates);
 
       setMessageMetadata((prev) => ({ ...prev, [message.id]: fetchResponses }));
+
+      // Return focus to the input field after the response is received so user can type immediately.
+      const textarea = getInputElement();
+      if (textarea) {
+        textarea.focus();
+      }
     },
   });
 

--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -12,6 +12,12 @@ interface InputProps {
   onStop?: () => void;
 }
 
+const id = 'dynamic-textarea';
+
+export function getInputElement(): HTMLElement | null {
+  return document.getElementById(id);
+}
+
 export default function Input({
   handleSubmit,
   handleInputChange,
@@ -65,7 +71,7 @@ export default function Input({
     }} className="flex relative bg-white h-auto px-[16px] pr-[38px] py-[1rem] rounded-b-2xl">
       <textarea
         autoFocus
-        id="dynamic-textarea"
+        id={id}
         placeholder="What should goose do?"
         value={value}
         onChange={handleChange}


### PR DESCRIPTION
**Old behavior**: After sending a message, user would need to click on the input box before being able to type again. This is really annoying in the flow of interaction particular for quick back and forth.

**New behavior**: Once goose finishes responding the input box is focussed and you can immediately start typing again to continue the conversation.