### PR TITLE
docs: changed home button text

### DIFF
--- a/documentation/src/pages/index.tsx
+++ b/documentation/src/pages/index.tsx
@@ -23,9 +23,8 @@ function HomepageHeader() {
           <Link
             className="button button--primary button--lg"
             to="docs/getting-started/installation"
-          >
-            <IconDownload />
-            install goose desktop
+          >            
+            install goose
           </Link>
         </div>
       </div>


### PR DESCRIPTION

## Before
![image](https://github.com/user-attachments/assets/d861d690-e579-4831-9e16-375cda423db6)


## After
![image](https://github.com/user-attachments/assets/4e1c4bd4-4ed5-4649-8928-5b5afa42f9e6)


## Reason for Change

- button links to Install page. the download icon is misleading
- button only encourages desktop download. we also have CLI option