### PR TITLE
fix: send event to reload settings on link

### DIFF
--- a/ui/desktop/src/components/settings/Settings.tsx
+++ b/ui/desktop/src/components/settings/Settings.tsx
@@ -77,6 +77,22 @@ export default function Settings() {
     localStorage.setItem('user_settings', JSON.stringify(settings));
   }, [settings]);
 
+  // Listen for settings updates from extension storage
+  useEffect(() => {
+    const handleSettingsUpdate = (_: any) => {
+      const saved = localStorage.getItem('user_settings');
+      if (saved) {
+        let currentSettings = JSON.parse(saved);
+        setSettings(currentSettings);
+      }
+    };
+
+    window.electron.on('settings-updated', handleSettingsUpdate);
+    return () => {
+      window.electron.off('settings-updated', handleSettingsUpdate);
+    };
+  }, []);
+
   // Handle URL parameters for auto-opening extension configuration
   useEffect(() => {
     const params = new URLSearchParams(location.search);

--- a/ui/desktop/src/extensions.tsx
+++ b/ui/desktop/src/extensions.tsx
@@ -193,6 +193,8 @@ function storeExtensionConfig(config: FullExtensionConfig) {
       userSettings.extensions.push(config);
       localStorage.setItem('user_settings', JSON.stringify(userSettings));
       console.log('Extension config stored successfully in user_settings');
+      // Notify settings update through electron IPC
+      window.electron.send('settings-updated');
     } else {
       console.log('Extension config already exists in user_settings');
     }


### PR DESCRIPTION
Otherwise if settings page was already open it would not immediately load the env vars dialog or render the new extension