### PR TITLE
styles: tweaks to tool call UI

### DIFF
--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -76,11 +76,11 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
   // Determine whether dark mode is enabled
   const isDarkMode = document.documentElement.classList.contains('dark');
   return (
-    <div className="w-full overflow-x-hidden">
+    <div className="w-full overflow-x-hidden mb-2">
       <ReactMarkdown
         rehypePlugins={[rehypeinlineCodeProperty]}
         className={`prose prose-xs dark:prose-invert w-full max-w-full break-words
-          prose-pre:p-0 prose-pre:m-0
+          prose-pre:p-0 prose-pre:m-0 !p-0
           prose-code:break-all prose-code:whitespace-pre-wrap
           ${className}`}
         components={{
@@ -96,6 +96,11 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
                 {children}
               </code>
             );
+          },
+          // h3: 'div',
+          h3(props) {
+            const { node, ...rest } = props;
+            return <div className="text-textStandard text-sm" {...rest} />;
           },
         }}
       >

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -76,7 +76,7 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
   // Determine whether dark mode is enabled
   const isDarkMode = document.documentElement.classList.contains('dark');
   return (
-    <div className="w-full overflow-x-hidden mb-2">
+    <div className="w-full overflow-x-hidden">
       <ReactMarkdown
         rehypePlugins={[rehypeinlineCodeProperty]}
         className={`prose prose-xs dark:prose-invert w-full max-w-full break-words

--- a/ui/desktop/src/components/ToolCallArguments.tsx
+++ b/ui/desktop/src/components/ToolCallArguments.tsx
@@ -1,3 +1,4 @@
+import { ChevronUp } from 'lucide-react';
 import React, { useState } from 'react';
 import MarkdownContent from './MarkdownContent';
 
@@ -19,32 +20,40 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
 
       if (!needsExpansion) {
         return (
-          <div className="p-1">
-            <div className="flex">
-              <span className="text-textStandard mr-2">{key}:</span>
-              <span className="text-textStandard">{value}</span>
+          <div className="mb-4">
+            <div className="flex flex-col">
+              <span className="text-sm font-medium text-textSubtle">{key}</span>
+              <span className="text-sm text-textStandard">{value}</span>
             </div>
           </div>
         );
       }
 
       return (
-        <div className="p-1">
-          <div className="flex items-baseline">
-            <span className="text-textStandard mr-2">{key}:</span>
-            <div className="flex-1">
+        <div className="mb-4">
+          <div className="flex flex-col">
+            <span className="text-sm font-medium text-textSubtle">{key}</span>
+            <div className="flex items-center">
+              {!isExpanded && (
+                <span className="text-sm text-textStandard mr-2">{value.slice(0, 60)}...</span>
+              )}
               <button
                 onClick={() => toggleKey(key)}
-                className="hover:opacity-75 text-gray-600 dark:text-white"
+                className="text-sm hover:opacity-75 text-textStandard"
               >
-                {isExpanded ? '▼ ' : '▶ '}
+                {/* {isExpanded ? '▼ ' : '▶ '} */}
+                <ChevronUp
+                  className={`h-5 w-5 transition-all origin-center ${!isExpanded ? 'rotate-180' : ''}`}
+                />
               </button>
-              {!isExpanded && <span className="ml-2 text-gray-600">{value.slice(0, 60)}...</span>}
             </div>
           </div>
           {isExpanded && (
-            <div className="mt-2 ml-4">
+            <div className="mt-2">
               <MarkdownContent content={value} />
+              {/* <ReactMarkdown className="whitespace-pre-wrap break-words prose-pre:whitespace-pre-wrap prose-pre:break-words !p-0 !text-sm text-textStandard">
+                {value}
+              </ReactMarkdown> */}
             </div>
           )}
         </div>
@@ -59,7 +68,7 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
         : String(value);
 
     return (
-      <div className="p-1">
+      <div className="mb-4">
         <div className="flex">
           <span className="font-medium mr-2">{key}:</span>
           <pre className="whitespace-pre-wrap">{content}</pre>

--- a/ui/desktop/src/components/ToolCallArguments.tsx
+++ b/ui/desktop/src/components/ToolCallArguments.tsx
@@ -20,9 +20,9 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
 
       if (!needsExpansion) {
         return (
-          <div className="mb-4">
-            <div className="flex flex-col">
-              <span className="text-sm font-medium text-textSubtle">{key}</span>
+          <div className="mb-2">
+            <div className="flex flex-row">
+              <span className="text-sm font-medium text-textSubtle min-w-[140px]">{key}</span>
               <span className="text-sm text-textStandard">{value}</span>
             </div>
           </div>
@@ -30,11 +30,15 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
       }
 
       return (
-        <div className="mb-4">
-          <div className="flex flex-col">
-            <span className="text-sm font-medium text-textSubtle">{key}</span>
+        <div className="mb-2">
+          <div className="flex flex-row">
+            <span className="text-sm font-medium text-textSubtle min-w-[140px]">{key}</span>
             <div className="flex items-center">
-              {!isExpanded && (
+              {isExpanded ? (
+                <div className="mt-2">
+                  <MarkdownContent content={value} />
+                </div>
+              ) : (
                 <span className="text-sm text-textStandard mr-2">{value.slice(0, 60)}...</span>
               )}
               <button
@@ -48,14 +52,11 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
               </button>
             </div>
           </div>
-          {isExpanded && (
+          {/* {isExpanded && (
             <div className="mt-2">
               <MarkdownContent content={value} />
-              {/* <ReactMarkdown className="whitespace-pre-wrap break-words prose-pre:whitespace-pre-wrap prose-pre:break-words !p-0 !text-sm text-textStandard">
-                {value}
-              </ReactMarkdown> */}
             </div>
-          )}
+          )} */}
         </div>
       );
     }
@@ -68,9 +69,9 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
         : String(value);
 
     return (
-      <div className="mb-4">
-        <div className="flex">
-          <span className="font-medium mr-2">{key}:</span>
+      <div className="mb-2">
+        <div className="flex flex-row">
+          <span className="font-medium mr- min-w-[140px]2">{key}:</span>
           <pre className="whitespace-pre-wrap">{content}</pre>
         </div>
       </div>
@@ -78,7 +79,7 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
   };
 
   return (
-    <div className="mt-2">
+    <div className="my-2">
       {Object.entries(args).map(([key, value]) => (
         <div key={key}>{renderValue(key, value)}</div>
       ))}

--- a/ui/desktop/src/components/ToolInvocations.tsx
+++ b/ui/desktop/src/components/ToolInvocations.tsx
@@ -44,10 +44,10 @@ interface ToolCallProps {
 function ToolCall({ call }: ToolCallProps) {
   return (
     <div>
-      <div className="flex items-center">
-        <Box size={15} />
-        <span className="ml-[8px] text-sm text-textStandard font-medium tracking-widest">
-          {call.toolName.substring(call.toolName.lastIndexOf('__') + 2).toUpperCase()}
+      <div className="flex items-center mb-4">
+        <Box size={16} />
+        <span className="ml-[8px] text-textSubtle font-medium">
+          {snakeToTitleCase(call.toolName.substring(call.toolName.lastIndexOf('__') + 2))}
         </span>
       </div>
 
@@ -116,7 +116,7 @@ function ToolResult({ result }: ToolResultProps) {
   };
 
   return (
-    <div className="mt-2">
+    <div className="">
       {filteredResults.map((item: ResultItem, index: number) => {
         const isExpanded = shouldShowExpanded(item, index);
         // minimize if priority is not set or < 0.5
@@ -127,9 +127,9 @@ function ToolResult({ result }: ToolResultProps) {
             {shouldMinimize && (
               <button
                 onClick={() => toggleExpand(index)}
-                className="mb-1 p-1 flex items-center text-textStandard"
+                className="mb-2 flex items-center text-textStandard"
               >
-                <span className="mr-2">Output</span>
+                <span className="mr-2 text-sm">Output</span>
                 <ChevronUp
                   className={`h-5 w-5 transition-all origin-center ${!isExpanded ? 'rotate-180' : ''}`}
                 />

--- a/ui/desktop/src/components/ToolInvocations.tsx
+++ b/ui/desktop/src/components/ToolInvocations.tsx
@@ -46,7 +46,7 @@ function ToolCall({ call }: ToolCallProps) {
     <div>
       <div className="flex items-center mb-4">
         <Box size={16} />
-        <span className="ml-[8px] text-textSubtle font-medium">
+        <span className="ml-[8px] text-textStandard">
           {snakeToTitleCase(call.toolName.substring(call.toolName.lastIndexOf('__') + 2))}
         </span>
       </div>

--- a/ui/desktop/src/components/ToolInvocations.tsx
+++ b/ui/desktop/src/components/ToolInvocations.tsx
@@ -127,7 +127,7 @@ function ToolResult({ result }: ToolResultProps) {
             {shouldMinimize && (
               <button
                 onClick={() => toggleExpand(index)}
-                className="mb-2 flex items-center text-textStandard"
+                className="mb-1 flex items-center text-textStandard"
               >
                 <span className="mr-2 text-sm">Output</span>
                 <ChevronUp


### PR DESCRIPTION
Tightened the spacing and styles around the Tool Call UI.

** before **
<img width="862" alt="Screenshot 2025-01-30 at 4 38 26 PM" src="https://github.com/user-attachments/assets/1cb22868-e3d5-4630-8af5-def561680804" />

** after **
<img width="818" alt="Screenshot 2025-01-30 at 4 38 28 PM" src="https://github.com/user-attachments/assets/6d5681c6-ef7f-4747-925a-c8b8a9f0ab52" />