### PR TITLE
[cli] Resumes most recent modified session if no session name provided

### DIFF
--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -36,4 +36,5 @@ rustyline = "15.0.0"
 
 [dev-dependencies]
 tempfile = "3"
+temp-env = "0.3.6"
 

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -35,7 +35,6 @@ pub async fn handle_configure(
         ));
     }
 
-
     let provider_name = if let Some(provider) = provided_provider {
         provider
     } else {

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -9,7 +9,7 @@ use crate::profile::{get_provider_config, load_profiles, Profile};
 use crate::prompt::cliclack::CliclackPrompt;
 use crate::prompt::rustyline::RustylinePrompt;
 use crate::prompt::Prompt;
-use crate::session::{ensure_session_dir, Session};
+use crate::session::{ensure_session_dir, get_most_recent_session, Session};
 
 pub fn build_session<'a>(
     session: Option<String>,
@@ -17,7 +17,16 @@ pub fn build_session<'a>(
     resume: bool,
 ) -> Box<Session<'a>> {
     let session_dir = ensure_session_dir().expect("Failed to create session directory");
-    let session_file = session_path(session.clone(), &session_dir, session.is_none() && !resume);
+    let session_file = if resume && session.is_none() {
+        // When resuming without a specific session name, use the most recent session
+        get_most_recent_session()
+            .expect("Failed to get most recent session")
+            .unwrap_or_else(|| {
+                panic!("No existing session files found. Please provide a session name to resume.");
+            })
+    } else {
+        session_path(session.clone(), &session_dir, session.is_none() && !resume)
+    };
 
     // Guard against resuming a non-existent session
     if resume && !session_file.exists() {
@@ -148,15 +157,44 @@ fn load_profile(profile_name: Option<String>) -> Box<Profile> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
+    use crate::test_helpers::run_with_test_dir;
+    use std::fs;
+    use std::thread;
+    use std::time::Duration;
 
     #[test]
     #[should_panic(expected = "Cannot resume session: file")]
     fn test_resume_nonexistent_session_panics() {
-        let temp_dir = tempdir().unwrap();
-        // Set session directory to our temp directory so we don't actually create it.
-        std::env::set_var("GOOSE_SESSION_DIR", temp_dir.path());
+        run_with_test_dir(|| {
+            build_session(Some("nonexistent-session".to_string()), None, true);
+        })
+    }
 
-        build_session(Some("nonexistent-session".to_string()), None, true);
+    #[test]
+    fn test_resume_most_recent_session() -> anyhow::Result<()> {
+        run_with_test_dir(|| {
+            let session_dir = ensure_session_dir()?;
+            // Create test session files with different timestamps
+            let file1_path = session_dir.join("session1.jsonl");
+            let file2_path = session_dir.join("session2.jsonl");
+
+            fs::write(&file1_path, "{}")?;
+            thread::sleep(Duration::from_millis(1));
+            fs::write(&file2_path, "{}")?;
+
+            // Test resuming without a session name
+            let session = build_session(None, None, true);
+            assert_eq!(session.session_file().as_path(), file2_path.as_path());
+
+            Ok(())
+        })
+    }
+
+    #[test]
+    #[should_panic(expected = "No existing session files found")]
+    fn test_resume_most_recent_session_no_files() {
+        run_with_test_dir(|| {
+            build_session(None, None, true);
+        });
     }
 }

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -157,7 +157,7 @@ fn load_profile(profile_name: Option<String>) -> Box<Profile> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::test_helpers::run_with_test_dir;
+    use crate::test_helpers::run_with_tmp_dir;
     use std::fs;
     use std::thread;
     use std::time::Duration;
@@ -165,14 +165,14 @@ mod tests {
     #[test]
     #[should_panic(expected = "Cannot resume session: file")]
     fn test_resume_nonexistent_session_panics() {
-        run_with_test_dir(|| {
+        run_with_tmp_dir(|| {
             build_session(Some("nonexistent-session".to_string()), None, true);
         })
     }
 
     #[test]
     fn test_resume_most_recent_session() -> anyhow::Result<()> {
-        run_with_test_dir(|| {
+        run_with_tmp_dir(|| {
             let session_dir = ensure_session_dir()?;
             // Create test session files with different timestamps
             let file1_path = session_dir.join("session1.jsonl");
@@ -193,7 +193,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "No existing session files found")]
     fn test_resume_most_recent_session_no_files() {
-        run_with_test_dir(|| {
+        run_with_tmp_dir(|| {
             build_session(None, None, true);
         });
     }

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -19,11 +19,7 @@ pub fn build_session<'a>(
     let session_dir = ensure_session_dir().expect("Failed to create session directory");
     let session_file = if resume && session.is_none() {
         // When resuming without a specific session name, use the most recent session
-        get_most_recent_session()
-            .expect("Failed to get most recent session")
-            .unwrap_or_else(|| {
-                panic!("No existing session files found. Please provide a session name to resume.");
-            })
+        get_most_recent_session().expect("Failed to get most recent session")
     } else {
         session_path(session.clone(), &session_dir, session.is_none() && !resume)
     };
@@ -191,7 +187,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "No existing session files found")]
+    #[should_panic(expected = "No session files found")]
     fn test_resume_most_recent_session_no_files() {
         run_with_tmp_dir(|| {
             build_session(None, None, true);

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -18,6 +18,9 @@ use commands::version::print_version;
 use profile::has_no_profiles;
 use std::io::{self, Read};
 
+#[cfg(test)]
+mod test_helpers;
+
 use crate::systems::system_handler::{add_system, remove_system};
 
 #[derive(Parser)]

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -25,7 +25,7 @@ pub fn ensure_session_dir() -> Result<PathBuf> {
     Ok(config_dir)
 }
 
-pub fn get_most_recent_session() -> Result<Option<PathBuf>> {
+pub fn get_most_recent_session() -> Result<PathBuf> {
     let session_dir = ensure_session_dir()?;
     let mut entries = fs::read_dir(&session_dir)?
         .filter_map(|entry| entry.ok())
@@ -33,7 +33,7 @@ pub fn get_most_recent_session() -> Result<Option<PathBuf>> {
         .collect::<Vec<_>>();
 
     if entries.is_empty() {
-        return Ok(None);
+        return Err(anyhow::anyhow!("No session files found"));
     }
 
     // Sort by modification time, most recent first
@@ -48,7 +48,7 @@ pub fn get_most_recent_session() -> Result<Option<PathBuf>> {
             )
     });
 
-    Ok(Some(entries[0].path()))
+    Ok(entries[0].path())
 }
 
 pub fn readable_session_file(session_file: &PathBuf) -> Result<File> {
@@ -781,8 +781,7 @@ mod tests {
 
             // Test getting the most recent session
             let most_recent = get_most_recent_session()?;
-            assert!(most_recent.is_some());
-            assert_eq!(most_recent.unwrap(), file2_path);
+            assert_eq!(most_recent, file2_path);
 
             Ok(())
         })

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -338,7 +338,7 @@ mod tests {
 
     use crate::agents::mock_agent::MockAgent;
     use crate::prompt::{self, Input};
-    use crate::test_helpers::run_with_test_dir;
+    use crate::test_helpers::run_with_tmp_dir;
 
     use super::*;
     use goose::models::content::Content;
@@ -765,7 +765,7 @@ mod tests {
         use std::time::Duration;
 
         // Create a temporary directory for testing
-        run_with_test_dir(|| {
+        run_with_tmp_dir(|| {
             let session_dir = ensure_session_dir()?;
 
             // Create test session files with different timestamps

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -25,6 +25,32 @@ pub fn ensure_session_dir() -> Result<PathBuf> {
     Ok(config_dir)
 }
 
+pub fn get_most_recent_session() -> Result<Option<PathBuf>> {
+    let session_dir = ensure_session_dir()?;
+    let mut entries = fs::read_dir(&session_dir)?
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().extension().map_or(false, |ext| ext == "jsonl"))
+        .collect::<Vec<_>>();
+
+    if entries.is_empty() {
+        return Ok(None);
+    }
+
+    // Sort by modification time, most recent first
+    entries.sort_by(|a, b| {
+        b.metadata()
+            .and_then(|m| m.modified())
+            .unwrap_or_else(|_| std::time::SystemTime::UNIX_EPOCH)
+            .cmp(
+                &a.metadata()
+                    .and_then(|m| m.modified())
+                    .unwrap_or_else(|_| std::time::SystemTime::UNIX_EPOCH),
+            )
+    });
+
+    Ok(Some(entries[0].path()))
+}
+
 pub fn readable_session_file(session_file: &PathBuf) -> Result<File> {
     match fs::OpenOptions::new()
         .read(true)
@@ -295,6 +321,10 @@ We've removed the conversation up to the most recent user message
         ));
         self.prompt.close();
     }
+
+    pub fn session_file(&self) -> PathBuf {
+        self.session_file.clone()
+    }
 }
 
 fn raw_message(content: &str) -> Box<Message> {
@@ -308,6 +338,7 @@ mod tests {
 
     use crate::agents::mock_agent::MockAgent;
     use crate::prompt::{self, Input};
+    use crate::test_helpers::run_with_test_dir;
 
     use super::*;
     use goose::models::content::Content;
@@ -726,6 +757,35 @@ mod tests {
             &session,
             "We interrupted the existing calls to tools. How would you like to proceed?",
         );
+    }
+
+    #[test]
+    fn test_get_most_recent_session() -> Result<()> {
+        use std::thread;
+        use std::time::Duration;
+
+        // Create a temporary directory for testing
+        run_with_test_dir(|| {
+            let session_dir = ensure_session_dir()?;
+
+            // Create test session files with different timestamps
+            let file1_path = session_dir.join("session1.jsonl");
+            let file2_path = session_dir.join("session2.jsonl");
+            let file3_path = session_dir.join("not_a_session.txt");
+
+            fs::write(&file1_path, "test content")?;
+            thread::sleep(Duration::from_millis(1));
+            fs::write(&file2_path, "test content")?;
+            thread::sleep(Duration::from_millis(1));
+            fs::write(&file3_path, "test content")?;
+
+            // Test getting the most recent session
+            let most_recent = get_most_recent_session()?;
+            assert!(most_recent.is_some());
+            assert_eq!(most_recent.unwrap(), file2_path);
+
+            Ok(())
+        })
     }
 
     fn assert_last_prompt_text(session: &Session, expected_text: &str) {

--- a/crates/goose-cli/src/test_helpers.rs
+++ b/crates/goose-cli/src/test_helpers.rs
@@ -1,0 +1,35 @@
+#[cfg(test)]
+pub fn run_with_test_dir<F: FnOnce() -> T, T>(func: F) -> T {
+    use std::fs;
+    use tempfile::tempdir;
+
+    // Helper function to set up a temporary home directory for testing, returns path of that temp dir.
+    // Also creates a default profiles.json to avoid obscure test failures when there are no profiles.
+
+    let temp_dir = tempdir().unwrap();
+    // std::env::set_var("HOME", temp_dir.path());
+
+    let temp_dir_path = temp_dir.path().to_path_buf();
+    println!(
+        "Created temporary home directory: {}",
+        temp_dir_path.display()
+    );
+    let profile_path = temp_dir_path
+        .join(".config")
+        .join("goose")
+        .join("profiles.json");
+    fs::create_dir_all(profile_path.parent().unwrap()).unwrap();
+    let profile = r#"
+{
+    "profile_items": {
+        "default": {
+            "provider": "databricks",
+            "model": "claude-3-5-sonnet-2",
+            "additional_systems": []
+        }
+    }
+}"#;
+    fs::write(&profile_path, profile).unwrap();
+
+    temp_env::with_var("HOME", Some(temp_dir_path.as_os_str()), func)
+}

--- a/crates/goose-cli/src/test_helpers.rs
+++ b/crates/goose-cli/src/test_helpers.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-pub fn run_with_test_dir<F: FnOnce() -> T, T>(func: F) -> T {
+pub fn run_with_tmp_dir<F: FnOnce() -> T, T>(func: F) -> T {
     use std::fs;
     use tempfile::tempdir;
 

--- a/crates/goose-cli/src/test_helpers.rs
+++ b/crates/goose-cli/src/test_helpers.rs
@@ -1,5 +1,6 @@
 #[cfg(test)]
 pub fn run_with_tmp_dir<F: FnOnce() -> T, T>(func: F) -> T {
+    use std::ffi::OsStr;
     use std::fs;
     use tempfile::tempdir;
 
@@ -31,5 +32,11 @@ pub fn run_with_tmp_dir<F: FnOnce() -> T, T>(func: F) -> T {
 }"#;
     fs::write(&profile_path, profile).unwrap();
 
-    temp_env::with_var("HOME", Some(temp_dir_path.as_os_str()), func)
+    temp_env::with_vars(
+        [
+            ("HOME", Some(temp_dir_path.as_os_str())),
+            ("DATABRICKS_HOST", Some(OsStr::new("tmp_host_url"))),
+        ],
+        func,
+    )
 }


### PR DESCRIPTION
Copying the default python goose behavior where the latest session file is used when resuming a session when no session name is provided.

Note also added a `run_with_tmp_dir` to manage temporary profile and session files and the HOME env variable used for those.