### PR TITLE
Revert "[v1.0] adding the goosed key back in for localhost calls"

### DIFF
--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -278,16 +278,6 @@ async fn handler(
     headers: HeaderMap,
     Json(request): Json<ChatRequest>,
 ) -> Result<SseResponse, StatusCode> {
-    // Verify secret key
-    let secret_key = headers
-        .get("X-Secret-Key")
-        .and_then(|value| value.to_str().ok())
-        .ok_or(StatusCode::UNAUTHORIZED)?;
-
-    if secret_key != state.secret_key {
-        return Err(StatusCode::UNAUTHORIZED);
-    }
-
     // Check protocol header (optional in our case)
     if let Some(protocol) = headers.get("x-protocol") {
         if protocol.to_str().map(|p| p != "data").unwrap_or(true) {
@@ -388,19 +378,8 @@ struct AskResponse {
 // simple ask an AI for a response, non streaming
 async fn ask_handler(
     State(state): State<AppState>,
-    headers: HeaderMap,
     Json(request): Json<AskRequest>,
 ) -> Result<Json<AskResponse>, StatusCode> {
-    // Verify secret key
-    let secret_key = headers
-        .get("X-Secret-Key")
-        .and_then(|value| value.to_str().ok())
-        .ok_or(StatusCode::UNAUTHORIZED)?;
-
-    if secret_key != state.secret_key {
-        return Err(StatusCode::UNAUTHORIZED);
-    }
-
     let agent = state.agent.clone();
     let agent = agent.lock().await;
 
@@ -630,7 +609,6 @@ mod tests {
                 .uri("/ask")
                 .method("POST")
                 .header("content-type", "application/json")
-                .header("x-secret-key", "test-secret")
                 .body(Body::from(
                     serde_json::to_string(&AskRequest {
                         prompt: "test prompt".to_string(),

--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
 import { Message, useChat } from './ai-sdk-fork/useChat';
-
-import { Route, Routes, Navigate } from 'react-router-dom';
-import { getApiUrl, getSecretKey } from './config';
 import { ApiKeyWarning } from './components/ApiKeyWarning';
 import BottomMenu from './components/BottomMenu';
 import FlappyGoose from './components/FlappyGoose';
@@ -17,6 +15,7 @@ import { ScrollArea } from './components/ui/scroll-area';
 import UserMessage from './components/UserMessage';
 import { WelcomeScreen } from './components/WelcomeScreen';
 import WingToWing, { Working } from './components/WingToWing';
+import { getApiUrl } from './config';
 import { askAi } from './utils/askAI';
 
 // update this when you want to show the welcome screen again - doesn't have to be an actual version, just anything woudln't have been seen before
@@ -337,7 +336,6 @@ const addSystemConfig = async (system: string) => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Secret-Key': getSecretKey(),
       },
       body: JSON.stringify(systemConfig)
     });

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'child_process';
+import { exec } from 'child_process';
 import 'dotenv/config';
 import { app, BrowserWindow, dialog, globalShortcut, ipcMain, Menu, MenuItem, Notification, powerSaveBlocker, Tray } from 'electron';
 import started from "electron-squirrel-startup";
@@ -455,12 +455,13 @@ app.whenReady().then(async () => {
   ipcMain.on('open-in-chrome', (_, url) => {
     // On macOS, use the 'open' command with Chrome
     if (process.platform === 'darwin') {
-      spawn('open', ['-a', 'Google Chrome', url]);
+      exec(`open -a "Google Chrome" "${url}"`);
     } else if (process.platform === 'win32') {
-      // On Windows, start is built-in command of cmd.exe
-      spawn('cmd.exe', ['/c', 'start', '', 'chrome', url]);    } else {
+      // On Windows, use start command
+      exec(`start chrome "${url}"`);
+    } else {
       // On Linux, use xdg-open with chrome
-      spawn('xdg-open', [url]);
+      exec(`xdg-open "${url}"`);
     }
   });
 });


### PR DESCRIPTION
This reverts commit 5d4a4dc44f4b631e761a4c255c47979e6023ca9e.

it was failing with Unauthorized errors when testing out goosed with curl 

```
cargo run --bin goosed -- agent
```

this query fails with the secret key
```
curl --request POST \
  --url http://localhost:3000/ask \
  --header 'Content-Type: application/json' \
  --data '{
  "prompt": "hi there"
}'
```