### PR TITLE
fix: Don't do anything with an empty command

### DIFF
--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -306,6 +306,7 @@ impl Prompt for RustylinePrompt {
             Err(e) => {
                 match e {
                     rustyline::error::ReadlineError::Interrupted => (),
+                    rustyline::error::ReadlineError::Eof => (),
                     _ => eprintln!("Input error: {}", e),
                 }
                 return Ok(Input {

--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -316,7 +316,13 @@ impl Prompt for RustylinePrompt {
         };
         message_text = message_text.trim().to_string();
 
-        if message_text.eq_ignore_ascii_case("/exit") || message_text.eq_ignore_ascii_case("/quit")
+        if message_text.is_empty() {
+            return Ok(Input {
+                input_type: InputType::AskAgain,
+                content: None,
+            });
+        } else if message_text.eq_ignore_ascii_case("/exit")
+            || message_text.eq_ignore_ascii_case("/quit")
         {
             Ok(Input {
                 input_type: InputType::Exit,

--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -318,10 +318,10 @@ impl Prompt for RustylinePrompt {
         message_text = message_text.trim().to_string();
 
         if message_text.is_empty() {
-            return Ok(Input {
+            Ok(Input {
                 input_type: InputType::AskAgain,
                 content: None,
-            });
+            })
         } else if message_text.eq_ignore_ascii_case("/exit")
             || message_text.eq_ignore_ascii_case("/quit")
         {

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -107,9 +107,6 @@ impl<'a> Session<'a> {
             match input.input_type {
                 InputType::Message => {
                     if let Some(content) = &input.content {
-                        if content.trim().is_empty() {
-                            continue;
-                        }
                         self.messages.push(Message::user().with_text(content));
                         persist_messages(&self.session_file, &self.messages)?;
                     }

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -107,6 +107,9 @@ impl<'a> Session<'a> {
             match input.input_type {
                 InputType::Message => {
                     if let Some(content) = &input.content {
+                        if content.trim().is_empty() {
+                            continue;
+                        }
                         self.messages.push(Message::user().with_text(content));
                         persist_messages(&self.session_file, &self.messages)?;
                     }


### PR DESCRIPTION
I tend to hit enter on a REPL to see that it's alive (maybe that's just me?). It seems correct to do nothing if there's no content typed here by the user.