### PR TITLE
capture process exit and stderr

### DIFF
--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -9,6 +9,8 @@ use crate::config::Config;
 use crate::prompt::rustyline::RustylinePrompt;
 use crate::prompt::Prompt;
 use crate::session::{ensure_session_dir, get_most_recent_session, Session};
+use goose::agents::extension::ExtensionError;
+use mcp_client::transport::Error as McpClientError;
 
 /// Get the provider and model to use, following priority:
 /// 1. CLI arguments
@@ -91,7 +93,16 @@ pub async fn build_session<'a>(
             agent
                 .add_extension(extension_config.clone())
                 .await
-                .unwrap_or_else(|_| panic!("Failed to start extension: {}", name));
+                .unwrap_or_else(|e| {
+                    let err = match e {
+                        ExtensionError::Transport(McpClientError::StdioProcessError(inner)) => {
+                            inner
+                        }
+                        _ => e.to_string(),
+                    };
+                    println!("Failed to start extension: {}, {:?}", name, err);
+                    //process::exit(1);
+                });
         }
     }
 

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -101,7 +101,8 @@ pub async fn build_session<'a>(
                         _ => e.to_string(),
                     };
                     println!("Failed to start extension: {}, {:?}", name, err);
-                    //process::exit(1);
+                    println!("Please check extension configuration for {}.", name);
+                    process::exit(1);
                 });
         }
     }

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -143,7 +143,7 @@ impl Capabilities {
         let init_result = client
             .initialize(info, capabilities)
             .await
-            .map_err(|_| ExtensionError::Initialization(config.clone()))?;
+            .map_err(|e| ExtensionError::Initialization(config.clone(), e))?;
 
         // Store instructions if provided
         if let Some(instructions) = init_result.instructions {

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -7,8 +7,8 @@ use thiserror::Error;
 /// Errors from Extension operation
 #[derive(Error, Debug)]
 pub enum ExtensionError {
-    #[error("Failed to start the MCP server from configuration `{0}`")]
-    Initialization(ExtensionConfig),
+    #[error("Failed to start the MCP server from configuration `{0}` `{1}`")]
+    Initialization(ExtensionConfig, ClientError),
     #[error("Failed a client call to an MCP server: {0}")]
     Client(#[from] ClientError),
     #[error("User Message exceeded context-limit. History could not be truncated to accomodate.")]

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -7,7 +7,7 @@ use thiserror::Error;
 /// Errors from Extension operation
 #[derive(Error, Debug)]
 pub enum ExtensionError {
-    #[error("Failed to start the MCP server from configuration `{0}` within 60 seconds")]
+    #[error("Failed to start the MCP server from configuration `{0}`")]
     Initialization(ExtensionConfig),
     #[error("Failed a client call to an MCP server: {0}")]
     Client(#[from] ClientError),

--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -57,12 +57,13 @@ impl StdioActor {
         }
 
         let mut stderr_buffer = Vec::new();
-        // ignore response of bytes read
-        if self.stderr.read_to_end(&mut stderr_buffer).await.is_ok() {
-            tracing::error!(
-                "Process exited with stderr {:?}",
-                String::from_utf8_lossy(&stderr_buffer)
-            )
+        if let Ok(bytes) = self.stderr.read_to_end(&mut stderr_buffer).await {
+            if bytes > 0 {
+                tracing::error!(
+                    "Process exited with stderr {:?}",
+                    String::from_utf8_lossy(&stderr_buffer)
+                )
+            }
         }
         // Clean up regardless of which path we took
         self.pending_requests.clear().await;


### PR DESCRIPTION
# capture process exit and stderr

* Capture `stderr` instead of having it pipe back out to the main processes's stderr
* Use `tokio::select` to return when any of the concurrent operations return, in this case capture the process exit
* Capture the output of the subprocess's `stderr` on return and log it with `tracing::error`
* Prettify the error handling output for cli
* Move `eprintln` to `tracing::error`


When submitting a config/command like:
```yaml
# cli
extensions:
  bad_cmd:
    enabled: true
    type: stdio
    cmd: npx
    args:
      - this_is_not_real

# goosed
curl \
  -v \
  -XPOST \
  -H "Content-Type: application/json" \
  -H "X-Secret-Key: test" \
  http://localhost:3000/extensions/add \
  -d'{
    "type": "stdio",
    "cmd": "npx",
    "args": ["this_is_not_real"],
    "env_keys" : []
}'
```

The cli/curl command would hang for `300` seconds, the default timeout setup when adding an extension, even though the child process had already failed.

For example:
```bash
❯ ./target/debug/goose session --agent reference
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/this_is_not_real - Not found
npm error 404
npm error 404  'this_is_not_real@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: /Users/kalvin/.npm/_logs/2025-01-22T21_11_21_540Z-debug-0.log
Child process ended (EOF on stdout)

###
# 5 min later
###
thread 'main' panicked at crates/goose-cli/src/commands/session.rs:94:37:
Failed to start extension: bad_cmd
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

```

