### PR TITLE
fix: patch host config handling

### DIFF
--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -367,7 +367,7 @@ mod tests {
             client: Client::builder().build().unwrap(),
             host: mock_server.uri(),
             api_key: "test_api_key".to_string(),
-            model: ModelConfig::new("claude-3-sonnet-20241022".to_string())
+            model: ModelConfig::new("claude-3-5-sonnet-latest".to_string())
                 .with_temperature(Some(0.7))
                 .with_context_limit(Some(200_000)),
         };
@@ -433,7 +433,7 @@ mod tests {
                     "expression": "2 + 2"
                 }
             }],
-            "model": "claude-3-sonnet-20240229",
+            "model": "claude-3-5-sonnet-latest",
             "stop_reason": "end_turn",
             "stop_sequence": null,
             "usage": {
@@ -490,7 +490,7 @@ mod tests {
                 "type": "text",
                 "text": "Hello!"
             }],
-            "model": "claude-3-sonnet-20240229",
+            "model": "claude-3-5-sonnet-latest",
             "stop_reason": "end_turn",
             "stop_sequence": null,
             "usage": {

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -61,8 +61,10 @@ pub struct DatabricksProvider {
 
 impl DatabricksProvider {
     pub fn from_env() -> Result<Self> {
-        let host = std::env::var("DATABRICKS_HOST")
-            .unwrap_or_else(|_| "https://api.databricks.com".to_string());
+        // Although we don't need host to be stored secretly, we use the keyring to make
+        // it easier to coordinate with configuration. We could consider a non secret storage tool
+        // elsewhere in the future
+        let host = crate::key_manager::get_keyring_secret("DATABRICKS_HOST", Default::default())?;
         let model_name = std::env::var("DATABRICKS_MODEL")
             .unwrap_or_else(|_| DATABRICKS_DEFAULT_MODEL.to_string());
 

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -25,7 +25,11 @@ pub struct OllamaProvider {
 
 impl OllamaProvider {
     pub fn from_env() -> Result<Self> {
-        let host = std::env::var("OLLAMA_HOST").unwrap_or_else(|_| OLLAMA_HOST.to_string());
+        // Although we don't need host to be stored secretly, we use the keyring to make
+        // it easier to coordinate with configuration. We could consider a non secret storage tool
+        // elsewhere in the future
+        let host = crate::key_manager::get_keyring_secret("OLLAMA_HOST", Default::default())
+            .unwrap_or_else(|_| OLLAMA_HOST.to_string());
         let model_name = std::env::var("OLLAMA_MODEL").unwrap_or_else(|_| OLLAMA_MODEL.to_string());
 
         let client = Client::builder()


### PR DESCRIPTION
Ollama and databricks need host configured and stored