### PR TITLE
[fix] more graceful handling of missing usage in response

### DIFF
--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -243,7 +243,14 @@ impl Provider for DatabricksProvider {
 
         // Parse response
         let message = response_to_message(response.clone())?;
-        let usage = get_usage(&response)?;
+        let usage = match get_usage(&response) {
+            Ok(usage) => usage,
+            Err(ProviderError::UsageError(e)) => {
+                tracing::warn!("Failed to get usage data: {}", e);
+                Usage::default()
+            }
+            Err(e) => return Err(e),
+        };
         let model = get_model(&response);
         super::utils::emit_debug_trace(self, &payload, &response, &usage);
 

--- a/crates/goose/src/providers/errors.rs
+++ b/crates/goose/src/providers/errors.rs
@@ -19,6 +19,9 @@ pub enum ProviderError {
 
     #[error("Execution error: {0}")]
     ExecutionError(String),
+
+    #[error("Usage data error: {0}")]
+    UsageError(String),
 }
 
 impl From<anyhow::Error> for ProviderError {

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -1,6 +1,7 @@
 use crate::message::{Message, MessageContent};
 use crate::model::ModelConfig;
 use crate::providers::base::Usage;
+use crate::providers::errors::ProviderError;
 use crate::providers::utils::{
     convert_image, is_valid_function_name, sanitize_function_name, ImageFormat,
 };
@@ -221,10 +222,10 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
     })
 }
 
-pub fn get_usage(data: &Value) -> anyhow::Result<Usage> {
+pub fn get_usage(data: &Value) -> Result<Usage, ProviderError> {
     let usage = data
         .get("usage")
-        .ok_or_else(|| anyhow!("No usage data in response"))?;
+        .ok_or_else(|| ProviderError::UsageError("No usage data in response".to_string()))?;
 
     let input_tokens = usage
         .get("prompt_tokens")

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -104,7 +104,14 @@ impl Provider for OllamaProvider {
 
         // Parse response
         let message = response_to_message(response.clone())?;
-        let usage = get_usage(&response)?;
+        let usage = match get_usage(&response) {
+            Ok(usage) => usage,
+            Err(ProviderError::UsageError(e)) => {
+                tracing::warn!("Failed to get usage data: {}", e);
+                Usage::default()
+            }
+            Err(e) => return Err(e),
+        };
         let model = get_model(&response);
         super::utils::emit_debug_trace(self, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -4,7 +4,7 @@ use reqwest::Client;
 use serde_json::Value;
 use std::time::Duration;
 
-use super::base::{ConfigKey, Provider, ProviderMetadata, ProviderUsage};
+use super::base::{ConfigKey, Provider, ProviderMetadata, ProviderUsage, Usage};
 use super::errors::ProviderError;
 use super::formats::openai::{create_request, get_usage, response_to_message};
 use super::utils::{emit_debug_trace, get_model, handle_response_openai_compat, ImageFormat};
@@ -115,7 +115,14 @@ impl Provider for OpenAiProvider {
 
         // Parse response
         let message = response_to_message(response.clone())?;
-        let usage = get_usage(&response)?;
+        let usage = match get_usage(&response) {
+            Ok(usage) => usage,
+            Err(ProviderError::UsageError(e)) => {
+                tracing::warn!("Failed to get usage data: {}", e);
+                Usage::default()
+            }
+            Err(e) => return Err(e),
+        };
         let model = get_model(&response);
         emit_debug_trace(self, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -203,7 +203,14 @@ impl Provider for OpenRouterProvider {
 
         // Parse response
         let message = response_to_message(response.clone())?;
-        let usage = get_usage(&response)?;
+        let usage = match get_usage(&response) {
+            Ok(usage) => usage,
+            Err(ProviderError::UsageError(e)) => {
+                tracing::warn!("Failed to get usage data: {}", e);
+                Usage::default()
+            }
+            Err(e) => return Err(e),
+        };
         let model = get_model(&response);
         emit_debug_trace(self, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))


### PR DESCRIPTION
There seems to be a transient issue with usage failing to be returned on OpenRouter with the Anthropic model: https://github.com/block/goose/issues/899#issuecomment-2621909495

According to their documentation, usage _should_ always be returned for non-streaming calls, but that appears not to be the case. This PR allows more graceful failing and returning default usage with None fields in case that happens. It also does the same for the other providers so that getting the 'usage' won't cause a completion to fail.