### PR TITLE
docs: Goose on Windows via WSL

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -65,7 +65,7 @@ There isn't native installation support for Windows, however you can run Goose u
 
   Restart your computer if prompted.
 
-  #### Update and install required packages
+  #### Update and Install Required Packages
   Open the Ubuntu app from the start menu, complete the initial setup and update 
 
   ```bash

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -48,6 +48,88 @@ import RateLimits from '@site/src/components/RateLimits';
   </TabItem>
 </Tabs>
 
+#### Installing on Windows via WSL
+
+While Goose Desktop and CLI doesn't work on Windows directly atm, It may be possible to run Goose CLI on Windows using the Windows Subsystem for Linux (WSL).
+
+<details>
+
+  <summary>Installing Goose on WSL</summary>
+
+  #### Install WSL
+  Open PowerShell as Administrator and install WSL and the default Ubuntu distribution:
+
+  ```bash
+  wsl --install
+  ```
+
+  Restart your computer if prompted.
+
+  #### Update and install required packages
+  Open the Ubuntu app from the start menu, complete the initial setup and update 
+
+  ```bash
+  sudo apt update && sudo apt upgrade -y
+  ```
+
+  #### Install Goose CLI
+  Run the Goose installation script:
+  ```bash
+  curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+  ```
+  :::tip
+    If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file. 
+
+    ```bash
+    sudo apt update && sudo apt install bzip2 -y
+    ```
+  :::
+
+  On initial run, you might encounter errors about keyrings when setting your API Keys. Set the needed environment variables manually, e.g:
+
+  ```bash
+  export GOOGLE_API_KEY=your_google_api_key
+  ```
+
+  To make the changes persist in WSL across sessions, add the goose path and export commands to your `.bashrc` or `.bash_profile` file so you can load it later.
+
+  ```bash
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+  echo 'export GOOGLE_API_KEY=your_google_api_key' >> ~/.bashrc
+  source ~/.bashrc
+
+  ```
+
+  #### Configure Goose
+  Run `goose configure` to set up your LLM provider and model from the set environment variables. Choose to not store to keyring when prompted.
+
+
+  ```bash
+    ┌   goose-configure
+    │
+    ◇  Which model provider should we use?
+    │  Google Gemini
+    │
+    ●  GOOGLE_API_KEY is set via environment variable
+    │
+    ◇  Would you like to save this value to your keyring?
+    │  No
+    │
+    ◇  Enter a model from that provider:
+    │  gemini-2.0-flash-exp
+    │
+    ◇  Hello! You're all set and ready to go with this agent, so please don't hesitate to ask me anything.
+
+    │
+    └  Configuration saved successfully
+
+      Tip: Run 'goose configure' again to adjust your config or add extensions.
+  ```
+
+  Run `goose session` to start a session.
+</details>
+
+
 ### Set LLM Provider
 Goose works with a set of [supported LLM providers][providers], and you’ll need an API key to get started. When you use Goose for the first time, you’ll be prompted to select a provider and enter your API key.
 

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -50,7 +50,7 @@ import RateLimits from '@site/src/components/RateLimits';
 
 #### Installing on Windows via WSL
 
-While Goose Desktop and CLI doesn't work on Windows directly atm, It may be possible to run Goose CLI on Windows using the Windows Subsystem for Linux (WSL).
+While Goose Desktop and CLI doesn't work on Windows directly atm, It is possible to run Goose CLI on Windows using the Windows Subsystem for Linux (WSL).
 
 <details>
 

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -13,86 +13,73 @@ import RateLimits from '@site/src/components/RateLimits';
 
 <SupportedEnvironments />
 
-## macOS | Linux
+<Tabs>
+  <TabItem value="mac-linux" label="macOS | Linux" default>
+    Choose to install Goose on CLI and/or Desktop:
 
-<Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
-    Run the following command to install the latest version of Goose: 
+    <Tabs groupId="interface">
+      <TabItem value="cli" label="Goose CLI" default>
+        Run the following command to install the latest version of Goose: 
 
-    ```sh
+        ```sh
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+        ```
+        This script will fetch the latest version of Goose and set it up on your system.
+        
+        :::tip Best Practice
+        It’s best to keep Goose updated. You can update it by re-running the installation script.
+        :::
+      </TabItem>
+      <TabItem value="ui" label="Goose Desktop">
+        To install Goose, click the **button** below:
+        <div className="pill-button">
+          <Link
+            className="button button--primary button--lg"
+            to="https://github.com/block/goose/releases/download/stable/Goose.zip"
+          >
+            <IconDownload />
+            download goose desktop
+          </Link>
+        </div>
+        <div style={{ marginTop: '1rem' }}>  
+          1. Unzip the downloaded `Goose.zip` file.
+          2. Run the executable file to launch the Goose desktop application.
+          :::tip Best Practice
+          It’s best to keep Goose updated. You can do this by checking the [Goose GitHub Release page](https://github.com/block/goose/releases/stable) and downloading updates when available.
+          :::
+        </div>  
+
+      </TabItem>
+    </Tabs>
+
+  </TabItem>
+
+  <TabItem value="windows" label="Windows">
+    There isn't native installation support for Windows, however you can run Goose using WSL (Windows Subsystem for Linux).
+
+    1. Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
+
+    ```bash
+    wsl --install
+    ```
+
+    2. Restart your computer if prompted.
+
+    3. Run the Goose installation script:
+    ```bash
     curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
     ```
-    This script will fetch the latest version of Goose and set it up on your system.
-    
-    :::tip Best Practice
-    It’s best to keep Goose updated. You can update it by re-running the installation script.
+    :::tip
+      If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file:
+
+      ```bash
+      sudo apt update && sudo apt install bzip2 -y
+      ```
     :::
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-    To install Goose, click the **button** below:
-    <div className="pill-button">
-      <Link
-        className="button button--primary button--lg"
-        to="https://github.com/block/goose/releases/download/stable/Goose.zip"
-      >
-        <IconDownload />
-        download goose desktop
-      </Link>
-    </div>
-    <div style={{ marginTop: '1rem' }}>  
-      1. Unzip the downloaded `Goose.zip` file.
-      2. Run the executable file to launch the Goose desktop application.
-      :::tip Best Practice
-      It’s best to keep Goose updated. You can do this by checking the [Goose GitHub Release page](https://github.com/block/goose/releases/stable) and downloading updates when available.
-      :::
-    </div>  
-  </TabItem>
+
 </Tabs>
 
-## Windows via WSL
-
-There isn't native installation support for Windows, however you can run Goose using WSL (Windows Subsystem for Linux).
-
-#### Install WSL
-Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
-
-```bash
-wsl --install
-```
-
-Restart your computer if prompted.
-
-#### Install Goose CLI on WSL
-Run the Goose installation script:
-```bash
-curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
-```
-:::tip
-  If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file. 
-
-  ```bash
-  sudo apt update && sudo apt install bzip2 -y
-  ```
-:::
-
-On initial run, you might encounter errors about keyrings when setting your API Keys. Set the needed environment variables manually, e.g:
-
-```bash
-export GOOGLE_API_KEY=your_google_api_key
-```
-
-To make the changes persist in WSL across sessions, add the goose path and export commands to your `.bashrc` or `.bash_profile` file so you can load it later.
-
-```bash
-echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-echo 'export GOOGLE_API_KEY=your_google_api_key' >> ~/.bashrc
-source ~/.bashrc
-
-```
-
-:::tip Configuring Goose on WSL
-  Choose to not store to keyring when prompted.
-:::
 
 
 ## Set LLM Provider
@@ -101,6 +88,12 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
     Upon installing, Goose will automatically enter its configuration screen. Here is where you can set up your LLM provider.
+
+    :::tip Windows Users
+    Choose to not store to keyring when prompted.
+    :::
+
+    Example:
 
     ```
     ┌   goose-configure
@@ -121,6 +114,22 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
     │
     └  Configuration saved successfully
   ```
+
+  :::info Windows Users
+  On initial run, you may encounter errors about keyrings when setting your API Keys. Set the needed environment variables manually, e.g.:
+
+  ```bash
+  export OPENAI_API_KEY={your_google_api_key}
+  ```
+
+  To make the changes persist in WSL across sessions, add the goose path and export commands to your `.bashrc` or `.bash_profile` file so you can load it later.
+
+  ```bash
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+  echo 'export OPENAI_API_KEY=your_google_api_key' >> ~/.bashrc
+  source ~/.bashrc
+  ```
+  :::
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
     Upon installing, the Provider screen will appear. Here is where you can choose your LLM Provider.
@@ -131,7 +140,7 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
   </TabItem>
 </Tabs>
 
-## Update a Provider
+## Update Provider
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
     **To update your LLM provider and API key:** 

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -13,6 +13,7 @@ import RateLimits from '@site/src/components/RateLimits';
 
 <SupportedEnvironments />
 
+## macOS | Linux
 
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
@@ -48,7 +49,7 @@ import RateLimits from '@site/src/components/RateLimits';
   </TabItem>
 </Tabs>
 
-#### Installing on Windows via WSL
+## Windows via WSL
 
 There isn't native installation support for Windows, however you can run Goose using WSL (Windows Subsystem for Linux).
 
@@ -130,7 +131,7 @@ There isn't native installation support for Windows, however you can run Goose u
 </details>
 
 
-### Set LLM Provider
+## Set LLM Provider
 Goose works with a set of [supported LLM providers][providers], and you’ll need an API key to get started. When you use Goose for the first time, you’ll be prompted to select a provider and enter your API key.
 
 <Tabs groupId="interface">
@@ -166,7 +167,7 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
   </TabItem>
 </Tabs>
 
-### Update a Provider
+## Update a Provider
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
     **To update your LLM provider and API key:** 

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -53,82 +53,46 @@ import RateLimits from '@site/src/components/RateLimits';
 
 There isn't native installation support for Windows, however you can run Goose using WSL (Windows Subsystem for Linux).
 
-<details>
+#### Install WSL
+Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
 
-  <summary>Installing Goose on WSL</summary>
+```bash
+wsl --install
+```
 
-  #### Install WSL
-  Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
+Restart your computer if prompted.
 
-  ```bash
-  wsl --install
-  ```
-
-  Restart your computer if prompted.
-
-  #### Update and Install Required Packages
-  Open the Ubuntu app from the start menu, complete the initial setup and update 
-
-  ```bash
-  sudo apt update && sudo apt upgrade -y
-  ```
-
-  #### Install Goose CLI
-  Run the Goose installation script:
-  ```bash
-  curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
-  ```
-  :::tip
-    If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file. 
-
-    ```bash
-    sudo apt update && sudo apt install bzip2 -y
-    ```
-  :::
-
-  On initial run, you might encounter errors about keyrings when setting your API Keys. Set the needed environment variables manually, e.g:
+#### Install Goose CLI on WSL
+Run the Goose installation script:
+```bash
+curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+```
+:::tip
+  If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file. 
 
   ```bash
-  export GOOGLE_API_KEY=your_google_api_key
+  sudo apt update && sudo apt install bzip2 -y
   ```
+:::
 
-  To make the changes persist in WSL across sessions, add the goose path and export commands to your `.bashrc` or `.bash_profile` file so you can load it later.
+On initial run, you might encounter errors about keyrings when setting your API Keys. Set the needed environment variables manually, e.g:
 
-  ```bash
-  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
-  echo 'export GOOGLE_API_KEY=your_google_api_key' >> ~/.bashrc
-  source ~/.bashrc
+```bash
+export GOOGLE_API_KEY=your_google_api_key
+```
 
-  ```
+To make the changes persist in WSL across sessions, add the goose path and export commands to your `.bashrc` or `.bash_profile` file so you can load it later.
 
-  #### Configure Goose
-  Run `goose configure` to set up your LLM provider and model from the set environment variables. Choose to not store to keyring when prompted.
+```bash
+echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+echo 'export GOOGLE_API_KEY=your_google_api_key' >> ~/.bashrc
+source ~/.bashrc
 
+```
 
-  ```bash
-    ┌   goose-configure
-    │
-    ◇  Which model provider should we use?
-    │  Google Gemini
-    │
-    ●  GOOGLE_API_KEY is set via environment variable
-    │
-    ◇  Would you like to save this value to your keyring?
-    │  No
-    │
-    ◇  Enter a model from that provider:
-    │  gemini-2.0-flash-exp
-    │
-    ◇  Hello! You're all set and ready to go with this agent, so please don't hesitate to ask me anything.
-
-    │
-    └  Configuration saved successfully
-
-      Tip: Run 'goose configure' again to adjust your config or add extensions.
-  ```
-
-  Run `goose session` to start a session.
-</details>
+:::tip Configuring Goose on WSL
+  Choose to not store to keyring when prompted.
+:::
 
 
 ## Set LLM Provider

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -50,7 +50,7 @@ import RateLimits from '@site/src/components/RateLimits';
 
 #### Installing on Windows via WSL
 
-While Goose Desktop and CLI doesn't work on Windows directly atm, It is possible to run Goose CLI on Windows using the Windows Subsystem for Linux (WSL).
+There isn't native installation support for Windows, however you can run Goose using WSL (Windows Subsystem for Linux).
 
 <details>
 

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -57,7 +57,7 @@ There isn't native installation support for Windows, however you can run Goose u
   <summary>Installing Goose on WSL</summary>
 
   #### Install WSL
-  Open PowerShell as Administrator and install WSL and the default Ubuntu distribution:
+  Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
 
   ```bash
   wsl --install

--- a/documentation/src/components/SupportedEnvironments.js
+++ b/documentation/src/components/SupportedEnvironments.js
@@ -4,7 +4,9 @@ import Admonition from "@theme/Admonition";
 const SupportedEnvironments = () => {
   return (
     <Admonition type="info" title="Supported Environments">
-      Goose currently works on <strong>macOS</strong> and <strong>Linux</strong> systems and supports both <strong>ARM</strong> and <strong>x86</strong> architectures. If you'd like to request support for additional operating systems, please{" "}
+      Goose currently works on <strong>macOS</strong> and <strong>Linux</strong> systems and supports both <strong>ARM</strong> and <strong>x86</strong> architectures. 
+      
+      On <strong>Windows</strong>, you can run Goose CLI using WSL to run it via Ubuntu. If you'd like to request support for additional operating systems, please{" "}
       <a
         href="https://github.com/block/goose/discussions/867"
         target="_blank"

--- a/documentation/src/components/SupportedEnvironments.js
+++ b/documentation/src/components/SupportedEnvironments.js
@@ -6,7 +6,7 @@ const SupportedEnvironments = () => {
     <Admonition type="info" title="Supported Environments">
       Goose currently works on <strong>macOS</strong> and <strong>Linux</strong> systems and supports both <strong>ARM</strong> and <strong>x86</strong> architectures. 
       
-      On <strong>Windows</strong>, you can run Goose CLI using WSL to run it via Ubuntu. If you'd like to request support for additional operating systems, please{" "}
+      On <strong>Windows</strong>, Goose CLI can run via WSL. If you'd like to request support for additional operating systems, please{" "}
       <a
         href="https://github.com/block/goose/discussions/867"
         target="_blank"


### PR DESCRIPTION
This pull request adds a new section to the installation documentation for Goose, providing detailed instructions on how to install and configure Goose CLI on Windows using the Windows Subsystem for Linux (WSL).

Documentation updates:

* [`documentation/docs/getting-started/installation.md`](diffhunk://#diff-1da95befef448a968841697bffcbb8f9c53f1238842a36a63444ca5d4ea0499aR51-R132): Added a new subsection "Installing on Windows via WSL" with step-by-step instructions for installing WSL, updating packages, installing Goose CLI, setting environment variables, and configuring Goose.