### PR TITLE
feat: set process_group(0) on stdio systems to avoid ctrl-c handling

### DIFF
--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -120,6 +120,7 @@ impl StdioTransport {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::inherit())
             .kill_on_drop(true)
+            // 0 sets the process group ID equal to the process ID
             .process_group(0) // don't inherit signal handling from parent process
             .spawn()
             .map_err(|e| Error::Other(e.to_string()))?;

--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -120,6 +120,7 @@ impl StdioTransport {
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::inherit())
             .kill_on_drop(true)
+            .process_group(0) // don't inherit signal handling from parent process
             .spawn()
             .map_err(|e| Error::Other(e.to_string()))?;
 


### PR DESCRIPTION
when you ctrl-c from a `goose session` the ctrl-c signal is propagated to the child processes, set a different process_group to avoid that