### PR TITLE
feat: Release devtools opening keyboard shortcut when goose window is not focused

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -159,14 +159,31 @@ const createChat = async (app, query?: string, dir?: string, version?: string) =
     );
   }
 
-  // DevTools
-  globalShortcut.register('Alt+Command+I', () => {
-    mainWindow.webContents.openDevTools();
+  // DevTools shortcut management
+  const registerDevToolsShortcut = (window: BrowserWindow) => {
+    globalShortcut.register('Alt+Command+I', () => {
+      window.webContents.openDevTools();
+    });
+  };
+
+  const unregisterDevToolsShortcut = () => {
+    globalShortcut.unregister('Alt+Command+I');
+  };
+
+  // Register shortcut when window is focused
+  mainWindow.on('focus', () => {
+    registerDevToolsShortcut(mainWindow);
+  });
+
+  // Unregister shortcut when window loses focus
+  mainWindow.on('blur', () => {
+    unregisterDevToolsShortcut();
   });
 
   windowMap.set(windowId, mainWindow);
   mainWindow.on('closed', () => {
     windowMap.delete(windowId);
+    unregisterDevToolsShortcut();
   });
 };
 


### PR DESCRIPTION
Releases the devtools opening keyboard shortcut (`Alt+Command+I`) when goose window is not focused. This makes it so it works for Chrome when not focusing on the Goose app.