### PR TITLE
feat: set priority of google drive text as 0.1

### DIFF
--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -353,7 +353,7 @@ impl GoogleDriveRouter {
                             response
                         };
 
-                        Ok(vec![Content::text(content)])
+                        Ok(vec![Content::text(content).with_priority(0.1)])
                     } else {
                         Err(ToolError::ExecutionError(format!(
                             "Failed to export google drive to string, {}.",
@@ -405,7 +405,7 @@ impl GoogleDriveRouter {
                                 response
                             };
 
-                            Ok(vec![Content::text(content)])
+                            Ok(vec![Content::text(content).with_priority(0.1)])
                         } else {
                             Err(ToolError::ExecutionError(format!(
                                 "Failed to convert google drive to string, {}.",


### PR DESCRIPTION
# lower priority of google drive text to minimize text body

Set priority of google drive text to `0.1`, the UI then hides the entire body in an `▶ Output` section.

CLI output stays the same.

## before
<img width="669" alt="image" src="https://github.com/user-attachments/assets/7347f2f1-f259-449b-af87-8f54864d98b1" />


## after

<img width="648" alt="image" src="https://github.com/user-attachments/assets/7c7f800c-5097-4a2c-addc-392be7373fb6" />
<img width="639" alt="image" src="https://github.com/user-attachments/assets/738eae8c-93dc-4413-889b-2cf8777461ac" />
