### PR TITLE
fix: replace empty window

### DIFF
--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -52,7 +52,9 @@ function ChatContent({
   setWorking: React.Dispatch<React.SetStateAction<Working>>;
 }) {
   const chat = chats.find((c: Chat) => c.id === selectedChatId);
-  const [messageMetadata, setMessageMetadata] = useState<Record<string, string[]>>({});
+  const [messageMetadata, setMessageMetadata] = useState<Record<string, string[]>>({});  
+  const [isWindowTainted, setIsWindowTainted] = useState(false);
+  
 
   const {
     messages,
@@ -102,6 +104,12 @@ function ChatContent({
       initialQueryAppended.current = true;
     }
   }, [initialQuery]);
+
+  useEffect(() => {
+    if (messages.length > 0) {
+      setIsWindowTainted(true);
+    }
+  }, [messages]);
 
   const handleSubmit = (e: React.FormEvent) => {
     const customEvent = e as CustomEvent;
@@ -241,7 +249,7 @@ function ChatContent({
           onStop={onStopGoose}
         />
         <div className="self-stretch h-px bg-black/5 rounded-sm" />
-        <BottomMenu />
+        <BottomMenu isWindowTainted={isWindowTainted} />
       </Card>
     </div>
   );

--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -53,7 +53,7 @@ function ChatContent({
 }) {
   const chat = chats.find((c: Chat) => c.id === selectedChatId);
   const [messageMetadata, setMessageMetadata] = useState<Record<string, string[]>>({});  
-  const [isWindowTainted, setIsWindowTainted] = useState(false);
+  const [hasMessages, setHasMessages] = useState(false);
   
 
   const {
@@ -107,7 +107,7 @@ function ChatContent({
 
   useEffect(() => {
     if (messages.length > 0) {
-      setIsWindowTainted(true);
+      setHasMessages(true);
     }
   }, [messages]);
 
@@ -249,7 +249,7 @@ function ChatContent({
           onStop={onStopGoose}
         />
         <div className="self-stretch h-px bg-black/5 rounded-sm" />
-        <BottomMenu isWindowTainted={isWindowTainted} />
+        <BottomMenu hasMessages={hasMessages} />
       </Card>
     </div>
   );

--- a/ui/desktop/src/components/BottomMenu.tsx
+++ b/ui/desktop/src/components/BottomMenu.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 
-export default function BottomMenu({isWindowTainted}) {
+export default function BottomMenu({hasMessages}) {
   return (
     <div className="flex relative text-bottom-menu pl-[15px] text-[10px] bg-white h-[30px] leading-[30px] align-middle bg-white rounded-b-2xl">
       <span
         className="cursor-pointer"
         onClick={async () => {
           console.log("Opening directory chooser");
-          if (isWindowTainted) {
+          if (hasMessages) {
             window.electron.directoryChooser();
           } else {
             window.electron.directoryChooser(true);  

--- a/ui/desktop/src/components/BottomMenu.tsx
+++ b/ui/desktop/src/components/BottomMenu.tsx
@@ -1,12 +1,17 @@
 import React from 'react';
 
-export default function BottomMenu() {
+export default function BottomMenu({isWindowTainted}) {
   return (
     <div className="flex relative text-bottom-menu pl-[15px] text-[10px] bg-white h-[30px] leading-[30px] align-middle bg-white rounded-b-2xl">
       <span
         className="cursor-pointer"
         onClick={async () => {
-          window.electron.directoryChooser();
+          console.log("Opening directory chooser");
+          if (isWindowTainted) {
+            window.electron.directoryChooser();
+          } else {
+            window.electron.directoryChooser(true);  
+          }          
       }}>
         Working in {window.appConfig.get("GOOSE_WORKING_DIR")}
       </span>

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -211,13 +211,16 @@ const buildRecentFilesMenu = () => {
   }));
 };
 
-const openDirectoryDialog = async () => {
+const openDirectoryDialog = async (replaceWindow: Boolean = false) => {
   const result = await dialog.showOpenDialog({
     properties: ['openDirectory']
   });
   
   if (!result.canceled && result.filePaths.length > 0) {
     addRecentDir(result.filePaths[0]);
+    if (replaceWindow) {
+      BrowserWindow.getFocusedWindow().close();
+    }
     createChat(app, undefined, result.filePaths[0]);
   }
 };
@@ -305,8 +308,8 @@ app.whenReady().then(async () => {
     createChat(app, query);
   });
 
-  ipcMain.on('directory-chooser', (_) => {
-    openDirectoryDialog();
+  ipcMain.on('directory-chooser', (_, replace: Boolean = false) => {
+    openDirectoryDialog(replace);
   });
 
   ipcMain.on('notify', (event, data) => {

--- a/ui/desktop/src/preload.js
+++ b/ui/desktop/src/preload.js
@@ -10,7 +10,7 @@ contextBridge.exposeInMainWorld('appConfig', {
 contextBridge.exposeInMainWorld('electron', {
   getConfig: () => config,
   hideWindow: () => ipcRenderer.send('hide-window'),
-  directoryChooser: () => ipcRenderer.send('directory-chooser'),
+  directoryChooser: (replace) => ipcRenderer.send('directory-chooser', replace),
   createChatWindow: (query) => ipcRenderer.send('create-chat-window', query),
   logInfo: (txt) => ipcRenderer.send('logInfo', txt),
   showNotification: (data) => ipcRenderer.send('notify', data),


### PR DESCRIPTION
Current behavior is that if you click open a dir from bottom left, then it will open a new window, vs replacing current one which hasn't been used. This fixes that. If user has interacted, it doesn't replace, but will open a new one

(tracks messages to set a tainted flag via react hooks)

cc @Kvadratni @alexhancock 