### PR TITLE
docs: Add using goose free guide

### DIFF
--- a/docs/guidance/using-goose-free.md
+++ b/docs/guidance/using-goose-free.md
@@ -1,0 +1,39 @@
+# Using Goose for Free
+
+Goose is a free and open-source developer agent that you can start using right away, but not all supported [LLM Providers][providers] provide a free tier. 
+
+Below, we outline a couple of free options and how to get started with them.
+
+
+## Google Gemini
+Google Gemini provides free access to its AI capabilities with some limitations. To start using the Gemini API with Goose, you need an API Key from [Google AI studio](https://aistudio.google.com/app/apikey).
+
+Update your `~/.config/goose/profiles.yaml` file with the following configuration:
+
+```yaml title="profiles.yaml"
+default:
+  provider: google
+  processor: gemini-1.5-flash
+  accelerator: gemini-1.5-flash
+  moderator: passive
+  toolkits:
+  - name: developer
+    requires: {}
+```
+
+Note: At the moment, the `synopsis` toolkit isn't supported by Google Gemini, so we use the `developer` toolkit to interact with the API. 
+
+When you run `goose session start`, you will be prompted to enter your Google API Key.
+
+
+
+## Limitations
+
+These free options are a great way to get started with Goose and explore its capabilities. However, if you need more advanced features or higher usage limits, you can always upgrade to a paid plan.
+
+---
+
+This guide will continue to be updated with more free options as they become available. If you have any questions or need help with a specific provider, feel free to reach out to us on the [Goose repo](https://github.com/block/goose) or on [Discord](https://discord.gg/block-opensource).
+
+[providers]: https://block.github.io/goose/plugins/providers.html
+```

--- a/docs/guidance/using-goose-free.md
+++ b/docs/guidance/using-goose-free.md
@@ -21,9 +21,12 @@ default:
     requires: {}
 ```
 
-Note: At the moment, the `synopsis` toolkit isn't supported by Google Gemini, so we use the `developer` toolkit to interact with the API. 
-
 When you run `goose session start`, you will be prompted to enter your Google API Key.
+
+> [!NOTE] 
+> At the moment, the `synopsis` toolkit isn't supported by Google Gemini, so we use the `developer` toolkit to interact with the API. 
+
+
 
 
 
@@ -33,7 +36,7 @@ These free options are a great way to get started with Goose and explore its cap
 
 ---
 
-This guide will continue to be updated with more free options as they become available. If you have any questions or need help with a specific provider, feel free to reach out to us on the [Goose repo](https://github.com/block/goose) or on [Discord](https://discord.gg/block-opensource).
+This guide will continue to be updated with more free options as they become available. If you have any questions or need help with a specific provider, feel free to reach out to us on [Discord](https://discord.gg/block-opensource) or on the [Goose repo](https://github.com/block/goose).
+
 
 [providers]: https://block.github.io/goose/plugins/providers.html
-```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -119,6 +119,7 @@ nav:
   - "Contributing": contributing.md
   - Guides:
       - "Getting Started": guidance/getting-started.md
+      - "Using Goose for Free": guidance/using-goose-free.md
       - "Managing Goose Sessions": guidance/managing-goose-sessions.md
       - "Quick Tips": guidance/tips.md
       - "Using Goosehints": guidance/using-goosehints.md


### PR DESCRIPTION
This pull request includes a new guide on using Goose for free and updates the navigation in the documentation to include this new guide.

Documentation updates:

* [`docs/guidance/using-goose-free.md`](diffhunk://#diff-06cc60c11c3e49f13ed3369e19d986eb5551045f1d7dfff023c2d5404efc9ec6R1-R39): Added a new guide detailing how to use Goose for free, including instructions for using Google Gemini and noting current limitations.
* [`mkdocs.yml`](diffhunk://#diff-98d0f806abc9af24e6a7c545d3d77e8f9ad57643e27211d7a7b896113e420ed2R122): Updated the navigation to include the new "Using Goose for Free" guide under the Guides section.