### PR TITLE
feat: env and secrets configuration for mcp server

### DIFF
--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -87,12 +87,19 @@ impl Capabilities {
     /// Add a new MCP system based on the provided client type
     // TODO IMPORTANT need to ensure this times out if the system command is broken!
     pub async fn add_system(&mut self, config: SystemConfig) -> SystemResult<()> {
+        // If secrets exist, set them as environment variables
+        if let Some(secrets) = config.secrets() {
+            secrets.set_environment_vars();
+        };
+
         let mut client: McpClient = match config {
-            SystemConfig::Sse { ref uri } => {
+            SystemConfig::Sse { ref uri, .. } => {
                 let transport = SseTransport::new(uri);
                 McpClient::new(transport.start().await?)
             }
-            SystemConfig::Stdio { ref cmd, ref args } => {
+            SystemConfig::Stdio {
+                ref cmd, ref args, ..
+            } => {
                 let transport = StdioTransport::new(cmd, args.to_vec());
                 McpClient::new(transport.start().await?)
             }

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -87,20 +87,20 @@ impl Capabilities {
     /// Add a new MCP system based on the provided client type
     // TODO IMPORTANT need to ensure this times out if the system command is broken!
     pub async fn add_system(&mut self, config: SystemConfig) -> SystemResult<()> {
-        // If secrets exist, set them as environment variables
-        if let Some(secrets) = config.secrets() {
-            secrets.set_environment_vars();
-        };
-
         let mut client: McpClient = match config {
-            SystemConfig::Sse { ref uri, .. } => {
-                let transport = SseTransport::new(uri);
+            SystemConfig::Sse {
+                ref uri,
+                ref secrets,
+            } => {
+                let transport = SseTransport::new(uri, secrets.get_env());
                 McpClient::new(transport.start().await?)
             }
             SystemConfig::Stdio {
-                ref cmd, ref args, ..
+                ref cmd,
+                ref args,
+                ref secrets,
             } => {
-                let transport = StdioTransport::new(cmd, args.to_vec());
+                let transport = StdioTransport::new(cmd, args.to_vec(), secrets.get_env());
                 McpClient::new(transport.start().await?)
             }
         };

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -88,19 +88,16 @@ impl Capabilities {
     // TODO IMPORTANT need to ensure this times out if the system command is broken!
     pub async fn add_system(&mut self, config: SystemConfig) -> SystemResult<()> {
         let mut client: McpClient = match config {
-            SystemConfig::Sse {
-                ref uri,
-                ref secrets,
-            } => {
-                let transport = SseTransport::new(uri, secrets.get_env());
+            SystemConfig::Sse { ref uri, ref envs } => {
+                let transport = SseTransport::new(uri, envs.get_env());
                 McpClient::new(transport.start().await?)
             }
             SystemConfig::Stdio {
                 ref cmd,
                 ref args,
-                ref secrets,
+                ref envs,
             } => {
-                let transport = StdioTransport::new(cmd, args.to_vec(), secrets.get_env());
+                let transport = StdioTransport::new(cmd, args.to_vec(), envs.get_env());
                 McpClient::new(transport.start().await?)
             }
         };

--- a/crates/goose/src/agents/system.rs
+++ b/crates/goose/src/agents/system.rs
@@ -18,14 +18,14 @@ pub enum SystemError {
 pub type SystemResult<T> = Result<T, SystemError>;
 
 #[derive(Debug, Clone, Deserialize, Serialize, Default)]
-pub struct Secrets {
-    /// A map of environment variables to set, e.g. API_KEY -> some_secret
+pub struct Envs {
+    /// A map of environment variables to set, e.g. API_KEY -> some_secret, HOST -> host
     #[serde(default)]
     #[serde(flatten)]
     map: HashMap<String, String>,
 }
 
-impl Secrets {
+impl Envs {
     pub fn new(map: HashMap<String, String>) -> Self {
         Self { map }
     }
@@ -50,14 +50,14 @@ pub enum SystemConfig {
     Sse {
         uri: String,
         #[serde(default)]
-        secrets: Secrets,
+        envs: Envs,
     },
     /// Standard I/O client with command and arguments
     Stdio {
         cmd: String,
         args: Vec<String>,
         #[serde(default)]
-        secrets: Secrets,
+        envs: Envs,
     },
 }
 
@@ -65,7 +65,7 @@ impl SystemConfig {
     pub fn sse<S: Into<String>>(uri: S) -> Self {
         Self::Sse {
             uri: uri.into(),
-            secrets: Secrets::default(),
+            envs: Envs::default(),
         }
     }
 
@@ -73,7 +73,7 @@ impl SystemConfig {
         Self::Stdio {
             cmd: cmd.into(),
             args: vec![],
-            secrets: Secrets::default(),
+            envs: Envs::default(),
         }
     }
 
@@ -83,9 +83,9 @@ impl SystemConfig {
         S: Into<String>,
     {
         match self {
-            Self::Stdio { cmd, secrets, .. } => Self::Stdio {
+            Self::Stdio { cmd, envs, .. } => Self::Stdio {
                 cmd,
-                secrets,
+                envs,
                 args: args.into_iter().map(Into::into).collect(),
             },
             other => other,

--- a/crates/goose/src/agents/system.rs
+++ b/crates/goose/src/agents/system.rs
@@ -17,7 +17,7 @@ pub enum SystemError {
 
 pub type SystemResult<T> = Result<T, SystemError>;
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
 pub struct Secrets {
     /// A map of environment variables to set, e.g. API_KEY -> some_secret
     #[serde(default)]
@@ -47,11 +47,16 @@ impl Secrets {
 #[serde(tag = "type")]
 pub enum SystemConfig {
     /// Server-sent events client with a URI endpoint
-    Sse { uri: String, secrets: Secrets },
+    Sse {
+        uri: String,
+        #[serde(default)]
+        secrets: Secrets,
+    },
     /// Standard I/O client with command and arguments
     Stdio {
         cmd: String,
         args: Vec<String>,
+        #[serde(default)]
         secrets: Secrets,
     },
 }

--- a/crates/mcp-client/examples/clients.rs
+++ b/crates/mcp-client/examples/clients.rs
@@ -4,8 +4,8 @@ use mcp_client::{
 };
 use rand::Rng;
 use rand::SeedableRng;
-use std::sync::Arc;
 use std::time::Duration;
+use std::{collections::HashMap, sync::Arc};
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -122,7 +122,7 @@ async fn create_stdio_client(
     _name: &str,
     _version: &str,
 ) -> Result<McpClient, Box<dyn std::error::Error>> {
-    let transport = StdioTransport::new("uvx", vec!["mcp-server-git".to_string()]);
+    let transport = StdioTransport::new("uvx", vec!["mcp-server-git".to_string()], HashMap::new());
     Ok(McpClient::new(transport.start().await?))
 }
 
@@ -130,6 +130,6 @@ async fn create_sse_client(
     _name: &str,
     _version: &str,
 ) -> Result<McpClient, Box<dyn std::error::Error>> {
-    let transport = SseTransport::new("http://localhost:8000/sse");
+    let transport = SseTransport::new("http://localhost:8000/sse", HashMap::new());
     Ok(McpClient::new(transport.start().await?))
 }

--- a/crates/mcp-client/examples/sse.rs
+++ b/crates/mcp-client/examples/sse.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use mcp_client::client::{ClientCapabilities, ClientInfo, McpClient};
 use mcp_client::transport::{SseTransport, Transport};
+use std::collections::HashMap;
 use std::time::Duration;
 use tracing_subscriber::EnvFilter;
 
@@ -16,7 +17,7 @@ async fn main() -> Result<()> {
         .init();
 
     // Create the base transport
-    let transport = SseTransport::new("http://localhost:8000/sse");
+    let transport = SseTransport::new("http://localhost:8000/sse", HashMap::new());
 
     // Start transport
     let handle = transport.start().await?;

--- a/crates/mcp-client/examples/stdio.rs
+++ b/crates/mcp-client/examples/stdio.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use anyhow::Result;
 use mcp_client::client::{ClientCapabilities, ClientInfo, Error as ClientError, McpClient};
 use mcp_client::transport::{StdioTransport, Transport};
@@ -15,7 +17,7 @@ async fn main() -> Result<(), ClientError> {
         .init();
 
     // 1) Create the transport
-    let transport = StdioTransport::new("uvx", vec!["mcp-server-git".to_string()]);
+    let transport = StdioTransport::new("uvx", vec!["mcp-server-git".to_string()], HashMap::new());
 
     // 2) Start the transport to get a handle
     let transport_handle = transport.start().await?;

--- a/crates/mcp-client/examples/stdio_integration.rs
+++ b/crates/mcp-client/examples/stdio_integration.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 // This example shows how to use the mcp-client crate to interact with a server that has a simple counter tool.
 // The server is started by running `cargo run -p mcp-server` in the root of the mcp-server crate.
 use anyhow::Result;
@@ -23,6 +25,7 @@ async fn main() -> Result<(), ClientError> {
             .into_iter()
             .map(|s| s.to_string())
             .collect(),
+        HashMap::new(),
     );
 
     // Start the transport to get a handle

--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::process::{Child, ChildStdin, ChildStdout, Command};
 
@@ -103,18 +104,25 @@ impl StdioActor {
 pub struct StdioTransport {
     command: String,
     args: Vec<String>,
+    env: HashMap<String, String>,
 }
 
 impl StdioTransport {
-    pub fn new<S: Into<String>>(command: S, args: Vec<String>) -> Self {
+    pub fn new<S: Into<String>>(
+        command: S,
+        args: Vec<String>,
+        env: HashMap<String, String>,
+    ) -> Self {
         Self {
             command: command.into(),
             args,
+            env: env,
         }
     }
 
     async fn spawn_process(&self) -> Result<(Child, ChildStdin, ChildStdout), Error> {
         let mut process = Command::new(&self.command)
+            .envs(&self.env)
             .args(&self.args)
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())


### PR DESCRIPTION
tested with [Tavily MCP Server](https://mcpserver.cloud/server/tavily-mcp-server) for web search:

1. build and run goosed: `cargo run --bin goosed -- agent`

2. add system with secret. you need to replace with free API key that you can get here: https://app.tavily.com/home
```
curl --request POST \
  --url http://localhost:3000/systems/add \
  --header 'Content-Type: application/json' \
  --data '{
  "type": "Stdio",
  "cmd": "uvx", 
  "args": ["mcp-tavily"], 
  "envs": {
    "TAVILY_API_KEY": "REPLACE_SECRET_HERE"
  }
}'
```

3. ask question that requires using the system's tools
```
curl --request POST \
  --url http://localhost:3000/ask \
  --header 'Content-Type: application/json' \
  --data '{
  "prompt": "can you do a search for recent news on LA wildfires - give me a timeline of events if possible. only provide breaking news and also let me know which tools you called in the process of getting the answer. be very concise!"
}'
```

![Screenshot 2025-01-09 at 1 34 19 PM](https://github.com/user-attachments/assets/ed78b93c-3044-413c-8d39-f11db0a0a07c)


step (2) validation depends on MCP server implementation - eg. it fails if env var is not set but does not fail if you set an invalid key - in that case, it will fail in step (3) by replying it can't get the news, which isn't good.

We can prompt the LLM to let the user know if the system contains secrets but its tools can't be used. 