### PR TITLE
fix: extension page link fix, change nondeveloper to 'computer controller'

### DIFF
--- a/extensions-site/app/components/server-card.tsx
+++ b/extensions-site/app/components/server-card.tsx
@@ -6,35 +6,8 @@ import type { MCPServer } from "../types/server";
 import { Link, NavLink } from "react-router";
 import { useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
+import { getGooseInstallLink } from "../utils/install-links";
 
-function getGooseInstallLink(server: MCPServer): string {
-  if (server.is_builtin) {
-    const queryParams = [
-      'cmd=goosed',
-      'arg=mcp',
-      `arg=${encodeURIComponent(server.id)}`,
-      `description=${encodeURIComponent(server.id)}`
-    ].join('&');
-    return `goose://extension?${queryParams}`;
-  }
-  const parts = server.command.split(" ");
-  const baseCmd = parts[0]; // npx or uvx
-  const args = parts.slice(1); // remaining arguments
-  const queryParams = [
-    `cmd=${encodeURIComponent(baseCmd)}`,
-    ...args.map((arg) => `arg=${encodeURIComponent(arg)}`),
-    `id=${encodeURIComponent(server.id)}`,
-    `name=${encodeURIComponent(server.name)}`,
-    `description=${encodeURIComponent(server.description)}`,
-    ...server.environmentVariables
-      .filter((env) => env.required)
-      .map(
-        (env) => `env=${encodeURIComponent(`${env.name}=${env.description}`)}`
-      ),
-  ].join("&");
-
-  return `goose://extension?${queryParams}`;
-}
 
 export function ServerCard({ server }: { server: MCPServer }) {
   const [isCommandVisible, setIsCommandVisible] = useState(false);

--- a/extensions-site/app/mcp-servers.ts
+++ b/extensions-site/app/mcp-servers.ts
@@ -1,4 +1,4 @@
-import type { MCPServer } from '../types/server';
+import type { MCPServer } from '../app/types/server';
 
 export async function fetchMCPServers(): Promise<MCPServer[]> {
   try {

--- a/extensions-site/app/routes/detail.tsx
+++ b/extensions-site/app/routes/detail.tsx
@@ -11,45 +11,13 @@ import { Badge } from "../components/ui/badge";
 import { Card, CardContent, CardHeader } from "../components/ui/card";
 import { useEffect, useState } from "react";
 import { fetchMCPServers } from "../mcp-servers";
+import { getGooseInstallLink } from "../utils/install-links";
+import type { MCPServer } from "../types/server";
 
-interface Server {
-  id: string;
-  name: string;
-  description: string;
-  command: string;
-  link: string;
-  installation_notes: string;
-  is_builtin: boolean;
-  endorsed: boolean;
-  githubStars: number;
-  environmentVariables: {
-    name: string;
-    description: string;
-    required: boolean;
-  }[];
-}
-
-function getGooseInstallLink(server: Server): string {
-  const parts = server.command.split(" ");
-  const baseCmd = parts[0];
-  const args = parts.slice(1);
-  const queryParams = [
-    `cmd=${encodeURIComponent(baseCmd)}`,
-    ...args.map((arg) => `arg=${encodeURIComponent(arg)}`),
-    `description=${encodeURIComponent(server.description)}`,
-    ...server.environmentVariables
-      .filter((env) => env.required)
-      .map(
-        (env) => `env=${encodeURIComponent(`${env.name}=${env.description}`)}`
-      ),
-  ].join("&");
-
-  return `goose://extension?${queryParams}`;
-}
 
 export default function DetailPage() {
   const { id } = useParams();
-  const [server, setServer] = useState<Server | null>(null);
+  const [server, setServer] = useState<MCPServer | null>(null);
   const [isCommandVisible, setIsCommandVisible] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -213,25 +181,25 @@ export default function DetailPage() {
                 <span>{server.githubStars} on Github</span>
               </div>
 
-              <a
-                href={getGooseInstallLink(server)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="no-underline"
-              >
-                {server.is_builtin ? (
-                  <div
-                    className="inline-block"
-                    title="This extension is built into goose and can be enabled in the settings page"
+              {server.is_builtin ? (
+                <div
+                  className="inline-block"
+                  title="This extension is built into goose and can be enabled in the settings page"
+                >
+                  <Badge
+                    variant="secondary"
+                    className="ml-2 text-xs cursor-help"
                   >
-                    <Badge
-                      variant="secondary"
-                      className="ml-2 text-xs cursor-help"
-                    >
-                      Built-in
-                    </Badge>
-                  </div>
-                ) : (
+                    Built-in
+                  </Badge>
+                </div>
+              ) : (
+                <a
+                  href={getGooseInstallLink(server)}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="no-underline"
+                >
                   <Button
                     size="icon"
                     variant="link"
@@ -241,8 +209,8 @@ export default function DetailPage() {
                     <span>Install</span>
                     <Download className="h-4 w-4 ml-2 group-hover/download:text-[#FA5204]" />
                   </Button>
-                )}
-              </a>
+                </a>
+              )}
             </div>
           </CardContent>
         </Card>

--- a/extensions-site/app/utils/install-links.tsx
+++ b/extensions-site/app/utils/install-links.tsx
@@ -1,0 +1,30 @@
+import type { MCPServer } from "../types/server";
+
+export function getGooseInstallLink(server: MCPServer): string {
+  if (server.is_builtin) {
+    const queryParams = [
+      'cmd=goosed',
+      'arg=mcp',
+      `arg=${encodeURIComponent(server.id)}`,
+      `description=${encodeURIComponent(server.id)}`
+    ].join('&');
+    return `goose://extension?${queryParams}`;
+  }
+  const parts = server.command.split(" ");
+  const baseCmd = parts[0]; // npx or uvx
+  const args = parts.slice(1); // remaining arguments
+  const queryParams = [
+    `cmd=${encodeURIComponent(baseCmd)}`,
+    ...args.map((arg) => `arg=${encodeURIComponent(arg)}`),
+    `id=${encodeURIComponent(server.id)}`,
+    `name=${encodeURIComponent(server.name)}`,
+    `description=${encodeURIComponent(server.description)}`,
+    ...server.environmentVariables
+      .filter((env) => env.required)
+      .map(
+        (env) => `env=${encodeURIComponent(`${env.name}=${env.description}`)}`
+      ),
+  ].join("&");
+
+  return `goose://extension?${queryParams}`;
+}

--- a/extensions-site/public/servers.json
+++ b/extensions-site/public/servers.json
@@ -12,7 +12,7 @@
     "environmentVariables": []
   },
   {
-    "id": "computer_control",
+    "id": "nondeveloper",
     "name": "Computer Controller",
     "description": "Built-in computer controlls for webscraping, file caching, and automations",
     "command": "",

--- a/extensions-site/public/servers.json
+++ b/extensions-site/public/servers.json
@@ -5,51 +5,23 @@
     "description": "Built-in developer tools for file editing and shell command execution",
     "command": "",
     "link": "https://github.com/block/goose/tree/v1.0/crates/goose-mcp/src/developer",
-    "installation_notes": "This is a built-in extension that comes with Goose by default. No installation required.",
+    "installation_notes": "This is a built-in extension that comes with goose by default. No installation required.",
     "is_builtin": true,
     "endorsed": true,
     "githubStars": 356,
     "environmentVariables": []
   },
   {
-    "id": "nondeveloper",
-    "name": "Non-developer",
-    "description": "Built-in tools for non-developer tasks and system interactions",
+    "id": "computer_control",
+    "name": "Computer Controller",
+    "description": "Built-in computer controlls for webscraping, file caching, and automations",
     "command": "",
     "link": "https://github.com/block/goose/tree/v1.0/crates/goose-mcp/src/nondeveloper",
-    "installation_notes": "This is a built-in extension that comes with Goose by default. No installation required.",
+    "installation_notes": "This is a built-in extension that comes with goose and can be enabled in the Settings page under 'Extensions'.",
     "is_builtin": true,
     "endorsed": true,
     "githubStars": 356,
     "environmentVariables": []
-  },
-  {
-    "id": "google_drive",
-    "name": "Google Drive",
-    "description": "Built-in Google Drive integration for file management and access",
-    "command": "",
-    "link": "https://github.com/block/goose/tree/v1.0/crates/goose-mcp/src/google_drive",
-    "installation_notes": "This is a built-in extension that comes with Goose by default. Can be accessed via goose://extension?cmd=goosed&arg=mcp&arg=google_drive&description=google_drive deeplink.",
-    "is_builtin": true,
-    "endorsed": true,
-    "githubStars": 356,
-    "environmentVariables": [
-      {
-        "name": "GOOGLE_DRIVE_OAUTH_PATH",
-        "description": "Path to the OAuth config file (required)",
-        "required": true
-      },
-      {
-        "name": "GOOGLE_DRIVE_CREDENTIALS_PATH",
-        "description": "Path to store OAuth credentials (required)",
-        "required": true
-      },
-      {
-        "name": "GOOGLE_DRIVE_OAUTH_CONFIG",
-        "description": "OAuth config JSON string (optional, if not provided expects valid config file at GOOGLE_DRIVE_OAUTH_PATH)",
-        "required": false
-      }
-    ]
   },
   {
     "id": "memory",
@@ -57,7 +29,7 @@
     "description": "Built-in memory system for persistent context and information storage",
     "command": "",
     "link": "https://github.com/block/goose/tree/v1.0/crates/goose-mcp/src/memory",
-    "installation_notes": "This is a built-in extension that comes with Goose by default. No installation required.",
+    "installation_notes": "This is a built-in extension that comes with goose and can be enabled in the Settings page under 'Extensions'.",
     "is_builtin": true,
     "endorsed": true,
     "githubStars": 356,
@@ -69,7 +41,7 @@
     "description": "Built-in JetBrains IDE integration for development workflows",
     "command": "",
     "link": "https://github.com/block/goose/tree/v1.0/crates/goose-mcp/src/jetbrains",
-    "installation_notes": "This is a built-in extension that comes with Goose by default. Can be accessed via goose://extension?cmd=goosed&arg=mcp&arg=jetbrains deeplink.",
+    "installation_notes": "This is a built-in extension that comes with goose and can be enabled in the Settings page under 'Extensions'.",
     "is_builtin": true,
     "endorsed": true,
     "githubStars": 356,

--- a/extensions-site/public/servers.json
+++ b/extensions-site/public/servers.json
@@ -75,7 +75,7 @@
     "id": "git",
     "name": "Git",
     "description": "Git version control system integration",
-    "command": "npx -y @modelcontextprotocol/server-git",
+    "command": "uvx mcp-server-git",
     "link": "https://github.com/modelcontextprotocol/servers/tree/main/src/git",
     "installation_notes": "Install using npx package manager. Note: Does not support git push, merge or rebase operations.",
     "is_builtin": false,


### PR DESCRIPTION
* fix links in the details page so goose can load extensions
* change 'nondeveloper' to computer controller 
<img width="460" alt="image" src="https://github.com/user-attachments/assets/26f03407-7ebd-4e2e-881e-9821702bee5b" />

* `servers.json`: update description in details card
* `servers.json`: fix github install command
