### PR TITLE
fix: Various improvements and fixes to rough edges in the UX

### DIFF
--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -39,7 +39,7 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
         </div>
 
         {urls.length > 0 && (
-          <div className="flex mt-[16px]">
+          <div className="flex flex-wrap mt-[16px]">
             {urls.map((url, index) => (
               <LinkPreview key={index} url={url} />
             ))}
@@ -47,7 +47,8 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
         )}
 
         {/* enable or disable prompts here */}
-        {metadata && (
+        {/* NOTE from alexhancock on 1/14/2025 - disabling again temporarily due to non-determinism in when the forms show up */}
+        {false && metadata && (
           <div className="flex mt-[16px]">
             <GooseResponseForm
               message={message.content}

--- a/ui/desktop/src/components/MoreMenu.tsx
+++ b/ui/desktop/src/components/MoreMenu.tsx
@@ -174,7 +174,8 @@ export default function MoreMenu() {
             )}
 
             {/* Versions Menu */}
-            {versions && versions.available_versions.length > 0 && (
+            {/* NOTE from alexhancock on 1/14/2025 - disabling temporarily until we figure out where this will go in settings */}
+            {false && versions && versions.available_versions.length > 0 && (
               <>
                 <button
                   onClick={() => setShowVersions(!showVersions)}

--- a/ui/desktop/src/utils/urlUtils.ts
+++ b/ui/desktop/src/utils/urlUtils.ts
@@ -10,29 +10,50 @@ function normalizeUrl(url: string): string {
   }
 }
 
+// Helper to determine if a link should be included in results
+function linkIsEligible(url: string): boolean {
+  try {
+    const parsed = new URL(url.toLowerCase());
+    const ineligibleHosts = ['localhost', '127.0.0.1'];
+    return !ineligibleHosts.some(host => parsed.hostname.includes(host));
+  } catch {
+    return false;
+  }
+}
+
 export function extractUrls(content: string, previousUrls: string[] = []): string[] {
-  // Modified regex to only match markdown links with http:// or https://
+  let remainingContent = content;
+  const extractedUrls: string[] = [];
+
+  // First, extract markdown links
   const markdownLinkRegex = /\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g;
   const markdownMatches = Array.from(content.matchAll(markdownLinkRegex));
-  const markdownUrls = markdownMatches.map(match => match[2]);
 
-  // Modified regex for standalone URLs with http:// or https://
+  // Add markdown URLs to our results and remove them from the content
+  markdownMatches.forEach(match => {
+    extractedUrls.push(match[2]);
+    // Replace the entire markdown link with whitespace to preserve string indices
+    remainingContent = remainingContent.replace(match[0], ' '.repeat(match[0].length));
+  });
+
+  // Now look for standalone URLs in the remaining content
   const urlRegex = /(https?:\/\/[^\s<>"']+)/g;
-  const urlMatches = Array.from(content.matchAll(urlRegex));
+  const urlMatches = Array.from(remainingContent.matchAll(urlRegex));
   const standardUrls = urlMatches.map(match => match[1]);
+  extractedUrls.push(...standardUrls);
 
-  // Combine markdown URLs with standard URLs
-  const currentUrls = [...new Set([...markdownUrls, ...standardUrls])];
-  
+  // Remove duplicates
+  const uniqueCurrentUrls = [...new Set(extractedUrls)];
+
+  // Filter out ineligible URLs
+  const eligibleUrls = uniqueCurrentUrls.filter(linkIsEligible);
+
   // Normalize all URLs for comparison
   const normalizedPreviousUrls = previousUrls.map(normalizeUrl);
-  const normalizedCurrentUrls = currentUrls.map(url => {
-    const normalized = normalizeUrl(url);
-    return normalized;
-  });
+  const normalizedCurrentUrls = eligibleUrls.map(normalizeUrl);
   
-  // Filter out duplicates
-  const uniqueUrls = currentUrls.filter((url, index) => {
+  // Filter out duplicates from previous URLs
+  const uniqueUrls = eligibleUrls.filter((url, index) => {
     const normalized = normalizedCurrentUrls[index];
     const isDuplicate = normalizedPreviousUrls.some(prevUrl => 
       normalizeUrl(prevUrl) === normalized


### PR DESCRIPTION
Fixes a few things we wanted to to get a build out today

* Removes link previews when the host is `localhost` or `127.0.0.1`
* Makes link previews `flex-wrap` so it doesn't make the chat window content too wide for the screen when there are a lot of links
* Fixes an issue where we matched uris in markdown form `[uri](uri)` twice
* Temporarily disables choosing agent version in the `MoreMenu` until we can determine where to put it in the new settings screen
* Temporarily disables the prompting of the user with plans/select options per @baxen mentioning it still doesn't always display at the correct times