### PR TITLE
remove use of bare unwrap() in error propagation

### DIFF
--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -144,7 +144,11 @@ where
             .call(request)
             .await
             .map_err(|e| Error::McpServerError {
-                server: self.server_info.as_ref().unwrap().name.clone(),
+                server: self
+                    .server_info
+                    .as_ref()
+                    .map(|s| s.name.clone())
+                    .unwrap_or("".to_string()),
                 method: method.to_string(),
                 params: params.clone(),
                 source: Box::new(e.into()),
@@ -206,7 +210,11 @@ where
             .call(notification)
             .await
             .map_err(|e| Error::McpServerError {
-                server: self.server_info.as_ref().unwrap().name.clone(),
+                server: self
+                    .server_info
+                    .as_ref()
+                    .map(|s| s.name.clone())
+                    .unwrap_or("".to_string()),
                 method: method.to_string(),
                 params: params.clone(),
                 source: Box::new(e.into()),


### PR DESCRIPTION

remove the bare `.unwrap()` when generating server name and default to `""` if we don't have `server_info` for some reason