### PR TITLE
fix: is_error is optional per MCP schema for CallToolResult

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -687,8 +687,8 @@ mod tests {
     use super::*;
     use lazy_static::lazy_static;
     use serde_json::json;
+    use std::fs;
     use std::sync::Mutex;
-    use std::{env, fs};
     use tempfile::TempDir;
     use tokio::sync::OnceCell;
 

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -584,7 +584,7 @@ mod tests {
             match name {
                 "tool" | "test__tool" => Ok(CallToolResult {
                     content: vec![],
-                    is_error: false,
+                    is_error: None,
                 }),
                 _ => Err(Error::NotInitialized),
             }

--- a/crates/mcp-core/src/protocol.rs
+++ b/crates/mcp-core/src/protocol.rs
@@ -218,7 +218,8 @@ pub struct ListToolsResult {
 #[serde(rename_all = "camelCase")]
 pub struct CallToolResult {
     pub content: Vec<Content>,
-    pub is_error: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub is_error: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -179,11 +179,11 @@ pub trait Router: Send + Sync + 'static {
             let result = match self.call_tool(name, arguments).await {
                 Ok(result) => CallToolResult {
                     content: result,
-                    is_error: false,
+                    is_error: None,
                 },
                 Err(err) => CallToolResult {
                     content: vec![Content::text(err.to_string())],
-                    is_error: true,
+                    is_error: Some(true),
                 },
             };
 


### PR DESCRIPTION
# Make isError optional in CallToolResult

Per Spec:
https://github.com/modelcontextprotocol/specification/blob/main/schema/2024-11-05/schema.ts#L646-L667

> /**
    * Whether the tool call ended in an error.
    *
    * If not set, this is assumed to be false (the call was successful).
    */
    isError?: boolean;


Was getting:
```
1. From Example Servers - Let's use the echo tool:

─── echo | example-servers_everything ──────────────────────────
message: Hello from the example server!


Execution failed: Serialization error: missing field `isError`
```