### PR TITLE
Newline in cli

### DIFF
--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -9,7 +9,7 @@ use super::{
 use anyhow::Result;
 use cliclack::spinner;
 use goose::message::Message;
-use rustyline::DefaultEditor;
+use rustyline::{DefaultEditor, EventHandler, KeyCode, KeyEvent, Modifiers};
 
 const PROMPT: &str = "\x1b[1m\x1b[38;5;30m( O)> \x1b[0m";
 
@@ -31,7 +31,11 @@ impl RustylinePrompt {
             Box::new(bash_dev_system_renderer),
         );
 
-        let editor = DefaultEditor::new().expect("Failed to create editor");
+        let mut editor = DefaultEditor::new().expect("Failed to create editor");
+        editor.bind_sequence(
+            KeyEvent(KeyCode::Char('j'), Modifiers::CTRL),
+            EventHandler::Simple(rustyline::Cmd::Newline),
+        );
 
         RustylinePrompt {
             spinner: spinner(),
@@ -118,6 +122,7 @@ impl Prompt for RustylinePrompt {
             println!("/t - Toggle Light/Dark theme");
             println!("/? | /help - Display this help message");
             println!("Ctrl+C - Interrupt goose (resets the interaction to before the interrupted user request)");
+            println!("Ctrl+j - Adds a newline");
             println!("Use Up/Down arrow keys to navigate through command history");
             return Ok(Input {
                 input_type: InputType::AskAgain,


### PR DESCRIPTION
I tried all sorts of modifiers with ENTER and couldn't get any to work. We could implement it so if line ends with `\` and enter is pressed it adds a newline but its a bit fragile given its only for the last line.

Therefore I ended up with Ctrl+j which is 'linefeed' generally speaking. So it adds a newline wherever you are you can navigate anywhere with the arrow keys, you can also delete the new lines as needed so its a pretty good experience. The problem is knowing that 'Ctrl+j' is the shortcut to use. I added it to the help section but its the best option I've come across at the moment.