### PR TITLE
feat: Add cli options for configure to specify provider and model

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -9,7 +9,11 @@ use goose::providers::factory;
 use goose::providers::ollama::OLLAMA_MODEL;
 use std::error::Error;
 
-pub async fn handle_configure(provided_profile_name: Option<String>) -> Result<(), Box<dyn Error>> {
+pub async fn handle_configure(
+    provided_profile_name: Option<String>,
+    provided_provider: Option<String>,
+    provided_model: Option<String>,
+) -> Result<(), Box<dyn Error>> {
     cliclack::intro(style(" configure-goose ").on_cyan().black())?;
 
     let profile_name = if let Some(name) = provided_profile_name {
@@ -31,18 +35,24 @@ pub async fn handle_configure(provided_profile_name: Option<String>) -> Result<(
         ));
     }
 
-    let default_provider = existing_profile.map_or("openai", |profile| profile.provider.as_str());
-    let provider_name = cliclack::select("Which model provider should we use?")
-        .initial_value(default_provider)
-        .items(&[
-            ("openai", "OpenAI", "GPT-4o etc"),
-            ("databricks", "Databricks", "Models on AI Gateway"),
-            ("ollama", "Ollama", "Local open source models"),
-        ])
-        .interact()?;
+    let provider_name = if let Some(provider) = provided_provider {
+        provider
+    } else {
+        let default_provider =
+            existing_profile.map_or("openai", |profile| profile.provider.as_str());
+        cliclack::select("Which model provider should we use?")
+            .initial_value(default_provider)
+            .items(&[
+                ("openai", "OpenAI", "GPT-4o etc"),
+                ("databricks", "Databricks", "Models on AI Gateway"),
+                ("ollama", "Ollama", "Local open source models"),
+            ])
+            .interact()?
+            .to_string()
+    };
 
     // Depending on the provider, we now want to look for any required keys and check or set them in the keychain
-    for key in get_required_keys(provider_name).iter() {
+    for key in get_required_keys(&provider_name).iter() {
         // If the key is in the keyring, ask if we want to overwrite
         if get_keyring_secret(key, KeyRetrievalStrategy::KeyringOnly).is_ok() {
             let _ = cliclack::log::info(format!("{} is already available in the keyring", key));
@@ -74,12 +84,16 @@ pub async fn handle_configure(provided_profile_name: Option<String>) -> Result<(
         }
     }
 
-    let recommended_model = get_recommended_model(provider_name);
-    let default_model_value =
-        existing_profile.map_or(recommended_model, |profile| profile.model.as_str());
-    let model: String = cliclack::input("Enter a model from that provider:")
-        .placeholder(default_model_value)
-        .interact()?;
+    let model = if let Some(model) = provided_model {
+        model
+    } else {
+        let recommended_model = get_recommended_model(&provider_name);
+        let default_model_value =
+            existing_profile.map_or(recommended_model, |profile| profile.model.as_str());
+        cliclack::input("Enter a model from that provider:")
+            .placeholder(default_model_value)
+            .interact()?
+    };
 
     // Forward any existing systems from the profile if present
     let additional_systems =
@@ -98,7 +112,7 @@ pub async fn handle_configure(provided_profile_name: Option<String>) -> Result<(
     };
 
     // Confirm everything is configured correctly by calling a model!
-    let provider_config = get_provider_config(provider_name, model.clone());
+    let provider_config = get_provider_config(&provider_name, model.clone());
     let spin = spinner();
     spin.start("Checking your configuration...");
     let provider = factory::get_provider(provider_config).unwrap();

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -20,7 +20,7 @@ pub async fn handle_configure(
         name
     } else {
         cliclack::input("Which profile should we configure?")
-            .placeholder("default")
+            .default_input("default")
             .interact()?
     };
 
@@ -91,7 +91,7 @@ pub async fn handle_configure(
         let default_model_value =
             existing_profile.map_or(recommended_model, |profile| profile.model.as_str());
         cliclack::input("Enter a model from that provider:")
-            .placeholder(default_model_value)
+            .default_input(default_model_value)
             .interact()?
     };
 

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -37,10 +37,30 @@ enum Command {
     Configure {
         /// Name of the profile to configure
         #[arg(
+            short('n'),
+            long,
             help = "Profile name to configure",
             long_help = "Create or modify a named configuration profile. Use 'default' for the default profile."
         )]
         profile_name: Option<String>,
+
+        /// AI Provider to use
+        #[arg(
+            short,
+            long,
+            help = "AI Provider to use (e.g., 'openai', 'databricks', 'ollama')",
+            long_help = "Specify AI Provider to use (e.g., 'openai', 'databricks', 'ollama')."
+        )]
+        provider: Option<String>,
+
+        /// Model to use
+        #[arg(
+            short,
+            long,
+            help = "Model to use (e.g., 'gpt-4', 'llama2')",
+            long_help = "Specify which model to use for this profile."
+        )]
+        model: Option<String>,
     },
 
     /// Manage system prompts and behaviors
@@ -178,8 +198,12 @@ async fn main() -> Result<()> {
     }
 
     match cli.command {
-        Some(Command::Configure { profile_name }) => {
-            let _ = handle_configure(profile_name).await;
+        Some(Command::Configure {
+            profile_name,
+            provider,
+            model,
+        }) => {
+            let _ = handle_configure(profile_name, provider, model).await;
             return Ok(());
         }
         Some(Command::System { action }) => match action {


### PR DESCRIPTION
Allows running configure with all selections pre-specified, therefore requiring no intervention other than keychain questions.

`goose configure -n testcli -p databricks -m goose`

Change: I changed the profile short option from -p to -n so it didn't conflict with 'provider' short name.