### PR TITLE
feat: enable prompt cache for anthropic 

### DIFF
--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -161,8 +161,8 @@ impl AnthropicProvider {
             if message.get("role") == Some(&json!("user")) {
                 if let Some(content) = message.get_mut("content") {
                     if let Some(content_array) = content.as_array_mut() {
-                        for content_item in content_array {
-                            content_item
+                        if let Some(last_content) = content_array.last_mut() {
+                            last_content
                                 .as_object_mut()
                                 .unwrap()
                                 .insert("cache_control".to_string(), json!({ "type": "ephemeral" }));

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -62,10 +62,11 @@ impl AnthropicProvider {
             }
         }
 
-        // Add "cache_control" to the last tool spec, if any. This means that all tool definitions, 
+        // Add "cache_control" to the last tool spec, if any. This means that all tool definitions,
         // will be cached as a single prefix.
         if let Some(last_tool) = tool_specs.last_mut() {
-            last_tool.as_object_mut()
+            last_tool
+                .as_object_mut()
                 .unwrap()
                 .insert("cache_control".to_string(), json!({ "type": "ephemeral" }));
         }
@@ -150,11 +151,11 @@ impl AnthropicProvider {
                     "text": "Ignore"
                 }]
             }));
-        } 
+        }
 
         // Add "cache_control" to the last and second-to-last "user" messages.
-        // During each turn, we mark the final message with cache_control so the conversation can be 
-        // incrementally cached. The second-to-last user message is also marked for caching with the 
+        // During each turn, we mark the final message with cache_control so the conversation can be
+        // incrementally cached. The second-to-last user message is also marked for caching with the
         // cache_control parameter, so that this checkpoint can read from the previous cache.
         let mut user_count = 0;
         for message in anthropic_messages.iter_mut().rev() {
@@ -162,10 +163,10 @@ impl AnthropicProvider {
                 if let Some(content) = message.get_mut("content") {
                     if let Some(content_array) = content.as_array_mut() {
                         if let Some(last_content) = content_array.last_mut() {
-                            last_content
-                                .as_object_mut()
-                                .unwrap()
-                                .insert("cache_control".to_string(), json!({ "type": "ephemeral" }));
+                            last_content.as_object_mut().unwrap().insert(
+                                "cache_control".to_string(),
+                                json!({ "type": "ephemeral" }),
+                            );
                         }
                     }
                 }


### PR DESCRIPTION
Enable prompt cache for Anthropic following https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#how-prompt-caching-works.

Generally, we add `"cache_control": {"type": "ephemeral"}` into tool, system and message sections. The cache hit can be verified with the usage [response](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#tracking-cache-performance), like

```
usage: {
cache_creation_input_tokens: 1479
cache_read_input_tokens: 0
input_tokens: 4
output_tokens: 78
}
```
And currently, “ephemeral” is the only supported cache type, which corresponds to this 5-minute lifetime.

Cost saving: From the [pricing](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#pricing), 
1. Cache write tokens are 25% more expensive than base input tokens
2. Cache read tokens are 90% cheaper than base input tokens

Assume we have `N` turns conversion, `S` denotes to system prompt length and the average new tokens(user inputs + outputs) length for each turn is `M`
Before cache: our estimated cost is around 
1. `S + (S + M) + (S + M * 2) + ... + (S + M * (N - 1)) = S * N + (N - 1) * N / 2 * M`
After cache: our estimated cost is around 
2. `(S + M * (N - 1)) * 1.25 + (S + (S + M) + ... + (S + M * (N - 1))) * 0.1 = (S + M * (N - 1)) * 1.25  + (S * N + (N - 1) * N / 2 * M) * 0.1`
To compare result 1 and result 2, we need to compare `(S + M * (N - 1)) * 1.25` and `(S * N + (N - 1) * N / 2 * M) * 0.9`, if `(S + M * (N - 1)) * 1.25` is greater, then cache is cost more and vice visa. Normally, our S is greater than 1000 and M is large as well, `(S + M * (N - 1)) * 1.25` should be much smaller which means cache reduces our cost.
And some estimation from anthropic post:
![image](https://github.com/user-attachments/assets/95f97f3e-b826-4297-b2e9-91f0e8017a83)

Test with `just run-ui` and response verification:
<img width="1013" alt="Screenshot 2025-01-15 at 8 25 14 PM" src="https://github.com/user-attachments/assets/3489550d-7f6e-4eea-a5e7-74d0f6b74061" />
