### PR TITLE
fix: catch errors in configure_provider_dialog and report the error upwards

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -24,28 +24,40 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
         );
         println!();
         cliclack::intro(style(" goose-configure ").on_cyan().black())?;
-        if configure_provider_dialog().await? {
-            println!(
-                "\n  {}: Run '{}' again to adjust your config or add extensions",
-                style("Tip").green().italic(),
-                style("goose configure").cyan()
-            );
-            // Since we are setting up for the first time, we'll also enable the developer system
-            ExtensionManager::set(ExtensionEntry {
-                enabled: true,
-                config: ExtensionConfig::Builtin {
-                    name: "developer".to_string(),
-                },
-            })?;
-        } else {
-            let _ = config.clear();
-            println!(
-                "\n  {}: We did not save your config, inspect your credentials\n   and run '{}' again to ensure goose can connect",
-                style("Warning").yellow().italic(),
-                style("goose configure").cyan()
-            );
+        match configure_provider_dialog().await {
+            Ok(true) => {
+                println!(
+                    "\n  {}: Run '{}' again to adjust your config or add extensions",
+                    style("Tip").green().italic(),
+                    style("goose configure").cyan()
+                );
+                // Since we are setting up for the first time, we'll also enable the developer system
+                // This operation is best-effort and errors are ignored
+                ExtensionManager::set(ExtensionEntry {
+                    enabled: true,
+                    config: ExtensionConfig::Builtin {
+                        name: "developer".to_string(),
+                    },
+                })?;
+            }
+            Ok(false) => {
+                let _ = config.clear();
+                println!(
+                    "\n  {}: We did not save your config, inspect your credentials\n   and run '{}' again to ensure goose can connect",
+                    style("Warning").yellow().italic(),
+                    style("goose configure").cyan()
+                );
+            }
+            Err(e) => {
+                let _ = config.clear();
+                println!(
+                    "\n  {} {} \n: We did not save your config, inspect your credentials\n   and run '{}' again to ensure goose can connect",
+                    style("Error").red().italic(),
+                    e,
+                    style("goose configure").cyan()
+                );
+            }
         }
-
         Ok(())
     } else {
         println!();

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -185,7 +185,7 @@ pub async fn configure_provider_dialog() -> Result<bool, Box<dyn Error>> {
             Some(env_value) => {
                 let _ =
                     cliclack::log::info(format!("{} is set via environment variable", key.name));
-                if cliclack::confirm("Would you like to save this value to your config file?")
+                if cliclack::confirm("Would you like to save this value to your keyring?")
                     .initial_value(true)
                     .interact()?
                 {


### PR DESCRIPTION
# handle errors from configure_provider_dialog

we were previously just returning back up and never displaying the error to the user, instead we handle the error case and display the error along with the "retry" steps