### PR TITLE
instructions clearly explain what a developer can do with shell

### DIFF
--- a/crates/goose/src/developer.rs
+++ b/crates/goose/src/developer.rs
@@ -234,7 +234,8 @@ impl DeveloperSystem {
 
         let instructions = formatdoc! {r#"
             The developer system is loaded in the directory listed below.
-            You can use the shell tool to run any command that would work on the relevant operating system, such as api calls, web access/crawling and other things a developer would do from a command line.            
+            You can use the shell tool to run any command that would work on the relevant operating system, 
+            such as api calls, web access/crawling and other things a developer would do from a command line.
             Use the shell tool as needed to locate files or interact with the project. Only files
             that have been read or modified using the edit tools will show up in the active files list.
 

--- a/crates/goose/src/developer.rs
+++ b/crates/goose/src/developer.rs
@@ -234,7 +234,7 @@ impl DeveloperSystem {
 
         let instructions = formatdoc! {r#"
             The developer system is loaded in the directory listed below.
-            You can use the shell tool to run any command that would work on the relevant operating system.
+            You can use the shell tool to run any command that would work on the relevant operating system, such as api calls, web access/crawling and other things a developer would do from a command line.            
             Use the shell tool as needed to locate files or interact with the project. Only files
             that have been read or modified using the edit tools will show up in the active files list.
 


### PR DESCRIPTION
in some cases goose won't know it can do what it can do, this is a tiny tweak to let it know it can. 

eg:
asking "please provide the websites for the following businesses listed next to their name:"

and then a list of names (in seperate message) will produce:

![image](https://github.com/user-attachments/assets/383b305d-2d4e-4aef-86d6-c266e77897bd)

Now it knows to work it out.
