### PR TITLE
fix: post endpoint url on sse endpoint event

### DIFF
--- a/crates/mcp-client/examples/sse.rs
+++ b/crates/mcp-client/examples/sse.rs
@@ -43,7 +43,7 @@ async fn main() -> Result<()> {
     println!("Connected to server: {server_info:?}\n");
 
     // Sleep for 100ms to allow the server to start - surprisingly this is required!
-    tokio::time::sleep(Duration::from_millis(100)).await;
+    tokio::time::sleep(Duration::from_millis(500)).await;
 
     // List tools
     let tools = client.list_tools(None).await?;


### PR DESCRIPTION
should fix: https://github.com/block/goose/issues/893

works for these:
```
Base: http://localhost:8080/sse
Relative: /messages/?session=x2y3z
Expected: http://localhost:8080/messages/?session=x2y3z
-------------------------------
Base: http://localhost:8080/mcp/sse
Relative: /mcp/messages/xyz
Expected: http://localhost:8080/mcp/messages/xyz
-------------------------------
Base: http://localhost:8080/mcp/sse
Relative: messages/xyz
Expected: http://localhost:8080/mcp/messages/xyz
-------------------------------
Base: http://example.com/api/sse
Relative: /messages/xyz
Expected: http://example.com/messages/xyz
-------------------------------
Base: http://example.com/api/sse
Relative: messages/xyz
Expected: http://example.com/api/messages/xyz
-------------------------------
```