### PR TITLE
feat: allow setting ollama host

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -266,7 +266,8 @@ pub async fn configure_provider_dialog() -> Result<bool, Box<dyn Error>> {
     let spin = spinner();
     spin.start("Checking your configuration...");
 
-    let model_config = goose::model::ModelConfig::new(model.clone());
+    // Use max tokens to speed up the provider test.
+    let model_config = goose::model::ModelConfig::new(model.clone()).with_max_tokens(Some(10));
     let provider = create(provider_name, model_config)?;
 
     let message = Message::user().with_text(

--- a/crates/goose-server/src/routes/secrets.rs
+++ b/crates/goose-server/src/routes/secrets.rs
@@ -13,10 +13,10 @@ struct SecretResponse {
 }
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct SecretRequest {
     key: String,
     value: String,
-    #[serde(rename = "isSecret")]
     is_secret: bool,
 }
 

--- a/crates/goose-server/src/routes/secrets.rs
+++ b/crates/goose-server/src/routes/secrets.rs
@@ -36,12 +36,11 @@ async fn store_secret(
     }
 
     let config = Config::global();
-    let result;
-    if request.is_secret {
-        result = config.set_secret(&request.key, Value::String(request.value));
+    let result = if request.is_secret {
+        config.set_secret(&request.key, Value::String(request.value))
     } else {
-        result = config.set(&request.key, Value::String(request.value));
-    }
+        config.set(&request.key, Value::String(request.value))
+    };
     match result {
         Ok(_) => Ok(Json(SecretResponse { error: false })),
         Err(_) => Ok(Json(SecretResponse { error: true })),

--- a/crates/goose-server/src/routes/secrets.rs
+++ b/crates/goose-server/src/routes/secrets.rs
@@ -16,6 +16,8 @@ struct SecretResponse {
 struct SecretRequest {
     key: String,
     value: String,
+    #[serde(rename = "isSecret")]
+    is_secret: bool,
 }
 
 async fn store_secret(
@@ -33,7 +35,14 @@ async fn store_secret(
         return Err(StatusCode::UNAUTHORIZED);
     }
 
-    match Config::global().set_secret(&request.key, Value::String(request.value)) {
+    let config = Config::global();
+    let result;
+    if request.is_secret {
+        result = config.set_secret(&request.key, Value::String(request.value));
+    } else {
+        result = config.set(&request.key, Value::String(request.value));
+    }
+    match result {
         Ok(_) => Ok(Json(SecretResponse { error: false })),
         Err(_) => Ok(Json(SecretResponse { error: true })),
     }

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -71,7 +71,7 @@ impl Provider for OllamaProvider {
             OLLAMA_DOC_URL,
             vec![ConfigKey::new(
                 "OLLAMA_HOST",
-                false,
+                true,
                 false,
                 Some(OLLAMA_HOST),
             )],

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -159,6 +159,9 @@ goose configure
 ◇  Which model provider should we use?
 │  Ollama 
 │
+◇  Provider Ollama requires OLLAMA_HOST, please enter a value
+│  http://localhost:11434
+│
 ◇  Enter a model from that provider:
 │  qwen2.5
 │

--- a/ui/desktop/src/components/settings/ProviderSetupModal.tsx
+++ b/ui/desktop/src/components/settings/ProviderSetupModal.tsx
@@ -58,7 +58,7 @@ export function ProviderSetupModal({
                 />
                 <div className="flex mt-4 text-gray-600 dark:text-gray-300">
                   <Lock className="w-6 h-6" />
-                  <span className="text-sm font-light ml-4 mt-[2px]">{`Your API key will be stored securely in the keychain and used only for making requests to ${provider}`}</span>
+                  <span className="text-sm font-light ml-4 mt-[2px]">{`Your API key or host will be stored securely in the keychain and used only for making requests to ${provider}`}</span>
                 </div>
               </div>
             </div>

--- a/ui/desktop/src/components/settings/ProviderSetupModal.tsx
+++ b/ui/desktop/src/components/settings/ProviderSetupModal.tsx
@@ -4,6 +4,7 @@ import { Lock } from 'lucide-react';
 import { Input } from '../ui/input';
 import { Button } from '../ui/button';
 import { required_keys } from './models/hardcoded_stuff';
+import { isSecretKey } from './api_keys/utils';
 // import UnionIcon from "../images/Union@2x.svg";
 
 interface ProviderSetupModalProps {
@@ -30,6 +31,7 @@ export function ProviderSetupModal({
     e.preventDefault();
     onSubmit(apiKey);
   };
+  const inputType = isSecretKey(keyName) ? 'password' : 'text';
 
   return (
     <div className="fixed inset-0 bg-black/20 dark:bg-white/20 backdrop-blur-sm transition-colors animate-[fadein_200ms_ease-in_forwards]">
@@ -49,7 +51,7 @@ export function ProviderSetupModal({
             <div className="mt-[24px]">
               <div>
                 <Input
-                  type="password"
+                  type={inputType}
                   value={apiKey}
                   onChange={(e) => setApiKey(e.target.value)}
                   placeholder={keyName}

--- a/ui/desktop/src/components/settings/api_keys/utils.tsx
+++ b/ui/desktop/src/components/settings/api_keys/utils.tsx
@@ -2,6 +2,11 @@ import { Provider, ProviderResponse } from './types';
 import { getApiUrl, getSecretKey } from '../../../config';
 import { special_provider_cases } from '../providers/utils';
 
+export function isSecretKey(keyName: string): boolean {
+  // Ollama and Databricks use host name right now and it should not be stored as secret.
+  return keyName != 'DATABRICKS_HOST' && keyName != 'OLLAMA_HOST';
+}
+
 export async function getActiveProviders(): Promise<string[]> {
   try {
     // Fetch the secrets settings

--- a/ui/desktop/src/components/settings/extensions/ConfigureBuiltInExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ConfigureBuiltInExtensionModal.tsx
@@ -52,6 +52,7 @@ export function ConfigureBuiltInExtensionModal({
             body: JSON.stringify({
               key: envKey,
               value: value.trim(),
+              is_secret: true,
             }),
           });
 

--- a/ui/desktop/src/components/settings/extensions/ConfigureBuiltInExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ConfigureBuiltInExtensionModal.tsx
@@ -52,7 +52,7 @@ export function ConfigureBuiltInExtensionModal({
             body: JSON.stringify({
               key: envKey,
               value: value.trim(),
-              is_secret: true,
+              isSecret: true,
             }),
           });
 

--- a/ui/desktop/src/components/settings/extensions/ConfigureExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ConfigureExtensionModal.tsx
@@ -54,6 +54,7 @@ export function ConfigureExtensionModal({
             body: JSON.stringify({
               key: envKey,
               value: value.trim(),
+              is_secret: true,
             }),
           });
 

--- a/ui/desktop/src/components/settings/extensions/ConfigureExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ConfigureExtensionModal.tsx
@@ -54,7 +54,7 @@ export function ConfigureExtensionModal({
             body: JSON.stringify({
               key: envKey,
               value: value.trim(),
-              is_secret: true,
+              isSecret: true,
             }),
           });
 

--- a/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
@@ -68,7 +68,7 @@ export function ManualExtensionModal({ isOpen, onClose, onSubmit }: ManualExtens
           body: JSON.stringify({
             key: envVar.key,
             value: envVar.value.trim(),
-            is_secret: true,
+            isSecret: true,
           }),
         });
 

--- a/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
@@ -68,6 +68,7 @@ export function ManualExtensionModal({ isOpen, onClose, onSubmit }: ManualExtens
           body: JSON.stringify({
             key: envVar.key,
             value: envVar.value.trim(),
+            is_secret: true,
           }),
         });
 

--- a/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
+++ b/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
@@ -72,7 +72,7 @@ export const required_keys = {
   Anthropic: ['ANTHROPIC_API_KEY'],
   Databricks: ['DATABRICKS_HOST'],
   Groq: ['GROQ_API_KEY'],
-  Ollama: [],
+  Ollama: ['OLLAMA_HOST'],
   Google: ['GOOGLE_API_KEY'],
   OpenRouter: ['OPENROUTER_API_KEY'],
 };

--- a/ui/desktop/src/components/settings/providers/ConfigureProvidersGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ConfigureProvidersGrid.tsx
@@ -5,7 +5,7 @@ import { supported_providers, provider_aliases, required_keys } from '../models/
 import { ProviderSetupModal } from '../ProviderSetupModal';
 import { getApiUrl, getSecretKey } from '../../../config';
 import { toast } from 'react-toastify';
-import { getActiveProviders } from '../api_keys/utils';
+import { getActiveProviders, isSecretKey } from '../api_keys/utils';
 import { useModel } from '../models/ModelContext';
 import { Button } from '../../ui/button';
 
@@ -116,6 +116,7 @@ export function ConfigureProvidersGrid() {
         body: JSON.stringify({
           key: keyName,
           value: apiKey.trim(),
+          isSecret: isSecretKey(keyName),
         }),
       });
 

--- a/ui/desktop/src/components/settings/providers/ConfigureProvidersGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ConfigureProvidersGrid.tsx
@@ -107,6 +107,7 @@ export function ConfigureProvidersGrid() {
       }
 
       // Store new key
+      const isSecret = isSecretKey(keyName);
       const storeResponse = await fetch(getApiUrl('/secrets/store'), {
         method: 'POST',
         headers: {
@@ -116,7 +117,7 @@ export function ConfigureProvidersGrid() {
         body: JSON.stringify({
           key: keyName,
           value: apiKey.trim(),
-          isSecret: isSecretKey(keyName),
+          isSecret,
         }),
       });
 
@@ -126,10 +127,11 @@ export function ConfigureProvidersGrid() {
         throw new Error('Failed to store new key');
       }
 
+      const toastInfo = isSecret ? 'API key' : 'host';
       toast.success(
         isUpdate
-          ? `Successfully updated API key for ${provider}`
-          : `Successfully added API key for ${provider}`
+          ? `Successfully updated ${toastInfo} for ${provider}`
+          : `Successfully added ${toastInfo} for ${provider}`
       );
 
       const updatedKeys = await getActiveProviders();

--- a/ui/desktop/src/components/welcome_screen/ProviderGrid.tsx
+++ b/ui/desktop/src/components/welcome_screen/ProviderGrid.tsx
@@ -14,7 +14,7 @@ import { getDefaultModel } from '../settings/models/hardcoded_stuff';
 import { initializeSystem } from '../../utils/providerUtils';
 import { getApiUrl, getSecretKey } from '../../config';
 import { toast } from 'react-toastify';
-import { getActiveProviders } from '../settings/api_keys/utils';
+import { getActiveProviders, isSecretKey } from '../settings/api_keys/utils';
 import { useNavigate } from 'react-router-dom';
 import { BaseProviderGrid, getProviderDescription } from '../settings/providers/BaseProviderGrid';
 
@@ -108,6 +108,7 @@ export function ProviderGrid({ onSubmit }: ProviderGridProps) {
         body: JSON.stringify({
           key: keyName,
           value: apiKey.trim(),
+          isSecret: isSecretKey(keyName),
         }),
       });
 

--- a/ui/desktop/src/components/welcome_screen/ProviderGrid.tsx
+++ b/ui/desktop/src/components/welcome_screen/ProviderGrid.tsx
@@ -99,6 +99,7 @@ export function ProviderGrid({ onSubmit }: ProviderGridProps) {
         }
       }
 
+      const isSecret = isSecretKey(keyName);
       const storeResponse = await fetch(getApiUrl('/secrets/store'), {
         method: 'POST',
         headers: {
@@ -108,7 +109,7 @@ export function ProviderGrid({ onSubmit }: ProviderGridProps) {
         body: JSON.stringify({
           key: keyName,
           value: apiKey.trim(),
-          isSecret: isSecretKey(keyName),
+          isSecret,
         }),
       });
 
@@ -119,10 +120,11 @@ export function ProviderGrid({ onSubmit }: ProviderGridProps) {
       }
 
       const isUpdate = selectedId && providers.find((p) => p.id === selectedId)?.isConfigured;
+      const toastInfo = isSecret ? 'API key' : 'host';
       toast.success(
         isUpdate
-          ? `Successfully updated API key for ${provider}`
-          : `Successfully added API key for ${provider}`
+          ? `Successfully updated ${toastInfo} for ${provider}`
+          : `Successfully added ${toastInfo} for ${provider}`
       );
 
       const updatedKeys = await getActiveProviders();


### PR DESCRIPTION
Allow setting ollama host during configuration

Test step:

 1. Run `launchctl setenv OLLAMA_HOST "0.0.0.0:11111"` on mac and start run ollama
 2. Check ollama ls: `OLLAMA_HOST=0.0.0.0:11111 ollama ls` 
 3. Verify the ollama host by sending request:
 4. 
 ```
curl http://localhost:11111/api/generate -d '{
  "model": "qwen2.5",
  "prompt":"Why is the sky blue?"
}'
{"model":"qwen2.5","created_at":"2025-01-29T02:53:09.321698Z","response":"The","done":false}
{"model":"qwen2.5","created_at":"2025-01-29T02:53:09.337099Z","response":" sky","done":false}
{"model":"qwen2.5","created_at":"2025-01-29T02:53:09.352554Z","response":" appears","done":false}
{"model":"qwen2.5","created_at":"2025-01-29T02:53:09.368318Z","response":" blue","done":false}
```

 5.  Run the UI can test with host change
![image](https://github.com/user-attachments/assets/546d8934-2eb6-4abc-94b6-62c157d1276e)

6. Run goose configure CLI:

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Configure Providers 
│
◇  Which model provider should we use?
│  Ollama 
│
●  OLLAMA_HOST is already configured
│  
◇  Would you like to update this value?
│  Yes 
│
◇  Enter new value for OLLAMA_HOST
│  http://localhost:11111
│
◆  Enter a model from that provider:
│  qwen2.5 (default)
└  
```

7. Verify the config yaml file:
```
extensions:
  developer:
    enabled: true
    name: developer
    type: builtin
default_model: claude-3-5-sonnet-latest
GOOSE_MODEL: llama3.2
OLLAMA_HOST: http://localhost:11111
default_provider: anthropic
DATABRICKS_HOST: https://block-lakehouse-production.cloud.databricks.com
GOOSE_PROVIDER: ollama
/Users/yingjiehe/.config/goose/config.yaml (END)
```
