### PR TITLE
feat: lowercase extension names when sanitizing

### DIFF
--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -67,7 +67,7 @@ impl ResourceItem {
 
 /// Sanitizes a string by replacing invalid characters with underscores.
 /// Valid characters match [a-zA-Z0-9_-]
-fn sanitize_and_lowercase(input: String) -> String {
+fn normalize(input: String) -> String {
     let mut result = String::with_capacity(input.len());
     for c in input.chars() {
         result.push(match c {
@@ -143,7 +143,7 @@ impl Capabilities {
             .await
             .map_err(|e| ExtensionError::Initialization(config.clone(), e))?;
 
-        let sanitized_name = sanitize_and_lowercase(config.name().to_string());
+        let sanitized_name = normalize(config.name().to_string());
 
         // Store instructions if provided
         if let Some(instructions) = init_result.instructions {
@@ -177,11 +177,9 @@ impl Capabilities {
 
     /// Get aggregated usage statistics
     pub async fn remove_extension(&mut self, name: &str) -> ExtensionResult<()> {
-        let sanitized_name = sanitize_and_lowercase(name.to_string());
+        let sanitized_name = normalize(name.to_string());
 
-        tracing::error!(name = sanitized_name, clients= ?self.clients.keys(), "removing extension");
         self.clients.remove(&sanitized_name);
-        tracing::error!(name = sanitized_name, clients= ?self.clients.keys(), "removed extension");
         self.instructions.remove(&sanitized_name);
         self.resource_capable_extensions.remove(&sanitized_name);
         Ok(())
@@ -604,22 +602,22 @@ mod tests {
 
         // Add some mock clients
         capabilities.clients.insert(
-            sanitize_and_lowercase("test_client".to_string()),
+            normalize("test_client".to_string()),
             Arc::new(Mutex::new(Box::new(MockClient {}))),
         );
 
         capabilities.clients.insert(
-            sanitize_and_lowercase("__client".to_string()),
+            normalize("__client".to_string()),
             Arc::new(Mutex::new(Box::new(MockClient {}))),
         );
 
         capabilities.clients.insert(
-            sanitize_and_lowercase("__cli__ent__".to_string()),
+            normalize("__cli__ent__".to_string()),
             Arc::new(Mutex::new(Box::new(MockClient {}))),
         );
 
         capabilities.clients.insert(
-            sanitize_and_lowercase("client 🚀".to_string()),
+            normalize("client 🚀".to_string()),
             Arc::new(Mutex::new(Box::new(MockClient {}))),
         );
 
@@ -653,17 +651,17 @@ mod tests {
 
         // Add some mock clients
         capabilities.clients.insert(
-            sanitize_and_lowercase("test_client".to_string()),
+            normalize("test_client".to_string()),
             Arc::new(Mutex::new(Box::new(MockClient {}))),
         );
 
         capabilities.clients.insert(
-            sanitize_and_lowercase("__cli__ent__".to_string()),
+            normalize("__cli__ent__".to_string()),
             Arc::new(Mutex::new(Box::new(MockClient {}))),
         );
 
         capabilities.clients.insert(
-            sanitize_and_lowercase("client 🚀".to_string()),
+            normalize("client 🚀".to_string()),
             Arc::new(Mutex::new(Box::new(MockClient {}))),
         );
 


### PR DESCRIPTION
when we sanitize extension names, we should make it case-insensitive and lowercase the response as well