### PR TITLE
test: reintroduce relevant developer mcp tests

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -719,3 +719,308 @@ impl Clone for DeveloperRouter {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tokio::sync::OnceCell;
+
+    static DEV_ROUTER: OnceCell<DeveloperRouter> = OnceCell::const_new();
+
+    async fn get_router() -> &'static DeveloperRouter {
+        DEV_ROUTER
+            .get_or_init(|| async { DeveloperRouter::new() })
+            .await
+    }
+
+    #[tokio::test]
+    async fn test_shell_missing_parameters() {
+        let router = get_router().await;
+        let result = router.call_tool("shell", json!({})).await;
+
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(matches!(err, ToolError::InvalidParameters(_)));
+    }
+
+    #[tokio::test]
+    async fn test_shell_change_directory() {
+        let router = get_router().await;
+        let result = router
+            .call_tool("shell", json!({ "working_dir": ".", "command": "pwd" }))
+            .await;
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        // Check that the output contains the current directory
+        assert!(!output.is_empty());
+        let text = output.first().unwrap().as_text().unwrap();
+        assert!(text.contains(&std::env::current_dir().unwrap().display().to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_shell_invalid_directory() {
+        let router = get_router().await;
+        let result = router
+            .call_tool("shell", json!({ "working_dir": "non_existent_dir"}))
+            .await;
+        assert!(result.is_err());
+        let err = result.err().unwrap();
+        assert!(matches!(err, ToolError::InvalidParameters(_)));
+    }
+
+    #[tokio::test]
+    async fn test_text_editor_size_limits() {
+        let router = get_router().await;
+        let temp_dir = tempfile::tempdir().unwrap();
+
+        // Test file size limit
+        {
+            let large_file_path = temp_dir.path().join("large.txt");
+            let large_file_str = large_file_path.to_str().unwrap();
+
+            // Create a file larger than 2MB
+            let content = "x".repeat(3 * 1024 * 1024); // 3MB
+            std::fs::write(&large_file_path, content).unwrap();
+
+            let result = router
+                .call_tool(
+                    "text_editor",
+                    json!({
+                        "command": "view",
+                        "path": large_file_str
+                    }),
+                )
+                .await;
+
+            assert!(result.is_err());
+            let err = result.err().unwrap();
+            assert!(matches!(err, ToolError::ExecutionError(_)));
+            assert!(err.to_string().contains("too large"));
+        }
+
+        // Test character count limit
+        {
+            let many_chars_path = temp_dir.path().join("many_chars.txt");
+            let many_chars_str = many_chars_path.to_str().unwrap();
+
+            // Create a file with more than 2^20 characters but less than 2MB
+            let content = "x".repeat((1 << 20) + 1); // 2^20 + 1 characters
+            std::fs::write(&many_chars_path, content).unwrap();
+
+            let result = router
+                .call_tool(
+                    "text_editor",
+                    json!({
+                        "command": "view",
+                        "path": many_chars_str
+                    }),
+                )
+                .await;
+
+            assert!(result.is_err());
+            let err = result.err().unwrap();
+            assert!(matches!(err, ToolError::ExecutionError(_)));
+            assert!(err.to_string().contains("too many characters"));
+        }
+
+        temp_dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_text_editor_write_and_view_file() {
+        let router = get_router().await;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        let file_path_str = file_path.to_str().unwrap();
+
+        // Create a new file
+        router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "write",
+                    "path": file_path_str,
+                    "file_text": "Hello, world!"
+                }),
+            )
+            .await
+            .unwrap();
+
+        // View the file
+        let view_result = router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "view",
+                    "path": file_path_str
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert!(!view_result.is_empty());
+        let text = view_result
+            .iter()
+            .find(|c| {
+                c.audience()
+                    .is_some_and(|roles| roles.contains(&Role::User))
+            })
+            .unwrap()
+            .as_text()
+            .unwrap();
+        assert!(text.contains("Hello, world!"));
+
+        temp_dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_text_editor_str_replace() {
+        let router = get_router().await;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        let file_path_str = file_path.to_str().unwrap();
+
+        // Create a new file
+        router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "write",
+                    "path": file_path_str,
+                    "file_text": "Hello, world!"
+                }),
+            )
+            .await
+            .unwrap();
+
+        // Replace string
+        let replace_result = router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "str_replace",
+                    "path": file_path_str,
+                    "old_str": "world",
+                    "new_str": "Rust"
+                }),
+            )
+            .await
+            .unwrap();
+
+        let text = replace_result
+            .iter()
+            .find(|c| {
+                c.audience()
+                    .is_some_and(|roles| roles.contains(&Role::Assistant))
+            })
+            .unwrap()
+            .as_text()
+            .unwrap();
+
+        assert!(text.contains("has been edited, and the section now reads"));
+
+        // View the file to verify the change
+        let view_result = router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "view",
+                    "path": file_path_str
+                }),
+            )
+            .await
+            .unwrap();
+
+        let text = view_result
+            .iter()
+            .find(|c| {
+                c.audience()
+                    .is_some_and(|roles| roles.contains(&Role::User))
+            })
+            .unwrap()
+            .as_text()
+            .unwrap();
+        assert!(text.contains("Hello, Rust!"));
+
+        temp_dir.close().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_text_editor_undo_edit() {
+        let router = get_router().await;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let file_path = temp_dir.path().join("test.txt");
+        let file_path_str = file_path.to_str().unwrap();
+
+        // Create a new file
+        router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "write",
+                    "path": file_path_str,
+                    "file_text": "First line"
+                }),
+            )
+            .await
+            .unwrap();
+
+        // Replace string
+        router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "str_replace",
+                    "path": file_path_str,
+                    "old_str": "First line",
+                    "new_str": "Second line"
+                }),
+            )
+            .await
+            .unwrap();
+
+        // Undo the edit
+        let undo_result = router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "undo_edit",
+                    "path": file_path_str
+                }),
+            )
+            .await
+            .unwrap();
+
+        let text = undo_result.first().unwrap().as_text().unwrap();
+        assert!(text.contains("Undid the last edit"));
+
+        // View the file to verify the undo
+        let view_result = router
+            .call_tool(
+                "text_editor",
+                json!({
+                    "command": "view",
+                    "path": file_path_str
+                }),
+            )
+            .await
+            .unwrap();
+
+        let text = view_result
+            .iter()
+            .find(|c| {
+                c.audience()
+                    .is_some_and(|roles| roles.contains(&Role::User))
+            })
+            .unwrap()
+            .as_text()
+            .unwrap();
+        assert!(text.contains("First line"));
+
+        temp_dir.close().unwrap();
+    }
+}

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -43,44 +43,6 @@ impl Default for DeveloperRouter {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use lazy_static::lazy_static;
-    use std::fs;
-    use std::sync::Mutex;
-    use tempfile::TempDir;
-
-    lazy_static! {
-        static ref TEST_MUTEX: Mutex<()> = Mutex::new(());
-    }
-
-    #[test]
-    fn test_goosehints_when_present() {
-        let _lock = TEST_MUTEX.lock().unwrap();
-        let dir = TempDir::new().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        fs::write(".goosehints", "Test hint content").unwrap();
-        let router = DeveloperRouter::new();
-        let instructions = router.instructions();
-
-        assert!(instructions.contains("Test hint content"));
-    }
-
-    #[test]
-    fn test_goosehints_when_missing() {
-        let _lock = TEST_MUTEX.lock().unwrap();
-        let dir = TempDir::new().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        let router = DeveloperRouter::new();
-        let instructions = router.instructions();
-
-        assert!(!instructions.contains("Project Hints"));
-    }
-}
-
 impl DeveloperRouter {
     pub fn new() -> Self {
         // TODO consider rust native search tools, we could use
@@ -723,8 +685,41 @@ impl Clone for DeveloperRouter {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lazy_static::lazy_static;
     use serde_json::json;
+    use std::fs;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
     use tokio::sync::OnceCell;
+
+    lazy_static! {
+        static ref TEST_MUTEX: Mutex<()> = Mutex::new(());
+    }
+
+    #[test]
+    fn test_goosehints_when_present() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        fs::write(".goosehints", "Test hint content").unwrap();
+        let router = DeveloperRouter::new();
+        let instructions = router.instructions();
+
+        assert!(instructions.contains("Test hint content"));
+    }
+
+    #[test]
+    fn test_goosehints_when_missing() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let dir = TempDir::new().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let router = DeveloperRouter::new();
+        let instructions = router.instructions();
+
+        assert!(!instructions.contains("Project Hints"));
+    }
 
     static DEV_ROUTER: OnceCell<DeveloperRouter> = OnceCell::const_new();
 

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -745,31 +745,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_shell_change_directory() {
-        let router = get_router().await;
-        let result = router
-            .call_tool("shell", json!({ "working_dir": ".", "command": "pwd" }))
-            .await;
-        assert!(result.is_ok());
-        let output = result.unwrap();
-        // Check that the output contains the current directory
-        assert!(!output.is_empty());
-        let text = output.first().unwrap().as_text().unwrap();
-        assert!(text.contains(&std::env::current_dir().unwrap().display().to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_shell_invalid_directory() {
-        let router = get_router().await;
-        let result = router
-            .call_tool("shell", json!({ "working_dir": "non_existent_dir"}))
-            .await;
-        assert!(result.is_err());
-        let err = result.err().unwrap();
-        assert!(matches!(err, ToolError::InvalidParameters(_)));
-    }
-
-    #[tokio::test]
     async fn test_text_editor_size_limits() {
         let router = get_router().await;
         let temp_dir = tempfile::tempdir().unwrap();

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -687,8 +687,8 @@ mod tests {
     use super::*;
     use lazy_static::lazy_static;
     use serde_json::json;
-    use std::fs;
     use std::sync::Mutex;
+    use std::{env, fs};
     use tempfile::TempDir;
     use tokio::sync::OnceCell;
 
@@ -741,8 +741,10 @@ mod tests {
 
     #[tokio::test]
     async fn test_text_editor_size_limits() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         let router = get_router().await;
         let temp_dir = tempfile::tempdir().unwrap();
+        std::env::set_current_dir(&temp_dir).unwrap();
 
         // Test file size limit
         {
@@ -799,11 +801,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_text_editor_write_and_view_file() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         let router = get_router().await;
 
         let temp_dir = tempfile::tempdir().unwrap();
         let file_path = temp_dir.path().join("test.txt");
         let file_path_str = file_path.to_str().unwrap();
+        std::env::set_current_dir(&temp_dir).unwrap();
 
         // Create a new file
         router
@@ -847,11 +851,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_text_editor_str_replace() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         let router = get_router().await;
 
         let temp_dir = tempfile::tempdir().unwrap();
         let file_path = temp_dir.path().join("test.txt");
         let file_path_str = file_path.to_str().unwrap();
+        std::env::set_current_dir(&temp_dir).unwrap();
 
         // Create a new file
         router
@@ -920,11 +926,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_text_editor_undo_edit() {
+        let _lock = TEST_MUTEX.lock().unwrap();
         let router = get_router().await;
 
         let temp_dir = tempfile::tempdir().unwrap();
         let file_path = temp_dir.path().join("test.txt");
         let file_path_str = file_path.to_str().unwrap();
+        std::env::set_current_dir(&temp_dir).unwrap();
 
         // Create a new file
         router


### PR DESCRIPTION
Adds back in the tests that were previously in https://github.com/block/goose/blob/23987f7c892e31b10445488149dcc47680f20c45/crates/goose-mcp/src/developer/mod.rs#L902-L1297 for tests that are still relevant.

`test_read_resource` - no longer relevant, since the router `list_resources` just returns an empty list and `read_resource` returns an empty string.