### PR TITLE
fix: Switch electron.send to named method via preload.js

### DIFF
--- a/ui/desktop/src/extensions.ts
+++ b/ui/desktop/src/extensions.ts
@@ -194,7 +194,7 @@ function storeExtensionConfig(config: FullExtensionConfig) {
       localStorage.setItem('user_settings', JSON.stringify(userSettings));
       console.log('Extension config stored successfully in user_settings');
       // Notify settings update through electron IPC
-      window.electron.send('settings-updated');
+      window.electron.settingsUpdated();
     } else {
       console.log('Extension config already exists in user_settings');
     }

--- a/ui/desktop/src/preload.js
+++ b/ui/desktop/src/preload.js
@@ -19,6 +19,7 @@ contextBridge.exposeInMainWorld('electron', {
   fetchMetadata: (url) => ipcRenderer.invoke('fetch-metadata', url),
   reloadApp: () => ipcRenderer.send('reload-app'),
   selectFileOrDirectory: () => ipcRenderer.invoke('select-file-or-directory'),
+  settingsUpdated: () => ipcRenderer.send('settingsUpdated'),
   startPowerSaveBlocker: () => ipcRenderer.invoke('start-power-save-blocker'),
   stopPowerSaveBlocker: () => ipcRenderer.invoke('stop-power-save-blocker'),
   getBinaryPath: (binaryName) => ipcRenderer.invoke('get-binary-path', binaryName),


### PR DESCRIPTION
This should make this IPC message available to the frontend

NOTE: We have a very messy situation with TS typings for the `preload.js` module right now. I will mitigate in the days ahead.