### PR TITLE
docs: Use bash (not sh) for Goose CLI installation script one-liner

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -19,7 +19,7 @@ import RateLimits from '@site/src/components/RateLimits';
     Run the following command to install the latest version of Goose: 
 
     ```sh
-    curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | sh
+    curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
     ```
     This script will fetch the latest version of Goose and set it up on your system.
     

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -26,7 +26,7 @@ You can use Goose via CLI or Desktop application.
     Run the following command to install the latest version of Goose: 
 
     ```sh
-    curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | sh
+    curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
     ```
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">


### PR DESCRIPTION
The Goose CLI installation script uses `bash` shell. (Note the `#!/usr/bin/env bash` shebang https://github.com/block/goose/blob/main/download_cli.sh#L1)

However, the documentation suggests piping the installation script to `sh` instead of `bash`.

On a number of Linux distributions (Debian, Ubuntu, etc.) `sh` is a symlink to `dash`, a more minimal shell that doesn't support certain `bash` features, like the `pipefail` option. https://github.com/block/goose/blob/main/download_cli.sh#L2

Attempting to run the installation script and piping it to `sh` as outlined in the docs will fail on Debian, Ubuntu, and other Linux distributions which symlink `sh` to `dash`:

```
$ curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | sh
sh: 2: set: Illegal option -o pipefail
```

Since the script is designed for use with the `bash` shell, it makes sense to update the installation docs to pipe the script to `bash` instead of `sh` to avoid this type of issue.