### PR TITLE
docs: social card meta inject method

### DIFF
--- a/docs/blog/posts/2024-11-22-screenshot-driven-development.md
+++ b/docs/blog/posts/2024-11-22-screenshot-driven-development.md
@@ -1,16 +1,13 @@
 ---
 draft: false
 title: "Screenshot-Driven Development"
+description: "AI Agent uses screenshots to assist in styling."
+background_image: "https://block.github.io/goose/blog/images/screenshot-driven-development-blog/screenshot-driven-development.png" 
 date: 2024-11-22
 authors:
   - rizel
 categories:
   - Web Development
-social:
-  cards_layout_options:
-    title: "Screenshot-Driven Development"  
-    description: "AI Agent uses screenshots to assist in styling."
-    background_image: "https://block.github.io/goose/blog/images/screenshot-driven-development-blog/screenshot-driven-development.png" 
 ---
 ![calendar](../images/screenshot-driven-development-blog/screenshot-driven-development.png)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ use_directory_urls: false
 # theme
 theme:
   name: material
+  custom_dir: overrides
   features:
     - announce.dismiss
     - content.action.edit
@@ -41,11 +42,11 @@ theme:
 # plugins
 plugins:
   - blog
+  - social:
+      enabled: true
   - include-markdown
   - callouts
   - glightbox
-  - social:
-      enabled: !ENV [CI, true]
   - mkdocstrings:
       handlers:
         python:

--- a/overrides/social-meta-inject.html
+++ b/overrides/social-meta-inject.html
@@ -1,0 +1,10 @@
+{% block head %}
+  {{ super() }}
+  {% if page.meta.description %}
+    <meta name="description" content="{{ page.meta.description }}">
+  {% endif %}
+  {% if page.meta.background_image %}
+    <meta property="og:image" content="{{ page.meta.background_image }}">
+    <meta name="twitter:image" content="{{ page.meta.background_image }}">
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
## Problem
The `social` plugin for MkDocs is enabled and working  however, since we are not sponsors, we do not have access to the `Insiders` features. This limitation makes it impossible for us to use the `background_image` and a few other features. Leaving us with a default social card that looks like this: 

<img width="557" alt="Screenshot 2024-12-05 at 11 11 59 AM" src="https://github.com/user-attachments/assets/1aabc278-f491-4ac2-b378-9cb0f3d3540e">

which isn't desirable, and will impact our social media engagement. 

## Solution
I'm implementing a method to inject custom meta tags into the `<head>`  of our pages. This approach allows us to choose a `background_image` and other meta properties directly in the blog post front matter, overriding the image the `social` plugin is creating.

I wasn't able to fully test this locally, hopefully with this merge we will get the desired output. 

The **second solution** I tried was the standard approach of adding `meta` tags directly inside the `blog.md` file, bypassing the social plugin. While this worked and correctly injected the metadata, it also caused the metadata to render inside a `<p>` tag, resulting in a large gap between the blog title and the blog image.

## Test
Locally, it wasn't showing the image updated but there is a change that it needs to be deployed to fully load 
