### PR TITLE
fix: check server capability when client sends requests

### DIFF
--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -1,9 +1,6 @@
-use mcp_core::protocol::ListResourcesResult;
 use rust_decimal_macros::dec;
-use tokio::time::timeout;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Duration;
 use tokio::sync::Mutex;
 
 use super::system::{SystemConfig, SystemError, SystemInfo, SystemResult};
@@ -35,7 +32,7 @@ impl Capabilities {
     /// Add a new MCP system based on the provided client type
     // TODO IMPORTANT need to ensure this times out if the system command is broken!
     pub async fn add_system(&mut self, config: SystemConfig) -> SystemResult<()> {
-        let client: McpClient = match config {
+        let mut client: McpClient = match config {
             SystemConfig::Sse { ref uri } => {
                 let transport = SseTransport::new(uri);
                 McpClient::new(transport.start().await?)
@@ -149,23 +146,10 @@ impl Capabilities {
     pub async fn get_resources(
         &self,
     ) -> SystemResult<HashMap<String, HashMap<String, (Resource, String)>>> {
-        println!("In get_resources");
         let mut client_resource_content = HashMap::new();
         for (name, client) in &self.clients {
             let client_guard = client.lock().await;
-
-            // Add timeout of 3 seconds, return empty vec if timeout occurs
-            let resources: ListResourcesResult = match timeout(Duration::from_secs(3), client_guard.list_resources()).await {
-                Ok(Ok(resources)) => resources,
-                Ok(Err(e)) => return Err(e.into()),  // Preserve original errors
-                Err(_) => {
-                    println!("Timeout occurred while fetching resources for client {}", name);
-                    ListResourcesResult{resources: vec![]}  // Skip this client and continue with others
-                }
-            };
-
-            // let resources = client_guard.list_resources().await?;
-            println!("In get_resources, list_resources ({}): {:?}", resources.resources.len(), resources);
+            let resources = client_guard.list_resources().await?;
 
             let mut resource_content = HashMap::new();
             for resource in resources.resources {

--- a/crates/goose/src/agents/default.rs
+++ b/crates/goose/src/agents/default.rs
@@ -42,7 +42,6 @@ impl DefaultAgent {
         model_name: &str,
         resource_content: &HashMap<String, HashMap<String, (Resource, String)>>,
     ) -> SystemResult<Vec<Message>> {
-        println!("In prepare_inference");
         // Flatten all resource content into a vector of strings
         let mut resources = Vec::new();
         for system_resources in resource_content.values() {
@@ -50,7 +49,6 @@ impl DefaultAgent {
                 resources.push(content.clone());
             }
         }
-        println!("Resources: {:?}", resources);
 
         let approx_count = self.token_counter.count_everything(
             system_prompt,
@@ -59,7 +57,6 @@ impl DefaultAgent {
             &resources,
             Some(model_name),
         );
-        println!("Approx count: {:?}", approx_count);
         let mut status_content: Vec<String> = Vec::new();
 
         if approx_count > target_limit {
@@ -131,7 +128,6 @@ impl DefaultAgent {
                 }
             }
         } else {
-            println!("No trimming needed");
             // Create status messages from all resources when no trimming needed
             for resources in resource_content.values() {
                 for (resource, content) in resources.values() {
@@ -139,8 +135,6 @@ impl DefaultAgent {
                 }
             }
         }
-
-        println!("Status content: {:?}", status_content);
 
         // Join remaining status content and create status message
         let status_str = status_content.join("\n");
@@ -201,7 +195,6 @@ impl Agent for DefaultAgent {
         &self,
         messages: &[Message],
     ) -> anyhow::Result<BoxStream<'_, anyhow::Result<Message>>> {
-        println!("In goose agent reply");
         let mut capabilities = self.capabilities.lock().await;
         let tools = capabilities.get_prefixed_tools().await?;
         let system_prompt = capabilities.get_system_prompt().await;
@@ -211,12 +204,7 @@ impl Agent for DefaultAgent {
             .get_estimated_limit();
 
         // Update conversation history for the start of the reply
-        println!("Preparing inference (before loop)");
-        let model_name = capabilities.provider().get_model_config().model_name.clone();
-        println!("Model name: {:?}", model_name);
         let resources = capabilities.get_resources().await?;
-        println!("Resources: {:?}", resources);
-
         let mut messages = self
             .prepare_inference(
                 &system_prompt,
@@ -224,7 +212,11 @@ impl Agent for DefaultAgent {
                 messages,
                 &Vec::new(),
                 estimated_limit,
-                &model_name,
+                &capabilities
+                    .provider()
+                    .get_model_config()
+                    .model_name
+                    .clone(),
                 &resources,
             )
             .await?;
@@ -232,7 +224,6 @@ impl Agent for DefaultAgent {
         Ok(Box::pin(async_stream::try_stream! {
             loop {
                 // Get completion from provider
-                println!("(in loop) Getting completion from provider with messages: {:?}", messages);
                 let (response, usage) = capabilities.provider().complete(
                     &system_prompt,
                     &messages,

--- a/crates/mcp-client/examples/sse.rs
+++ b/crates/mcp-client/examples/sse.rs
@@ -22,7 +22,7 @@ async fn main() -> Result<()> {
     let handle = transport.start().await?;
 
     // Create client
-    let client = McpClient::new(handle);
+    let mut client = McpClient::new(handle);
     println!("Client created\n");
 
     // Initialize

--- a/crates/mcp-client/examples/stdio.rs
+++ b/crates/mcp-client/examples/stdio.rs
@@ -21,7 +21,7 @@ async fn main() -> Result<(), ClientError> {
     let transport_handle = transport.start().await?;
 
     // 3) Create the client
-    let client = McpClient::new(transport_handle);
+    let mut client = McpClient::new(transport_handle);
 
     // Initialize
     let server_info = client
@@ -44,6 +44,10 @@ async fn main() -> Result<(), ClientError> {
         .call_tool("git_status", serde_json::json!({ "repo_path": "." }))
         .await?;
     println!("Tool result: {tool_result:?}\n");
+
+    // List resources
+    let resources = client.list_resources().await?;
+    println!("Available resources: {resources:?}\n");
 
     Ok(())
 }

--- a/crates/mcp-client/examples/stdio_integration.rs
+++ b/crates/mcp-client/examples/stdio_integration.rs
@@ -29,7 +29,7 @@ async fn main() -> Result<(), ClientError> {
     let transport_handle = transport.start().await.unwrap();
 
     // Create client
-    let client = McpClient::new(transport_handle);
+    let mut client = McpClient::new(transport_handle);
 
     // Initialize
     let server_info = client


### PR DESCRIPTION
currently, goose agent hangs when we try to list tools or resources on a server that doesn't support that capability. for example: 
`mcp-server-git` server capabilities: 
```
{ prompts: None, resources: None, tools: Some(ToolsCapability { list_changed: Some(false) }) }
```

instructions on testing:
1. build all the crates with cargo
2. run goosed - `./target/debug/goosed agent`
3. open a terminal and add mcp server
```
curl --request POST \
  --url http://localhost:3000/systems/add \
  --header 'Content-Type: application/json' \
  --data '{
  "type": "Stdio",
  "cmd": "uvx",
  "args": ["mcp-server-git"]
}'\'''
```
4. verify goose has access to tools 
```
curl --request POST \
  --url http://localhost:3000/ask \
  --header 'Content-Type: application/json' \
  --data '{
  "prompt": "what tools & resources do you have? list out the names, do NOT describe them - be very concise"
}' | jq .
```