### PR TITLE
feat: adding Resource objects, System.status to return list of Resources and trim when needed

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -33,6 +33,7 @@ nanoid = "0.4"
 sha2 = "0.10"
 base64 = "0.21"
 url = "2.5"
+urlencoding = "2.1.3"
 axum = "0.7"
 tower-http = { version = "0.5", features = ["cors"] }
 webbrowser = "0.8"
@@ -51,7 +52,13 @@ wiremock = "0.6.0"
 mockito = "1.2"
 tempfile = "3.8"
 mockall = "0.11"
+criterion = "0.5"
+tokio-test = "0.4"
 
 [[example]]
 name = "databricks_oauth"
 path = "examples/databricks_oauth.rs"
+
+[[bench]]
+name = "tokenization_benchmark"
+harness = false

--- a/crates/goose/benches/tokenization_benchmark.rs
+++ b/crates/goose/benches/tokenization_benchmark.rs
@@ -1,0 +1,23 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use goose::token_counter::TokenCounter;
+
+fn benchmark_tokenization(c: &mut Criterion) {
+    let counter = TokenCounter::new();
+    let lengths = [1_000, 5_000, 10_000, 50_000, 100_000, 124_000, 200_000];
+    let models = [
+        "gpt-4o",
+        "claude-3.5-sonnet"
+    ];
+
+    for &length in &lengths {
+        for model_name in models {
+            let text = "hello ".repeat(length);
+            c.bench_function(&format!("{}_{}_tokens", model_name, length), |b| {
+                b.iter(|| counter.count_tokens(black_box(&text), Some(model_name)))
+            });
+        }
+    }
+}
+
+criterion_group!(benches, benchmark_tokenization);
+criterion_main!(benches);

--- a/crates/goose/src/models/message.rs
+++ b/crates/goose/src/models/message.rs
@@ -65,6 +65,30 @@ impl MessageContent {
         }
     }
 
+    pub fn as_tool_response(&self) -> Option<&ToolResponse> {
+        if let MessageContent::ToolResponse(ref tool_response) = self {
+            Some(tool_response)
+        } else {
+            None
+        }
+    }
+
+    pub fn as_tool_response_text(&self) -> Option<String> {
+        if let Some(tool_response) = self.as_tool_response() {
+            if let Ok(contents) = &tool_response.tool_result {
+                let texts: Vec<String> = contents
+                    .iter()
+                    .filter_map(|content| content.as_text().map(String::from))
+                    .collect();
+                if !texts.is_empty() {
+                    return Some(texts.join("\n"));
+                }
+            }
+        }
+        None
+    }
+
+
     /// Get the text content if this is a TextContent variant
     pub fn as_text(&self) -> Option<&str> {
         match self {

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -139,12 +139,10 @@ impl Provider for OpenAiProvider {
         // Make request
         let response = self.post(payload).await?;
 
-        // Check for context length error if single message
+        // Raise specific error if context length is exceeded
         if let Some(error) = response.get("error") {
-            if messages.len() == 1 {
-                if let Some(err) = check_openai_context_length_error(error) {
-                    return Err(err.into());
-                }
+            if let Some(err) = check_openai_context_length_error(error) {
+                return Err(err.into());
             }
             return Err(anyhow!("OpenAI API error: {}", error));
         }

--- a/crates/goose/src/systems/goose_hints.rs
+++ b/crates/goose/src/systems/goose_hints.rs
@@ -1,10 +1,9 @@
 use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
-use serde_json::Value;
-use std::collections::HashMap;
 use std::fs;
 
 use crate::errors::{AgentError, AgentResult};
+use super::Resource;
 use crate::models::content::Content;
 use crate::models::tool::Tool;
 use crate::models::tool::ToolCall;
@@ -69,12 +68,16 @@ impl System for GooseHintsSystem {
         &[]
     }
 
-    async fn status(&self) -> AnyhowResult<HashMap<String, Value>> {
-        Ok(HashMap::new())
+    async fn status(&self) -> AnyhowResult<Vec<Resource>> {
+        Ok(Vec::new())
     }
 
     async fn call(&self, tool_call: ToolCall) -> AgentResult<Vec<Content>> {
         Err(AgentError::ToolNotFound(tool_call.name))
+    }
+
+    async fn read_resource(&self, _uri: &str) -> AgentResult<String> {
+        Ok("".to_string())
     }
 }
 

--- a/crates/goose/src/systems/mod.rs
+++ b/crates/goose/src/systems/mod.rs
@@ -1,4 +1,7 @@
 mod system;
 pub use system::System;
 
+mod resource;
+pub use resource::Resource;
+
 pub mod goose_hints;

--- a/crates/goose/src/systems/resource.rs
+++ b/crates/goose/src/systems/resource.rs
@@ -1,0 +1,204 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use anyhow::{Result, anyhow};
+use url::Url;
+
+/// Represents a resource in the system with metadata
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Resource {
+    /// URI representing the resource location (e.g., "file:///path/to/file" or "str:///content")
+    pub uri: String,
+    /// Name of the resource
+    pub name: String,
+    /// Last modified timestamp
+    pub timestamp: DateTime<Utc>,
+    /// Priority of the resource (higher number means higher priority)
+    pub priority: i32,
+    /// Optional description of the resource
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// MIME type of the resource content ("text" or "blob")
+    #[serde(default = "default_mime_type")]
+    pub mime_type: String,
+}
+
+fn default_mime_type() -> String {
+    "text".to_string()
+}
+
+impl Resource {
+    /// Creates a new Resource from a URI with explicit mime type
+    pub fn new<S: AsRef<str>>(uri: S, mime_type: Option<String>, name: Option<String>) -> Result<Self> {
+        let uri = uri.as_ref();
+        let url = Url::parse(uri)
+            .map_err(|e| anyhow!("Invalid URI: {}", e))?;
+
+        // Extract name from the path component of the URI
+        // Use provided name if available, otherwise extract from URI
+        let name = match name {
+            Some(n) => n,
+            None => url.path_segments()
+                .and_then(|segments| segments.last())
+                .unwrap_or("unnamed")
+                .to_string()
+        };
+
+        // Use provided mime_type or default
+        let mime_type = match mime_type {
+            Some(t) if t == "text" || t == "blob" => t,
+            _ => default_mime_type(),
+        };
+
+        Ok(Self {
+            uri: uri.to_string(),
+            name,
+            timestamp: Utc::now(),
+            priority: 0,
+            description: None,
+            mime_type,
+        })
+    }
+
+    /// Creates a new Resource with explicit URI, name, and priority
+    pub fn with_uri<S: Into<String>>(uri: S, name: S, priority: i32, mime_type: Option<String>) -> Result<Self> {
+        let uri_string = uri.into();
+        Url::parse(&uri_string)
+            .map_err(|e| anyhow!("Invalid URI: {}", e))?;
+
+        // Use provided mime_type or default
+        let mime_type = match mime_type {
+            Some(t) if t == "text" || t == "blob" => t,
+            _ => default_mime_type(),
+        };
+
+        Ok(Self {
+            uri: uri_string,
+            name: name.into(),
+            timestamp: Utc::now(),
+            priority,
+            description: None,
+            mime_type,
+        })
+    }
+
+    /// Updates the resource's timestamp to the current time
+    pub fn update_timestamp(&mut self) {
+        self.timestamp = Utc::now();
+    }
+
+    /// Sets the priority of the resource and returns self for method chaining
+    pub fn with_priority(mut self, priority: i32) -> Self {
+        self.priority = priority;
+        self
+    }
+
+    /// Returns the scheme of the URI
+    pub fn scheme(&self) -> Result<String> {
+        let url = Url::parse(&self.uri)?;
+        Ok(url.scheme().to_string())
+    }
+
+    /// Sets the description of the resource
+    pub fn with_description<S: Into<String>>(mut self, description: S) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Sets the MIME type of the resource
+    pub fn with_mime_type<S: Into<String>>(mut self, mime_type: S) -> Self {
+        let mime_type = mime_type.into();
+        match mime_type.as_str() {
+            "text" | "blob" => self.mime_type = mime_type,
+            _ => self.mime_type = default_mime_type(),
+        }
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+    use std::io::Write;
+
+    #[test]
+    fn test_new_resource_with_file_uri() -> Result<()> {
+        let mut temp_file = NamedTempFile::new()?;
+        writeln!(temp_file, "test content")?;
+        
+        let uri = Url::from_file_path(temp_file.path())
+            .map_err(|_| anyhow!("Invalid file path"))?
+            .to_string();
+        
+        let resource = Resource::new(&uri, Some("text".to_string()), None)?;
+        assert!(resource.uri.starts_with("file:///"));
+        assert_eq!(resource.priority, 0);
+        assert_eq!(resource.mime_type, "text");
+        assert_eq!(resource.scheme()?, "file");
+        
+        Ok(())
+    }
+
+    #[test]
+    fn test_resource_with_str_uri() -> Result<()> {
+        let test_content = "Hello, world!";
+        let uri = format!("str:///{}", test_content);
+        let resource = Resource::with_uri(uri.clone(), "test.txt".to_string(), 5, Some("text".to_string()))?;
+        
+        assert_eq!(resource.uri, uri);
+        assert_eq!(resource.name, "test.txt");
+        assert_eq!(resource.priority, 5);
+        assert_eq!(resource.mime_type, "text");
+        assert_eq!(resource.scheme()?, "str");
+        
+        Ok(())
+    }
+
+    #[test]
+    fn test_mime_type_validation() -> Result<()> {
+        // Test valid mime types
+        let resource = Resource::new("file:///test.txt", Some("text".to_string()), None)?;
+        assert_eq!(resource.mime_type, "text");
+
+        let resource = Resource::new("file:///test.bin", Some("blob".to_string()), None)?;
+        assert_eq!(resource.mime_type, "blob");
+
+        // Test invalid mime type defaults to "text"
+        let resource = Resource::new("file:///test.txt", Some("invalid".to_string()), None)?;
+        assert_eq!(resource.mime_type, "text");
+
+        // Test None defaults to "text"
+        let resource = Resource::new("file:///test.txt", None, None)?;
+        assert_eq!(resource.mime_type, "text");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_description() -> Result<()> {
+        let resource = Resource::with_uri("file:///test.txt", "test.txt", 0, None)?
+            .with_description("A test resource");
+        
+        assert_eq!(resource.description, Some("A test resource".to_string()));
+        Ok(())
+    }
+
+    #[test]
+    fn test_with_mime_type() -> Result<()> {
+        let resource = Resource::with_uri("file:///test.txt", "test.txt", 0, None)?
+            .with_mime_type("blob");
+        
+        assert_eq!(resource.mime_type, "blob");
+
+        // Test invalid mime type defaults to "text"
+        let resource = resource.with_mime_type("invalid");
+        assert_eq!(resource.mime_type, "text");
+        Ok(())
+    }
+
+    #[test]
+    fn test_invalid_uri() {
+        let result = Resource::new("not-a-uri", None, None);
+        assert!(result.is_err());
+    }
+}

--- a/crates/goose/src/systems/system.rs
+++ b/crates/goose/src/systems/system.rs
@@ -1,11 +1,10 @@
 use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
-use serde_json::Value;
-use std::collections::HashMap;
 
 use crate::errors::AgentResult;
 use crate::models::content::Content;
 use crate::models::tool::{Tool, ToolCall};
+use super::Resource;
 
 /// Core trait that defines a system that can be operated by an AI agent
 #[async_trait]
@@ -23,8 +22,22 @@ pub trait System: Send + Sync {
     fn tools(&self) -> &[Tool];
 
     /// Get current system status
-    async fn status(&self) -> AnyhowResult<HashMap<String, Value>>;
+    async fn status(&self) -> AnyhowResult<Vec<Resource>>;
 
     /// Call a tool with the given parameters
     async fn call(&self, tool_call: ToolCall) -> AgentResult<Vec<Content>>;
+
+    /// Read a resource from a URI. Each system should implement this to handle its own
+    /// resource types appropriately. The URI scheme should indicate how to handle the resource.
+    /// Common schemes include:
+    /// - file:///path/to/file - A file on disk
+    /// - str:///content - Direct string content
+    /// - http(s)://url - Web content (if supported by the system)
+    /// 
+    /// # Arguments
+    /// * `uri` - The URI of the resource to read
+    ///
+    /// # Returns
+    /// The content of the resource as a string. Binary content should be base64 encoded.
+    async fn read_resource(&self, uri: &str) -> AgentResult<String>;
 }

--- a/crates/goose/src/token_counter.rs
+++ b/crates/goose/src/token_counter.rs
@@ -1,6 +1,9 @@
 use include_dir::{include_dir, Dir};
 use std::collections::HashMap;
 use tokenizers::tokenizer::Tokenizer;
+use crate::models::message::Message;
+use crate::models::tool::Tool;
+
 
 // Embed the tokenizer files directory
 static TOKENIZER_FILES: Dir = include_dir!("$CARGO_MANIFEST_DIR/../../tokenizer_files");
@@ -68,16 +71,137 @@ impl TokenCounter {
         }
     }
 
-    pub fn count_tokens(&self, text: &str, model_name: Option<&str>) -> usize {
+    fn get_tokenizer(&self, model_name: Option<&str>) -> &Tokenizer {
         let tokenizer_key = Self::model_to_tokenizer_key(model_name);
-        dbg!(&model_name, &tokenizer_key);
-        let tokenizer = self
-            .tokenizers
+        self.tokenizers
             .get(tokenizer_key)
-            .expect("Tokenizer not found");
+            .expect("Tokenizer not found")
+    }
+
+    pub fn count_tokens(&self, text: &str, model_name: Option<&str>) -> usize {
+        let tokenizer = self.get_tokenizer(model_name);
         let encoding = tokenizer.encode(text, false).unwrap();
         encoding.len()
     }
+
+    fn count_tokens_for_tools(&self, tools: &[Tool], model_name: Option<&str>) -> usize {
+        // Token counts for different function components
+        let func_init = 7;     // Tokens for function initialization
+        let prop_init = 3;     // Tokens for properties initialization
+        let prop_key = 3;      // Tokens for each property key
+        let enum_init: isize = -3;    // Tokens adjustment for enum list start
+        let enum_item = 3;     // Tokens for each enum item
+        let func_end = 12;     // Tokens for function ending
+
+        let mut func_token_count = 0;
+        if !tools.is_empty() {
+            for tool in tools {
+                func_token_count += func_init; // Add tokens for start of each function
+                let name = &tool.name;
+                let description = &tool.description.trim_end_matches('.');
+                let line = format!("{}:{}", name, description);
+                func_token_count += self.count_tokens(&line, model_name); // Add tokens for name and description
+
+                if let serde_json::Value::Object(properties) = &tool.input_schema["properties"] {
+                    if !properties.is_empty() {
+                        func_token_count += prop_init; // Add tokens for start of properties
+                        for (key, value) in properties {
+                            func_token_count += prop_key; // Add tokens for each property
+                            let p_name = key;
+                            let p_type = value["type"].as_str().unwrap_or("");
+                            let p_desc = value["description"]
+                                .as_str()
+                                .unwrap_or("")
+                                .trim_end_matches('.');
+                            let line = format!("{}:{}:{}", p_name, p_type, p_desc);
+                            func_token_count += self.count_tokens(&line, model_name);
+                            if let Some(enum_values) = value["enum"].as_array() {
+                                func_token_count = func_token_count.saturating_add_signed(enum_init); // Add tokens if property has enum list
+                                for item in enum_values {
+                                    if let Some(item_str) = item.as_str() {
+                                        func_token_count += enum_item;
+                                        func_token_count += self.count_tokens(item_str, model_name);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            func_token_count += func_end;
+        }
+
+        func_token_count
+    }
+
+    pub fn count_chat_tokens(
+        &self,
+        system_prompt: &str,
+        messages: &[Message],
+        tools: &[Tool],
+        model_name: Option<&str>,
+    ) -> usize {
+        // <|im_start|>ROLE<|im_sep|>MESSAGE<|im_end|>
+        let tokens_per_message = 4;
+
+        // Count tokens in the system prompt
+        let mut num_tokens = 0;
+        if !system_prompt.is_empty() {
+            num_tokens += self.count_tokens(system_prompt, model_name) + tokens_per_message;
+        }
+
+        for message in messages {
+            num_tokens += tokens_per_message;
+            // Count tokens in the content
+            for content in &message.content {
+                // content can either be text response or tool request
+                if let Some(content_text) = content.as_text() {
+                    num_tokens += self.count_tokens(&content_text, model_name);
+                } else if let Some(tool_request) = content.as_tool_request() {
+                    // TODO: count tokens for tool request
+                    let tool_call = tool_request.tool_call.as_ref().unwrap();
+                    let text = format!("{}:{}:{}", tool_request.id, tool_call.name, tool_call.arguments);
+                    num_tokens += self.count_tokens(&text, model_name);
+                } else if let Some(tool_response_text) = content.as_tool_response_text() {
+                    num_tokens += self.count_tokens(&tool_response_text, model_name);
+                } else {
+                    // unsupported content type such as image - pass
+                    continue;
+                }
+            }
+        }
+
+        // Count tokens for tools if provided
+        if !tools.is_empty() {
+            num_tokens += self.count_tokens_for_tools(tools, model_name);
+        }
+
+        // Every reply is primed with <|start|>assistant<|message|>
+        num_tokens += 3;
+
+        num_tokens
+    }
+
+    pub fn count_everything(
+        &self,
+        system_prompt: &str,
+        messages: &[Message],
+        tools: &[Tool],
+        resources: &[String],
+        model_name: Option<&str>,
+    ) -> usize {
+        
+        let mut num_tokens = self.count_chat_tokens(system_prompt, messages, tools, model_name);
+
+        if !resources.is_empty() {
+            for resource in resources {
+                num_tokens += self.count_tokens(resource, model_name);
+            }
+        }
+        num_tokens
+    }
+
+
 }
 
 #[cfg(test)]
@@ -91,7 +215,6 @@ mod tests {
         let text = "Hey there!";
         let count = counter.count_tokens(text, Some("qwen2.5-ollama"));
         println!("Token count for '{}': {:?}", text, count);
-
         assert_eq!(count, 3);
     }
 
@@ -101,7 +224,6 @@ mod tests {
         let counter = TokenCounter::new();
         let text = "Hello, how are you?";
         let count = counter.count_tokens(text, Some("claude-3-5-sonnet-2"));
-
         println!("Token count for '{}': {:?}", text, count);
         assert_eq!(count, 6);
     }
@@ -112,4 +234,77 @@ mod tests {
         let count = counter.count_tokens("Hey there!", None);
         assert_eq!(count, 3);
     }
+
+    #[cfg(test)]
+mod tests {
+    use crate::models::{message::MessageContent, role::Role};
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_count_chat_tokens() {
+        let token_counter = TokenCounter::new();
+
+        let system_prompt = "You are a helpful assistant that can answer questions about the weather.";
+
+        let messages = vec![
+            Message {
+                role: Role::User,
+                created: 0,
+                content: vec![MessageContent::text("What's the weather like in San Francisco?")],
+            },
+            Message {
+                role: Role::Assistant,
+                created: 1,
+                content: vec![MessageContent::text("Looks like it's 60 degrees Fahrenheit in San Francisco.")],
+            },
+            Message {
+                role: Role::User,
+                created: 2,
+                content: vec![MessageContent::text("How about New York?")],
+            },
+        ];
+
+        let tools = vec![Tool {
+            name: "get_current_weather".to_string(),
+            description: "Get the current weather in a given location".to_string(),
+            input_schema: json!({
+                "properties": {
+                    "location": {
+                        "type": "string",
+                        "description": "The city and state, e.g. San Francisco, CA"
+                    },
+                    "unit": {
+                        "type": "string",
+                        "description": "The unit of temperature to return",
+                        "enum": ["celsius", "fahrenheit"]
+                    }
+                },
+                "required": ["location"]
+            }),
+        }];
+
+        let token_count_without_tools = token_counter.count_chat_tokens(
+            system_prompt,
+            &messages,
+            &vec![],
+            Some("gpt-4o"),
+        );
+        println!("Total tokens without tools: {}", token_count_without_tools);
+
+        let token_count_with_tools = token_counter.count_chat_tokens(
+            system_prompt,
+            &messages,
+            &tools,
+            Some("gpt-4o"),
+        );
+        println!("Total tokens with tools: {}", token_count_with_tools);
+
+        // The token count for messages without tools is calculated using the tokenizer - https://tiktokenizer.vercel.app/
+        // The token count for messages with tools is taken from tiktoken github repo example (notebook)
+        assert_eq!(token_count_without_tools, 56);
+        assert_eq!(token_count_with_tools, 124);
+    }
+}
+
 }

--- a/crates/goose/tests/systems.rs
+++ b/crates/goose/tests/systems.rs
@@ -1,12 +1,11 @@
 use anyhow::Result as AnyhowResult;
 use async_trait::async_trait;
 use serde_json::{json, Value};
-use std::collections::HashMap;
 
 use goose::errors::{AgentError, AgentResult};
 use goose::models::content::Content;
 use goose::models::tool::{Tool, ToolCall};
-use goose::systems::System;
+use goose::systems::{System, Resource};
 
 /// A simple system that echoes input back to the caller
 pub struct EchoSystem {
@@ -67,8 +66,8 @@ impl System for EchoSystem {
         &self.tools
     }
 
-    async fn status(&self) -> AnyhowResult<HashMap<String, Value>> {
-        Ok(HashMap::new()) // Echo system has no state to report
+    async fn status(&self) -> AnyhowResult<Vec<Resource>> {
+        Ok(Vec::new()) // Echo system has no state to report
     }
 
     async fn call(&self, tool_call: ToolCall) -> AgentResult<Vec<Content>> {
@@ -76,6 +75,10 @@ impl System for EchoSystem {
             "echo" => self.echo(tool_call.arguments).await,
             _ => Err(AgentError::ToolNotFound(tool_call.name)),
         }
+    }
+
+    async fn read_resource(&self, _uri: &str) -> AgentResult<String> {
+        Ok("".to_string())
     }
 }
 


### PR DESCRIPTION
Changes:
- adds Resource object (from go/mcp) 
- system status returns resources 
- resources can get trimmed based on approx token counts
- benchmarking scripts for tokenization (time taken to compute increases linearly based on # tokens)

TODO: 
- model context limit is hardcoded but this will vary based on the provider