### PR TITLE
fix flaky unit test

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -734,6 +734,8 @@ mod tests {
         assert!(result.is_err());
         let err = result.err().unwrap();
         assert!(matches!(err, ToolError::InvalidParameters(_)));
+
+        temp_dir.close().unwrap();
     }
 
     #[tokio::test]

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -800,38 +800,6 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_text_editor_char_count_limits() {
-        let router = get_router().await;
-        let temp_dir = tempfile::tempdir().unwrap();
-        std::env::set_current_dir(&temp_dir).unwrap();
-
-        let many_chars_path = temp_dir.path().join("many_chars.txt");
-        let many_chars_str = many_chars_path.to_str().unwrap();
-
-        // Create a file with more than 2^20 characters but less than 2MB
-        let content = "x".repeat((1 << 20) + 1); // 2^20 + 1 characters
-        std::fs::write(&many_chars_path, content).unwrap();
-
-        let result = router
-            .call_tool(
-                "text_editor",
-                json!({
-                    "command": "view",
-                    "path": many_chars_str
-                }),
-            )
-            .await;
-
-        assert!(result.is_err());
-        let err = result.err().unwrap();
-        assert!(matches!(err, ToolError::ExecutionError(_)));
-        assert!(err.to_string().contains("too many characters"));
-
-        temp_dir.close().unwrap();
-    }
-
-    #[tokio::test]
-    #[serial]
     async fn test_text_editor_write_and_view_file() {
         let router = get_router().await;
 

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -740,32 +740,60 @@ mod tests {
 
     #[tokio::test]
     #[serial]
-    async fn test_text_editor_file_size_limits() {
+    async fn test_text_editor_size_limits() {
         let router = get_router().await;
         let temp_dir = tempfile::tempdir().unwrap();
         std::env::set_current_dir(&temp_dir).unwrap();
 
-        let large_file_path = temp_dir.path().join("large.txt");
-        let large_file_str = large_file_path.to_str().unwrap();
+        // Test file size limit
+        {
+            let large_file_path = temp_dir.path().join("large.txt");
+            let large_file_str = large_file_path.to_str().unwrap();
 
-        // Create a file larger than 2MB
-        let content = "x".repeat(3 * 1024 * 1024); // 3MB
-        std::fs::write(&large_file_path, content).unwrap();
+            // Create a file larger than 2MB
+            let content = "x".repeat(3 * 1024 * 1024); // 3MB
+            std::fs::write(&large_file_path, content).unwrap();
 
-        let result = router
-            .call_tool(
-                "text_editor",
-                json!({
-                    "command": "view",
-                    "path": large_file_str
-                }),
-            )
-            .await;
+            let result = router
+                .call_tool(
+                    "text_editor",
+                    json!({
+                        "command": "view",
+                        "path": large_file_str
+                    }),
+                )
+                .await;
 
-        assert!(result.is_err());
-        let err = result.err().unwrap();
-        assert!(matches!(err, ToolError::ExecutionError(_)));
-        assert!(err.to_string().contains("too large"));
+            assert!(result.is_err());
+            let err = result.err().unwrap();
+            assert!(matches!(err, ToolError::ExecutionError(_)));
+            assert!(err.to_string().contains("too large"));
+        }
+
+        // Test character count limit
+        {
+            let many_chars_path = temp_dir.path().join("many_chars.txt");
+            let many_chars_str = many_chars_path.to_str().unwrap();
+
+            // Create a file with more than 2^20 characters but less than 2MB
+            let content = "x".repeat((1 << 20) + 1); // 2^20 + 1 characters
+            std::fs::write(&many_chars_path, content).unwrap();
+
+            let result = router
+                .call_tool(
+                    "text_editor",
+                    json!({
+                        "command": "view",
+                        "path": many_chars_str
+                    }),
+                )
+                .await;
+
+            assert!(result.is_err());
+            let err = result.err().unwrap();
+            assert!(matches!(err, ToolError::ExecutionError(_)));
+            assert!(err.to_string().contains("too many characters"));
+        }
 
         temp_dir.close().unwrap();
     }


### PR DESCRIPTION
Add missing serial annotation to the test.

Re-ran 8 times and all looked good, should be less flaky now

![image](https://github.com/user-attachments/assets/16d1dea3-8abf-4564-8066-b6a2e0b93338)
