### PR TITLE
[app] Conditionally start goosed based on valid config

### DIFF
--- a/ui/desktop/src/components/ApiKeyWarning.tsx
+++ b/ui/desktop/src/components/ApiKeyWarning.tsx
@@ -64,7 +64,7 @@ export function ApiKeyWarning({ className }: ApiKeyWarningProps) {
         <Bird />
       </div>
       <div className="text-center space-y-4 max-w-2xl w-full">
-        <h2 className="text-2xl font-semibold text-gray-800">API Key Required</h2>
+        <h2 className="text-2xl font-semibold text-gray-800">Credentials Required</h2>
         <p className="text-gray-600 mb-4">
           To use Goose, you need to set environment variables for one of the following providers:
         </p>
@@ -94,8 +94,7 @@ export function ApiKeyWarning({ className }: ApiKeyWarningProps) {
             </pre>
           </Collapsible>
         </div>
-
-        <p className="text-sm text-gray-500 mt-4">
+        <p className="text-gray-600 mt-4">
           After setting these variables, restart Goose for the changes to take effect.
         </p>
       </div>

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -35,23 +35,20 @@ const parseArgs = () => {
 };
 
 const checkApiCredentials = () => {
-
   loadZshEnv(app.isPackaged);
 
-  //{env-macro-start}//    
   const apiKeyProvidersValid =
-  ['openai', 'anthropic', 'google', 'groq', 'openrouter'].includes(process.env.GOOSE_PROVIDER__TYPE) &&
-    process.env.GOOSE_PROVIDER__HOST &&
-    process.env.GOOSE_PROVIDER__MODEL &&
-    process.env.GOOSE_PROVIDER__API_KEY;
-    
+    ['openai', 'anthropic', 'google', 'groq', 'openrouter'].includes(process.env.GOOSE_PROVIDER__TYPE) &&
+      process.env.GOOSE_PROVIDER__HOST &&
+      process.env.GOOSE_PROVIDER__MODEL &&
+      process.env.GOOSE_PROVIDER__API_KEY;
+
   const optionalApiKeyProvidersValid =
     ['ollama', 'databricks'].includes(process.env.GOOSE_PROVIDER__TYPE) &&
-    process.env.GOOSE_PROVIDER__HOST &&
-    process.env.GOOSE_PROVIDER__MODEL;    
+      process.env.GOOSE_PROVIDER__HOST &&
+      process.env.GOOSE_PROVIDER__MODEL;
 
-  return apiKeyProvidersValid|| optionalApiKeyProvidersValid;
-  //{env-macro-end}//
+  return apiKeyProvidersValid || optionalApiKeyProvidersValid;
 };
 
 const generateSecretKey = () => {
@@ -119,7 +116,15 @@ const createChat = async (app, query?: string, dir?: string) => {
   // Apply current environment settings before creating chat
   updateEnvironmentVariables(envToggles);
 
-  const [port, working_dir] = await startGoosed(app, dir);  
+  const maybeStartGoosed = async () => {
+    if (checkApiCredentials()) {
+      return startGoosed(app, dir);
+    } else {
+      return [0, ''];
+    }
+  }
+
+  const [port, working_dir] = await maybeStartGoosed();
   const mainWindow = new BrowserWindow({
     titleBarStyle: 'hidden',
     trafficLightPosition: { x: 16, y: 10 },

--- a/ui/desktop/src/utils/binaryPath.ts
+++ b/ui/desktop/src/utils/binaryPath.ts
@@ -1,4 +1,5 @@
 import path from 'node:path';
+import Electron from 'electron';
 
 export const getBinaryPath = (app: Electron.App, binaryName: string): string => {
   const isDev = process.env.NODE_ENV === 'development';


### PR DESCRIPTION
`goosed` bombs now without valid config, so this change conditionally starts `goosed` based on the presence of valid config. It fixes the app from crash looping without launching a window, and instead now shows the "Credentials Needed" screen as expected.