### PR TITLE
keep extension name consistent when inserting and removing from state

### DIFF
--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -92,7 +92,7 @@ impl ExtensionManager {
     pub fn get_all() -> Result<Vec<ExtensionEntry>> {
         let config = Config::global();
         let extensions: HashMap<String, ExtensionEntry> =
-            config.get("extensions").unwrap_or(HashMap::new());
+            config.get("extensions").unwrap_or_default();
         Ok(Vec::from_iter(extensions.values().cloned()))
     }
 


### PR DESCRIPTION
sanitize name of the extension before storing in various state within capabilities, and run the same sanitize on the name when attempting to remove the extension