### PR TITLE
Adds 'instructions' field to InitializeResult

### DIFF
--- a/crates/mcp-core/src/protocol.rs
+++ b/crates/mcp-core/src/protocol.rs
@@ -147,6 +147,8 @@ pub struct InitializeResult {
     pub protocol_version: String,
     pub capabilities: ServerCapabilities,
     pub server_info: Implementation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -44,6 +44,10 @@ impl CounterRouter {
 }
 
 impl Router for CounterRouter {
+    fn instructions(&self) -> String {
+        "This server provides a counter tool that can increment and decrement values. The counter starts at 0 and can be modified using the 'increment' and 'decrement' tools. Use 'get_value' to check the current count.".to_string()
+    }
+
     fn capabilities(&self) -> ServerCapabilities {
         CapabilitiesBuilder::new().with_tools(true).build()
     }

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -78,6 +78,8 @@ impl CapabilitiesBuilder {
 }
 
 pub trait Router: Send + Sync + 'static {
+    // in the protocol, instructions are optional but we make it required
+    fn instructions(&self) -> String;
     fn capabilities(&self) -> ServerCapabilities;
     fn list_tools(&self) -> Vec<mcp_core::tool::Tool>;
     fn call_tool(
@@ -113,6 +115,7 @@ pub trait Router: Send + Sync + 'static {
                     name: "mcp-server".to_string(),
                     version: env!("CARGO_PKG_VERSION").to_string(),
                 },
+                instructions: Some(self.instructions()),
             };
 
             let mut response = self.create_response(req.id);


### PR DESCRIPTION
Instructions describe how to use the server and its features - its part of the initialization phase
https://github.com/modelcontextprotocol/specification/blob/8008e38dc7180acdc95dc6762ea6b92a7976f174/schema/schema.ts#L175

in the protocol, instructions are optional but we make it required in this sdk
