### PR TITLE
fix: remove configure args '-n default' which no longer exists

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -127,7 +127,7 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
 fi
 
 # --- 8) Auto-configure Goose (Optional) ---
-CONFIG_ARGS="-n default"
+CONFIG_ARGS=""
 if [ -n "${GOOSE_PROVIDER:-}" ]; then
   CONFIG_ARGS="$CONFIG_ARGS -p $GOOSE_PROVIDER"
 fi

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -127,7 +127,7 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
 fi
 
 # --- 8) Auto-configure Goose (Optional) ---
-CONFIG_ARGS=""
+CONFIG_ARGS="-n default"
 if [ -n "${GOOSE_PROVIDER:-}" ]; then
   CONFIG_ARGS="$CONFIG_ARGS -p $GOOSE_PROVIDER"
 fi
@@ -135,20 +135,11 @@ if [ -n "${GOOSE_MODEL:-}" ]; then
   CONFIG_ARGS="$CONFIG_ARGS -m $GOOSE_MODEL"
 fi
 
-# --- 8) Auto-configure Goose (Optional) ---
-CONFIG_ARGS=""
-[ -n "${GOOSE_PROVIDER:-}" ] && CONFIG_ARGS="$CONFIG_ARGS -p $GOOSE_PROVIDER"
-[ -n "${GOOSE_MODEL:-}" ] && CONFIG_ARGS="$CONFIG_ARGS -m $GOOSE_MODEL"
+echo ""
+echo "Configuring Goose with: '$CONFIG_ARGS'"
+echo ""
+"$GOOSE_BIN_DIR/$OUT_FILE" configure $CONFIG_ARGS
 
-if [ -n "${GOOSE_PROVIDER:-}" ] || [ -n "${GOOSE_MODEL:-}" ]; then
-  echo ""
-  echo "Configuring Goose with: '$CONFIG_ARGS'"
-  echo ""
-  "$GOOSE_BIN_DIR/$OUT_FILE" configure $CONFIG_ARGS
-  echo ""
-  echo "Goose installed successfully! Run '$OUT_FILE session' to get started."
-else
-  echo ""
-  echo "Goose installed successfully! Run '$OUT_FILE configure' to configure Goose and then run '$OUT_FILE session' to get started."
-fi
+echo ""
+echo "Goose installed successfully! Run '$OUT_FILE session' to get started."
 echo ""

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -127,7 +127,7 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
 fi
 
 # --- 8) Auto-configure Goose (Optional) ---
-CONFIG_ARGS="-n default"
+CONFIG_ARGS=""
 if [ -n "${GOOSE_PROVIDER:-}" ]; then
   CONFIG_ARGS="$CONFIG_ARGS -p $GOOSE_PROVIDER"
 fi
@@ -135,11 +135,20 @@ if [ -n "${GOOSE_MODEL:-}" ]; then
   CONFIG_ARGS="$CONFIG_ARGS -m $GOOSE_MODEL"
 fi
 
-echo ""
-echo "Configuring Goose with: '$CONFIG_ARGS'"
-echo ""
-"$GOOSE_BIN_DIR/$OUT_FILE" configure $CONFIG_ARGS
+# --- 8) Auto-configure Goose (Optional) ---
+CONFIG_ARGS=""
+[ -n "${GOOSE_PROVIDER:-}" ] && CONFIG_ARGS="$CONFIG_ARGS -p $GOOSE_PROVIDER"
+[ -n "${GOOSE_MODEL:-}" ] && CONFIG_ARGS="$CONFIG_ARGS -m $GOOSE_MODEL"
 
-echo ""
-echo "Goose installed successfully! Run '$OUT_FILE session' to get started."
+if [ -n "${GOOSE_PROVIDER:-}" ] || [ -n "${GOOSE_MODEL:-}" ]; then
+  echo ""
+  echo "Configuring Goose with: '$CONFIG_ARGS'"
+  echo ""
+  "$GOOSE_BIN_DIR/$OUT_FILE" configure $CONFIG_ARGS
+  echo ""
+  echo "Goose installed successfully! Run '$OUT_FILE session' to get started."
+else
+  echo ""
+  echo "Goose installed successfully! Run '$OUT_FILE configure' to configure Goose and then run '$OUT_FILE session' to get started."
+fi
 echo ""


### PR DESCRIPTION
- download_cli.sh failed to configure goose with '-n default'. We probably don't wanna start off with "goose configure" cause you have to approve in Mac system security settings first and this makes the flow confusing
- pop up for the download_cli script will look like this. hard to know that this is happening cause it needs an approval in security settings

![Screen Shot 2025-01-18 at 9 45 26 AM (1)](https://github.com/user-attachments/assets/a36de986-35e7-49ca-95e7-18534f0fa15f)

