### PR TITLE
fix: truncation agent token calculations

### DIFF
--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -59,7 +59,7 @@ impl TruncateAgent {
         // Our token count is an estimate since model providers often don't provide the tokenizer (eg. Claude)
         let context_limit = (context_limit as f32 * estimate_factor) as usize;
 
-        // Taken into account the system prompt, and our tools input and subtract that from the
+        // Take into account the system prompt, and our tools input and subtract that from the
         // remaining context limit
         let system_prompt_token_count = self.token_counter.count_tokens(system_prompt);
         let tools_token_count = self.token_counter.count_tokens_for_tools(tools.as_slice());
@@ -74,7 +74,8 @@ impl TruncateAgent {
 
         let context_limit = remaining_tokens;
 
-        // Calculate current token count of each message
+        // Calculate current token count of each message, use count_chat_tokens to ensure we
+        // capture the full content of the message
         let mut token_counts: Vec<usize> = messages
             .iter()
             .map(|msg| {

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -83,8 +83,6 @@ impl TruncateAgent {
             })
             .collect();
 
-        tracing::warn!("{:?}", token_counts);
-
         truncate_messages(
             messages,
             &mut token_counts,

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -263,7 +263,7 @@ impl Agent for TruncateAgent {
                         drop(capabilities);
 
                         if let Err(err) = self.truncate_messages(&mut messages, estimate_factor, &system_prompt, &mut tools).await {
-                            yield Message::assistant().with_text(format!("Error: Unable to truncate messages to stay within context limit. \n\nRan into this error: {}", err));
+                            yield Message::assistant().with_text(format!("Error: Unable to truncate messages to stay within context limit. \n\nRan into this error: {}.\n\n Please start a new session with fresh context and try again.", err));
                             break;
                         }
 

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -75,7 +75,7 @@ impl TruncateAgent {
         let context_limit = remaining_tokens;
 
         // Calculate current token count of each message, use count_chat_tokens to ensure we
-        // capture the full content of the message
+        // capture the full content of the message, include ToolRequests and ToolResponses
         let mut token_counts: Vec<usize> = messages
             .iter()
             .map(|msg| {

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -263,7 +263,7 @@ impl Agent for TruncateAgent {
                         drop(capabilities);
 
                         if let Err(err) = self.truncate_messages(&mut messages, estimate_factor, &system_prompt, &mut tools).await {
-                            yield Message::assistant().with_text(format!("Error: Unable to truncate messages to stay within context limit. \n\nRan into this error: {}.\n\n Please start a new session with fresh context and try again.", err));
+                            yield Message::assistant().with_text(format!("Error: Unable to truncate messages to stay within context limit. \n\nRan into this error: {}.\n\nPlease start a new session with fresh context and try again.", err));
                             break;
                         }
 

--- a/crates/goose/src/token_counter.rs
+++ b/crates/goose/src/token_counter.rs
@@ -112,7 +112,7 @@ impl TokenCounter {
         encoding.len()
     }
 
-    fn count_tokens_for_tools(&self, tools: &[Tool]) -> usize {
+    pub fn count_tokens_for_tools(&self, tools: &[Tool]) -> usize {
         // Token counts for different function components
         let func_init = 7; // Tokens for function initialization
         let prop_init = 3; // Tokens for properties initialization

--- a/crates/goose/src/truncate.rs
+++ b/crates/goose/src/truncate.rs
@@ -63,7 +63,6 @@ impl TruncationStrategy for OldestFirstTruncation {
             for (message_idx, tool_id) in &tool_ids_to_remove {
                 if message_idx != &i && message_tool_ids.contains(tool_id.as_str()) {
                     indices_to_remove.insert(i);
-                    total_tokens -= token_counts[i];
                     // No need to check other tool_ids for this message since it's already marked
                     break;
                 }

--- a/crates/goose/src/truncate.rs
+++ b/crates/goose/src/truncate.rs
@@ -86,7 +86,7 @@ pub fn truncate_messages(
     token_counts: &mut Vec<usize>,
     context_limit: usize,
     strategy: &dyn TruncationStrategy,
-) -> Result<()> {
+) -> Result<(), anyhow::Error> {
     if messages.len() != token_counts.len() {
         return Err(anyhow!(
             "The vector for messages and token_counts must have same length"


### PR DESCRIPTION
# truncation agent token calculations

* propagate and display any errors that come back from `truncate_messages` instead of ignoring them
* add a note that users should restart in a fresh session if they hit the context limit
* `self.token_counter.count_tokens(&msg.as_concat_text())` was only counting messages of type `Message::Text`, ignoring any `ToolResponse`s which tend to be a large amount of tokens
* use `self.token_counter.count_chat_tokens("", std::slice::from_ref(msg), &[])` to get a full count of the message tokens
* update `context_limit` calculation to subtract the total amount of `system_prompt` and `tools` tokens already in use