### PR TITLE
docs: quickfix broken links

### DIFF
--- a/documentation/blog/2025-01-28-introducing-codename-goose/index.md
+++ b/documentation/blog/2025-01-28-introducing-codename-goose/index.md
@@ -23,7 +23,7 @@ While Goose's first use cases are engineering focused, the community has been ex
 
 Goose operates as an intelligent, autonomous agent capable of handling complex tasks through a well-orchestrated coordination of its core features:
   
-- **Using Extensions**: [Extensions](/docs/getting-started/using-extensions) are key to Goose’s adaptability, providing you the ability to connect with applications and tools that you already use. Whether it’s connecting to GitHub, accessing Google Drive or integrating with JetBrains IDEs, the possibilities are extensive. Some of these extensions have been curated in the [extensions](/extensions) directory. Goose extensions are built on the [Model Context Protocol (MCP)](https://www.anthropic.com/news/model-context-protocol) - enabling you to build or bring your own custom integrations to Goose. 
+- **Using Extensions**: [Extensions](/docs/getting-started/using-extensions) are key to Goose’s adaptability, providing you the ability to connect with applications and tools that you already use. Whether it’s connecting to GitHub, accessing Google Drive or integrating with JetBrains IDEs, the possibilities are extensive. Some of these extensions have been curated in the [extensions][extensions-directory] directory. Goose extensions are built on the [Model Context Protocol (MCP)](https://www.anthropic.com/news/model-context-protocol) - enabling you to build or bring your own custom integrations to Goose. 
 
 - **LLM Providers**: Goose is compatible with a wide range of [LLM providers](/docs/getting-started/providers), allowing you to choose and integrate your preferred model. 
 
@@ -58,3 +58,6 @@ Excited for upcoming features and events? Be sure to connect with us!
 - [LinkedIn](https://www.linkedin.com/company/block-opensource)
 - [X](https://x.com/blockopensource)
 - [BlueSky](https://bsky.app/profile/block-opensource.bsky.social)
+
+
+[extensions-directory]: https://block.github.io/goose/v1/extensions

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -48,7 +48,7 @@ A session is a single, continuous interaction between you and Goose, providing a
     </TabItem>
 </Tabs>
 :::info
-    If this is your first session, Goose will prompt you for an API key to access an LLM (Large Language Model) of your choice. For more information on setting up your API key, see the [Installation Guide](/docs/getting-started/installation#set-up-a-provider). Here is the list of [supported LLMs](/docs/getting-started/providers).
+    If this is your first session, Goose will prompt you for an API key to access an LLM (Large Language Model) of your choice. For more information on setting up your API key, see the [Installation Guide](/docs/getting-started/installation#set-llm-provider). Here is the list of [supported LLMs](/docs/getting-started/providers).
 :::
 
 ## Exit Session


### PR DESCRIPTION
This pull request includes updates to the documentation for Goose, focusing on improving clarity and accuracy in the guides and blog posts. The most important changes include updating links for better navigation and correcting references to setup instructions.

Documentation updates:

* [`documentation/blog/2025-01-28-introducing-codename-goose/index.md`](diffhunk://#diff-0186c426b6019be76fdaa64d36f73aa9f7e8970aa3ad10f6114c5f0b4c9349c6L26-R26): Updated the link to the extensions directory to use a reference-style link for better readability.
* [`documentation/blog/2025-01-28-introducing-codename-goose/index.md`](diffhunk://#diff-0186c426b6019be76fdaa64d36f73aa9f7e8970aa3ad10f6114c5f0b4c9349c6R61-R63): Added a reference link definition for the extensions directory at the end of the document.
* [`documentation/docs/guides/managing-goose-sessions.md`](diffhunk://#diff-08b4b977d065693949daba778a60368ed3033df53b958ca3a73405f1ceb95c34L51-R51): Corrected the link in the installation guide to point to the correct section for setting up an LLM provider.