### PR TITLE
fix: Make stop button more obvious

### DIFF
--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -119,7 +119,7 @@ export default function Input({
           size="icon"
           variant="ghost"
           onClick={onStop}
-          className="absolute right-2 top-1/2 -translate-y-1/2 bg-indigo-100 dark:bg-white text-indigo-600 hover:opacity-50"
+          className="absolute right-2 top-1/2 -translate-y-1/2 bg-indigo-100 dark:bg-indigo-800 dark:text-indigo-200 text-indigo-600 hover:opacity-50"
         >
           <Stop size={24} />
         </Button>

--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -119,7 +119,7 @@ export default function Input({
           size="icon"
           variant="ghost"
           onClick={onStop}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-indigo-600 hover:text-indigo-700 hover:bg-indigo-100"
+          className="absolute right-2 top-1/2 -translate-y-1/2 bg-indigo-100 dark:bg-white text-indigo-600 hover:text-indigo-700 hover:opacity-50"
         >
           <Stop size={24} />
         </Button>

--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -119,7 +119,7 @@ export default function Input({
           size="icon"
           variant="ghost"
           onClick={onStop}
-          className="absolute right-2 top-1/2 -translate-y-1/2 bg-indigo-100 dark:bg-white text-indigo-600 hover:text-indigo-700 hover:opacity-50"
+          className="absolute right-2 top-1/2 -translate-y-1/2 bg-indigo-100 dark:bg-white text-indigo-600 hover:opacity-50"
         >
           <Stop size={24} />
         </Button>


### PR DESCRIPTION
In the [Goose UI improvements list ](https://docs.google.com/document/d/1vRTSvTGejzLHM6t6SBxN74iABpPaWa6vQ72tvaUExek/edit?usp=sharing), there's a task to make the stop button more obvious, so I:

- Added a visible background to the stop button in both light and dark modes
- Added hover state for better interaction feedback
**Let me know if I should modify the colors**

### Light Mode
#### Default: 
 Light indigo background (`bg-indigo-100`) with indigo text (`text-indigo-600`)
<img width="566" alt="Screenshot 2024-12-21 at 2 15 55 AM" src="https://github.com/user-attachments/assets/464beb15-50bf-41e4-90c2-0af5473a2143" />
#### Hover: 
Reduced opacity (`hover:opacity-50`)
<img width="578" alt="Screenshot 2024-12-21 at 2 17 46 AM" src="https://github.com/user-attachments/assets/c95364b6-c09e-49ce-a523-253fb753c205" />


### Dark Mode
#### Default: 
Indigo background (`dark:bg-indigo-800`) with light indigo text `text-indigo-200`
<img width="273" alt="Screenshot 2024-12-21 at 4 26 47 PM" src="https://github.com/user-attachments/assets/ea0bd8b8-91ea-446c-8999-bf85453bc421" />

#### Hover: 
Reduced opacity (`hover:opacity-50`)
<img width="567" alt="Screenshot 2024-12-21 at 4 27 35 PM" src="https://github.com/user-attachments/assets/e071ce6b-a608-45c1-ad91-0bdbc8fd7cdf" />




