### PR TITLE
feat: port over MCP prompts to developer system

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -44,14 +44,17 @@ pub fn load_prompt_files() -> HashMap<String, Prompt> {
     for entry in PROMPTS_DIR.files() {
         let prompt_str = String::from_utf8_lossy(entry.contents()).into_owned();
 
-        let template: PromptTemplate =
-            match serde_json::from_str(&prompt_str) {
-                Ok(t) => t,
-                Err(e) => {
-                    eprintln!("Failed to parse prompt template in {}: {}", entry.path().display(), e);
-                    continue; // Skip invalid prompt file
-                }
-            };
+        let template: PromptTemplate = match serde_json::from_str(&prompt_str) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!(
+                    "Failed to parse prompt template in {}: {}",
+                    entry.path().display(),
+                    e
+                );
+                continue; // Skip invalid prompt file
+            }
+        };
 
         let arguments = template
             .arguments
@@ -75,7 +78,6 @@ pub fn load_prompt_files() -> HashMap<String, Prompt> {
 
     prompts
 }
-
 
 pub struct DeveloperRouter {
     tools: Vec<Tool>,

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -670,7 +670,10 @@ impl Router for DeveloperRouter {
     }
 
     fn capabilities(&self) -> ServerCapabilities {
-        CapabilitiesBuilder::new().with_tools(false).build()
+        CapabilitiesBuilder::new()
+            .with_tools(false)
+            .with_prompts(false)
+            .build()
     }
 
     fn list_tools(&self) -> Vec<Tool> {

--- a/crates/goose-mcp/src/developer/prompts/unit_test.json
+++ b/crates/goose-mcp/src/developer/prompts/unit_test.json
@@ -1,0 +1,16 @@
+{
+    "id": "unit_test",
+    "template": "Generate or update unit tests for a given source code file.\n\nThe source code file is provided in {source_code}.\nPlease update the existing tests, ensure they are passing, and add any new tests as needed.\n\nThe test suite should:\n- Follow language-specific test naming conventions for {language}\n- Include all necessary imports and annotations\n- Thoroughly test the specified functionality\n- Ensure tests are passing before completion\n- Handle edge cases and error conditions\n- Use clear test names that reflect what is being tested",
+    "arguments": [
+      {
+        "name": "source_code",
+        "description": "The source code file content to be tested",
+        "required": true
+      },
+      {
+        "name": "language",
+        "description": "The programming language of the source code",
+        "required": true
+      }
+    ]
+  }


### PR DESCRIPTION
we missed [these prompt methods](https://github.com/block/goose/blob/23987f7c892e31b10445488149dcc47680f20c45/crates/goose-mcp/src/developer/mod.rs#L846-L887) (used to be in developer1) during the [cleanup](https://github.com/block/goose/pull/663). will make a PR to add them to current developer (no rush since we don't currently support them)