### PR TITLE
fix: Broken open directory and new session buttons in more menu

### DIFF
--- a/ui/desktop/src/components/MoreMenu.tsx
+++ b/ui/desktop/src/components/MoreMenu.tsx
@@ -87,13 +87,19 @@ export default function MoreMenu() {
                         </button>
                     </div>)}
                     <button
-                        onClick={() => handleAction(window.electron.directoryChooser)}
+                        onClick={() => {
+                            setOpen(false);
+                            window.electron.directoryChooser();
+                        }}
                         className="w-full text-left px-2 py-1.5 text-sm"
                     >
                         Open Directory (cmd+O)
                     </button>
                     <button
-                        onClick={() => handleAction(window.electron.createChatWindow)}
+                        onClick={() => {
+                            setOpen(false);
+                            window.electron.createChatWindow();
+                        }}
                         className="w-full text-left px-2 py-1.5 text-sm"
                     >
                         New Session (cmd+N)


### PR DESCRIPTION
### BEFORE
Choosing Open Directory or New Session in the More Menu was not working because `handleAction` is not defined.

https://github.com/user-attachments/assets/1319a61d-adab-460f-87b4-3e7e330b3c41


### AFTER
 
Remove handleAction from the onClick because that wrapper is unnecessary, so now it works.

https://github.com/user-attachments/assets/1af8f3af-58ed-4184-bdd7-3b916f8bbf82



