### PR TITLE
fix: ignore payload in the CLI output if provider has error

### DIFF
--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -1,14 +1,13 @@
 use anyhow::Result;
 use async_trait::async_trait;
 use reqwest::Client;
-use reqwest::StatusCode;
 use serde_json::Value;
 use std::time::Duration;
 
 use super::base::{Provider, ProviderUsage, Usage};
 use super::configs::ModelConfig;
 use super::formats::anthropic::{create_request, get_usage, response_to_message};
-use super::utils::{emit_debug_trace, get_model, non_ok_response_to_provider_error};
+use super::utils::{emit_debug_trace, get_model, handle_response};
 use crate::message::Message;
 use mcp_core::tool::Tool;
 
@@ -56,13 +55,7 @@ impl AnthropicProvider {
             .send()
             .await?;
 
-        match response.status() {
-            StatusCode::OK => Ok(response.json().await?),
-            _ => {
-                let provider_error = non_ok_response_to_provider_error(payload, response).await;
-                Err(anyhow::anyhow!(provider_error.to_string()))
-            }
-        }
+        handle_response(payload, response).await
     }
 }
 

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -51,7 +51,12 @@ pub async fn non_ok_response_to_provider_error(
         StatusCode::INTERNAL_SERVER_ERROR | StatusCode::SERVICE_UNAVAILABLE => {
             ProviderError::ServerError(format!("Server error occurred. Status: {}", response.status()))
         }
-        _ => ProviderError::RequestFailed(format!("Request failed with status: {}. Payload: {}", response.status(), payload))
+        _ => {
+            tracing::debug!(
+                "{}", format!("Provider request failed with status: {}. Payload: {}", response.status(), payload)
+            );
+            ProviderError::RequestFailed(format!("Request failed with status: {}.", response.status()))
+        }
     }
 }
 


### PR DESCRIPTION
Ignore the payload in the error message when the providers have errors. Instead, we output them into the log file.

Before:

It will have the whole page in the CLI output

```
( O)> hello
◒  Caching cosmic calculations... 
2025-01-23T04:27:46.647350Z ERROR goose::providers::utils: Provider request failed with status: 400 Bad Request. Payload: {"max_tokens":4096,"messages":[{"content":[{"cache_control":{"type":"ephemeral"},"text":"hello","type":"text"}],"role":"user"}],"model":"claude-3-5-sonnet-latest","system":[{"cache_control":{"type":"invalid"},"text":"You are a general purpose AI agent called Goose. You are capable\nof dynamically plugging into new extensions and learning how to use them.\n\nYou solve higher level problems using the tools in these extensions, and can\ninteract with multiple at once.\n\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n# Extensions:\n\n\n## developer\n\n### Instructions\nThe developer extension gives you the capabilities to edit code files and run shell commands,\nand can be used to solve a wide range of problems.\n\nYou can use the shell tool to run any command that would work on the relevant operating system.\nUse the shell tool as needed to locate files or interact with the project.\n\nYour windows/screen tools can be used for visual debugging. You should not use these tools unless\nprompted to, but you can mention they are available if they are relevant.\n\noperating system: macos\ncurrent directory: /Users/yingjiehe/Documents/block/goose\n\n\n### Project Hints\nThe developer extension includes some hints for working on the project in this directory.\nYou are an expert programmer in Rust teaching who is teaching another developer who is learning Rust.\nThe students are familiar with programming in languages such as Python (advanced), Java (novice) and C (novice) so\nwhen possible use analogies from those languages.\n\nKey Principles\n- Write clear, concise, and idiomatic Rust code with accurate examples.\n- Use async programming paradigms effectively, leveraging `tokio` for concurrency.\n- Prioritize modularity, clean code organization, and efficient resource management.\n- Use expressive variable names that convey intent (e.g., `is_ready`, `has_data`).\n- Adhere to Rust's naming conventions: snake_case for variables and functions, PascalCase for types and structs.\n- Avoid code duplication; use functions and modules to encapsulate reusable logic.\n- Write code with safety, concurrency, and performance in mind, embracing Rust's ownership and type system.\n\nError Handling and Safety\n- Embrace Rust's Result and Option types for error handling.\n- Use `?` operator to propagate errors in async functions.\n- Implement custom error types using `thiserror` or `anyhow` for more descriptive errors.\n- Handle errors and edge cases early, returning errors where appropriate.\n- Use `.await` responsibly, ensuring safe points for context switching.\n\nKey Conventions\n1. Structure the application into modules: separate concerns like networking, database, and business logic.\n2. Use environment variables for configuration management (e.g., `dotenv` crate).\n3. Ensure code is well-documented with inline comments and Rustdoc.\n4. Do not use the older style of \"MOD/mod.rs\" for separing modules and instead use the \"MOD.rs\" filename convention.\n\nRefer to \"The Rust Programming Language\" book (2024 version) and \"Command line apps in Rust\" documentation for in-depth information on best practices, and advanced features.","type":"text"}],"tools":[{"description":"Execute a command in the shell.\n\nThis will return the output and error concatenated into a single string, as\nyou would see from running on the command line. There will also be an indication\nof if the command succeeded or failed.\n\nAvoid commands that produce a large amount of ouput, and consider piping those outputs to files.\nIf you need to run a long lived command, background it - e.g. `uvicorn main:app &` so that\nthis tool does not run indefinitely.\n\n**Important**: Use ripgrep - `rg` - when you need to locate a file or a code reference, other solutions\nmay show ignored or hidden files. For example *do not* use `find` or `ls -r`\n  - To locate a file by name: `rg --files | rg example.py`\n  - To locate consent inside files: `rg 'class Example'`\n","input_schema":{"properties":{"command":{"type":"string"}},"required":["command"],"type":"object"},"name":"developer__shell"},{"description":"Perform text editing operations on files.\n\nThe `command` parameter specifies the operation to perform. Allowed options are:\n- `view`: View the content of a file.\n- `write`: Create or overwrite a file with the given content\n- `str_replace`: Replace a string in a file with a new string.\n- `undo_edit`: Undo the last edit made to a file.\n\nTo use the write command, you must specify `file_text` which will become the new content of the file. Be careful with\nexisting files! This is a full overwrite, so you must include everything - not just sections you are modifying.\n\nTo use the str_replace command, you must specify both `old_str` and `new_str` - the `old_str` needs to exactly match one\nunique section of the original file, including any whitespace. Make sure to include enough context that the match is not\nambiguous. The entire original string will be replaced with `new_str`.\n","input_schema":{"properties":{"command":{"description":"Allowed options are: `view`, `write`, `str_replace`, undo_edit`.","enum":["view","write","str_replace","undo_edit"],"type":"string"},"file_text":{"type":"string"},"new_str":{"type":"string"},"old_str":{"type":"string"},"path":{"description":"Absolute path to file or directory, e.g. `/repo/file.py` or `/repo`.","type":"string"}},"required":["command","path"],"type":"object"},"name":"developer__text_editor"},{"description":"List all available window titles that can be used with screen_capture.\nReturns a list of window titles that can be used with the window_title parameter\nof the screen_capture tool.\n","input_schema":{"properties":{},"required":[],"type":"object"},"name":"developer__list_windows"},{"cache_control":{"type":"ephemeral"},"description":"Capture a screenshot of a specified display or window.\nYou can capture either:\n1. A full display (monitor) using the display parameter\n2. A specific window by its title using the window_title parameter\n\nOnly one of display or window_title should be specified.\n","input_schema":{"properties":{"display":{"default":0,"description":"The display number to capture (0 is main display)","type":"integer"},"window_title":{"default":null,"description":"Optional: the exact title of the window to capture. use the list_windows tool to find the available windows.","type":"string"}},"required":[],"type":"object"},"name":"developer__screen_capture"}]}
    at crates/goose/src/providers/utils.rs:55
    in goose::providers::anthropic::complete
    in goose::agents::truncate::reply

Error: Request failed: Request failed with status: 400 Bad Request.

◐  Caching cosmic calculations... 
The error above was an exception we were not able to handle.\n\n
These errors are often related to connection or authentication\n
We've removed the conversation up to the most recent user message
 - depending on the error you may be able to continue

( O)> 
```

After:
It will be in the CLI output, instead, we can find it under `~/.config/goose/logs/cli/xxxx.log` file

```
( O)> hello
◒  Debugging dream drivers...                                                                                                       Error: Request failed: Request failed with status: 400 Bad Request.
◐  Debugging dream drivers...                                                                                                       
The error above was an exception we were not able to handle.\n\n
These errors are often related to connection or authentication\n
We've removed the conversation up to the most recent user message
 - depending on the error you may be able to continue

( O)>
```