### PR TITLE
hotfix: databricks uses openais format

### DIFF
--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -96,7 +96,7 @@ impl DatabricksProvider {
                 host,
                 auth: DatabricksAuth::token(api_key),
                 model,
-                image_format: ImageFormat::Anthropic,
+                image_format: ImageFormat::OpenAi,
             });
         }
 
@@ -106,7 +106,7 @@ impl DatabricksProvider {
             auth: DatabricksAuth::oauth(host.clone()),
             host,
             model,
-            image_format: ImageFormat::Anthropic,
+            image_format: ImageFormat::OpenAi,
         })
     }
 


### PR DESCRIPTION
tiny change - openai format is required (even with anthropic models)