### PR TITLE
Add Databricks moderation

### DIFF
--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -168,7 +168,10 @@ impl ProtocolFormatter {
     fn format_moderation_error(error: &ModerationError) -> String {
         let error_part = match error {
             ModerationError::ContentFlagged { categories, .. } => {
-                format!("Content was flagged in the following categories: {}", categories)
+                format!(
+                    "Content was flagged in the following categories: {}",
+                    categories
+                )
             }
         };
         format!("3:{}\n", error_part)
@@ -209,7 +212,8 @@ async fn stream_message(
                         }
                         Err(err) => {
                             // Send an error message first
-                            tx.send(ProtocolFormatter::format_error(&err.to_string())).await?;
+                            tx.send(ProtocolFormatter::format_error(&err.to_string()))
+                                .await?;
                             // Then send an empty tool response to maintain the protocol
                             let result = vec![Content::text("Error occurred").with_priority(0.0)];
                             tx.send(ProtocolFormatter::format_tool_response(
@@ -238,7 +242,8 @@ async fn stream_message(
                             Err(err) => {
                                 println!("Error: {}", err);
                                 // Send error message for invalid tool call
-                                tx.send(ProtocolFormatter::format_error(&err.to_string())).await?;
+                                tx.send(ProtocolFormatter::format_error(&err.to_string()))
+                                    .await?;
                                 // Send a placeholder tool call to maintain protocol
                                 tx.send(ProtocolFormatter::format_tool_call(
                                     &request.id,
@@ -302,10 +307,14 @@ async fn handler(
                 tracing::error!("Failed to start reply stream: {}", e);
                 // Check if it's a moderation error
                 if let Some(moderation_error) = e.downcast_ref::<ModerationError>() {
-                    let _ = tx.send(ProtocolFormatter::format_moderation_error(moderation_error)).await;
+                    let _ = tx
+                        .send(ProtocolFormatter::format_moderation_error(moderation_error))
+                        .await;
                 } else {
                     // Send a generic error message
-                    let _ = tx.send(ProtocolFormatter::format_error(&e.to_string())).await;
+                    let _ = tx
+                        .send(ProtocolFormatter::format_error(&e.to_string()))
+                        .await;
                 }
                 // Send a finish message with error as the reason
                 let _ = tx.send(ProtocolFormatter::format_finish("error")).await;

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -174,7 +174,7 @@ impl ProtocolFormatter {
                 )
             }
         };
-        format!("3:{}\n", error_part)
+        format!("3:\"{}\"\n", error_part)
     }
 
     fn format_finish(reason: &str) -> String {
@@ -215,7 +215,7 @@ async fn stream_message(
                             tx.send(ProtocolFormatter::format_error(&err.to_string()))
                                 .await?;
                             // Then send an empty tool response to maintain the protocol
-                            let result = vec![Content::text("Error occurred").with_priority(0.0)];
+                            let result = vec![Content::text(format!("Error: {}", err)).with_priority(0.0)];
                             tx.send(ProtocolFormatter::format_tool_response(
                                 &response.id,
                                 &result,
@@ -240,10 +240,6 @@ async fn stream_message(
                                 .await?;
                             }
                             Err(err) => {
-                                println!("Error: {}", err);
-                                // Send error message for invalid tool call
-                                tx.send(ProtocolFormatter::format_error(&err.to_string()))
-                                    .await?;
                                 // Send a placeholder tool call to maintain protocol
                                 tx.send(ProtocolFormatter::format_tool_call(
                                     &request.id,

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -307,6 +307,7 @@ async fn handler(
                     let _ = tx
                         .send(ProtocolFormatter::format_moderation_error(moderation_error))
                         .await;
+                    // Kill the stream since we encountered a moderation error
                 } else {
                     // Send a generic error message
                     let _ = tx

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -9,10 +9,10 @@ use axum::{
 use bytes::Bytes;
 use futures::{stream::StreamExt, Stream};
 use goose::message::{Message, MessageContent};
-use goose::providers::base::{Moderation, ModerationError, ModerationResult};
+use goose::providers::base::ModerationError;
 use mcp_core::{content::Content, role::Role};
 use serde::Deserialize;
-use serde_json::{error, json, Value};
+use serde_json::{json, Value};
 use std::{
     convert::Infallible,
     pin::Pin,
@@ -215,7 +215,8 @@ async fn stream_message(
                             tx.send(ProtocolFormatter::format_error(&err.to_string()))
                                 .await?;
                             // Then send an empty tool response to maintain the protocol
-                            let result = vec![Content::text(format!("Error: {}", err)).with_priority(0.0)];
+                            let result =
+                                vec![Content::text(format!("Error: {}", err)).with_priority(0.0)];
                             tx.send(ProtocolFormatter::format_tool_response(
                                 &response.id,
                                 &result,
@@ -546,9 +547,9 @@ mod tests {
 
         // Test error formatting
         let formatted = ProtocolFormatter::format_error("Test error");
+        println!("Formatted error: {}", formatted);
         assert!(formatted.starts_with("3:"));
-        assert!(formatted.contains("\"message\":\"Test error\""));
-        assert!(formatted.contains("\"code\":\"server_error\""));
+        assert!(formatted.contains("Test error"));
 
         // Test moderation error formatting
         let moderation_error = ModerationError::ContentFlagged {
@@ -560,9 +561,8 @@ mod tests {
         };
         let formatted = ProtocolFormatter::format_moderation_error(&moderation_error);
         assert!(formatted.starts_with("3:"));
-        assert!(formatted.contains("\"code\":\"content_flagged\""));
-        assert!(formatted.contains("\"categories\":\"hate, violence\""));
-        assert!(formatted.contains("\"categoryScores\""));
+        assert!(formatted
+            .contains("\"Content was flagged in the following categories: hate, violence\""));
 
         // Test finish formatting
         let formatted = ProtocolFormatter::format_finish("stop");

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -169,7 +169,7 @@ impl ProtocolFormatter {
         let error_part = match error {
             ModerationError::ContentFlagged { categories, .. } => {
                 format!(
-                    "Content was flagged in the following categories: {}",
+                    "Content was flagged by moderation in the following categories: {}",
                     categories
                 )
             }
@@ -561,9 +561,11 @@ mod tests {
             })),
         };
         let formatted = ProtocolFormatter::format_moderation_error(&moderation_error);
+        println!("{}", formatted);
         assert!(formatted.starts_with("3:"));
-        assert!(formatted
-            .contains("\"Content was flagged in the following categories: hate, violence\""));
+        assert!(
+            formatted.contains("Content was flagged by moderation in the following categories:")
+        );
 
         // Test finish formatting
         let formatted = ProtocolFormatter::format_finish("stop");

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -4,9 +4,9 @@ use rust_decimal::Decimal;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
+use thiserror::Error;
 use tokio::select;
 use tokio::sync::RwLock;
-use thiserror::Error;
 
 use super::configs::ModelConfig;
 use crate::message::{Message, MessageContent};
@@ -19,7 +19,7 @@ pub enum ModerationError {
     ContentFlagged {
         categories: String,
         category_scores: Option<serde_json::Value>,
-    }
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -6,11 +6,21 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::select;
 use tokio::sync::RwLock;
+use thiserror::Error;
 
 use super::configs::ModelConfig;
 use crate::message::{Message, MessageContent};
 use mcp_core::role::Role;
 use mcp_core::tool::Tool;
+
+#[derive(Error, Debug)]
+pub enum ModerationError {
+    #[error("Content was flagged for moderation in categories: {categories}")]
+    ContentFlagged {
+        categories: String,
+        category_scores: Option<serde_json::Value>,
+    }
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProviderUsage {
@@ -197,10 +207,10 @@ pub trait Provider: Send + Sync + Moderation {
                     let categories = result.categories
                         .unwrap_or_else(|| vec!["unknown".to_string()])
                         .join(", ");
-                    return Err(anyhow::anyhow!(
-                        "Content was flagged for moderation in categories: {}",
-                        categories
-                    ));
+                    return Err(ModerationError::ContentFlagged {
+                        categories,
+                        category_scores: result.category_scores,
+                    }.into());
                 }
 
                 // Moderation passed, wait for completion
@@ -215,10 +225,10 @@ pub trait Provider: Send + Sync + Moderation {
                     let categories = moderation_result.categories
                         .unwrap_or_else(|| vec!["unknown".to_string()])
                         .join(", ");
-                    return Err(anyhow::anyhow!(
-                        "Content was flagged for moderation in categories: {}",
-                        categories
-                    ));
+                    return Err(ModerationError::ContentFlagged {
+                        categories,
+                        category_scores: moderation_result.category_scores,
+                    }.into());
                 }
 
                 Ok(completion_result)
@@ -338,10 +348,8 @@ mod tests {
         let result = provider.complete("system", &[test_message], &[]).await;
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Content was flagged"));
+        let err = result.unwrap_err();
+        assert!(err.downcast_ref::<ModerationError>().is_some());
     }
 
     #[tokio::test]
@@ -407,10 +415,8 @@ mod tests {
         let result = provider.complete("system", &[test_message], &[]).await;
 
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Content was flagged"));
+        let err = result.unwrap_err();
+        assert!(err.downcast_ref::<ModerationError>().is_some());
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -158,7 +158,7 @@ impl Moderation for DatabricksProvider {
         );
 
         let auth_header = self.ensure_auth_header().await?;
-        let payload = json!({            
+        let payload = json!({
             "messages": [
                 {
                     "role": "user",

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -369,9 +369,9 @@ mod tests {
     use super::*;
 
     use crate::providers::mock_server::{
-        create_mock_google_ai_response, create_mock_google_ai_response_with_tools,
-        create_test_tool, get_expected_function_call_arguments, setup_mock_server,
-        TEST_INPUT_TOKENS, TEST_OUTPUT_TOKENS, TEST_TOOL_FUNCTION_NAME, TEST_TOTAL_TOKENS,
+        create_mock_google_ai_response_with_tools, create_test_tool,
+        get_expected_function_call_arguments, setup_mock_server, TEST_INPUT_TOKENS,
+        TEST_OUTPUT_TOKENS, TEST_TOOL_FUNCTION_NAME, TEST_TOTAL_TOKENS,
     };
     use wiremock::MockServer;
 

--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -1,21 +1,21 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { Message, useChat } from './ai-sdk-fork/useChat';
-import { Route, Routes, Navigate } from 'react-router-dom';
-import { getApiUrl } from './config';
+import { ApiKeyWarning } from './components/ApiKeyWarning';
+import BottomMenu from './components/BottomMenu';
+import FlappyGoose from './components/FlappyGoose';
+import GooseMessage from './components/GooseMessage';
+import Input from './components/Input';
+import LoadingGoose from './components/LoadingGoose';
+import MoreMenu from './components/MoreMenu';
+import Splash from './components/Splash';
 import { Card } from './components/ui/card';
 import { ScrollArea } from './components/ui/scroll-area';
-import Splash from './components/Splash';
-import GooseMessage from './components/GooseMessage';
 import UserMessage from './components/UserMessage';
-import Input from './components/Input';
-import MoreMenu from './components/MoreMenu';
-import BottomMenu from './components/BottomMenu';
-import LoadingGoose from './components/LoadingGoose';
-import { ApiKeyWarning } from './components/ApiKeyWarning';
-import { askAi } from './utils/askAI';
-import WingToWing, { Working } from './components/WingToWing';
 import { WelcomeScreen } from './components/WelcomeScreen';
-import FlappyGoose from './components/FlappyGoose';
+import WingToWing, { Working } from './components/WingToWing';
+import { getApiUrl } from './config';
+import { askAi } from './utils/askAI';
 
 // update this when you want to show the welcome screen again - doesn't have to be an actual version, just anything woudln't have been seen before
 const CURRENT_VERSION = '0.0.0';
@@ -89,16 +89,6 @@ function ChatContent({
       if (!response.ok) {
         setProgressMessage('An error occurred while receiving the response.');
         updateWorking(Working.Idle);
-        
-        // Check if this is a moderation error
-        if (response.status === 400) {
-          response.json().then(data => {
-            if (data.error && data.error.includes('moderation')) {
-              // Kill the goosed process for moderation violations
-              window.electron.stopGooseProcess();
-            }
-          });
-        }
       } else {
         setProgressMessage('thinking...');
         updateWorking(Working.Working);

--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -89,6 +89,16 @@ function ChatContent({
       if (!response.ok) {
         setProgressMessage('An error occurred while receiving the response.');
         updateWorking(Working.Idle);
+        
+        // Check if this is a moderation error
+        if (response.status === 400) {
+          response.json().then(data => {
+            if (data.error && data.error.includes('moderation')) {
+              // Kill the goosed process for moderation violations
+              window.electron.stopGooseProcess();
+            }
+          });
+        }
       } else {
         setProgressMessage('thinking...');
         updateWorking(Working.Working);


### PR DESCRIPTION
Add moderation for Databricks provider. 

For moderation in Databricks, there is some setup required for end users. Users will need to create an external endpoint called `moderation`. This endpoint needs to have guardrails enabled through AI Gateway, with a minimum of the `input safety` box checked. Other guardrails like pii and keywords can also be enabled. Only user messages will be sent to this endpoint, not the whole history, but it's good practice to pick the cheapest/fastest model to minimize latency and cost.


This PR also adds ModerationError and updates the reply method in goose-server to add ErrorPart's for the Vercel protocol, which gets used for moderation errors. 