### PR TITLE
fix: Set stdin to null in shell/bash tools

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -271,6 +271,7 @@ impl DeveloperRouter {
         let child = Command::new("bash")
             .stdout(Stdio::piped()) // These two pipes required to capture output later.
             .stderr(Stdio::piped())
+            .stdin(Stdio::null())
             .kill_on_drop(true) // Critical so that the command is killed when the agent.reply stream is interrupted.
             .arg("-c")
             .arg(cmd_with_redirect)

--- a/crates/goose-mcp/src/developer2/mod.rs
+++ b/crates/goose-mcp/src/developer2/mod.rs
@@ -169,6 +169,7 @@ impl Developer2Router {
         let child = Command::new("bash")
             .stdout(Stdio::piped()) // These two pipes required to capture output later.
             .stderr(Stdio::piped())
+            .stdin(Stdio::null())
             .kill_on_drop(true) // Critical so that the command is killed when the agent.reply stream is interrupted.
             .arg("-c")
             .arg(cmd_with_redirect)


### PR DESCRIPTION
Some command behavior, notably ripgrep, depend on if stdin is present. Not setting it here led to rg occasionally hanging waiting for input