### PR TITLE
fix: suggest correct model on switch

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -195,8 +195,7 @@ pub async fn configure_provider_dialog() -> Result<bool, Box<dyn Error>> {
     }
 
     // Select model, defaulting to the provider's recommended model UNLESS there is an env override
-    let default_model = std::env::var("GOOSE_MODEL")
-        .unwrap_or(provider_meta.default_model.clone());
+    let default_model = std::env::var("GOOSE_MODEL").unwrap_or(provider_meta.default_model.clone());
     let model: String = cliclack::input("Enter a model from that provider:")
         .default_input(&default_model)
         .interact()?;

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -194,9 +194,8 @@ pub async fn configure_provider_dialog() -> Result<bool, Box<dyn Error>> {
         }
     }
 
-    // Select model, defaulting to the provider's recommended model
-    let default_model = config
-        .get("GOOSE_MODEL")
+    // Select model, defaulting to the provider's recommended model UNLESS there is an env override
+    let default_model = std::env::var("GOOSE_MODEL")
         .unwrap_or(provider_meta.default_model.clone());
     let model: String = cliclack::input("Enter a model from that provider:")
         .default_input(&default_model)


### PR DESCRIPTION
Only an active env var can override this, which is still useful for installers

Fixes #787