### PR TITLE
fix: configure allows selecting the suggested option with return

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -16,7 +16,7 @@ pub async fn handle_configure(provided_profile_name: Option<String>) -> Result<(
         name
     } else {
         cliclack::input("Which profile should we configure?")
-            .placeholder("default")
+            .default_input("default")
             .interact()?
     };
 
@@ -78,7 +78,7 @@ pub async fn handle_configure(provided_profile_name: Option<String>) -> Result<(
     let default_model_value =
         existing_profile.map_or(recommended_model, |profile| profile.model.as_str());
     let model: String = cliclack::input("Enter a model from that provider:")
-        .placeholder(default_model_value)
+        .default_input(default_model_value)
         .interact()?;
 
     // Forward any existing systems from the profile if present


### PR DESCRIPTION
Old behavior: You can see a placeholder text but you cannot just press return to use it.

New behavior: The provider and model option has placeholder text with '(default)' after it. Just pressing return selects that.
<img width="281" alt="image" src="https://github.com/user-attachments/assets/7a69662d-4cf5-499c-a8d1-7e5cf5bd8d08">
