### PR TITLE
fix: Make it possible to remove extensions which are disabled

### DIFF
--- a/ui/desktop/src/components/settings/Settings.tsx
+++ b/ui/desktop/src/components/settings/Settings.tsx
@@ -130,7 +130,7 @@ export default function Settings() {
   };
 
   const handleExtensionRemove = async () => {
-    if (!extensionBeingConfigured || !extensionBeingConfigured.enabled) return;
+    if (!extensionBeingConfigured) return;
 
     const response = await removeExtension(extensionBeingConfigured.name);
 


### PR DESCRIPTION
Small bugfix: we weren't allowing removal of extensions which were disabled