### PR TITLE
Adds session cost to goose.log

### DIFF
--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -39,5 +39,5 @@ rust_decimal_macros = "1.36.0"
 
 [dev-dependencies]
 tempfile = "3"
-temp-env = "0.3.6"
+temp-env = { version = "0.3.6", features = ["async_closure"] }
 

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -34,6 +34,8 @@ reqwest = "0.11.27"
 rand = "0.8.5"
 async-trait = "0.1"
 rustyline = "15.0.0"
+rust_decimal = "1.36.0"
+rust_decimal_macros = "1.36.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/goose-cli/src/agents/agent.rs
+++ b/crates/goose-cli/src/agents/agent.rs
@@ -2,14 +2,14 @@ use anyhow::Result;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use goose::{
-    agent::Agent as GooseAgent, message::Message, providers::base::Usage, systems::System,
+    agent::Agent as GooseAgent, message::Message, providers::base::ProviderUsage, systems::System,
 };
 
 #[async_trait]
 pub trait Agent {
     fn add_system(&mut self, system: Box<dyn System>);
     async fn reply(&self, messages: &[Message]) -> Result<BoxStream<'_, Result<Message>>>;
-    fn total_usage(&self) -> Usage;
+    async fn usage(&self) -> Result<Vec<ProviderUsage>>;
 }
 
 #[async_trait]
@@ -22,7 +22,7 @@ impl Agent for GooseAgent {
         self.reply(messages).await
     }
 
-    fn total_usage(&self) -> Usage {
-        self.total_usage()
+    async fn usage(&self) -> Result<Vec<ProviderUsage>> {
+        self.usage().await
     }
 }

--- a/crates/goose-cli/src/agents/mock_agent.rs
+++ b/crates/goose-cli/src/agents/mock_agent.rs
@@ -1,7 +1,9 @@
+use std::vec;
+
 use anyhow::Result;
 use async_trait::async_trait;
 use futures::stream::BoxStream;
-use goose::{message::Message, systems::System};
+use goose::{message::Message, providers::base::ProviderUsage, systems::System};
 
 use crate::agents::agent::Agent;
 
@@ -15,7 +17,7 @@ impl Agent for MockAgent {
         Ok(Box::pin(futures::stream::empty()))
     }
 
-    fn total_usage(&self) -> goose::providers::base::Usage {
-        goose::providers::base::Usage::default()
+    async fn usage(&self) -> Result<Vec<ProviderUsage>> {
+        Ok(vec![ProviderUsage::new("mock".to_string(), Default::default(), None)])
     }
 }

--- a/crates/goose-cli/src/agents/mock_agent.rs
+++ b/crates/goose-cli/src/agents/mock_agent.rs
@@ -18,6 +18,10 @@ impl Agent for MockAgent {
     }
 
     async fn usage(&self) -> Result<Vec<ProviderUsage>> {
-        Ok(vec![ProviderUsage::new("mock".to_string(), Default::default(), None)])
+        Ok(vec![ProviderUsage::new(
+            "mock".to_string(),
+            Default::default(),
+            None,
+        )])
     }
 }

--- a/crates/goose-cli/src/log_usage.rs
+++ b/crates/goose-cli/src/log_usage.rs
@@ -64,7 +64,11 @@ mod tests {
 
             log_usage(
                 "path.txt".to_string(),
-                vec![ProviderUsage::new("model".to_string(), Usage::new(Some(10), Some(20), Some(30)), Some(dec!(0.5)))],
+                vec![ProviderUsage::new(
+                    "model".to_string(),
+                    Usage::new(Some(10), Some(20), Some(30)),
+                    Some(dec!(0.5)),
+                )],
             );
 
             // Check if log file exists and contains the expected content

--- a/crates/goose-cli/src/log_usage.rs
+++ b/crates/goose-cli/src/log_usage.rs
@@ -1,12 +1,12 @@
-use goose::providers::base::Usage;
+use goose::providers::base::ProviderUsage;
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct SessionLog {
     session_file: String,
-    usage: goose::providers::base::Usage,
+    usage: Vec<ProviderUsage>,
 }
 
-pub fn log_usage(session_file: String, usage: Usage) {
+pub fn log_usage(session_file: String, usage: Vec<ProviderUsage>) {
     let log = SessionLog {
         session_file,
         usage,
@@ -49,7 +49,8 @@ pub fn log_usage(session_file: String, usage: Usage) {
 
 #[cfg(test)]
 mod tests {
-    use goose::providers::base::Usage;
+    use goose::providers::base::{ProviderUsage, Usage};
+    use rust_decimal_macros::dec;
 
     use crate::{
         log_usage::{log_usage, SessionLog},
@@ -63,7 +64,7 @@ mod tests {
 
             log_usage(
                 "path.txt".to_string(),
-                Usage::new(Some(10), Some(20), Some(30)),
+                vec![ProviderUsage::new("model".to_string(), Usage::new(Some(10), Some(20), Some(30)), Some(dec!(0.5)))],
             );
 
             // Check if log file exists and contains the expected content
@@ -75,9 +76,11 @@ mod tests {
                 serde_json::from_str(log_content.lines().last().unwrap()).unwrap();
 
             assert!(log.session_file.contains("path.txt"));
-            assert_eq!(log.usage.input_tokens, Some(10));
-            assert_eq!(log.usage.output_tokens, Some(20));
-            assert_eq!(log.usage.total_tokens, Some(30));
+            assert_eq!(log.usage[0].usage.input_tokens, Some(10));
+            assert_eq!(log.usage[0].usage.output_tokens, Some(20));
+            assert_eq!(log.usage[0].usage.total_tokens, Some(30));
+            assert_eq!(log.usage[0].model, "model");
+            assert_eq!(log.usage[0].cost, Some(dec!(0.5)));
         })
     }
 }

--- a/crates/goose-cli/src/log_usage.rs
+++ b/crates/goose-cli/src/log_usage.rs
@@ -56,6 +56,7 @@ mod tests {
         log_usage::{log_usage, SessionLog},
         test_helpers::run_with_tmp_dir,
     };
+
     #[test]
     fn test_session_logging() {
         run_with_tmp_dir(|| {

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -812,7 +812,6 @@ mod tests {
             // Create a log directory
             let home_dir = dirs::home_dir().unwrap();
             let log_dir = home_dir.join(".config").join("goose").join("logs");
-            std::fs::create_dir_all(&log_dir)?;
 
             session.close_session().await;
 

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -322,10 +322,7 @@ We've removed the conversation up to the most recent user message
         ));
         self.prompt.close();
         match self.agent.usage().await {
-            Ok(usage) => log_usage(
-                self.session_file.to_string_lossy().to_string(),
-                usage,
-            ),
+            Ok(usage) => log_usage(self.session_file.to_string_lossy().to_string(), usage),
             Err(e) => eprintln!("Failed to collect total provider usage: {}", e),
         }
     }
@@ -336,9 +333,7 @@ We've removed the conversation up to the most recent user message
 }
 
 impl<'a> Drop for Session<'a> {
-    fn drop(&mut self) {
-        
-    }
+    fn drop(&mut self) {}
 }
 
 fn raw_message(content: &str) -> Box<Message> {
@@ -836,7 +831,8 @@ mod tests {
             assert!(log_content.contains("total_tokens"));
 
             Ok(())
-        }).await
+        })
+        .await
     }
 
     fn assert_last_prompt_text(session: &Session, expected_text: &str) {

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -146,7 +146,7 @@ impl<'a> Session<'a> {
             self.agent_process_messages().await;
             self.prompt.hide_busy();
         }
-        self.close_session();
+        self.close_session().await;
         Ok(())
     }
 
@@ -162,7 +162,7 @@ impl<'a> Session<'a> {
 
         self.agent_process_messages().await;
 
-        self.close_session();
+        self.close_session().await;
         Ok(())
     }
 
@@ -312,7 +312,7 @@ We've removed the conversation up to the most recent user message
         self.agent.add_system(goosehints_system);
     }
 
-    fn close_session(&mut self) {
+    async fn close_session(&mut self) {
         self.prompt.render(raw_message(
             format!(
                 "Closing session. Recorded to {}\n",
@@ -321,6 +321,13 @@ We've removed the conversation up to the most recent user message
             .as_str(),
         ));
         self.prompt.close();
+        match self.agent.usage().await {
+            Ok(usage) => log_usage(
+                self.session_file.to_string_lossy().to_string(),
+                usage,
+            ),
+            Err(e) => eprintln!("Failed to collect total provider usage: {}", e),
+        }
     }
 
     pub fn session_file(&self) -> PathBuf {
@@ -330,10 +337,7 @@ We've removed the conversation up to the most recent user message
 
 impl<'a> Drop for Session<'a> {
     fn drop(&mut self) {
-        log_usage(
-            self.session_file.to_string_lossy().to_string(),
-            self.agent.total_usage(),
-        );
+        
     }
 }
 
@@ -348,7 +352,7 @@ mod tests {
 
     use crate::agents::mock_agent::MockAgent;
     use crate::prompt::{self, Input};
-    use crate::test_helpers::run_with_tmp_dir;
+    use crate::test_helpers::{run_with_tmp_dir, run_with_tmp_dir_async};
 
     use super::*;
     use goose::errors::AgentResult;
@@ -808,19 +812,18 @@ mod tests {
         })
     }
 
-    #[test]
-    fn test_session_logging() -> Result<()> {
-        run_with_tmp_dir(|| {
+    #[tokio::test]
+    async fn test_session_logging() -> Result<()> {
+        run_with_tmp_dir_async(|| async {
             // Create a test session
-            let session = create_test_session();
+            let mut session = create_test_session();
             let session_file = session.session_file.clone();
             // Create a log directory
             let home_dir = dirs::home_dir().unwrap();
             let log_dir = home_dir.join(".config").join("goose").join("logs");
             std::fs::create_dir_all(&log_dir)?;
 
-            // Drop the session to trigger logging
-            drop(session);
+            session.close_session().await;
 
             // Check if log file exists and contains the expected content
             let log_file = log_dir.join("goose.log");
@@ -833,7 +836,7 @@ mod tests {
             assert!(log_content.contains("total_tokens"));
 
             Ok(())
-        })
+        }).await
     }
 
     fn assert_last_prompt_text(session: &Session, expected_text: &str) {

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -332,10 +332,6 @@ We've removed the conversation up to the most recent user message
     }
 }
 
-impl<'a> Drop for Session<'a> {
-    fn drop(&mut self) {}
-}
-
 fn raw_message(content: &str) -> Box<Message> {
     Box::new(Message::assistant().with_text(content))
 }

--- a/crates/goose-cli/src/test_helpers.rs
+++ b/crates/goose-cli/src/test_helpers.rs
@@ -40,3 +40,51 @@ pub fn run_with_tmp_dir<F: FnOnce() -> T, T>(func: F) -> T {
         func,
     )
 }
+
+#[cfg(test)]
+pub async fn run_with_tmp_dir_async<F, Fut, T>(func: F) -> T
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = T>,
+{
+    use std::ffi::OsStr;
+    use std::fs;
+    use tempfile::tempdir;
+
+    // Helper function to set up a temporary home directory for testing, returns path of that temp dir.
+    // Also creates a default profiles.json to avoid obscure test failures when there are no profiles.
+
+    let temp_dir = tempdir().unwrap();
+    // std::env::set_var("HOME", temp_dir.path());
+
+    let temp_dir_path = temp_dir.path().to_path_buf();
+    println!(
+        "Created temporary home directory: {}",
+        temp_dir_path.display()
+    );
+    let profile_path = temp_dir_path
+        .join(".config")
+        .join("goose")
+        .join("profiles.json");
+    fs::create_dir_all(profile_path.parent().unwrap()).unwrap();
+    let profile = r#"
+{
+    "profile_items": {
+        "default": {
+            "provider": "databricks",
+            "model": "claude-3-5-sonnet-2",
+            "additional_systems": []
+        }
+    }
+}"#;
+    fs::write(&profile_path, profile).unwrap();
+
+    temp_env::with_vars(
+        [
+            ("HOME", Some(temp_dir_path.as_os_str())),
+            ("DATABRICKS_HOST", Some(OsStr::new("tmp_host_url"))),
+        ],
+        func,
+    )
+    .await
+}

--- a/crates/goose-cli/src/test_helpers.rs
+++ b/crates/goose-cli/src/test_helpers.rs
@@ -1,36 +1,13 @@
+/// Helper function to set up a temporary home directory for testing, returns path of that temp dir.
+/// Also creates a default profiles.json to avoid obscure test failures when there are no profiles.
 #[cfg(test)]
 pub fn run_with_tmp_dir<F: FnOnce() -> T, T>(func: F) -> T {
     use std::ffi::OsStr;
-    use std::fs;
     use tempfile::tempdir;
 
-    // Helper function to set up a temporary home directory for testing, returns path of that temp dir.
-    // Also creates a default profiles.json to avoid obscure test failures when there are no profiles.
-
     let temp_dir = tempdir().unwrap();
-    // std::env::set_var("HOME", temp_dir.path());
-
     let temp_dir_path = temp_dir.path().to_path_buf();
-    println!(
-        "Created temporary home directory: {}",
-        temp_dir_path.display()
-    );
-    let profile_path = temp_dir_path
-        .join(".config")
-        .join("goose")
-        .join("profiles.json");
-    fs::create_dir_all(profile_path.parent().unwrap()).unwrap();
-    let profile = r#"
-{
-    "profile_items": {
-        "default": {
-            "provider": "databricks",
-            "model": "claude-3-5-sonnet-2",
-            "additional_systems": []
-        }
-    }
-}"#;
-    fs::write(&profile_path, profile).unwrap();
+    setup_profile(&temp_dir_path);
 
     temp_env::with_vars(
         [
@@ -48,20 +25,28 @@ where
     Fut: std::future::Future<Output = T>,
 {
     use std::ffi::OsStr;
-    use std::fs;
     use tempfile::tempdir;
 
-    // Helper function to set up a temporary home directory for testing, returns path of that temp dir.
-    // Also creates a default profiles.json to avoid obscure test failures when there are no profiles.
-
     let temp_dir = tempdir().unwrap();
-    // std::env::set_var("HOME", temp_dir.path());
-
     let temp_dir_path = temp_dir.path().to_path_buf();
-    println!(
-        "Created temporary home directory: {}",
-        temp_dir_path.display()
-    );
+    setup_profile(&temp_dir_path);
+
+    temp_env::async_with_vars(
+        [
+            ("HOME", Some(temp_dir_path.as_os_str())),
+            ("DATABRICKS_HOST", Some(OsStr::new("tmp_host_url"))),
+        ],
+        func(),
+    )
+    .await
+}
+
+#[cfg(test)]
+use std::path::PathBuf;
+#[cfg(test)]
+fn setup_profile(temp_dir_path: &PathBuf) {
+    use std::fs;
+
     let profile_path = temp_dir_path
         .join(".config")
         .join("goose")
@@ -78,13 +63,4 @@ where
     }
 }"#;
     fs::write(&profile_path, profile).unwrap();
-
-    temp_env::with_vars(
-        [
-            ("HOME", Some(temp_dir_path.as_os_str())),
-            ("DATABRICKS_HOST", Some(OsStr::new("tmp_host_url"))),
-        ],
-        func,
-    )
-    .await
 }

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -391,7 +391,10 @@ mod tests {
     use super::*;
     use goose::{
         agent::Agent,
-        providers::{base::{Provider, ProviderUsage, Usage}, configs::OpenAiProviderConfig},
+        providers::{
+            base::{Provider, ProviderUsage, Usage},
+            configs::OpenAiProviderConfig,
+        },
     };
     use mcp_core::tool::Tool;
 

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -391,7 +391,7 @@ mod tests {
     use super::*;
     use goose::{
         agent::Agent,
-        providers::{base::Provider, configs::OpenAiProviderConfig},
+        providers::{base::{Provider, ProviderUsage, Usage}, configs::OpenAiProviderConfig},
     };
     use mcp_core::tool::Tool;
 
@@ -406,15 +406,11 @@ mod tests {
             _system_prompt: &str,
             _messages: &[Message],
             _tools: &[Tool],
-        ) -> Result<(Message, goose::providers::base::Usage), anyhow::Error> {
+        ) -> Result<(Message, ProviderUsage), anyhow::Error> {
             Ok((
                 Message::assistant().with_text("Mock response"),
-                goose::providers::base::Usage::default(),
+                ProviderUsage::new("mock".to_string(), Usage::default(), None),
             ))
-        }
-
-        fn total_usage(&self) -> goose::providers::base::Usage {
-            goose::providers::base::Usage::default()
         }
     }
 

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -46,6 +46,8 @@ kill_tree = "0.2.4"
 
 keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service"] }
 shellexpand = "3.1.0"
+rust_decimal = "1.36.0"
+rust_decimal_macros = "1.36.0"
 
 [dev-dependencies]
 sysinfo = "0.32.1"

--- a/crates/goose/examples/databricks_oauth.rs
+++ b/crates/goose/examples/databricks_oauth.rs
@@ -41,9 +41,9 @@ async fn main() -> Result<()> {
     }
     println!("\nToken Usage:");
     println!("------------");
-    println!("Input tokens: {:?}", usage.input_tokens);
-    println!("Output tokens: {:?}", usage.output_tokens);
-    println!("Total tokens: {:?}", usage.total_tokens);
+    println!("Input tokens: {:?}", usage.usage.input_tokens);
+    println!("Output tokens: {:?}", usage.usage.output_tokens);
+    println!("Total tokens: {:?}", usage.usage.total_tokens);
 
     Ok(())
 }

--- a/crates/goose/examples/image_tool.rs
+++ b/crates/goose/examples/image_tool.rs
@@ -89,9 +89,9 @@ async fn main() -> Result<()> {
         }
         println!("\nToken Usage:");
         println!("------------");
-        println!("Input tokens: {:?}", usage.input_tokens);
-        println!("Output tokens: {:?}", usage.output_tokens);
-        println!("Total tokens: {:?}", usage.total_tokens);
+        println!("Input tokens: {:?}", usage.usage.input_tokens);
+        println!("Output tokens: {:?}", usage.usage.output_tokens);
+        println!("Total tokens: {:?}", usage.usage.total_tokens);
     }
 
     Ok(())

--- a/crates/goose/src/agent.rs
+++ b/crates/goose/src/agent.rs
@@ -546,11 +546,11 @@ mod tests {
         let initial_messages = vec![initial_message];
 
         let mut stream = agent.reply(&initial_messages).await?;
-        while let Some(_) = stream.try_next().await? {}
+        while stream.try_next().await?.is_some() {}
 
         // Second message
         let mut stream = agent.reply(&initial_messages).await?;
-        while let Some(_) = stream.try_next().await? {}
+        while stream.try_next().await?.is_some() {}
 
         let usage = agent.usage().await?;
         assert_eq!(usage.len(), 1); // 2 messages rolled up to one usage per model

--- a/crates/goose/src/agent.rs
+++ b/crates/goose/src/agent.rs
@@ -3,8 +3,8 @@ use async_stream;
 use futures::stream::BoxStream;
 use rust_decimal_macros::dec;
 use serde_json::json;
-use tokio::sync::Mutex;
 use std::collections::HashMap;
+use tokio::sync::Mutex;
 
 use crate::errors::{AgentError, AgentResult};
 use crate::message::{Message, ToolRequest};
@@ -407,18 +407,24 @@ impl Agent {
         let mut usage_map: HashMap<String, ProviderUsage> = HashMap::new();
         provider_usage.iter().for_each(|usage| {
             usage_map
-            .entry(usage.model.clone())
-            .and_modify(|e| {
-                e.usage.input_tokens = Some(e.usage.input_tokens.unwrap_or(0) + usage.usage.input_tokens.unwrap_or(0));
-                e.usage.output_tokens = Some(e.usage.output_tokens.unwrap_or(0) + usage.usage.output_tokens.unwrap_or(0));
-                e.usage.total_tokens = Some(e.usage.total_tokens.unwrap_or(0) + usage.usage.total_tokens.unwrap_or(0));
-                if e.cost.is_none() || usage.cost.is_none() {
-                    e.cost = None; // Pricing is not available for all models
-                } else {
-                    e.cost = Some(e.cost.unwrap_or(dec!(0)) + usage.cost.unwrap_or(dec!(0)));
-                }
-            })
-            .or_insert_with(|| usage.clone());
+                .entry(usage.model.clone())
+                .and_modify(|e| {
+                    e.usage.input_tokens = Some(
+                        e.usage.input_tokens.unwrap_or(0) + usage.usage.input_tokens.unwrap_or(0),
+                    );
+                    e.usage.output_tokens = Some(
+                        e.usage.output_tokens.unwrap_or(0) + usage.usage.output_tokens.unwrap_or(0),
+                    );
+                    e.usage.total_tokens = Some(
+                        e.usage.total_tokens.unwrap_or(0) + usage.usage.total_tokens.unwrap_or(0),
+                    );
+                    if e.cost.is_none() || usage.cost.is_none() {
+                        e.cost = None; // Pricing is not available for all models
+                    } else {
+                        e.cost = Some(e.cost.unwrap_or(dec!(0)) + usage.cost.unwrap_or(dec!(0)));
+                    }
+                })
+                .or_insert_with(|| usage.clone());
         });
         Ok(usage_map.into_values().collect())
     }

--- a/crates/goose/src/agent.rs
+++ b/crates/goose/src/agent.rs
@@ -1,13 +1,15 @@
 use anyhow::Result;
 use async_stream;
 use futures::stream::BoxStream;
+use rust_decimal_macros::dec;
 use serde_json::json;
+use tokio::sync::Mutex;
 use std::collections::HashMap;
 
 use crate::errors::{AgentError, AgentResult};
 use crate::message::{Message, ToolRequest};
 use crate::prompt_template::load_prompt_file;
-use crate::providers::base::Provider;
+use crate::providers::base::{Provider, ProviderUsage};
 use crate::systems::System;
 use crate::token_counter::TokenCounter;
 use mcp_core::{Content, Resource, Tool, ToolCall};
@@ -56,6 +58,7 @@ impl SystemStatus {
 pub struct Agent {
     systems: Vec<Box<dyn System>>,
     provider: Box<dyn Provider>,
+    provider_usage: Mutex<Vec<ProviderUsage>>,
 }
 
 #[allow(dead_code)]
@@ -65,6 +68,7 @@ impl Agent {
         Self {
             systems: Vec::new(),
             provider,
+            provider_usage: Mutex::new(Vec::new()),
         }
     }
 
@@ -339,11 +343,12 @@ impl Agent {
             loop {
 
                 // Get completion from provider
-                let (response, _) = self.provider.complete(
+                let (response, usage) = self.provider.complete(
                     &system_prompt,
                     &messages,
                     &tools,
                 ).await?;
+                self.provider_usage.lock().await.push(usage);
 
                 // The assistant's response is added in rewrite_messages_on_tool_response
                 // Yield the assistant's response
@@ -396,8 +401,26 @@ impl Agent {
         }))
     }
 
-    pub fn total_usage(&self) -> crate::providers::base::Usage {
-        self.provider.total_usage()
+    pub async fn usage(&self) -> Result<Vec<ProviderUsage>> {
+        let provider_usage = self.provider_usage.lock().await.clone();
+
+        let mut usage_map: HashMap<String, ProviderUsage> = HashMap::new();
+        provider_usage.iter().for_each(|usage| {
+            usage_map
+            .entry(usage.model.clone())
+            .and_modify(|e| {
+                e.usage.input_tokens = Some(e.usage.input_tokens.unwrap_or(0) + usage.usage.input_tokens.unwrap_or(0));
+                e.usage.output_tokens = Some(e.usage.output_tokens.unwrap_or(0) + usage.usage.output_tokens.unwrap_or(0));
+                e.usage.total_tokens = Some(e.usage.total_tokens.unwrap_or(0) + usage.usage.total_tokens.unwrap_or(0));
+                if e.cost.is_none() || usage.cost.is_none() {
+                    e.cost = None; // Pricing is not available for all models
+                } else {
+                    e.cost = Some(e.cost.unwrap_or(dec!(0)) + usage.cost.unwrap_or(dec!(0)));
+                }
+            })
+            .or_insert_with(|| usage.clone());
+        });
+        Ok(usage_map.into_values().collect())
     }
 }
 
@@ -504,6 +527,32 @@ mod tests {
 
         assert_eq!(messages.len(), 1);
         assert_eq!(messages[0], response);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_usage_rollup() -> Result<()> {
+        let response = Message::assistant().with_text("Hello!");
+        let provider = MockProvider::new(vec![response.clone()]);
+        let agent = Agent::new(Box::new(provider));
+
+        let initial_message = Message::user().with_text("Hi");
+        let initial_messages = vec![initial_message];
+
+        let mut stream = agent.reply(&initial_messages).await?;
+        while let Some(_) = stream.try_next().await? {}
+
+        // Second message
+        let mut stream = agent.reply(&initial_messages).await?;
+        while let Some(_) = stream.try_next().await? {}
+
+        let usage = agent.usage().await?;
+        assert_eq!(usage.len(), 1); // 2 messages rolled up to one usage per model
+        assert_eq!(usage[0].usage.input_tokens, Some(2));
+        assert_eq!(usage[0].usage.output_tokens, Some(2));
+        assert_eq!(usage[0].usage.total_tokens, Some(4));
+        assert_eq!(usage[0].model, "mock");
+        assert_eq!(usage[0].cost, Some(dec!(2)));
         Ok(())
     }
 

--- a/crates/goose/src/providers.rs
+++ b/crates/goose/src/providers.rs
@@ -3,6 +3,7 @@ pub mod base;
 pub mod configs;
 pub mod databricks;
 pub mod factory;
+pub mod model_pricing;
 pub mod oauth;
 pub mod ollama;
 pub mod openai;

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -9,8 +9,8 @@ use std::time::Duration;
 use super::base::ProviderUsage;
 use super::base::{Provider, Usage};
 use super::configs::AnthropicProviderConfig;
-use super::model_pricing::model_pricing_for;
 use super::model_pricing::cost;
+use super::model_pricing::model_pricing_for;
 use super::utils::get_model;
 use crate::message::{Message, MessageContent};
 use mcp_core::content::Content;
@@ -28,10 +28,7 @@ impl AnthropicProvider {
             .timeout(Duration::from_secs(600)) // 10 minutes timeout
             .build()?;
 
-        Ok(Self {
-            client,
-            config,
-        })
+        Ok(Self { client, config })
     }
 
     fn get_usage(data: &Value) -> Result<Usage> {

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -6,8 +6,12 @@ use serde_json::{json, Value};
 use std::collections::HashSet;
 use std::time::Duration;
 
-use super::base::{Provider, ProviderUsageCollector, Usage};
+use super::base::ProviderUsage;
+use super::base::{Provider, Usage};
 use super::configs::AnthropicProviderConfig;
+use super::model_pricing::model_pricing_for;
+use super::model_pricing::cost;
+use super::utils::get_model;
 use crate::message::{Message, MessageContent};
 use mcp_core::content::Content;
 use mcp_core::role::Role;
@@ -16,7 +20,6 @@ use mcp_core::tool::{Tool, ToolCall};
 pub struct AnthropicProvider {
     client: Client,
     config: AnthropicProviderConfig,
-    usage_collector: ProviderUsageCollector,
 }
 
 impl AnthropicProvider {
@@ -28,7 +31,6 @@ impl AnthropicProvider {
         Ok(Self {
             client,
             config,
-            usage_collector: ProviderUsageCollector::new(),
         })
     }
 
@@ -216,7 +218,7 @@ impl Provider for AnthropicProvider {
         system: &str,
         messages: &[Message],
         tools: &[Tool],
-    ) -> Result<(Message, Usage)> {
+    ) -> Result<(Message, ProviderUsage)> {
         let anthropic_messages = Self::messages_to_anthropic_spec(messages);
         let tool_specs = Self::tools_to_anthropic_spec(tools);
 
@@ -261,19 +263,17 @@ impl Provider for AnthropicProvider {
         // Parse response
         let message = Self::parse_anthropic_response(response.clone())?;
         let usage = Self::get_usage(&response)?;
-        self.usage_collector.add_usage(usage.clone());
+        let model = get_model(&response);
+        let cost = cost(&usage, &model_pricing_for(&model));
 
-        Ok((message, usage))
-    }
-
-    fn total_usage(&self) -> Usage {
-        self.usage_collector.get_usage()
+        Ok((message, ProviderUsage::new(model, usage, cost)))
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rust_decimal_macros::dec;
     use serde_json::json;
     use wiremock::matchers::{header, method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -309,7 +309,7 @@ mod tests {
                 "type": "text",
                 "text": "Hello! How can I assist you today?"
             }],
-            "model": "claude-3-sonnet-20240229",
+            "model": "claude-3-5-sonnet-latest",
             "stop_reason": "end_turn",
             "stop_sequence": null,
             "usage": {
@@ -332,15 +332,11 @@ mod tests {
             panic!("Expected Text content");
         }
 
-        assert_eq!(usage.input_tokens, Some(12));
-        assert_eq!(usage.output_tokens, Some(15));
-        assert_eq!(usage.total_tokens, Some(27));
-
-        // Check total usage
-        let total = provider.total_usage();
-        assert_eq!(total.input_tokens, Some(12));
-        assert_eq!(total.output_tokens, Some(15));
-        assert_eq!(total.total_tokens, Some(27));
+        assert_eq!(usage.usage.input_tokens, Some(12));
+        assert_eq!(usage.usage.output_tokens, Some(15));
+        assert_eq!(usage.usage.total_tokens, Some(27));
+        assert_eq!(usage.model, "claude-3-5-sonnet-latest");
+        assert_eq!(usage.cost, Some(dec!(0.000261)));
 
         Ok(())
     }
@@ -397,9 +393,9 @@ mod tests {
             panic!("Expected ToolRequest content");
         }
 
-        assert_eq!(usage.input_tokens, Some(15));
-        assert_eq!(usage.output_tokens, Some(20));
-        assert_eq!(usage.total_tokens, Some(35));
+        assert_eq!(usage.usage.input_tokens, Some(15));
+        assert_eq!(usage.usage.output_tokens, Some(20));
+        assert_eq!(usage.usage.total_tokens, Some(35));
 
         Ok(())
     }

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -14,11 +14,7 @@ pub struct ProviderUsage {
 
 impl ProviderUsage {
     pub fn new(model: String, usage: Usage, cost: Option<Decimal>) -> Self {
-        Self {
-            model,
-            usage,
-            cost,
-        }
+        Self { model, usage, cost }
     }
 }
 

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -1,9 +1,33 @@
 use anyhow::Result;
+use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
-use std::sync::Mutex;
 
 use crate::message::Message;
 use mcp_core::tool::Tool;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProviderUsage {
+    pub model: String,
+    pub usage: Usage,
+    pub cost: Option<Decimal>,
+}
+
+impl ProviderUsage {
+    pub fn new(model: String, usage: Usage, cost: Option<Decimal>) -> Self {
+        Self {
+            model,
+            usage,
+            cost,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct Pricing {
+    /// Prices are per million tokens.
+    pub input_token_price: Decimal,
+    pub output_token_price: Decimal,
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct Usage {
@@ -39,56 +63,13 @@ pub trait Provider: Send + Sync {
     /// * `tools` - Optional list of tools the model can use
     ///
     /// # Returns
-    /// A tuple containing the model's response message and usage statistics
+    /// A tuple containing the model's response message and provider usage statistics
     async fn complete(
         &self,
         system: &str,
         messages: &[Message],
         tools: &[Tool],
-    ) -> Result<(Message, Usage)>;
-
-    /// Providers should implement this method to return their total usage statistics from provider.complete (or others)
-    fn total_usage(&self) -> Usage;
-}
-
-/// A simple struct to reuse for collecting usage statistics for provider implementations.
-pub struct ProviderUsageCollector {
-    usage: Mutex<Usage>,
-}
-
-impl Default for ProviderUsageCollector {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ProviderUsageCollector {
-    pub fn new() -> Self {
-        Self {
-            usage: Mutex::new(Usage::default()),
-        }
-    }
-
-    pub fn add_usage(&self, usage: Usage) {
-        if let Ok(mut current) = self.usage.lock() {
-            if let Some(input_tokens) = usage.input_tokens {
-                current.input_tokens = Some(current.input_tokens.unwrap_or(0) + input_tokens);
-            }
-            if let Some(output_tokens) = usage.output_tokens {
-                current.output_tokens = Some(current.output_tokens.unwrap_or(0) + output_tokens);
-            }
-            if let Some(total_tokens) = usage.total_tokens {
-                current.total_tokens = Some(current.total_tokens.unwrap_or(0) + total_tokens);
-            }
-        }
-    }
-
-    pub fn get_usage(&self) -> Usage {
-        self.usage
-            .lock()
-            .map(|guard| guard.clone())
-            .unwrap_or_default()
-    }
+    ) -> Result<(Message, ProviderUsage)>;
 }
 
 #[cfg(test)]
@@ -121,24 +102,5 @@ mod tests {
         assert_eq!(json_value["total_tokens"], json!(30));
 
         Ok(())
-    }
-
-    #[test]
-    fn test_usage_collector() {
-        let collector = ProviderUsageCollector::new();
-
-        // Add first usage
-        collector.add_usage(Usage::new(Some(10), Some(20), Some(30)));
-        let usage1 = collector.get_usage();
-        assert_eq!(usage1.input_tokens, Some(10));
-        assert_eq!(usage1.output_tokens, Some(20));
-        assert_eq!(usage1.total_tokens, Some(30));
-
-        // Add second usage
-        collector.add_usage(Usage::new(Some(5), Some(10), Some(15)));
-        let usage2 = collector.get_usage();
-        assert_eq!(usage2.input_tokens, Some(15));
-        assert_eq!(usage2.output_tokens, Some(30));
-        assert_eq!(usage2.total_tokens, Some(45));
     }
 }

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -4,12 +4,12 @@ use reqwest::{Client, StatusCode};
 use serde_json::{json, Value};
 use std::time::Duration;
 
-use super::base::{Provider, ProviderUsageCollector, Usage};
+use super::base::{Provider, ProviderUsage, Usage};
 use super::configs::{DatabricksAuth, DatabricksProviderConfig};
+use super::model_pricing::{model_pricing_for, cost};
 use super::oauth;
 use super::utils::{
-    check_bedrock_context_length_error, check_openai_context_length_error, messages_to_openai_spec,
-    openai_response_to_message, tools_to_openai_spec,
+    check_bedrock_context_length_error, check_openai_context_length_error, get_model, messages_to_openai_spec, openai_response_to_message, tools_to_openai_spec
 };
 use crate::message::Message;
 use mcp_core::tool::Tool;
@@ -17,7 +17,6 @@ use mcp_core::tool::Tool;
 pub struct DatabricksProvider {
     client: Client,
     config: DatabricksProviderConfig,
-    usage_collector: ProviderUsageCollector,
 }
 
 impl DatabricksProvider {
@@ -29,7 +28,6 @@ impl DatabricksProvider {
         Ok(Self {
             client,
             config,
-            usage_collector: ProviderUsageCollector::new(),
         })
     }
 
@@ -114,7 +112,7 @@ impl Provider for DatabricksProvider {
         system: &str,
         messages: &[Message],
         tools: &[Tool],
-    ) -> Result<(Message, Usage)> {
+    ) -> Result<(Message, ProviderUsage)> {
         // Prepare messages and tools
         let messages_spec = messages_to_openai_spec(messages, &self.config.image_format);
         let tools_spec = if !tools.is_empty() {
@@ -167,13 +165,10 @@ impl Provider for DatabricksProvider {
         // Parse response
         let message = openai_response_to_message(response.clone())?;
         let usage = Self::get_usage(&response)?;
-        self.usage_collector.add_usage(usage.clone());
+        let model = get_model(&response);
+        let cost = cost(&usage, &model_pricing_for(&model));
 
-        Ok((message, usage))
-    }
-
-    fn total_usage(&self) -> Usage {
-        self.usage_collector.get_usage()
+        Ok((message, ProviderUsage::new(model, usage, cost)))
     }
 }
 
@@ -248,13 +243,9 @@ mod tests {
         } else {
             panic!("Expected Text content");
         }
-        assert_eq!(reply_usage.total_tokens, Some(35));
-
-        // Check total usage
-        let total = provider.total_usage();
-        assert_eq!(total.input_tokens, Some(10));
-        assert_eq!(total.output_tokens, Some(25));
-        assert_eq!(total.total_tokens, Some(35));
+        assert_eq!(reply_usage.usage.input_tokens, Some(10));
+        assert_eq!(reply_usage.usage.output_tokens, Some(25));
+        assert_eq!(reply_usage.usage.total_tokens, Some(35));
 
         Ok(())
     }

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -6,10 +6,11 @@ use std::time::Duration;
 
 use super::base::{Provider, ProviderUsage, Usage};
 use super::configs::{DatabricksAuth, DatabricksProviderConfig};
-use super::model_pricing::{model_pricing_for, cost};
+use super::model_pricing::{cost, model_pricing_for};
 use super::oauth;
 use super::utils::{
-    check_bedrock_context_length_error, check_openai_context_length_error, get_model, messages_to_openai_spec, openai_response_to_message, tools_to_openai_spec
+    check_bedrock_context_length_error, check_openai_context_length_error, get_model,
+    messages_to_openai_spec, openai_response_to_message, tools_to_openai_spec,
 };
 use crate::message::Message;
 use mcp_core::tool::Tool;
@@ -25,10 +26,7 @@ impl DatabricksProvider {
             .timeout(Duration::from_secs(600)) // 10 minutes timeout
             .build()?;
 
-        Ok(Self {
-            client,
-            config,
-        })
+        Ok(Self { client, config })
     }
 
     async fn ensure_auth_header(&self) -> Result<String> {

--- a/crates/goose/src/providers/mock.rs
+++ b/crates/goose/src/providers/mock.rs
@@ -1,11 +1,14 @@
 use anyhow::Result;
 use async_trait::async_trait;
+use rust_decimal_macros::dec;
 use std::sync::Arc;
 use std::sync::Mutex;
 
 use crate::message::Message;
 use crate::providers::base::{Provider, Usage};
 use mcp_core::tool::Tool;
+
+use super::base::ProviderUsage;
 
 /// A mock provider that returns pre-configured responses for testing
 pub struct MockProvider {
@@ -28,17 +31,14 @@ impl Provider for MockProvider {
         _system_prompt: &str,
         _messages: &[Message],
         _tools: &[Tool],
-    ) -> Result<(Message, Usage)> {
+    ) -> Result<(Message, ProviderUsage)> {
         let mut responses = self.responses.lock().unwrap();
+        let usage = Usage::new(Some(1), Some(1), Some(2));
         if responses.is_empty() {
             // Return empty response if no more pre-configured responses
-            Ok((Message::assistant().with_text(""), Usage::default()))
+            Ok((Message::assistant().with_text(""), ProviderUsage::new("mock".to_string(), usage, Some(dec!(1)))))
         } else {
-            Ok((responses.remove(0), Usage::default()))
+            Ok((responses.remove(0), ProviderUsage::new("mock".to_string(), usage, Some(dec!(1)))))
         }
-    }
-
-    fn total_usage(&self) -> Usage {
-        Usage::default()
     }
 }

--- a/crates/goose/src/providers/mock.rs
+++ b/crates/goose/src/providers/mock.rs
@@ -36,9 +36,15 @@ impl Provider for MockProvider {
         let usage = Usage::new(Some(1), Some(1), Some(2));
         if responses.is_empty() {
             // Return empty response if no more pre-configured responses
-            Ok((Message::assistant().with_text(""), ProviderUsage::new("mock".to_string(), usage, Some(dec!(1)))))
+            Ok((
+                Message::assistant().with_text(""),
+                ProviderUsage::new("mock".to_string(), usage, Some(dec!(1))),
+            ))
         } else {
-            Ok((responses.remove(0), ProviderUsage::new("mock".to_string(), usage, Some(dec!(1)))))
+            Ok((
+                responses.remove(0),
+                ProviderUsage::new("mock".to_string(), usage, Some(dec!(1))),
+            ))
         }
     }
 }

--- a/crates/goose/src/providers/model_pricing.rs
+++ b/crates/goose/src/providers/model_pricing.rs
@@ -1,0 +1,121 @@
+use std::collections::HashMap;
+
+use rust_decimal::Decimal;
+use rust_decimal_macros::dec;
+
+use super::base::{Pricing, Usage};
+
+lazy_static::lazy_static! {
+    static ref MODEL_PRICING: HashMap<String, Pricing> = {
+        let mut m = HashMap::new();
+        // Anthropic
+        m.insert("claude-3-5-sonnet-latest".to_string(), Pricing {
+            input_token_price: dec!(3),
+            output_token_price: dec!(15),
+        });
+        m.insert("claude-3-5-sonnet-20241022".to_string(), Pricing {
+            input_token_price: dec!(3),
+            output_token_price: dec!(15),
+        });
+        m.insert("anthropic.claude-3-5-sonnet-20241022-v2:0".to_string(), Pricing {
+            input_token_price: dec!(3),
+            output_token_price: dec!(15),
+        });
+        m.insert("claude-3-5-sonnet-20241022-v2:0".to_string(), Pricing {
+            input_token_price: dec!(3),
+            output_token_price: dec!(15),
+        });
+        m.insert("claude-3-5-sonnet-v2@20241022".to_string(), Pricing {
+            input_token_price: dec!(3),
+            output_token_price: dec!(15),
+        });
+        m.insert("claude-3-5-haiku-latest".to_string(), Pricing {
+            input_token_price: dec!(0.8),
+            output_token_price: dec!(4),
+        });
+        m.insert("claude-3-5-haiku-20241022".to_string(), Pricing {
+            input_token_price: dec!(0.8),
+            output_token_price: dec!(4),
+        });
+        m.insert("anthropic.claude-3-5-haiku-20241022-v1:0".to_string(), Pricing {
+            input_token_price: dec!(0.8),
+            output_token_price: dec!(4),
+        });
+        m.insert("claude-3-5-haiku@20241022".to_string(), Pricing {
+            input_token_price: dec!(0.8),
+            output_token_price: dec!(4),
+        });
+        m.insert("claude-3-opus-latest".to_string(), Pricing {
+            input_token_price: dec!(15.00),
+            output_token_price: dec!(75.00),
+        });
+        m.insert("claude-3-opus-20240229".to_string(), Pricing {
+            input_token_price: dec!(15.00),
+            output_token_price: dec!(75.00),
+        });
+        m.insert("anthropic.claude-3-opus-20240229-v1:0".to_string(), Pricing {
+            input_token_price: dec!(15.00),
+            output_token_price: dec!(75.00),
+        });
+        m.insert("claude-3-opus@20240229".to_string(), Pricing {
+            input_token_price: dec!(15.00),
+            output_token_price: dec!(75.00),
+        });
+        // OpenAI
+        m.insert("gpt-4o".to_string(), Pricing {
+            input_token_price: dec!(2.50),
+            output_token_price: dec!(10.00),
+        });
+        m.insert("gpt-4o-2024-11-20".to_string(), Pricing {
+            input_token_price: dec!(2.50),
+            output_token_price: dec!(10.00),
+        });
+        m.insert("gpt-4o-2024-08-06".to_string(), Pricing {
+            input_token_price: dec!(2.50),
+            output_token_price: dec!(10.00),
+        });
+        m.insert("gpt-4o-2024-05-13".to_string(), Pricing {
+            input_token_price: dec!(5.00),
+            output_token_price: dec!(15.00),
+        });
+        m.insert("gpt-4o-mini".to_string(), Pricing {
+            input_token_price: dec!(0.150),
+            output_token_price: dec!(0.600),
+        });
+        m.insert("gpt-4o-mini-2024-07-18".to_string(), Pricing {
+            input_token_price: dec!(0.150),
+            output_token_price: dec!(0.600),
+        });
+        m.insert("o1-preview".to_string(), Pricing {
+            input_token_price: dec!(15.00),
+            output_token_price: dec!(60.00),
+        });
+        m.insert("o1-preview-2024-09-12".to_string(), Pricing {
+            input_token_price: dec!(15.00),
+            output_token_price: dec!(60.00),
+        });
+        m.insert("o1-mini".to_string(), Pricing {
+            input_token_price: dec!(3.00),
+            output_token_price: dec!(12.00),
+        });
+        m.insert("o1-mini-2024-09-12".to_string(), Pricing {
+            input_token_price: dec!(3.00),
+            output_token_price: dec!(12.00),
+        });
+        m
+    };
+}
+
+pub fn model_pricing_for(model: &str) -> Option<Pricing> {
+    MODEL_PRICING.get(model).cloned()
+}
+
+pub fn cost(usage: &Usage, model_pricing: &Option<Pricing>) -> Option<Decimal> {
+    if let Some(model_pricing) = model_pricing {
+        let input_price = Decimal::from(usage.input_tokens.unwrap_or(0)) * model_pricing.input_token_price / Decimal::from(1_000_000);
+        let output_price = Decimal::from(usage.output_tokens.unwrap_or(0)) * model_pricing.output_token_price / Decimal::from(1_000_000);
+        Some(input_price + output_price)
+    } else {
+        None
+    }
+}

--- a/crates/goose/src/providers/model_pricing.rs
+++ b/crates/goose/src/providers/model_pricing.rs
@@ -112,8 +112,12 @@ pub fn model_pricing_for(model: &str) -> Option<Pricing> {
 
 pub fn cost(usage: &Usage, model_pricing: &Option<Pricing>) -> Option<Decimal> {
     if let Some(model_pricing) = model_pricing {
-        let input_price = Decimal::from(usage.input_tokens.unwrap_or(0)) * model_pricing.input_token_price / Decimal::from(1_000_000);
-        let output_price = Decimal::from(usage.output_tokens.unwrap_or(0)) * model_pricing.output_token_price / Decimal::from(1_000_000);
+        let input_price = Decimal::from(usage.input_tokens.unwrap_or(0))
+            * model_pricing.input_token_price
+            / Decimal::from(1_000_000);
+        let output_price = Decimal::from(usage.output_tokens.unwrap_or(0))
+            * model_pricing.output_token_price
+            / Decimal::from(1_000_000);
         Some(input_price + output_price)
     } else {
         None

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -1,7 +1,7 @@
-use super::base::{Provider, ProviderUsageCollector, Usage};
+use super::base::{Provider, ProviderUsage, Usage};
 use super::configs::OllamaProviderConfig;
 use super::utils::{
-    messages_to_openai_spec, openai_response_to_message, tools_to_openai_spec, ImageFormat,
+    get_model, messages_to_openai_spec, openai_response_to_message, tools_to_openai_spec, ImageFormat
 };
 use crate::message::Message;
 use anyhow::{anyhow, Result};
@@ -18,7 +18,6 @@ pub const OLLAMA_MODEL: &str = "qwen2.5";
 pub struct OllamaProvider {
     client: Client,
     config: OllamaProviderConfig,
-    usage_collector: ProviderUsageCollector,
 }
 
 impl OllamaProvider {
@@ -30,7 +29,6 @@ impl OllamaProvider {
         Ok(Self {
             client,
             config,
-            usage_collector: ProviderUsageCollector::new(),
         })
     }
 
@@ -90,7 +88,7 @@ impl Provider for OllamaProvider {
         system: &str,
         messages: &[Message],
         tools: &[Tool],
-    ) -> Result<(Message, Usage)> {
+    ) -> Result<(Message, ProviderUsage)> {
         let system_message = json!({
             "role": "system",
             "content": system
@@ -131,13 +129,10 @@ impl Provider for OllamaProvider {
         // Parse response
         let message = openai_response_to_message(response.clone())?;
         let usage = Self::get_usage(&response)?;
-        self.usage_collector.add_usage(usage.clone());
+        let model = get_model(&response);
+        let cost = None;
 
-        Ok((message, usage))
-    }
-
-    fn total_usage(&self) -> Usage {
-        self.usage_collector.get_usage()
+        Ok((message, ProviderUsage::new(model, usage, cost)))
     }
 }
 
@@ -207,15 +202,9 @@ mod tests {
         } else {
             panic!("Expected Text content");
         }
-        assert_eq!(usage.input_tokens, Some(12));
-        assert_eq!(usage.output_tokens, Some(15));
-        assert_eq!(usage.total_tokens, Some(27));
-
-        // Check total usage
-        let total = provider.total_usage();
-        assert_eq!(total.input_tokens, Some(12));
-        assert_eq!(total.output_tokens, Some(15));
-        assert_eq!(total.total_tokens, Some(27));
+        assert_eq!(usage.usage.input_tokens, Some(12));
+        assert_eq!(usage.usage.output_tokens, Some(15));
+        assert_eq!(usage.usage.total_tokens, Some(27));
 
         Ok(())
     }
@@ -284,15 +273,9 @@ mod tests {
             panic!("Expected ToolCall content");
         }
 
-        assert_eq!(usage.input_tokens, Some(63));
-        assert_eq!(usage.output_tokens, Some(70));
-        assert_eq!(usage.total_tokens, Some(133));
-
-        // Check total usage
-        let total = provider.total_usage();
-        assert_eq!(total.input_tokens, Some(63));
-        assert_eq!(total.output_tokens, Some(70));
-        assert_eq!(total.total_tokens, Some(133));
+        assert_eq!(usage.usage.input_tokens, Some(63));
+        assert_eq!(usage.usage.output_tokens, Some(70));
+        assert_eq!(usage.usage.total_tokens, Some(133));
 
         Ok(())
     }

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -1,7 +1,8 @@
 use super::base::{Provider, ProviderUsage, Usage};
 use super::configs::OllamaProviderConfig;
 use super::utils::{
-    get_model, messages_to_openai_spec, openai_response_to_message, tools_to_openai_spec, ImageFormat
+    get_model, messages_to_openai_spec, openai_response_to_message, tools_to_openai_spec,
+    ImageFormat,
 };
 use crate::message::Message;
 use anyhow::{anyhow, Result};
@@ -26,10 +27,7 @@ impl OllamaProvider {
             .timeout(Duration::from_secs(600)) // 10 minutes timeout
             .build()?;
 
-        Ok(Self {
-            client,
-            config,
-        })
+        Ok(Self { client, config })
     }
 
     fn get_usage(data: &Value) -> Result<Usage> {

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -5,8 +5,12 @@ use reqwest::StatusCode;
 use serde_json::{json, Value};
 use std::time::Duration;
 
-use super::base::{Provider, ProviderUsageCollector, Usage};
+use super::base::ProviderUsage;
+use super::base::{Provider, Usage};
 use super::configs::OpenAiProviderConfig;
+use super::model_pricing::model_pricing_for;
+use super::model_pricing::cost;
+use super::utils::get_model;
 use super::utils::{
     check_openai_context_length_error, messages_to_openai_spec, openai_response_to_message,
     tools_to_openai_spec, ImageFormat,
@@ -17,7 +21,6 @@ use mcp_core::tool::Tool;
 pub struct OpenAiProvider {
     client: Client,
     config: OpenAiProviderConfig,
-    usage_collector: ProviderUsageCollector,
 }
 
 impl OpenAiProvider {
@@ -29,7 +32,6 @@ impl OpenAiProvider {
         Ok(Self {
             client,
             config,
-            usage_collector: ProviderUsageCollector::new(),
         })
     }
 
@@ -96,7 +98,7 @@ impl Provider for OpenAiProvider {
         system: &str,
         messages: &[Message],
         tools: &[Tool],
-    ) -> Result<(Message, Usage)> {
+    ) -> Result<(Message, ProviderUsage)> {
         // Not checking for o1 model here since system message is not supported by o1
         let system_message = json!({
             "role": "system",
@@ -155,13 +157,10 @@ impl Provider for OpenAiProvider {
         // Parse response
         let message = openai_response_to_message(response.clone())?;
         let usage = Self::get_usage(&response)?;
-        self.usage_collector.add_usage(usage.clone());
+        let model = get_model(&response);
+        let cost = cost(&usage, &model_pricing_for(&model));
 
-        Ok((message, usage))
-    }
-
-    fn total_usage(&self) -> Usage {
-        self.usage_collector.get_usage()
+        Ok((message, ProviderUsage::new(model, usage, cost)))
     }
 }
 
@@ -169,6 +168,7 @@ impl Provider for OpenAiProvider {
 mod tests {
     use super::*;
     use crate::message::MessageContent;
+    use rust_decimal_macros::dec;
     use serde_json::json;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
@@ -213,7 +213,8 @@ mod tests {
                 "prompt_tokens": 12,
                 "completion_tokens": 15,
                 "total_tokens": 27
-            }
+            },
+            "model": "gpt-4o"
         });
 
         let (_, provider) = _setup_mock_server(response_body).await;
@@ -232,15 +233,11 @@ mod tests {
         } else {
             panic!("Expected Text content");
         }
-        assert_eq!(usage.input_tokens, Some(12));
-        assert_eq!(usage.output_tokens, Some(15));
-        assert_eq!(usage.total_tokens, Some(27));
-
-        // Check total usage
-        let total = provider.total_usage();
-        assert_eq!(total.input_tokens, Some(12));
-        assert_eq!(total.output_tokens, Some(15));
-        assert_eq!(total.total_tokens, Some(27));
+        assert_eq!(usage.usage.input_tokens, Some(12));
+        assert_eq!(usage.usage.output_tokens, Some(15));
+        assert_eq!(usage.usage.total_tokens, Some(27));
+        assert_eq!(usage.model, "gpt-4o");
+        assert_eq!(usage.cost, Some(dec!(0.00018)));
 
         Ok(())
     }
@@ -312,9 +309,9 @@ mod tests {
             panic!("Expected ToolCall content");
         }
 
-        assert_eq!(usage.input_tokens, Some(20));
-        assert_eq!(usage.output_tokens, Some(15));
-        assert_eq!(usage.total_tokens, Some(35));
+        assert_eq!(usage.usage.input_tokens, Some(20));
+        assert_eq!(usage.usage.output_tokens, Some(15));
+        assert_eq!(usage.usage.total_tokens, Some(35));
 
         Ok(())
     }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -8,8 +8,8 @@ use std::time::Duration;
 use super::base::ProviderUsage;
 use super::base::{Provider, Usage};
 use super::configs::OpenAiProviderConfig;
-use super::model_pricing::model_pricing_for;
 use super::model_pricing::cost;
+use super::model_pricing::model_pricing_for;
 use super::utils::get_model;
 use super::utils::{
     check_openai_context_length_error, messages_to_openai_spec, openai_response_to_message,
@@ -29,10 +29,7 @@ impl OpenAiProvider {
             .timeout(Duration::from_secs(600)) // 10 minutes timeout
             .build()?;
 
-        Ok(Self {
-            client,
-            config,
-        })
+        Ok(Self { client, config })
     }
 
     fn get_usage(data: &Value) -> Result<Usage> {

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -274,6 +274,19 @@ pub fn check_bedrock_context_length_error(error: &Value) -> Option<ContextLength
     }
 }
 
+/// Extract the model name from a JSON object. Common with most providers to have this top level attribute.
+pub fn get_model(data: &Value) -> String {
+    if let Some(model) = data.get("model") {
+        if let Some(model_str) = model.as_str() {
+            model_str.to_string()
+        } else {
+            "Unknown".to_string()
+        }
+    } else {
+        "Unknown".to_string()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Adds cost to session.log. We can update the format later just getting the data piped through.
```json
{"session_file":"~/.config/goose/sessions/yoyqaq3e.jsonl","usage":[{"model":"claude-3-5-sonnet-20241022-v2:0","usage":{"input_tokens":2067,"output_tokens":204,"total_tokens":2271},"cost":"0.009261"}]}
{"session_file":"~/.config/goose/sessions/hao4empo.jsonl","usage":[{"model":"gpt-4o-2024-08-06","usage":{"input_tokens":2749,"output_tokens":41,"total_tokens":2790},"cost":"0.0072825"}]}
```

### Changes
Adds costs for models.

Instead of providers collecting usage and the agent asking for it, the provider returns usage (as it already did) to the agent along with the cost on each 'complete' call. The agent collects all usages (which now includes cost). This keeps providers with less state and also makes it trivial for the agent to collect usage from different providers/models if we ever head back down that path.

```
pub struct ProviderUsage {
    pub model: String,
    pub usage: Usage,
    pub cost: Option<Decimal>,
}
```