### PR TITLE
add error in /extensions/add response body

### DIFF
--- a/crates/goose-server/src/routes/extension.rs
+++ b/crates/goose-server/src/routes/extension.rs
@@ -149,7 +149,10 @@ async fn add_extension(
             eprintln!("Failed to add extension configuration: {:?}", e);
             Ok(Json(ExtensionResponse {
                 error: true,
-                message: Some("Failed to add extension configuration".to_string()),
+                message: Some(format!(
+                    "Failed to add extension configuration, error: {:?}",
+                    e
+                )),
             }))
         }
     }


### PR DESCRIPTION
Actually respond back to the caller with the error message (stderr if available) in the response body.

```
# old
{
  "error": true,
  "message": "Failed to add extension configuration"
}

# new, can be verbose depending on stderr
{
  "error": true,
  "message": "Failed to add extension configuration, error: Initialization(Stdio { cmd: \"uvx\", args: [\"this_is_not_real\"], envs: Envs { map: {} } }, McpServerError { method: \"initialize\", server: \"\", source: ServerBoxError(StdioProcessError(\"  × No solution found when resolving tool dependencies:\\n  ╰─▶ Because this-is-not-real was not found in the package registry and you\\n      require this-is-not-real, we can conclude that your requirements are\\n      unsatisfiable.\\n\")) })"
}
```

part of #694 