### PR TITLE
feat: read only active resources in the agent loop

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -140,6 +140,24 @@ impl DeveloperRouter {
         }
     }
 
+    // Helper method to mark a resource as active, and insert it into the active_resources map
+    fn add_active_resource(&self, uri: &str, resource: Resource) {
+        self.active_resources
+            .lock()
+            .unwrap()
+            .insert(uri.to_string(), resource.mark_active());
+    }
+
+    // Helper method to check if a resource is already an active one
+    // Tries to get the resource and then checks if it is active
+    fn is_active_resource(&self, uri: &str) -> bool {
+        self.active_resources
+            .lock()
+            .unwrap()
+            .get(uri)
+            .map_or(false, |r| r.is_active())
+    }
+
     // Helper method to resolve a path relative to cwd
     fn resolve_path(&self, path_str: &str) -> Result<PathBuf, ToolError> {
         let cwd = self.cwd.lock().unwrap();
@@ -313,7 +331,7 @@ impl DeveloperRouter {
                     ToolError::ExecutionError(format!("Failed to create resource: {}", e))
                 })?;
 
-            self.active_resources.lock().unwrap().insert(uri, resource);
+            self.add_active_resource(&uri, resource);
 
             let language = lang::get_language_identifier(path);
             let formatted = formatdoc! {"
@@ -358,7 +376,7 @@ impl DeveloperRouter {
             .to_string();
 
         // Check if file already exists and is active
-        if path.exists() && !self.active_resources.lock().unwrap().contains_key(&uri) {
+        if path.exists() && !self.is_active_resource(&uri) {
             return Err(ToolError::InvalidParameters(format!(
                 "File '{}' exists but is not active. View it first before overwriting.",
                 path.display()
@@ -376,7 +394,7 @@ impl DeveloperRouter {
 
         let resource = Resource::new(uri.clone(), Some("text".to_string()), None)
             .map_err(|e| ToolError::ExecutionError(e.to_string()))?;
-        self.active_resources.lock().unwrap().insert(uri, resource);
+        self.add_active_resource(&uri, resource);
 
         // Try to detect the language from the file extension
         let language = path.extension().and_then(|ext| ext.to_str()).unwrap_or("");
@@ -417,7 +435,7 @@ impl DeveloperRouter {
                 path.display()
             )));
         }
-        if !self.active_resources.lock().unwrap().contains_key(&uri) {
+        if !self.is_active_resource(&uri) {
             return Err(ToolError::InvalidParameters(format!(
                 "You must view '{}' before editing it",
                 path.display()

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -1,8 +1,8 @@
 use chrono::{DateTime, TimeZone, Utc};
 use rust_decimal_macros::dec;
 use std::collections::HashMap;
-use std::sync::LazyLock;
 use std::sync::Arc;
+use std::sync::LazyLock;
 use tokio::sync::Mutex;
 use tracing::{debug, instrument};
 
@@ -15,9 +15,8 @@ use mcp_core::{Content, Tool, ToolCall, ToolError, ToolResult};
 
 // By default, we set it to Jan 1, 2020 if the resource does not have a timestamp
 // This is to ensure that the resource is considered less important than resources with a more recent timestamp
-static DEFAULT_TIMESTAMP: LazyLock<DateTime<Utc>> = LazyLock::new(|| {
-    Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap()
-});
+static DEFAULT_TIMESTAMP: LazyLock<DateTime<Utc>> =
+    LazyLock::new(|| Utc.with_ymd_and_hms(2020, 1, 1, 0, 0, 0).unwrap());
 
 /// Manages MCP clients and their interactions
 pub struct Capabilities {

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -154,6 +154,12 @@ impl Capabilities {
 
             let mut resource_content = HashMap::new();
             for resource in resources.resources {
+                // Skip inactive resources
+                if !resource.is_active() {
+                    continue;
+                }
+
+                // Read the resource contents for active resources
                 if let Ok(contents) = client_guard.read_resource(&resource.uri).await {
                     for content in contents.contents {
                         let (uri, content_str) = match content {

--- a/crates/goose/src/agents/default.rs
+++ b/crates/goose/src/agents/default.rs
@@ -1,20 +1,20 @@
 use async_trait::async_trait;
 use futures::stream::BoxStream;
 use serde_json::json;
-use std::collections::HashMap;
 use tokio::sync::Mutex;
 use tracing::{debug, instrument};
 
 use super::Agent;
-use crate::agents::capabilities::Capabilities;
+use crate::agents::capabilities::{Capabilities, ResourceItem};
 use crate::agents::system::{SystemConfig, SystemResult};
 use crate::message::{Message, MessageContent, ToolRequest};
 use crate::providers::base::Provider;
 use crate::providers::base::ProviderUsage;
 use crate::register_agent;
 use crate::token_counter::TokenCounter;
-use mcp_core::{Content, Resource, Tool, ToolCall};
+use mcp_core::{Content, Tool, ToolCall};
 use serde_json::Value;
+
 // used to sort resources by priority within error margin
 const PRIORITY_EPSILON: f32 = 0.001;
 
@@ -41,15 +41,13 @@ impl DefaultAgent {
         pending: &[Message],
         target_limit: usize,
         model_name: &str,
-        resource_content: &HashMap<String, HashMap<String, (Resource, String)>>,
+        resource_items: &mut [ResourceItem],
     ) -> SystemResult<Vec<Message>> {
         // Flatten all resource content into a vector of strings
-        let mut resources = Vec::new();
-        for system_resources in resource_content.values() {
-            for (_, content) in system_resources.values() {
-                resources.push(content.clone());
-            }
-        }
+        let resources: Vec<String> = resource_items
+            .iter()
+            .map(|item| item.content.clone())
+            .collect();
 
         let approx_count = self.token_counter.count_everything(
             system_prompt,
@@ -64,77 +62,47 @@ impl DefaultAgent {
         if approx_count > target_limit {
             println!("[WARNING] Token budget exceeded. Current count: {} \n Difference: {} tokens over buget. Removing context", approx_count, approx_count - target_limit);
 
-            // Get token counts for each resource
-            let mut system_token_counts = HashMap::new();
-
-            // Iterate through each system and its resources
-            for (system_name, resources) in resource_content {
-                let mut resource_counts = HashMap::new();
-                for (uri, (_resource, content)) in resources {
-                    let token_count =
-                        self.token_counter.count_tokens(content, Some(model_name)) as u32;
-                    resource_counts.insert(uri.clone(), token_count);
-                }
-                system_token_counts.insert(system_name.clone(), resource_counts);
-            }
-
-            // Sort resources by priority and timestamp and trim to fit context limit
-            let mut all_resources: Vec<(String, String, Resource, u32)> = Vec::new();
-            for (system_name, resources) in resource_content {
-                for (uri, (resource, _)) in resources {
-                    if let Some(token_count) = system_token_counts
-                        .get(system_name)
-                        .and_then(|counts| counts.get(uri))
-                    {
-                        all_resources.push((
-                            system_name.clone(),
-                            uri.clone(),
-                            resource.clone(),
-                            *token_count,
-                        ));
-                    }
+            for item in resource_items.iter_mut() {
+                if item.token_count.is_none() {
+                    let count = self
+                        .token_counter
+                        .count_tokens(&item.content, Some(model_name))
+                        as u32;
+                    item.token_count = Some(count);
                 }
             }
 
             // Sort by priority (high to low) and timestamp (newest to oldest)
-            all_resources.sort_by(|a, b| {
-                let a_priority = a.2.priority().unwrap_or(0.0);
-                let b_priority = b.2.priority().unwrap_or(0.0);
-                if (b_priority - a_priority).abs() < PRIORITY_EPSILON {
-                    b.2.timestamp().cmp(&a.2.timestamp())
+            let mut all_items: Vec<ResourceItem> = resource_items.to_vec();
+            all_items.sort_by(|a, b| {
+                // Compare priority first (descending)
+                let diff = b.priority - a.priority;
+                if diff.abs() < PRIORITY_EPSILON {
+                    // If same priority, compare timestamp (descending = newer first)
+                    b.timestamp.cmp(&a.timestamp)
                 } else {
-                    b.2.priority()
-                        .partial_cmp(&a.2.priority())
-                        .unwrap_or(std::cmp::Ordering::Equal)
+                    diff.partial_cmp(&0.0).unwrap_or(std::cmp::Ordering::Equal)
                 }
             });
 
             // Remove resources until we're under target limit
             let mut current_tokens = approx_count;
-
-            while current_tokens > target_limit && !all_resources.is_empty() {
-                if let Some((system_name, uri, _, token_count)) = all_resources.pop() {
-                    if let Some(system_counts) = system_token_counts.get_mut(&system_name) {
-                        system_counts.remove(&uri);
-                        current_tokens -= token_count as usize;
-                    }
+            while current_tokens > target_limit && !all_items.is_empty() {
+                let removed = all_items.pop().unwrap();
+                // Subtract removed item’s token_count
+                if let Some(tc) = removed.token_count {
+                    current_tokens = current_tokens.saturating_sub(tc as usize);
                 }
             }
 
-            // Create status messages only from resources that remain after token trimming
-            for (system_name, uri, _, _) in &all_resources {
-                if let Some(system_resources) = resource_content.get(system_name) {
-                    if let Some((resource, content)) = system_resources.get(uri) {
-                        status_content.push(format!("{}\n```\n{}\n```\n", resource.name, content));
-                    }
-                }
+            // We removed some items, so let's use only the trimmed set `all_items`
+            for item in &all_items {
+                status_content.push(format!("{}\n```\n{}\n```\n", item.name, item.content));
             }
         } else {
             // Create status messages from all resources when no trimming needed
-            for resources in resource_content.values() {
-                for (resource, content) in resources.values() {
-                    status_content.push(format!("{}\n```\n{}\n```\n", resource.name, content));
-                }
+            for item in resource_items {
+                status_content.push(format!("{}\n```\n{}\n```\n", item.name, item.content));
             }
         }
 
@@ -149,17 +117,15 @@ impl DefaultAgent {
             new_messages.push(msg.clone());
         }
 
-        // Finally add the status messages, if we have any
-        if !status_str.is_empty() {
-            let message_use = Message::assistant()
-                .with_tool_request("000", Ok(ToolCall::new("status", json!({}))));
+        // Finally add the status messages
+        let message_use =
+            Message::assistant().with_tool_request("000", Ok(ToolCall::new("status", json!({}))));
 
-            let message_result =
-                Message::user().with_tool_response("000", Ok(vec![Content::text(status_str)]));
+        let message_result =
+            Message::user().with_tool_response("000", Ok(vec![Content::text(status_str)]));
 
-            new_messages.push(message_use);
-            new_messages.push(message_result);
-        }
+        new_messages.push(message_use);
+        new_messages.push(message_result);
 
         Ok(new_messages)
     }
@@ -225,7 +191,7 @@ impl Agent for DefaultAgent {
                 &Vec::new(),
                 estimated_limit,
                 &capabilities.provider().get_model_config().model_name,
-                &capabilities.get_resources().await?,
+                &mut capabilities.get_resources().await?,
             )
             .await?;
 
@@ -290,7 +256,7 @@ impl Agent for DefaultAgent {
 
 
                 let pending = vec![response, message_tool_response];
-                messages = self.prepare_inference(&system_prompt, &tools, &messages, &pending, estimated_limit, &capabilities.provider().get_model_config().model_name, &capabilities.get_resources().await?).await?;
+                messages = self.prepare_inference(&system_prompt, &tools, &messages, &pending, estimated_limit, &capabilities.provider().get_model_config().model_name, &mut capabilities.get_resources().await?).await?;
             }
         }))
     }

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -6,6 +6,8 @@ use url::Url;
 
 use crate::content::Annotations;
 
+const EPSILON: f32 = 1e-6; // Tolerance for floating point comparison
+
 /// Represents a resource in the system with metadata
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
@@ -124,7 +126,6 @@ impl Resource {
 
     // Check if the resource is active
     pub fn is_active(&self) -> bool {
-        const EPSILON: f32 = 1e-6; // Tolerance for floating point comparison
         if let Some(priority) = self.priority() {
             (priority - 1.0).abs() < EPSILON
         } else {

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -118,13 +118,18 @@ impl Resource {
     }
 
     /// Mark the resource as active, i.e. set its priority to 1.0
-    pub fn mark_active(mut self) -> Self {
+    pub fn mark_active(self) -> Self {
         self.with_priority(1.0)
     }
 
     // Check if the resource is active
     pub fn is_active(&self) -> bool {
-        self.priority() == Some(1.0)
+        const EPSILON: f32 = 1e-6; // Tolerance for floating point comparison
+        if let Some(priority) = self.priority() {
+            (priority - 1.0).abs() < EPSILON
+        } else {
+            false
+        }
     }
 
     /// Returns the priority of the resource, if set

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -117,6 +117,16 @@ impl Resource {
         self
     }
 
+    /// Mark the resource as active, i.e. set its priority to 1.0
+    pub fn mark_active(mut self) -> Self {
+        self.with_priority(1.0)
+    }
+
+    // Check if the resource is active
+    pub fn is_active(&self) -> bool {
+        self.priority() == Some(1.0)
+    }
+
     /// Returns the priority of the resource, if set
     pub fn priority(&self) -> Option<f32> {
         self.annotations.as_ref().and_then(|a| a.priority)


### PR DESCRIPTION
MCP servers (such as gdrive) list out 100s of files so reading each file in the agent loop leads to context limit exceeded errors. we make this change to only read 'active' files, i.e. files that have been viewed by the user using the developer system. It's unclear whether this will work well with other MCP servers cause this requires other MCP servers to use the priority annotation on the resource as well which may be less widely used.