### PR TITLE
feat: support googledrive as mcp server name

### DIFF
--- a/crates/goose-cli/src/commands/mcp.rs
+++ b/crates/goose-cli/src/commands/mcp.rs
@@ -16,7 +16,7 @@ pub async fn run_server(name: &str) -> Result<()> {
         "developer" => Some(Box::new(RouterService(DeveloperRouter::new()))),
         "computercontroller" => Some(Box::new(RouterService(ComputerControllerRouter::new()))),
         "jetbrains" => Some(Box::new(RouterService(JetBrainsRouter::new()))),
-        "google_drive" => {
+        "google_drive" | "googledrive" => {
             let router = GoogleDriveRouter::new().await;
             Some(Box::new(RouterService(router)))
         }

--- a/crates/goose-server/src/commands/mcp.rs
+++ b/crates/goose-server/src/commands/mcp.rs
@@ -15,7 +15,7 @@ pub async fn run(name: &str) -> Result<()> {
         "developer" => Some(Box::new(RouterService(DeveloperRouter::new()))),
         "computercontroller" => Some(Box::new(RouterService(ComputerControllerRouter::new()))),
         "jetbrains" => Some(Box::new(RouterService(JetBrainsRouter::new()))),
-        "google_drive" => {
+        "google_drive" | "googledrive" => {
             let router = GoogleDriveRouter::new().await;
             Some(Box::new(RouterService(router)))
         }


### PR DESCRIPTION
# support using `googledrive` as mcp server name

* also leave in support for `google_drive` for backward compatibility
* allow both `goose-cli` and `goose-server` to use both names