### PR TITLE
Add Update Goose Tips to Docs

### DIFF
--- a/documentation/docs/guides/tips.md
+++ b/documentation/docs/guides/tips.md
@@ -44,4 +44,7 @@ You can tell Goose to run things for you continuously and it will iterate, try, 
 It doesn't have to be in a repo. Just ask Goose!
 
 ### Keep Goose updated
-Regularly update Goose to benefit from our latest features, bug fixes, and performance improvements.
+Regularly update Goose to benefit from the latest features, bug fixes, and performance improvements. For the CLI, the best way to keep it updated is by re-running the [Goose installation script][installation]. For Goose UI, check the [GitHub Releases page][ui-release] regularly for updates.
+
+[installation]: https://block.github.io/goose/v1/docs/quickstart/#installation
+[ui-release]: https://github.com/block/goose/releases/stable

--- a/documentation/docs/installation.md
+++ b/documentation/docs/installation.md
@@ -20,10 +20,14 @@ Goose currently works only on **OSX** and **Linux** systems, and supports both *
     curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | sh
     ```
     This script will fetch the latest version of Goose and set it up on your system.
+    
+    :::tip Best Practice
+    It’s best to keep Goose updated. You can update it by re-running the installation script.
+    :::
   </TabItem>
   <TabItem value="ui" label="Goose UI">
     #### Installing the Goose Desktop Application
-    To install Goose, click the button below:
+    To install Goose, click the **button** below:
       <Button 
         label=":arrow_down: Download Goose Desktop" 
         link="https://github.com/block/goose/releases/download/stable/Goose.zip" 
@@ -34,7 +38,10 @@ Goose currently works only on **OSX** and **Linux** systems, and supports both *
     <div style={{ marginTop: '1rem' }}>  
       1. Unzip the downloaded `Goose.zip` file.
       2. Run the executable file to launch the Goose desktop application.
-    </div>
+      :::tip Best Practice
+      It’s best to keep Goose updated. You can do this by checking the [Goose GitHub Release page](https://github.com/block/goose/releases/stable) and downloading updates when available.
+      :::
+    </div>  
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
This PR improves the Goose documentation by adding tips on how to keep Goose updated for both the CLI and UI. The update ensures users are informed about the best practices to maintain the latest version of Goose, benefiting from new features, bug fixes, and performance improvements.

#### **Changes:**
1. **Added update tips to the Installation Guide**:
   - Included a `:::tip Best Practice` section in both CLI and UI installation instructions:
     - `documentation/docs/installation.md`

2. **Updated the Tips Guide**:
   - Enhanced the "Keep Goose updated" note to include:
     - Instructions for updating the CLI via the installation script.
     - Instructions for checking the [GitHub Releases page](https://github.com/block/goose/releases/stable) for Goose UI updates.
     - `documentation/docs/guides/tips.md`


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209231522591752