### PR TITLE
fix: add explicit dependency to pr-comment job 

### DIFF
--- a/.github/workflows/pr-comment-bundle-desktop.yml
+++ b/.github/workflows/pr-comment-bundle-desktop.yml
@@ -53,7 +53,7 @@ jobs:
   pr-comment:
     name: PR Comment with Desktop App
     runs-on: ubuntu-latest
-    needs: [ bundle-desktop ]
+    needs: [trigger-on-command, bundle-desktop]
     permissions:
       pull-requests: write
 


### PR DESCRIPTION
if we don't add in the needs - `${{ needs.trigger-on-command.outputs.pr_number }}` is empty

github action doesn't inject outputs based on transitive dependency. tested this out here: https://github.com/block/goose/pull/775