### PR TITLE
styles: de-containerize the UI

### DIFF
--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -16,10 +16,7 @@ import UserMessage from "./components/UserMessage";
 import WingToWing, { Working } from "./components/WingToWing";
 import { askAi } from "./utils/askAI";
 import { ProviderSetupModal } from "./components/ProviderSetupModal";
-import {
-  providers,
-  ProviderOption,
-} from "./utils/providerUtils";
+import { providers, ProviderOption } from "./utils/providerUtils";
 
 declare global {
   interface Window {
@@ -122,6 +119,7 @@ function ChatContent({
       window.electron.logInfo("last interaction:" + lastInteractionTime);
       if (timeSinceLastInteraction > 60000) {
         // 60000ms = 1 minute
+
         window.electron.showNotification({
           title: "Goose finished the task.",
           body: "Click here to expand.",
@@ -243,17 +241,16 @@ function ChatContent({
   };
 
   return (
-    <div className="chat-content flex flex-col w-full h-screen items-center justify-center p-[10px]">
-      <div className="relative block h-[20px] w-full">
+    <div className="chat-content flex flex-col w-full h-screen items-center justify-center">
+      <div className="relative flex items-center h-[36px] w-full">
         <MoreMenu />
       </div>
-      <Card className="flex flex-col flex-1 h-[calc(100vh-95px)] w-full bg-card-gradient dark:bg-dark-card-gradient mt-0 border-none rounded-2xl relative">
+      <Card className="flex flex-col flex-1 rounded-none h-[calc(100vh-95px)] w-full bg-card-gradient dark:bg-dark-card-gradient mt-0 border-none relative">
         {messages.length === 0 ? (
           <Splash append={append} />
         ) : (
           <ScrollArea className="flex-1 px-[10px]" id="chat-scroll-area">
-            <div className="block h-10" />
-            <div>
+            <div className="pt-4">
               {messages.map((message) => (
                 <div key={message.id}>
                   {message.role === "user" ? (
@@ -318,7 +315,6 @@ function ChatContent({
           isLoading={isLoading}
           onStop={onStopGoose}
         />
-        <div className="self-stretch h-px bg-black/5 dark:bg-white/5 rounded-sm" />
         <BottomMenu hasMessages={hasMessages} />
       </Card>
 
@@ -341,7 +337,7 @@ export default function ChatWindow() {
         event.preventDefault(); // Prevent default browser behavior
         openNewChatWindow();
       }
-    };    
+    };
 
     // Add event listener
     window.addEventListener("keydown", handleKeyDown);
@@ -354,8 +350,8 @@ export default function ChatWindow() {
 
   useEffect(() => {
     // Listen for add-system from main process for a goose:// deep link
-    window.electron.on('add-system', (_, link) => {
-      console.log('Received message for add-system:', link); 
+    window.electron.on("add-system", (_, link) => {
+      console.log("Received message for add-system:", link);
       addMCPSystem(link);
     });
   }, []);
@@ -399,7 +395,8 @@ export default function ChatWindow() {
   useEffect(() => {
     // Check if we already have a provider set
     const config = window.electron.getConfig();
-    const storedProvider = config.GOOSE_PROVIDER || localStorage.getItem("GOOSE_PROVIDER");
+    const storedProvider =
+      config.GOOSE_PROVIDER || localStorage.getItem("GOOSE_PROVIDER");
 
     if (storedProvider) {
       setShowWelcomeModal(false);
@@ -444,15 +441,15 @@ export default function ChatWindow() {
 
   const addSystemConfig = async (system: string) => {
     await addMCP("goosed", ["mcp", system]);
-  }
+  };
 
   const initializeSystem = async (provider: string) => {
     try {
       await addAgent(provider);
       await addSystemConfig("developer2");
       // add system from deep link up front
-      if (window.appConfig.get('DEEP_LINK')) {
-        await addMCPSystem(window.appConfig.get('DEEP_LINK'));
+      if (window.appConfig.get("DEEP_LINK")) {
+        await addMCPSystem(window.appConfig.get("DEEP_LINK"));
       }
     } catch (error) {
       console.error("Failed to initialize system:", error);
@@ -488,7 +485,8 @@ export default function ChatWindow() {
   useEffect(() => {
     const setupStoredProvider = async () => {
       const config = window.electron.getConfig();
-      const storedProvider = config.GOOSE_PROVIDER || localStorage.getItem("GOOSE_PROVIDER");
+      const storedProvider =
+        config.GOOSE_PROVIDER || localStorage.getItem("GOOSE_PROVIDER");
       if (storedProvider) {
         try {
           await initializeSystem(storedProvider);

--- a/ui/desktop/src/components/BottomMenu.tsx
+++ b/ui/desktop/src/components/BottomMenu.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React from "react";
 
-export default function BottomMenu({hasMessages}) {
+export default function BottomMenu({ hasMessages }) {
   return (
-    <div className="flex relative text-bottom-menu dark:text-bottom-menu-dark pl-[15px] text-[10px] h-[30px] leading-[30px] align-middle bg-bottom-menu-background dark:bg-bottom-menu-background-dark rounded-b-2xl">
+    <div className="flex relative border-t dark:border-gray-700 text-bottom-menu dark:text-bottom-menu-dark pl-[15px] text-[10px] h-[30px] leading-[30px] align-middle bg-bottom-menu-background dark:bg-bottom-menu-background-dark rounded-b-2xl">
       <span
         className="cursor-pointer"
         onClick={async () => {
@@ -10,9 +10,10 @@ export default function BottomMenu({hasMessages}) {
           if (hasMessages) {
             window.electron.directoryChooser();
           } else {
-            window.electron.directoryChooser(true);  
-          }          
-      }}>
+            window.electron.directoryChooser(true);
+          }
+        }}
+      >
         Working in {window.appConfig.get("GOOSE_WORKING_DIR")}
       </span>
     </div>

--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -85,7 +85,7 @@ export default function Input({
   return (
     <form
       onSubmit={onFormSubmit}
-      className="flex relative h-auto px-[16px] pr-[68px] py-[1rem]"
+      className="flex relative h-auto px-[16px] pr-[68px] py-[1rem] border-t dark:border-gray-700"
     >
       <textarea
         autoFocus
@@ -112,7 +112,7 @@ export default function Input({
         variant="ghost"
         onClick={handleFileSelect}
         disabled={disabled}
-        className={`absolute right-[40px] top-1/2 -translate-y-1/2 text-indigo-600 dark:text-indigo-300 hover:text-indigo-700 dark:hover:text-indigo-200 hover:bg-indigo-100 dark:hover:bg-indigo-800 [&_svg]:size-5 ${
+        className={`absolute right-[40px] top-1/2 -translate-y-1/2 text-indigo-600 dark:text-indigo-300 hover:text-indigo-700 dark:hover:text-indigo-200 hover:bg-indigo-100 dark:hover:bg-indigo-800 ${
           disabled ? "opacity-50 cursor-not-allowed" : ""
         }`}
       >
@@ -134,7 +134,7 @@ export default function Input({
           size="icon"
           variant="ghost"
           disabled={disabled || !value.trim()}
-          className={`absolute right-2 top-1/2 -translate-y-1/2 text-indigo-600 dark:text-indigo-300 hover:text-indigo-700 dark:hover:text-indigo-200 hover:bg-indigo-100 dark:hover:bg-indigo-800 [&_svg]:size-5 ${
+          className={`absolute right-2 top-1/2 -translate-y-1/2 text-indigo-600 dark:text-indigo-300 hover:text-indigo-700 dark:hover:text-indigo-200 hover:bg-indigo-100 dark:hover:bg-indigo-800 ${
             disabled || !value.trim() ? "opacity-50 cursor-not-allowed" : ""
           }`}
         >

--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -1,7 +1,21 @@
+<<<<<<< HEAD
 import React, { useRef, useState, useEffect } from "react";
 import { Button } from "./ui/button";
 import Stop from "./ui/Stop";
 import { Attach, Send } from "./icons";
+||||||| parent of b490ac0e (style: removed container styles)
+import React, { useRef, useState, useEffect } from 'react';
+import { Button } from './ui/button';
+import Send from './ui/Send';
+import Stop from './ui/Stop';
+import { Paperclip } from 'lucide-react';
+=======
+import React, { useRef, useState, useEffect } from "react";
+import { Button } from "./ui/button";
+import Send from "./ui/Send";
+import Stop from "./ui/Stop";
+import { Paperclip } from "lucide-react";
+>>>>>>> b490ac0e (style: removed container styles)
 
 interface InputProps {
   handleSubmit: (e: React.FormEvent) => void;

--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -1,21 +1,7 @@
-<<<<<<< HEAD
 import React, { useRef, useState, useEffect } from "react";
 import { Button } from "./ui/button";
 import Stop from "./ui/Stop";
 import { Attach, Send } from "./icons";
-||||||| parent of b490ac0e (style: removed container styles)
-import React, { useRef, useState, useEffect } from 'react';
-import { Button } from './ui/button';
-import Send from './ui/Send';
-import Stop from './ui/Stop';
-import { Paperclip } from 'lucide-react';
-=======
-import React, { useRef, useState, useEffect } from "react";
-import { Button } from "./ui/button";
-import Send from "./ui/Send";
-import Stop from "./ui/Stop";
-import { Paperclip } from "lucide-react";
->>>>>>> b490ac0e (style: removed container styles)
 
 interface InputProps {
   handleSubmit: (e: React.FormEvent) => void;

--- a/ui/desktop/src/components/MoreMenu.tsx
+++ b/ui/desktop/src/components/MoreMenu.tsx
@@ -126,7 +126,7 @@ export default function MoreMenu() {
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
-        <button className="z-[100] absolute top-[-4px] right-[10px] w-[20px] h-[20px] cursor-pointer no-drag">
+        <button className="z-[100] absolute top-2 right-[10px] w-[20px] h-[20px] cursor-pointer no-drag">
           <More />
         </button>
       </PopoverTrigger>

--- a/ui/desktop/src/components/settings/KeyItem.tsx
+++ b/ui/desktop/src/components/settings/KeyItem.tsx
@@ -42,7 +42,7 @@ export function KeyItem({ keyData, onEdit, onCopy }: KeyItemProps) {
             <Tooltip content="Copy to clipboard">
               <button
                 onClick={handleCopy}
-                className="ml-2 text-indigo-500 hover:text-indigo-600"
+                className="ml-3 text-gray-400 hover:text-gray-600"
               >
                 <Copy className="h-5 w-5" />
               </button>
@@ -51,7 +51,7 @@ export function KeyItem({ keyData, onEdit, onCopy }: KeyItemProps) {
           <Tooltip content="Edit">
             <button
               onClick={() => onEdit(keyData)}
-              className="text-indigo-500 hover:text-indigo-600"
+              className="text-gray-400 hover:text-gray-600"
             >
               <Edit />
             </button>

--- a/ui/desktop/src/components/settings/Settings.tsx
+++ b/ui/desktop/src/components/settings/Settings.tsx
@@ -177,127 +177,125 @@ export default function Settings() {
   };
 
   return (
-    <div className="h-screen w-full p-[10px]">
-      <Card className="h-full w-full bg-card-gradient dark:bg-dark-card-gradient border-none rounded-2xl p-6">
-        <div className="h-full w-full bg-white dark:bg-gray-800 rounded-2xl overflow-hidden p-4">
-          <ScrollArea className="h-full w-full">
-            <div className="flex min-h-full">
-              {/* Left Navigation */}
-              <div className="w-48 border-r border-gray-100 dark:border-gray-700 px-6">
-                <div className="sticky top-8">
-                  <button
-                    onClick={handleExit}
-                    className="flex items-center gap-2 text-gray-600 hover:text-gray-800 
+    <div className="h-screen w-full pt-[36px]">
+      <div className="h-full w-full bg-white dark:bg-gray-800 overflow-hidden p-2 pt-0">
+        <ScrollArea className="h-full w-full">
+          <div className="flex min-h-full">
+            {/* Left Navigation */}
+            <div className="w-48 border-r border-gray-100 dark:border-gray-700 px-2 pt-2">
+              <div className="sticky top-8">
+                <button
+                  onClick={handleExit}
+                  className="flex items-center gap-2 text-gray-600 hover:text-gray-800 
                                             dark:text-gray-400 dark:hover:text-gray-200 mb-16 mt-4"
-                  >
-                    <Back className="w-4 h-4" />
-                    <span>Back</span>
-                  </button>
-                  <div className="space-y-2">
-                    {["Models", "Extensions", "Keys"].map((section) => (
-                      <button
-                        key={section}
-                        onClick={(e) => handleNavClick(section, e)}
-                        className="block w-full text-left px-3 py-2 rounded-lg transition-colors
+                >
+                  <Back className="w-4 h-4" />
+                  <span>Back</span>
+                </button>
+                <div className="space-y-2">
+                  {["Models", "Extensions", "Keys"].map((section) => (
+                    <button
+                      key={section}
+                      onClick={(e) => handleNavClick(section, e)}
+                      className="block w-full text-left px-3 py-2 rounded-lg transition-colors
                                                     text-gray-600 dark:text-gray-400 hover:bg-gray-100 dark:hover:bg-gray-800"
-                      >
-                        {section}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              </div>
-
-              {/* Content Area */}
-              <div className="flex-1 px-8 py-8">
-                <div className="max-w-3xl space-y-12">
-                  {/* Models Section */}
-                  <section id="models">
-                    <div className="flex justify-between items-center mb-4">
-                      <h2 className="text-2xl font-semibold">Models</h2>
-                      <button
-                        onClick={() => setAddModelOpen(true)}
-                        className="text-indigo-500 hover:text-indigo-600 font-medium"
-                      >
-                        Add Models
-                      </button>
-                    </div>
-                    {settings.models.map((model) => (
-                      <ToggleableItem
-                        key={model.id}
-                        {...model}
-                        onToggle={handleModelToggle}
-                      />
-                    ))}
-                  </section>
-
-                  {/* Extensions Section */}
-                  <section id="extensions">
-                    <div className="flex justify-between items-center mb-4">
-                      <h2 className="text-2xl font-semibold">Extensions</h2>
-                    </div>
-                    <p className="text-gray-500 dark:text-gray-400 mb-4">
-                      {EXTENSIONS_DESCRIPTION}
-                    </p>
-                    {settings.extensions.map((ext) => (
-                      <ToggleableItem
-                        key={ext.id}
-                        {...ext}
-                        onToggle={handleExtensionToggle}
-                      />
-                    ))}
-                  </section>
-
-                  {/* Keys Section */}
-                  <section id="keys">
-                    <div className="flex justify-between items-center mb-4">
-                      <h2 className="text-2xl font-semibold">Keys</h2>
-                      <button
-                        onClick={() => setAddKeyOpen(true)}
-                        className="text-indigo-500 hover:text-indigo-600 font-medium"
-                      >
-                        Add new key
-                      </button>
-                    </div>
-                    <p className="text-gray-500 dark:text-gray-400 mb-4">
-                      {EXTENSIONS_DESCRIPTION}
-                    </p>
-                    {settings.keys.map((keyItem) => (
-                      <KeyItem
-                        key={keyItem.id}
-                        keyData={keyItem}
-                        onEdit={setEditingKey}
-                        onCopy={handleCopyKey}
-                      />
-                    ))}
-
-                    <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
-                      <Button
-                        variant="outline"
-                        onClick={() => setShowAllKeys(true)}
-                        className="w-full text-yellow-600 hover:text-yellow-700 dark:text-yellow-500 dark:hover:text-yellow-400"
-                      >
-                        Reveal All Keys (Dev Only)
-                      </Button>
-                    </div>
-                  </section>
-
-                  {/* Reset Button */}
-                  <div className="pt-8 border-t border-gray-200 dark:border-gray-700">
-                    <Button
-                      onClick={() => setShowResetConfirm(true)}
-                      variant="destructive"
-                      className="w-full"
                     >
-                      Reset to Default Settings
-                    </Button>
-                  </div>
+                      {section}
+                    </button>
+                  ))}
                 </div>
               </div>
             </div>
-          </ScrollArea>
-        </div>
-      </Card>
+
+            {/* Content Area */}
+            <div className="flex-1 px-16 py-8 pt-[20px]">
+              <div className="max-w-3xl space-y-12">
+                {/* Models Section */}
+                <section id="models">
+                  <div className="flex justify-between items-center mb-4">
+                    <h2 className="text-2xl font-semibold">Models</h2>
+                    <button
+                      onClick={() => setAddModelOpen(true)}
+                      className="text-indigo-500 hover:text-indigo-600 font-medium"
+                    >
+                      Add Models
+                    </button>
+                  </div>
+                  {settings.models.map((model) => (
+                    <ToggleableItem
+                      key={model.id}
+                      {...model}
+                      onToggle={handleModelToggle}
+                    />
+                  ))}
+                </section>
+
+                {/* Extensions Section */}
+                <section id="extensions">
+                  <div className="flex justify-between items-center mb-4">
+                    <h2 className="text-2xl font-semibold">Extensions</h2>
+                  </div>
+                  <p className="text-gray-500 dark:text-gray-400 mb-4">
+                    {EXTENSIONS_DESCRIPTION}
+                  </p>
+                  {settings.extensions.map((ext) => (
+                    <ToggleableItem
+                      key={ext.id}
+                      {...ext}
+                      onToggle={handleExtensionToggle}
+                    />
+                  ))}
+                </section>
+
+                {/* Keys Section */}
+                <section id="keys">
+                  <div className="flex justify-between items-center mb-4">
+                    <h2 className="text-2xl font-semibold">Keys</h2>
+                    <button
+                      onClick={() => setAddKeyOpen(true)}
+                      className="text-indigo-500 hover:text-indigo-600 font-medium"
+                    >
+                      Add new key
+                    </button>
+                  </div>
+                  <p className="text-gray-500 dark:text-gray-400 mb-4">
+                    {EXTENSIONS_DESCRIPTION}
+                  </p>
+                  {settings.keys.map((keyItem) => (
+                    <KeyItem
+                      key={keyItem.id}
+                      keyData={keyItem}
+                      onEdit={setEditingKey}
+                      onCopy={handleCopyKey}
+                    />
+                  ))}
+
+                  <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
+                    <Button
+                      variant="outline"
+                      onClick={() => setShowAllKeys(true)}
+                      className="w-full text-yellow-600 hover:text-yellow-700 dark:text-yellow-500 dark:hover:text-yellow-400"
+                    >
+                      Reveal All Keys (Dev Only)
+                    </Button>
+                  </div>
+                </section>
+
+                {/* Reset Button */}
+                <div className="pt-8 border-t border-gray-200 dark:border-gray-700">
+                  <Button
+                    onClick={() => setShowResetConfirm(true)}
+                    variant="destructive"
+                    className="w-full"
+                  >
+                    Reset to Default Settings
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </ScrollArea>
+      </div>
 
       {/* Reset Confirmation Dialog */}
       <Modal open={showResetConfirm} onOpenChange={setShowResetConfirm}>


### PR DESCRIPTION
Reduction of "containers". This results in a flatter UI. And makes the input clearer to discern. 

Examples:

| Before | After |
|--------|--------|
| <img width="745" alt="Screenshot 2025-01-14 at 4 46 14 PM" src="https://github.com/user-attachments/assets/074febd8-987a-438a-9026-f83c8253d935" /> | <img width="750" alt="Screenshot 2025-01-14 at 4 46 20 PM" src="https://github.com/user-attachments/assets/30caa5ea-aab6-4d74-a5ad-8ffb6f8c42eb" /> |
| <img width="749" alt="Screenshot 2025-01-14 at 4 47 07 PM" src="https://github.com/user-attachments/assets/8079e06b-028e-46fa-ac94-86db8e841b93" /> | <img width="749" alt="Screenshot 2025-01-14 at 4 47 12 PM" src="https://github.com/user-attachments/assets/3718f7c9-2ddb-47f4-9bd8-3d794dd22900" /> |
| n/a | <img width="750" alt="Screenshot 2025-01-14 at 4 46 36 PM" src="https://github.com/user-attachments/assets/2e89a31e-1b3f-4d7d-bfb4-bddcaaad182c" /> | 