### PR TITLE
fix: screenshot windows

### DIFF
--- a/crates/goose/src/developer.rs
+++ b/crates/goose/src/developer.rs
@@ -498,8 +498,10 @@ impl DeveloperSystem {
             .map(|w| w.title().to_string())
             .collect();
 
-        Ok(vec![
+        Ok(vec![                    
+            
             Content::text(format!("Available windows:\n{}", window_titles.join("\n")))
+                .with_audience(vec![Role::Assistant]).with_priority(0.0),                
         ])
     }
 

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -315,10 +315,27 @@ app.whenReady().then(async () => {
 
   Menu.setApplicationMenu(menu);
 
-  app.on('activate', () => {
+  app.on('activate', async () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createChat(app);
     }
+    const sources = await electron.desktopCapturer.getSources({ types: ['screen'] })
+    for (const source of sources) {
+      if (source.name === 'Entire screen' || source.name === 'Screen 1') {
+        navigator.mediaDevices.getUserMedia({
+          audio: false,
+          video: true,
+        })
+          .then(async (stream) => {
+            // You can open settings if needed
+            shell.openExternal("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
+          })
+          .catch((err) => {
+            console.error(err)
+          });
+        return;
+      }
+    }    
   });
 
   ipcMain.on('create-chat-window', (_, query) => {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -327,7 +327,7 @@ app.whenReady().then(async () => {
 
   Menu.setApplicationMenu(menu);
 
-  app.on('activate', async () => {
+  app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createChat(app);
     }

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { loadZshEnv } from './utils/loadEnv';
-import { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain, Notification, MenuItem, dialog, shell } from 'electron';
+import { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain, Notification, MenuItem, dialog } from 'electron';
 import path from 'node:path';
 import { startGoosed } from './goosed';
 import started from "electron-squirrel-startup";

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -2,7 +2,7 @@ import 'dotenv/config';
 import { loadZshEnv } from './utils/loadEnv';
 import { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain, Notification, MenuItem, dialog, shell } from 'electron';
 import path from 'node:path';
-import { findAvailablePort, startGoosed } from './goosed';
+import { startGoosed } from './goosed';
 import started from "electron-squirrel-startup";
 import log from './utils/logger';
 import { exec } from 'child_process';
@@ -319,22 +319,6 @@ app.whenReady().then(async () => {
     if (BrowserWindow.getAllWindows().length === 0) {
       createChat(app);
     }
-    const sources = await electron.desktopCapturer.getSources({ types: ['screen'] })
-    for (const source of sources) {
-      if (source.name === 'Entire screen' || source.name === 'Screen 1') {
-        // Handle permissions based on platform
-        if (process.platform === 'darwin') {
-          shell.openExternal("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture");
-        } else if (process.platform === 'win32') {
-          // Windows typically handles permissions through UAC
-          console.log("Windows: Screen capture permissions requested");
-        } else {
-          // Linux typically handles permissions through desktop environment
-          console.log("Linux: Screen capture permissions requested");
-        }
-        return;
-      }
-    }    
   });
 
   ipcMain.on('create-chat-window', (_, query) => {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import { loadZshEnv } from './utils/loadEnv';
-import { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain, Notification, MenuItem, dialog } from 'electron';
+import { app, BrowserWindow, Tray, Menu, globalShortcut, ipcMain, Notification, MenuItem, dialog, shell } from 'electron';
 import path from 'node:path';
 import { findAvailablePort, startGoosed } from './goosed';
 import started from "electron-squirrel-startup";
@@ -322,17 +322,16 @@ app.whenReady().then(async () => {
     const sources = await electron.desktopCapturer.getSources({ types: ['screen'] })
     for (const source of sources) {
       if (source.name === 'Entire screen' || source.name === 'Screen 1') {
-        navigator.mediaDevices.getUserMedia({
-          audio: false,
-          video: true,
-        })
-          .then(async (stream) => {
-            // You can open settings if needed
-            shell.openExternal("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")
-          })
-          .catch((err) => {
-            console.error(err)
-          });
+        // Handle permissions based on platform
+        if (process.platform === 'darwin') {
+          shell.openExternal("x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture");
+        } else if (process.platform === 'win32') {
+          // Windows typically handles permissions through UAC
+          console.log("Windows: Screen capture permissions requested");
+        } else {
+          // Linux typically handles permissions through desktop environment
+          console.log("Linux: Screen capture permissions requested");
+        }
         return;
       }
     }    


### PR DESCRIPTION
Adds a tool to enumerate open windows, which allows screen capture of a specific window based on vague description. Whole screen capture I found didn't work well with multiple monitors and not at all if I wanted something specific. 

<img width="749" alt="Screenshot 2024-12-09 at 5 39 00 PM" src="https://github.com/user-attachments/assets/ab59ce32-0ad0-46e0-91c0-ae69052e05e9">
<img width="743" alt="Screenshot 2024-12-09 at 5 39 10 PM" src="https://github.com/user-attachments/assets/6aefe528-06c0-4b57-aa8e-8daa80ea88a7">


asking goose to match a design and iterate: 


![image](https://github.com/user-attachments/assets/795909fa-370c-47f1-959a-1df8797acca2)

