### PR TITLE
fix: sanitize server names for passing into model tool calls

### DIFF
--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -19,6 +19,20 @@ pub struct Capabilities {
     provider_usage: Mutex<Vec<ProviderUsage>>,
 }
 
+/// Sanitizes a string by replacing invalid characters with underscores.
+/// Valid characters match [a-zA-Z0-9_-]
+fn sanitize(input: String) -> String {
+    let mut result = String::with_capacity(input.len());
+    for c in input.chars() {
+        result.push(if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+            c
+        } else {
+            '_'
+        });
+    }
+    result
+}
+
 impl Capabilities {
     /// Create a new Capabilities with the specified provider
     pub fn new(provider: Box<dyn Provider>) -> Self {
@@ -64,7 +78,7 @@ impl Capabilities {
 
         // Store the client
         self.clients.insert(
-            init_result.server_info.name.clone(),
+            sanitize(init_result.server_info.name.clone()),
             Arc::new(Mutex::new(client)),
         );
 


### PR DESCRIPTION
sanitize the server name response from the MCP servers, this is propagated throughout the agent's usage and eventually into the tool call to the LLMs

a couple of the example servers use `example-server/$NAME` and that currently breaks goose the error is a `Error: Request failed: 400 Bad Request` and digging into it you eventually get a cryptic 
```
"x-amzn-errortype": "ValidationException:http://internal.amazon.com/coral/com.amazon.bedrock/"
```

Both [anthropic](https://docs.anthropic.com/en/docs/build-with-claude/tool-use#specifying-tools) and [openai](https://platform.openai.com/docs/api-reference/chat/create#chat-create-tools) have the same format:
>  The name of the tool. Must match the regex `^[a-zA-Z0-9_-]{1,64}$`

*note:* this does not handle the tool names nor the char limit, will need to have a broader design
