### PR TITLE
address pr comments on truncate feature

### DIFF
--- a/crates/goose/src/agents/system.rs
+++ b/crates/goose/src/agents/system.rs
@@ -11,7 +11,7 @@ pub enum SystemError {
     Initialization(SystemConfig),
     #[error("Failed a client call to an MCP server: {0}")]
     Client(#[from] ClientError),
-    #[error("Messages exceeded context-limit and could not be truncated to fit.")]
+    #[error("User Message exceeded context-limit. History could not be truncated to accomodate.")]
     ContextLimit,
     #[error("Transport error: {0}")]
     Transport(#[from] mcp_client::transport::Error),

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -51,16 +51,6 @@ impl TruncateAgent {
 
         let mut new_messages = messages.to_vec();
         if approx_count > target_limit {
-            let user_msg_size = self.text_content_size(new_messages.last(), model);
-            if user_msg_size > target_limit {
-                debug!(
-                    "[WARNING] User message {} exceeds token budget {}.",
-                    user_msg_size,
-                    user_msg_size - target_limit
-                );
-                return Err(SystemError::ContextLimit);
-            }
-
             new_messages = self.chop_front_messages(messages, approx_count, target_limit, model);
             if new_messages.is_empty() {
                 return Err(SystemError::ContextLimit);

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -29,7 +29,7 @@ impl TruncateAgent {
         }
     }
 
-    async fn prepare_inference(
+    async fn enforce_ctx_limit_pre_flight(
         &self,
         system_prompt: &str,
         tools: &[Tool],
@@ -146,7 +146,7 @@ impl Agent for TruncateAgent {
 
         // Update conversation history for the start of the reply
         let mut messages = self
-            .prepare_inference(
+            .enforce_ctx_limit_pre_flight(
                 &system_prompt,
                 &tools,
                 messages,
@@ -203,15 +203,6 @@ impl Agent for TruncateAgent {
                 }
 
                 yield message_tool_response.clone();
-
-                messages = self.prepare_inference(
-                    &system_prompt,
-                    &tools,
-                    &messages,
-                    estimated_limit,
-                    &capabilities.provider().get_model_config().model_name,
-                    &mut capabilities.get_resources().await?
-                ).await?;
 
                 messages.push(response);
                 messages.push(message_tool_response);


### PR DESCRIPTION
@baxen reviewed:
- [x] nit: we should remove the leading underscore cause we use these vars
  - [x] https://github.com/block/goose/pull/579/files#diff-e9f1004635098df88301c14620e0c92e8eab82da838c58c9892d54317ccb612dR28
  - [x] https://github.com/block/goose/pull/579/files#diff-e9f1004635098df88301c14620e0c92e8eab82da838c58c9892d54317ccb612dR133
- [x] shouldn't we push the messages into the array before running truncation? in normal usage shouldn't matter but if there's a large pending tool result this won't account for it yet 
  - [x] https://github.com/block/goose/pull/579/files#diff-e9f1004635098df88301c14620e0c92e8eab82da838c58c9892d54317ccb612dR216
- [x] i'm not sure i understand this check - this is the last message in the history, so this could be a tool result as well right? or am i just confused by the comment, is this just to prevent chopping everything effectively?
  - [x] https://github.com/block/goose/pull/579/files#diff-e9f1004635098df88301c14620e0c92e8eab82da838c58c9892d54317ccb612dR54