### PR TITLE
fix: Do not wait 5s before adding extensions to agent

### DIFF
--- a/ui/desktop/src/utils/providerUtils.ts
+++ b/ui/desktop/src/utils/providerUtils.ts
@@ -78,14 +78,9 @@ export const initializeSystem = async (provider: string, model: string) => {
     console.log('initializing agent with provider', provider, 'model', model);
     await addAgent(provider.toLowerCase(), model);
 
-    // TODO - Needs to be replaced with something which can interface
-    // with the agent to tell when it is ready to add extensions
-    setTimeout(() => {
-      window.electron.logInfo('Loading and adding stored extension configs');
-      loadAndAddStoredExtensions().catch((error) => {
-        console.error('Failed to load and add stored extension configs:', error);
-      });
-    }, 5000);
+    loadAndAddStoredExtensions().catch((error) => {
+      console.error('Failed to load and add stored extension configs:', error);
+    });
   } catch (error) {
     console.error('Failed to initialize agent:', error);
     throw error;


### PR DESCRIPTION
In theory, we no longer need this delay as the agent should be ready to add extensions when `addAgent` resolves