### PR TITLE
feat:model-specific-configuration

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -110,10 +110,14 @@ pub async fn handle_configure(
         provider: provider_name.to_string(),
         model: model.clone(),
         additional_systems,
+        temperature: None,
+        context_limit: None,
+        max_tokens: None,
+        estimate_factor: None,
     };
 
     // Confirm everything is configured correctly by calling a model!
-    let provider_config = get_provider_config(&provider_name, model.clone());
+    let provider_config = get_provider_config(&provider_name, profile.clone());
     let spin = spinner();
     spin.start("Checking your configuration...");
     let provider = factory::get_provider(provider_config).unwrap();

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -42,8 +42,7 @@ pub fn build_session<'a>(
 
     let loaded_profile = load_profile(profile);
 
-    let provider_config =
-        get_provider_config(&loaded_profile.provider, loaded_profile.model.clone());
+    let provider_config = get_provider_config(&loaded_profile.provider, (*loaded_profile).clone());
 
     // TODO: Odd to be prepping the provider rather than having that done in the agent?
     let provider = factory::get_provider(provider_config).unwrap();

--- a/crates/goose-server/src/configuration.rs
+++ b/crates/goose-server/src/configuration.rs
@@ -2,8 +2,8 @@ use crate::error::{to_env_var, ConfigError};
 use config::{Config, Environment};
 use goose::providers::{
     configs::{
-        DatabricksAuth, DatabricksProviderConfig, OllamaProviderConfig, OpenAiProviderConfig,
-        ProviderConfig,
+        DatabricksAuth, DatabricksProviderConfig, ModelConfig, OllamaProviderConfig,
+        OpenAiProviderConfig, ProviderConfig,
     },
     factory::ProviderType,
     ollama,
@@ -41,6 +41,10 @@ pub enum ProviderSettings {
         temperature: Option<f32>,
         #[serde(default)]
         max_tokens: Option<i32>,
+        #[serde(default)]
+        context_limit: Option<usize>,
+        #[serde(default)]
+        estimate_factor: Option<f32>,
     },
     Databricks {
         #[serde(default = "default_databricks_host")]
@@ -51,6 +55,10 @@ pub enum ProviderSettings {
         temperature: Option<f32>,
         #[serde(default)]
         max_tokens: Option<i32>,
+        #[serde(default)]
+        context_limit: Option<usize>,
+        #[serde(default)]
+        estimate_factor: Option<f32>,
         #[serde(default = "default_image_format")]
         image_format: ImageFormat,
     },
@@ -63,6 +71,10 @@ pub enum ProviderSettings {
         temperature: Option<f32>,
         #[serde(default)]
         max_tokens: Option<i32>,
+        #[serde(default)]
+        context_limit: Option<usize>,
+        #[serde(default)]
+        estimate_factor: Option<f32>,
     },
 }
 
@@ -86,25 +98,33 @@ impl ProviderSettings {
                 model,
                 temperature,
                 max_tokens,
+                context_limit,
+                estimate_factor,
             } => ProviderConfig::OpenAi(OpenAiProviderConfig {
                 host,
                 api_key,
-                model,
-                temperature,
-                max_tokens,
+                model: ModelConfig::new(model)
+                    .with_temperature(temperature)
+                    .with_max_tokens(max_tokens)
+                    .with_context_limit(context_limit)
+                    .with_estimate_factor(estimate_factor),
             }),
             ProviderSettings::Databricks {
                 host,
                 model,
                 temperature,
                 max_tokens,
+                context_limit,
                 image_format,
+                estimate_factor,
             } => ProviderConfig::Databricks(DatabricksProviderConfig {
                 host: host.clone(),
                 auth: DatabricksAuth::oauth(host),
-                model,
-                temperature,
-                max_tokens,
+                model: ModelConfig::new(model)
+                    .with_temperature(temperature)
+                    .with_max_tokens(max_tokens)
+                    .with_context_limit(context_limit)
+                    .with_estimate_factor(estimate_factor),
                 image_format,
             }),
             ProviderSettings::Ollama {
@@ -112,11 +132,15 @@ impl ProviderSettings {
                 model,
                 temperature,
                 max_tokens,
+                context_limit,
+                estimate_factor,
             } => ProviderConfig::Ollama(OllamaProviderConfig {
                 host,
-                model,
-                temperature,
-                max_tokens,
+                model: ModelConfig::new(model)
+                    .with_temperature(temperature)
+                    .with_max_tokens(max_tokens)
+                    .with_context_limit(context_limit)
+                    .with_estimate_factor(estimate_factor),
             }),
         }
     }
@@ -246,6 +270,8 @@ mod tests {
             model,
             temperature,
             max_tokens,
+            context_limit,
+            estimate_factor,
         } = settings.provider
         {
             assert_eq!(host, "https://api.openai.com");
@@ -253,6 +279,8 @@ mod tests {
             assert_eq!(model, "gpt-4o");
             assert_eq!(temperature, None);
             assert_eq!(max_tokens, None);
+            assert_eq!(context_limit, None);
+            assert_eq!(estimate_factor, None);
         } else {
             panic!("Expected OpenAI provider");
         }
@@ -264,6 +292,33 @@ mod tests {
 
     #[test]
     #[serial]
+    fn test_into_config_conversion() {
+        // Test OpenAI conversion
+        let settings = ProviderSettings::OpenAi {
+            host: "https://api.openai.com".to_string(),
+            api_key: "test-key".to_string(),
+            model: "gpt-4o".to_string(),
+            temperature: Some(0.7),
+            max_tokens: Some(1000),
+            context_limit: Some(150_000),
+            estimate_factor: Some(0.8),
+        };
+
+        if let ProviderConfig::OpenAi(config) = settings.into_config() {
+            assert_eq!(config.host, "https://api.openai.com");
+            assert_eq!(config.api_key, "test-key");
+            assert_eq!(config.model.model_name, "gpt-4o");
+            assert_eq!(config.model.temperature, Some(0.7));
+            assert_eq!(config.model.max_tokens, Some(1000));
+            assert_eq!(config.model.context_limit, Some(150_000));
+            assert_eq!(config.model.estimate_factor, Some(0.8));
+        } else {
+            panic!("Expected OpenAI config");
+        }
+    }
+
+    #[test]
+    #[serial]
     fn test_databricks_settings() {
         clean_env();
         env::set_var("GOOSE_PROVIDER__TYPE", "databricks");
@@ -271,6 +326,7 @@ mod tests {
         env::set_var("GOOSE_PROVIDER__MODEL", "llama-2-70b");
         env::set_var("GOOSE_PROVIDER__TEMPERATURE", "0.7");
         env::set_var("GOOSE_PROVIDER__MAX_TOKENS", "2000");
+        env::set_var("GOOSE_PROVIDER__CONTEXT_LIMIT", "150000");
 
         let settings = Settings::new().unwrap();
         if let ProviderSettings::Databricks {
@@ -278,6 +334,8 @@ mod tests {
             model,
             temperature,
             max_tokens,
+            context_limit,
+            estimate_factor,
             image_format: _,
         } = settings.provider
         {
@@ -285,6 +343,8 @@ mod tests {
             assert_eq!(model, "llama-2-70b");
             assert_eq!(temperature, Some(0.7));
             assert_eq!(max_tokens, Some(2000));
+            assert_eq!(context_limit, Some(150000));
+            assert_eq!(estimate_factor, None);
         } else {
             panic!("Expected Databricks provider");
         }
@@ -295,6 +355,7 @@ mod tests {
         env::remove_var("GOOSE_PROVIDER__MODEL");
         env::remove_var("GOOSE_PROVIDER__TEMPERATURE");
         env::remove_var("GOOSE_PROVIDER__MAX_TOKENS");
+        env::remove_var("GOOSE_PROVIDER__CONTEXT_LIMIT");
     }
 
     #[test]
@@ -306,6 +367,8 @@ mod tests {
         env::set_var("GOOSE_PROVIDER__MODEL", "llama2");
         env::set_var("GOOSE_PROVIDER__TEMPERATURE", "0.7");
         env::set_var("GOOSE_PROVIDER__MAX_TOKENS", "2000");
+        env::set_var("GOOSE_PROVIDER__CONTEXT_LIMIT", "150000");
+        env::set_var("GOOSE_PROVIDER__ESTIMATE_FACTOR", "0.7");
 
         let settings = Settings::new().unwrap();
         if let ProviderSettings::Ollama {
@@ -313,12 +376,16 @@ mod tests {
             model,
             temperature,
             max_tokens,
+            context_limit,
+            estimate_factor,
         } = settings.provider
         {
             assert_eq!(host, "http://custom.ollama.host");
             assert_eq!(model, "llama2");
             assert_eq!(temperature, Some(0.7));
             assert_eq!(max_tokens, Some(2000));
+            assert_eq!(context_limit, Some(150000));
+            assert_eq!(estimate_factor, Some(0.7));
         } else {
             panic!("Expected Ollama provider");
         }
@@ -329,6 +396,8 @@ mod tests {
         env::remove_var("GOOSE_PROVIDER__MODEL");
         env::remove_var("GOOSE_PROVIDER__TEMPERATURE");
         env::remove_var("GOOSE_PROVIDER__MAX_TOKENS");
+        env::remove_var("GOOSE_PROVIDER__CONTEXT_LIMIT");
+        env::remove_var("GOOSE_PROVIDER__ESTIMATE_FACTOR");
     }
 
     #[test]
@@ -341,6 +410,7 @@ mod tests {
         env::set_var("GOOSE_PROVIDER__HOST", "https://custom.openai.com");
         env::set_var("GOOSE_PROVIDER__MODEL", "gpt-3.5-turbo");
         env::set_var("GOOSE_PROVIDER__TEMPERATURE", "0.8");
+        env::set_var("GOOSE_PROVIDER__CONTEXT_LIMIT", "150000");
 
         let settings = Settings::new().unwrap();
         assert_eq!(settings.server.port, 8080);
@@ -350,6 +420,7 @@ mod tests {
             api_key,
             model,
             temperature,
+            context_limit,
             ..
         } = settings.provider
         {
@@ -357,6 +428,7 @@ mod tests {
             assert_eq!(api_key, "test-key");
             assert_eq!(model, "gpt-3.5-turbo");
             assert_eq!(temperature, Some(0.8));
+            assert_eq!(context_limit, Some(150000));
         } else {
             panic!("Expected OpenAI provider");
         }
@@ -368,6 +440,7 @@ mod tests {
         env::remove_var("GOOSE_PROVIDER__HOST");
         env::remove_var("GOOSE_PROVIDER__MODEL");
         env::remove_var("GOOSE_PROVIDER__TEMPERATURE");
+        env::remove_var("GOOSE_PROVIDER__CONTEXT_LIMIT");
     }
 
     #[test]

--- a/crates/goose-server/src/state.rs
+++ b/crates/goose-server/src/state.rs
@@ -41,8 +41,6 @@ impl Clone for AppState {
                         host: config.host.clone(),
                         api_key: config.api_key.clone(),
                         model: config.model.clone(),
-                        temperature: config.temperature,
-                        max_tokens: config.max_tokens,
                     })
                 }
                 ProviderConfig::Databricks(config) => ProviderConfig::Databricks(
@@ -50,8 +48,6 @@ impl Clone for AppState {
                         host: config.host.clone(),
                         auth: config.auth.clone(),
                         model: config.model.clone(),
-                        temperature: config.temperature,
-                        max_tokens: config.max_tokens,
                         image_format: config.image_format,
                     },
                 ),
@@ -59,8 +55,6 @@ impl Clone for AppState {
                     ProviderConfig::Ollama(goose::providers::configs::OllamaProviderConfig {
                         host: config.host.clone(),
                         model: config.model.clone(),
-                        temperature: config.temperature,
-                        max_tokens: config.max_tokens,
                     })
                 }
                 ProviderConfig::Anthropic(config) => {
@@ -68,8 +62,6 @@ impl Clone for AppState {
                         host: config.host.clone(),
                         api_key: config.api_key.clone(),
                         model: config.model.clone(),
-                        temperature: config.temperature,
-                        max_tokens: config.max_tokens,
                     })
                 }
             },

--- a/crates/goose/examples/image_tool.rs
+++ b/crates/goose/examples/image_tool.rs
@@ -4,7 +4,7 @@ use dotenv::dotenv;
 use goose::{
     message::Message,
     providers::{
-        configs::{DatabricksProviderConfig, OpenAiProviderConfig, ProviderConfig},
+        configs::{DatabricksProviderConfig, ModelConfig, OpenAiProviderConfig, ProviderConfig},
         factory::get_provider,
     },
 };
@@ -34,9 +34,7 @@ async fn main() -> Result<()> {
     let config2 = ProviderConfig::OpenAi(OpenAiProviderConfig {
         host: "https://api.openai.com".into(),
         api_key,
-        model: "gpt-4o".into(),
-        temperature: None,
-        max_tokens: None,
+        model: ModelConfig::new("gpt-4o".into()),
     });
 
     for config in [config1, config2] {

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 
+use super::configs::ModelConfig;
 use crate::message::Message;
 use mcp_core::tool::Tool;
 
@@ -51,6 +52,9 @@ use async_trait::async_trait;
 /// Base trait for AI providers (OpenAI, Anthropic, etc)
 #[async_trait]
 pub trait Provider: Send + Sync {
+    /// Get the model configuration
+    fn get_model_config(&self) -> &ModelConfig;
+
     /// Generate the next message using the configured model and other parameters
     ///
     /// # Arguments

--- a/crates/goose/src/providers/configs.rs
+++ b/crates/goose/src/providers/configs.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 const DEFAULT_CLIENT_ID: &str = "databricks-cli";
 const DEFAULT_REDIRECT_URL: &str = "http://localhost:8020";
 const DEFAULT_SCOPES: &[&str] = &["all-apis"];
+const DEFAULT_CONTEXT_LIMIT: usize = 200_000;
+const DEFAULT_ESTIMATE_FACTOR: f32 = 0.8;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ProviderConfig {
@@ -11,6 +13,117 @@ pub enum ProviderConfig {
     Databricks(DatabricksProviderConfig),
     Ollama(OllamaProviderConfig),
     Anthropic(AnthropicProviderConfig),
+}
+
+/// Configuration for model-specific settings and limits
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelConfig {
+    /// The name of the model to use
+    pub model_name: String,
+    /// Optional explicit context limit that overrides any defaults
+    pub context_limit: Option<usize>,
+    /// Optional temperature setting (0.0 - 1.0)
+    pub temperature: Option<f32>,
+    /// Optional maximum tokens to generate
+    pub max_tokens: Option<i32>,
+    /// Factor used to estimate safe context window size (0.0 - 1.0)
+    /// Defaults to 0.8 (80%) of the context limit to leave headroom for responses
+    pub estimate_factor: Option<f32>,
+}
+
+impl ModelConfig {
+    /// Create a new ModelConfig with the specified model name
+    ///
+    /// The context limit is set with the following precedence:
+    /// 1. Explicit context_limit if provided in config
+    /// 2. Model-specific default based on model name
+    /// 3. Global default (128_000) (in get_context_limit)
+    pub fn new(model_name: String) -> Self {
+        let context_limit = Self::get_model_specific_limit(&model_name);
+
+        Self {
+            model_name,
+            context_limit,
+            temperature: None,
+            max_tokens: None,
+            estimate_factor: None,
+        }
+    }
+
+    /// Get model-specific context limit based on model name
+    fn get_model_specific_limit(model_name: &str) -> Option<usize> {
+        // Implement some sensible defaults
+        match model_name {
+            // OpenAI models, https://platform.openai.com/docs/models#models-overview
+            name if name.contains("gpt-4o") => Some(128_000),
+            name if name.contains("gpt-4-turbo") => Some(128_000),
+
+            // Anthropic models, https://docs.anthropic.com/en/docs/about-claude/models
+            name if name.contains("claude-3") => Some(200_000),
+
+            // Meta Llama models, https://github.com/meta-llama/llama-models/tree/main?tab=readme-ov-file#llama-models-1
+            name if name.contains("llama3.2") => Some(128_000),
+            name if name.contains("llama3.3") => Some(128_000),
+            _ => None,
+        }
+    }
+
+    /// Set an explicit context limit
+    pub fn with_context_limit(mut self, limit: Option<usize>) -> Self {
+        // Default is None and therefore DEFAULT_CONTEXT_LIMIT, only set
+        // if input is Some to allow passing through with_context_limit in
+        // configuration cases
+        if limit.is_some() {
+            self.context_limit = limit;
+        }
+        self
+    }
+
+    /// Set the temperature
+    pub fn with_temperature(mut self, temp: Option<f32>) -> Self {
+        self.temperature = temp;
+        self
+    }
+
+    /// Set the max tokens
+    pub fn with_max_tokens(mut self, tokens: Option<i32>) -> Self {
+        self.max_tokens = tokens;
+        self
+    }
+
+    /// Set the estimate factor
+    pub fn with_estimate_factor(mut self, factor: Option<f32>) -> Self {
+        self.estimate_factor = factor;
+        self
+    }
+
+    /// Get the context_limit for the current model
+    /// If none are defined, use the DEFAULT_CONTEXT_LIMIT
+    pub fn context_limit(&self) -> usize {
+        self.context_limit.unwrap_or(DEFAULT_CONTEXT_LIMIT)
+    }
+
+    /// Get the estimate factor for the current model configuration
+    ///
+    /// # Returns
+    /// The estimate factor with the following precedence:
+    /// 1. Explicit estimate_factor if provided in config
+    /// 2. Default value (0.8)
+    pub fn estimate_factor(&self) -> f32 {
+        self.estimate_factor.unwrap_or(DEFAULT_ESTIMATE_FACTOR)
+    }
+
+    /// Get the estimated limit of the context size, this is defined as
+    /// context_limit * estimate_factor
+    pub fn get_estimated_limit(&self) -> usize {
+        (self.context_limit() as f32 * self.estimate_factor()) as usize
+    }
+}
+
+/// Base trait for provider configurations
+pub trait ProviderModelConfig {
+    /// Get the model configuration
+    fn model_config(&self) -> &ModelConfig;
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -39,36 +152,36 @@ impl DatabricksAuth {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DatabricksProviderConfig {
     pub host: String,
-    pub model: String,
     pub auth: DatabricksAuth,
-    pub temperature: Option<f32>,
-    pub max_tokens: Option<i32>,
+    pub model: ModelConfig,
     pub image_format: ImageFormat,
 }
 
 impl DatabricksProviderConfig {
     /// Create a new configuration with token authentication
-    pub fn with_token(host: String, model: String, token: String) -> Self {
+    pub fn with_token(host: String, model_name: String, token: String) -> Self {
         Self {
             host,
-            model,
             auth: DatabricksAuth::Token(token),
-            temperature: None,
-            max_tokens: None,
+            model: ModelConfig::new(model_name),
             image_format: ImageFormat::Anthropic,
         }
     }
 
     /// Create a new configuration with OAuth authentication using default settings
-    pub fn with_oauth(host: String, model: String) -> Self {
+    pub fn with_oauth(host: String, model_name: String) -> Self {
         Self {
             host: host.clone(),
-            model,
             auth: DatabricksAuth::oauth(host),
-            temperature: None,
-            max_tokens: None,
+            model: ModelConfig::new(model_name),
             image_format: ImageFormat::Anthropic,
         }
+    }
+}
+
+impl ProviderModelConfig for DatabricksProviderConfig {
+    fn model_config(&self) -> &ModelConfig {
+        &self.model
     }
 }
 
@@ -76,24 +189,158 @@ impl DatabricksProviderConfig {
 pub struct OpenAiProviderConfig {
     pub host: String,
     pub api_key: String,
-    pub model: String,
-    pub temperature: Option<f32>,
-    pub max_tokens: Option<i32>,
+    pub model: ModelConfig,
+}
+
+impl OpenAiProviderConfig {
+    pub fn new(host: String, api_key: String, model_name: String) -> Self {
+        Self {
+            host,
+            api_key,
+            model: ModelConfig::new(model_name),
+        }
+    }
+}
+
+impl ProviderModelConfig for OpenAiProviderConfig {
+    fn model_config(&self) -> &ModelConfig {
+        &self.model
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OllamaProviderConfig {
     pub host: String,
-    pub model: String,
-    pub temperature: Option<f32>,
-    pub max_tokens: Option<i32>,
+    pub model: ModelConfig,
+}
+
+impl OllamaProviderConfig {
+    pub fn new(host: String, model_config: ModelConfig) -> Self {
+        Self {
+            host,
+            model: model_config,
+        }
+    }
+}
+
+impl ProviderModelConfig for OllamaProviderConfig {
+    fn model_config(&self) -> &ModelConfig {
+        &self.model
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AnthropicProviderConfig {
     pub host: String,
     pub api_key: String,
-    pub model: String,
-    pub temperature: Option<f32>,
-    pub max_tokens: Option<i32>,
+    pub model: ModelConfig,
+}
+
+impl AnthropicProviderConfig {
+    pub fn new(host: String, api_key: String, model_name: String) -> Self {
+        Self {
+            host,
+            api_key,
+            model: ModelConfig::new(model_name),
+        }
+    }
+}
+
+impl ProviderModelConfig for AnthropicProviderConfig {
+    fn model_config(&self) -> &ModelConfig {
+        &self.model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_model_config_context_limits() {
+        // Test explicit limit
+        let config =
+            ModelConfig::new("claude-3-opus".to_string()).with_context_limit(Some(150_000));
+        assert_eq!(config.context_limit(), 150_000);
+
+        // Test model-specific defaults
+        let config = ModelConfig::new("claude-3-opus".to_string());
+        assert_eq!(config.context_limit(), 200_000);
+
+        let config = ModelConfig::new("gpt-4-turbo".to_string());
+        assert_eq!(config.context_limit(), 128_000);
+
+        // Test fallback to default
+        let config = ModelConfig::new("unknown-model".to_string());
+        assert_eq!(config.context_limit(), DEFAULT_CONTEXT_LIMIT);
+    }
+
+    #[test]
+    fn test_estimate_factor() {
+        // Test default value
+        let config = ModelConfig::new("test-model".to_string());
+        assert_eq!(config.estimate_factor(), DEFAULT_ESTIMATE_FACTOR);
+
+        // Test explicit value
+        let config = ModelConfig::new("test-model".to_string()).with_estimate_factor(Some(0.9));
+        assert_eq!(config.estimate_factor(), 0.9);
+    }
+
+    #[test]
+    fn test_anthropic_config() {
+        let config = AnthropicProviderConfig::new(
+            "https://api.anthropic.com".to_string(),
+            "test-key".to_string(),
+            "claude-3-opus".to_string(),
+        );
+
+        assert_eq!(config.model_config().context_limit(), 200_000);
+
+        let config = AnthropicProviderConfig::new(
+            "https://api.anthropic.com".to_string(),
+            "test-key".to_string(),
+            "claude-3-opus".to_string(),
+        );
+        let model_config = config
+            .model_config()
+            .clone()
+            .with_context_limit(Some(150_000));
+        assert_eq!(model_config.context_limit(), 150_000);
+    }
+
+    #[test]
+    fn test_openai_config() {
+        let config = OpenAiProviderConfig::new(
+            "https://api.openai.com".to_string(),
+            "test-key".to_string(),
+            "gpt-4-turbo".to_string(),
+        );
+
+        assert_eq!(config.model_config().context_limit(), 128_000);
+
+        let config = OpenAiProviderConfig::new(
+            "https://api.openai.com".to_string(),
+            "test-key".to_string(),
+            "gpt-4-turbo".to_string(),
+        );
+        let model_config = config
+            .model_config()
+            .clone()
+            .with_context_limit(Some(150_000));
+        assert_eq!(model_config.context_limit(), 150_000);
+    }
+
+    #[test]
+    fn test_model_config_settings() {
+        let config = ModelConfig::new("test-model".to_string())
+            .with_temperature(Some(0.7))
+            .with_max_tokens(Some(1000))
+            .with_context_limit(Some(50_000))
+            .with_estimate_factor(Some(0.9));
+
+        assert_eq!(config.temperature, Some(0.7));
+        assert_eq!(config.max_tokens, Some(1000));
+        assert_eq!(config.context_limit, Some(50_000));
+        assert_eq!(config.estimate_factor, Some(0.9));
+    }
 }

--- a/crates/goose/src/providers/mock.rs
+++ b/crates/goose/src/providers/mock.rs
@@ -6,6 +6,7 @@ use std::sync::Mutex;
 
 use crate::message::Message;
 use crate::providers::base::{Provider, Usage};
+use crate::providers::configs::ModelConfig;
 use mcp_core::tool::Tool;
 
 use super::base::ProviderUsage;
@@ -13,6 +14,7 @@ use super::base::ProviderUsage;
 /// A mock provider that returns pre-configured responses for testing
 pub struct MockProvider {
     responses: Arc<Mutex<Vec<Message>>>,
+    model_config: ModelConfig,
 }
 
 impl MockProvider {
@@ -20,12 +22,25 @@ impl MockProvider {
     pub fn new(responses: Vec<Message>) -> Self {
         Self {
             responses: Arc::new(Mutex::new(responses)),
+            model_config: ModelConfig::new("mock-model".to_string()),
+        }
+    }
+
+    /// Create a new mock provider with specific responses and model config
+    pub fn with_config(responses: Vec<Message>, model_config: ModelConfig) -> Self {
+        Self {
+            responses: Arc::new(Mutex::new(responses)),
+            model_config,
         }
     }
 }
 
 #[async_trait]
 impl Provider for MockProvider {
+    fn get_model_config(&self) -> &ModelConfig {
+        &self.model_config
+    }
+
     async fn complete(
         &self,
         _system_prompt: &str,

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -7,7 +7,9 @@ use mcp_core::tool::Tool;
 
 use goose::providers::{
     base::Provider,
-    configs::{DatabricksAuth, DatabricksProviderConfig, OpenAiProviderConfig, ProviderConfig},
+    configs::{
+        DatabricksAuth, DatabricksProviderConfig, ModelConfig, OpenAiProviderConfig, ProviderConfig,
+    },
     factory::get_provider,
 };
 
@@ -113,9 +115,7 @@ async fn test_openai_provider() -> Result<()> {
     let config = ProviderConfig::OpenAi(OpenAiProviderConfig {
         host: "https://api.openai.com".to_string(),
         api_key: std::env::var("OPENAI_API_KEY")?,
-        model: std::env::var("OPENAI_MODEL")?,
-        temperature: None,
-        max_tokens: None,
+        model: ModelConfig::new(std::env::var("OPENAI_MODEL")?),
     });
 
     let tester = ProviderTester::new(config)?;
@@ -139,10 +139,8 @@ async fn test_databricks_provider() -> Result<()> {
 
     let config = ProviderConfig::Databricks(DatabricksProviderConfig {
         host: std::env::var("DATABRICKS_HOST")?,
-        model: std::env::var("DATABRICKS_MODEL")?,
+        model: ModelConfig::new(std::env::var("DATABRICKS_MODEL")?),
         auth: DatabricksAuth::Token(std::env::var("DATABRICKS_TOKEN")?),
-        temperature: None,
-        max_tokens: None,
         image_format: goose::providers::utils::ImageFormat::Anthropic,
     });
 
@@ -164,10 +162,8 @@ async fn test_databricks_provider_oauth() -> Result<()> {
 
     let config = ProviderConfig::Databricks(DatabricksProviderConfig {
         host: std::env::var("DATABRICKS_HOST")?,
-        model: std::env::var("DATABRICKS_MODEL")?,
+        model: ModelConfig::new(std::env::var("DATABRICKS_MODEL")?),
         auth: DatabricksAuth::oauth(std::env::var("DATABRICKS_HOST")?),
-        temperature: None,
-        max_tokens: None,
         image_format: goose::providers::utils::ImageFormat::Anthropic,
     });
 
@@ -190,9 +186,9 @@ async fn test_ollama_provider() -> Result<()> {
 
     let config = ProviderConfig::Ollama(OllamaProviderConfig {
         host: std::env::var("OLLAMA_HOST").unwrap_or_else(|_| String::from(OLLAMA_HOST)),
-        model: std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| String::from(OLLAMA_MODEL)),
-        temperature: None,
-        max_tokens: None,
+        model: ModelConfig::new(
+            std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| String::from(OLLAMA_MODEL)),
+        ),
     });
 
     let tester = ProviderTester::new(config)?;


### PR DESCRIPTION
# add model specific configuration
This PR adds model specific configuration and updates the `goose-cli` and `goose-server` crates to use the updated Provider configuration and handle new configuration

## changes
- Introduce a new `ModelConfig` struct that is composed into each `Provider` specific config
  - add support for configuring `context_limit` + `estimate_factor` , `temperature` and `max_tokens`
  - `context_limit` has some defaults for known models set during [`ModelConfig::new()` construction time](https://github.com/block/goose/blob/kalvin/model-context-limits/crates/goose/src/providers/configs.rs#L54-L69).
    - order of preference: `an explicitly set limit > default known model limit > DEFAULT_CONTEXT_LIMIT (128_000)`
- Refactored provider configurations to embed the `ModelConfig` struct and updated relevant uses of the model configuration
- Update `goose-cli` and `goose-server` to use `ModelConfig` when constructing `Providers`
- Update `goose-cli` and `goose-server` to handle the new config parameters following the current approach in each respective crate

