### PR TITLE
feat: add pagination support for tools/list and resources/list

### DIFF
--- a/crates/mcp-client/examples/clients.rs
+++ b/crates/mcp-client/examples/clients.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // List tools for all clients
     for (i, client) in clients.iter_mut().enumerate() {
-        let tools = client.list_tools().await?;
+        let tools = client.list_tools(None).await?;
         println!("\nClient {} tools: {:?}", i + 1, tools);
     }
 
@@ -61,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             match rng.gen_range(0..4) {
                 0 => {
                     println!("\n{i}: Listing tools for client 1 (stdio)");
-                    match clients[0].list_tools().await {
+                    match clients[0].list_tools(None).await {
                         Ok(tools) => {
                             println!("  {i}: -> Got tools, first one: {:?}", tools.tools.first())
                         }
@@ -83,7 +83,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 }
                 2 => {
                     println!("\n{i}: Listing tools for client 3 (sse)");
-                    match clients[2].list_tools().await {
+                    match clients[2].list_tools(None).await {
                         Ok(tools) => {
                             println!("  {i}: -> Got tools, first one: {:?}", tools.tools.first())
                         }

--- a/crates/mcp-client/examples/sse.rs
+++ b/crates/mcp-client/examples/sse.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     tokio::time::sleep(Duration::from_millis(100)).await;
 
     // List tools
-    let tools = client.list_tools().await?;
+    let tools = client.list_tools(None).await?;
     println!("Available tools: {tools:?}\n");
 
     // Call tool
@@ -54,7 +54,7 @@ async fn main() -> Result<()> {
     println!("Tool result: {tool_result:?}\n");
 
     // List resources
-    let resources = client.list_resources().await?;
+    let resources = client.list_resources(None).await?;
     println!("Resources: {resources:?}\n");
 
     // Read resource

--- a/crates/mcp-client/examples/stdio.rs
+++ b/crates/mcp-client/examples/stdio.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<(), ClientError> {
     println!("Connected to server: {server_info:?}\n");
 
     // List tools
-    let tools = client.list_tools().await?;
+    let tools = client.list_tools(None).await?;
     println!("Available tools: {tools:?}\n");
 
     // Call tool 'git_status' with arguments = {"repo_path": "."}
@@ -46,7 +46,7 @@ async fn main() -> Result<(), ClientError> {
     println!("Tool result: {tool_result:?}\n");
 
     // List resources
-    let resources = client.list_resources().await?;
+    let resources = client.list_resources(None).await?;
     println!("Available resources: {resources:?}\n");
 
     Ok(())

--- a/crates/mcp-client/examples/stdio_integration.rs
+++ b/crates/mcp-client/examples/stdio_integration.rs
@@ -44,7 +44,7 @@ async fn main() -> Result<(), ClientError> {
     println!("Connected to server: {server_info:?}\n");
 
     // List tools
-    let tools = client.list_tools().await?;
+    let tools = client.list_tools(None).await?;
     println!("Available tools: {tools:?}\n");
 
     // Call tool 'increment' tool 3 times
@@ -66,7 +66,7 @@ async fn main() -> Result<(), ClientError> {
     println!("Tool result for 'get_value': {get_value_result:?}\n");
 
     // List resources
-    let resources = client.list_resources().await?;
+    let resources = client.list_resources(None).await?;
     println!("Resources: {resources:?}\n");
 
     // Read resource

--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -165,7 +165,10 @@ impl McpClient {
         self.server_capabilities.is_some()
     }
 
-    pub async fn list_resources(&self) -> Result<ListResourcesResult, Error> {
+    pub async fn list_resources(
+        &self,
+        next_cursor: Option<String>,
+    ) -> Result<ListResourcesResult, Error> {
         if !self.completed_initialization() {
             return Err(Error::NotInitialized);
         }
@@ -177,11 +180,17 @@ impl McpClient {
             .resources
             .is_none()
         {
-            return Ok(ListResourcesResult { resources: vec![] });
+            return Ok(ListResourcesResult {
+                resources: vec![],
+                next_cursor: None,
+            });
         }
 
-        self.send_request("resources/list", serde_json::json!({}))
-            .await
+        let payload = next_cursor
+            .map(|cursor| serde_json::json!({"next_cursor": cursor}))
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        self.send_request("resources/list", payload).await
     }
 
     pub async fn read_resource(&self, uri: &str) -> Result<ReadResourceResult, Error> {
@@ -206,16 +215,23 @@ impl McpClient {
         self.send_request("resources/read", params).await
     }
 
-    pub async fn list_tools(&self) -> Result<ListToolsResult, Error> {
+    pub async fn list_tools(&self, next_cursor: Option<String>) -> Result<ListToolsResult, Error> {
         if !self.completed_initialization() {
             return Err(Error::NotInitialized);
         }
         // If tools is not supported, return an empty list
         if self.server_capabilities.as_ref().unwrap().tools.is_none() {
-            return Ok(ListToolsResult { tools: vec![] });
+            return Ok(ListToolsResult {
+                tools: vec![],
+                next_cursor: None,
+            });
         }
 
-        self.send_request("tools/list", serde_json::json!({})).await
+        let payload = next_cursor
+            .map(|cursor| serde_json::json!({"next_cursor": cursor}))
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        self.send_request("tools/list", payload).await
     }
 
     pub async fn call_tool(&self, name: &str, arguments: Value) -> Result<CallToolResult, Error> {

--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -187,7 +187,7 @@ impl McpClient {
         }
 
         let payload = next_cursor
-            .map(|cursor| serde_json::json!({"next_cursor": cursor}))
+            .map(|cursor| serde_json::json!({"cursor": cursor}))
             .unwrap_or_else(|| serde_json::json!({}));
 
         self.send_request("resources/list", payload).await
@@ -228,7 +228,7 @@ impl McpClient {
         }
 
         let payload = next_cursor
-            .map(|cursor| serde_json::json!({"next_cursor": cursor}))
+            .map(|cursor| serde_json::json!({"cursor": cursor}))
             .unwrap_or_else(|| serde_json::json!({}));
 
         self.send_request("tools/list", payload).await

--- a/crates/mcp-core/src/protocol.rs
+++ b/crates/mcp-core/src/protocol.rs
@@ -188,8 +188,11 @@ pub struct ToolsCapability {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct ListResourcesResult {
     pub resources: Vec<Resource>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -198,8 +201,11 @@ pub struct ReadResourceResult {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct ListToolsResult {
     pub tools: Vec<Tool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -136,7 +136,10 @@ pub trait Router: Send + Sync + 'static {
         async move {
             let tools = self.list_tools();
 
-            let result = ListToolsResult { tools };
+            let result = ListToolsResult {
+                tools,
+                next_cursor: None,
+            };
             let mut response = self.create_response(req.id);
             response.result =
                 Some(serde_json::to_value(result).map_err(|e| {
@@ -191,7 +194,10 @@ pub trait Router: Send + Sync + 'static {
         async move {
             let resources = self.list_resources();
 
-            let result = ListResourcesResult { resources };
+            let result = ListResourcesResult {
+                resources,
+                next_cursor: None,
+            };
             let mut response = self.create_response(req.id);
             response.result =
                 Some(serde_json::to_value(result).map_err(|e| {


### PR DESCRIPTION
### add pagination support in mcp-client for `tools/list` and `resources/list`

https://spec.modelcontextprotocol.io/specification/2024-11-05/server/utilities/pagination/

we currently do not support `prompts/list` or `resources/templates/list`

* update the protocol to include `nextCursor`
* update goose to paginate over `tools/list`