### PR TITLE
fix: improve 'no command provided' error

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -17,6 +17,7 @@ use clap::{Parser, Subcommand};
 use commands::configure::handle_configure;
 use commands::session::build_session;
 use commands::version::print_version;
+use profile::has_no_profiles;
 use std::io::{self, Read};
 
 use crate::systems::system_handler::{add_system, remove_system};
@@ -258,7 +259,10 @@ async fn main() -> Result<()> {
             return Ok(());
         }
         None => {
-            println!("No command provided");
+            println!("No command provided - Run 'goose help' to see available commands.");
+            if has_no_profiles().unwrap_or(false) {
+                println!("\nRun 'goose configure' to setup goose for the first time.");
+            }
         }
     }
     Ok(())

--- a/crates/goose-cli/src/profile.rs
+++ b/crates/goose-cli/src/profile.rs
@@ -88,6 +88,10 @@ pub fn find_existing_profile(name: &str) -> Option<Profile> {
     }
 }
 
+pub fn has_no_profiles() -> Result<bool, Box<dyn Error>> {
+    load_profiles().map(|profiles| Ok(profiles.is_empty()))?
+}
+
 pub fn get_or_set_key(
     human_readable_name: &str,
     key_name: &str,


### PR DESCRIPTION
If you run 'goose' without any commands, improve messaging to help first time use.

Old: 
```
No command provided
```

New:
```
No command provided - Run 'goose help' to see available commands.
```

New when the user does not yet have a profile file:
```
No command provided - Run 'goose help' to see available commands.

Run 'goose configure' to setup goose for the first time.
```