### PR TITLE
feat(session): Print previous session prompts when resuming a session

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -104,8 +104,8 @@ enum Command {
         #[arg(
             short,
             long,
-            help = "Resume a previous session (last used or specified by --session)",
-            long_help = "Continue from a previous chat session. If --session is provided, resumes that specific session. Otherwise resumes the last used session."
+            help = "Resume a previous session (last used or specified by --name)",
+            long_help = "Continue from a previous chat session. If --name is provided, resumes that specific session. Otherwise resumes the last used session."
         )]
         resume: bool,
     },

--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -138,9 +138,13 @@ impl Prompt for RustylinePrompt {
     }
 
     fn load_user_message_history(&mut self, messages: Vec<Message>) {
+        if !messages.is_empty() {
+            println!("\nPrevious prompts for resuming session:");
+        }
         for message in messages.into_iter().filter(|m| m.role == Role::User) {
             for content in message.content {
                 if let Some(text) = content.as_text() {
+                    println!("> {}", text);
                     if let Err(e) = self.editor.add_history_entry(text) {
                         eprintln!("Failed to add to history: {}", e);
                     }

--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -138,13 +138,9 @@ impl Prompt for RustylinePrompt {
     }
 
     fn load_user_message_history(&mut self, messages: Vec<Message>) {
-        if !messages.is_empty() {
-            println!("\nPrevious prompts for resuming session:");
-        }
         for message in messages.into_iter().filter(|m| m.role == Role::User) {
             for content in message.content {
                 if let Some(text) = content.as_text() {
-                    println!("> {}", text);
                     if let Err(e) = self.editor.add_history_entry(text) {
                         eprintln!("Failed to add to history: {}", e);
                     }

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -91,6 +91,19 @@ pub fn deserialize_messages(file: File) -> Result<Vec<Message>> {
     Ok(messages)
 }
 
+pub fn print_previous_prompts(messages: Vec<Message>) {
+    if !messages.is_empty() {
+        println!("\nPrevious prompts for resuming session:");
+    }
+    for message in messages.into_iter().filter(|m| m.role == Role::User) {
+        for content in message.content {
+            if let Some(text) = content.as_text() {
+                println!("> {}", text);
+            }
+        }
+    }
+}
+
 // Session management
 pub struct Session<'a> {
     agent: Box<dyn Agent>,
@@ -121,6 +134,7 @@ impl<'a> Session<'a> {
         };
 
         prompt.load_user_message_history(messages.clone());
+        print_previous_prompts(messages.clone());
 
         Session {
             agent,


### PR DESCRIPTION
Sometimes i want to rerun a previous prompt with goose when the underlying data has changed. This change will print the previous prompts when resuming a session to help remind me of the context and help me copy paste older prompts that were effective.

Also fixed help output since `--session` flag doesn't exists. It's suppose to be the `--name` flag.

Resumed session
```
❯ ./target/debug/goose session -r --name t7alxs5d
resuming session | provider: databricks model: claude-3-5-sonnet-2
    logging to /Users/atish/.config/goose/sessions/t7alxs5d.jsonl

Previous prompts for resuming session:
> find all the csv files in the ./tmp directory. 
> Use the data in the csv files to create a new csv file that shows total number of empty nodes per dc compared to the total number of nodes


Goose is running! Enter your instructions, or try asking what goose can do.


( O)>
Closing session. Recorded to /Users/atish/.config/goose/sessions/t7alxs5d.jsonl

Child process ended (EOF on stdout)
```

New sessions
```
❯ ./target/debug/goose session
starting session | provider: databricks model: claude-3-5-sonnet-2
    logging to /Users/atish/.config/goose/sessions/aswuff9b.jsonl


Goose is running! Enter your instructions, or try asking what goose can do.


( O)>
```
