### PR TITLE
Truncate OpenAI tool.description to 1024

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -147,11 +147,12 @@ pub fn format_tools(tools: &[Tool]) -> anyhow::Result<Vec<Value>> {
             return Err(anyhow!("Duplicate tool name: {}", tool.name));
         }
 
+        // OpenAI's tool description max str len is 1024
         result.push(json!({
             "type": "function",
             "function": {
                 "name": tool.name,
-                "description": tool.description,
+                "description": tool.description.clone().truncate(1024),
                 "parameters": tool.input_schema,
             }
         }));

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -52,10 +52,11 @@ pub async fn non_ok_response_to_provider_error(
             ProviderError::ServerError(format!("Server error occurred. Status: {}", response.status()))
         }
         _ => {
+            let status = response.status();
             tracing::debug!(
-                "{}", format!("Provider request failed with status: {}. Payload: {}", response.status(), payload)
+                "{}", format!("Provider request failed with status: {}. Body: {:?}. Payload: {}", status, response.text().await.unwrap_or_default(), payload)
             );
-            ProviderError::RequestFailed(format!("Request failed with status: {}.", response.status()))
+            ProviderError::RequestFailed(format!("Request failed with status: {}.", status))
         }
     }
 }


### PR DESCRIPTION
## truncate OpenAI tool.description to 1024
* make `tool.description` a max of 1024 len string
* include `response.text()` response body from API call in debug tracing to find the errors easier

With `non-developer` extension we would get a `400 Bad Request` when using OpenAI.

The response body was:
```json
{
  "error": {
    "message": "Invalid 'tools[3].function.description': string too long. Expected a string with maximum length 1024, but got a string with length 2028 instead.",
    "type": "invalid_request_error",
    "param": "tools[3].function.description",
    "code": "string_above_max_length"
  }
}
```