### PR TITLE
feat: add CONFIGURE=false option in install script

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -19,15 +19,18 @@ import RateLimits from '@site/src/components/RateLimits';
 
     <Tabs groupId="interface">
       <TabItem value="cli" label="Goose CLI" default>
-        Run the following command to install the latest version of Goose: 
+        Run the following command to install the latest version of Goose:
 
         ```sh
         curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
         ```
         This script will fetch the latest version of Goose and set it up on your system.
-        
+
         :::tip Best Practice
         It’s best to keep Goose updated. You can update it by re-running the installation script.
+        :::
+        :::tip Automation
+        You can disable automatic interactive configuration by adding `| CONFIGURE=false bash` to the script above.
         :::
       </TabItem>
       <TabItem value="ui" label="Goose Desktop">
@@ -41,13 +44,13 @@ import RateLimits from '@site/src/components/RateLimits';
             download goose desktop
           </Link>
         </div>
-        <div style={{ marginTop: '1rem' }}>  
+        <div style={{ marginTop: '1rem' }}>
           1. Unzip the downloaded `Goose.zip` file.
           2. Run the executable file to launch the Goose desktop application.
           :::tip Best Practice
           It’s best to keep Goose updated. You can do this by checking the [Goose GitHub Release page](https://github.com/block/goose/releases/stable) and downloading updates when available.
           :::
-        </div>  
+        </div>
 
       </TabItem>
     </Tabs>
@@ -106,7 +109,7 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
     │
     ◇ Provider openai requires OPENAI_API_KEY, please enter a value
     │▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
-    │    
+    │
     ◇ Enter a model from that provider:
     │ gpt-4o
     │
@@ -143,13 +146,13 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
 ## Update Provider
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
-    **To update your LLM provider and API key:** 
-    1. Run the following command: 
+    **To update your LLM provider and API key:**
+    1. Run the following command:
     ```sh
     goose configure
     ```
     2. Select `Configure Providers` from the menu.
-    3. Follow the prompts to choose your LLM provider and enter or update your API key. 
+    3. Follow the prompts to choose your LLM provider and enter or update your API key.
 
     **Example:**
 
@@ -166,7 +169,7 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
     │
     ◇ Provider Google Gemini requires GOOGLE_API_KEY, please enter a value
     │▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
-    │    
+    │
     ◇ Enter a model from that provider:
     │ gemini-2.0-flash-exp
     │
@@ -176,7 +179,7 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
     ```
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  **To update your LLM provider and API key:** 
+  **To update your LLM provider and API key:**
 
     1. Click on the three dots in the top-right corner.
     2. Select `Provider Settings` from the menu.
@@ -194,13 +197,13 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
     <TabItem value="cli" label="Goose CLI" default>
         From your terminal, navigate to the directory you'd like to start from and run:
         ```sh
-        goose session 
+        goose session
         ```
     </TabItem>
     <TabItem value="ui" label="Goose Desktop">
         Starting a session in the Goose Desktop is straightforward. After choosing your provider, you’ll see the session interface ready for use.
-        
-        Type your questions, tasks, or instructions directly into the input field, and Goose will get to work immediately. 
+
+        Type your questions, tasks, or instructions directly into the input field, and Goose will get to work immediately.
     </TabItem>
 </Tabs>
 

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -23,11 +23,14 @@ You can use Goose via CLI or Desktop application.
 
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
-    Run the following command to install the latest version of Goose: 
+    Run the following command to install the latest version of Goose:
 
     ```sh
     curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
     ```
+    :::tip Automation
+    You can disable automatic interactive configuration by adding `| CONFIGURE=false bash` to the script above.
+    :::
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
     To install the latest version of Goose, click the **button** below:
@@ -40,10 +43,10 @@ You can use Goose via CLI or Desktop application.
         download goose desktop
       </Link>
     </div>
-    <div style={{ marginTop: '1rem' }}>  
+    <div style={{ marginTop: '1rem' }}>
       1. Unzip the downloaded `Goose.zip` file.
       2. Run the executable file to launch the Goose desktop application.
-    </div>  
+    </div>
   </TabItem>
 </Tabs>
 
@@ -66,7 +69,7 @@ Goose works with [supported LLM providers][providers]. When you install Goose, y
     │
     ◇ Provider Google Gemini requires GOOGLE_API_KEY, please enter a value
     │▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
-    │    
+    │
     ◇ Enter a model from that provider:
     │ gemini-2.0-flash-exp
     │
@@ -90,13 +93,13 @@ Sessions are single, continuous conversations between you and Goose. Let's start
         1. Make an empty directory (e.g. `goose-demo`) and navigate to that directory from the terminal.
         2. To start a new session, run:
         ```sh
-        goose session 
+        goose session
         ```
     </TabItem>
     <TabItem value="ui" label="Goose Desktop">
         After choosing an LLM provider, you’ll see the session interface ready for use.
-        
-        Type your questions, tasks, or instructions directly into the input field, and Goose will immediately get to work. 
+
+        Type your questions, tasks, or instructions directly into the input field, and Goose will immediately get to work.
 
         ![Install Extension](./assets/guides/ui-session-interface.png)
     </TabItem>
@@ -128,21 +131,21 @@ While you're able to manually navigate to your working directory and open the HT
         ```
         3. Choose `Add extension` > `Built-in Extension` > `Computer Controller`. This [extension](https://block.github.io/goose/v1/extensions/detail/nondeveloper) enables webscraping, file caching, and automations.
         ```
-        ┌   goose-configure 
+        ┌   goose-configure
         │
         ◇  What would you like to configure?
-        │  Add Extension 
+        │  Add Extension
         │
         ◇  What type of extension would you like to add?
-        │  Built-in Extension 
+        │  Built-in Extension
         │
         ◆  Which built-in extension would you like to enable?
-        │  ○ Developer Tools 
+        │  ○ Developer Tools
         │  ● Computer Controller (controls for webscraping, file caching, and automations)
-        │  ○ Google Drive 
-        │  ○ Memory 
-        │  ○ JetBrains 
-        └  
+        │  ○ Google Drive
+        │  ○ Memory
+        │  ○ JetBrains
+        └
         ```
         4. Now that Goose has browser capabilities, let's resume your last session:
         ```sh
@@ -158,7 +161,7 @@ While you're able to manually navigate to your working directory and open the HT
         5. Now that Goose has browser capabilities, let's ask it to launch your game in a browser:
     </TabItem>
 </Tabs>
-        
+
 ```
 open index.html in a browser
 ```

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -18,6 +18,7 @@ set -eu
 #   GOOSE_PROVIDER - Optional: provider for goose
 #   GOOSE_MODEL    - Optional: model for goose
 #   CANARY         - Optional: if set to "true", downloads from canary release instead of stable
+#   CONFIGURE      - Optional: if set to "false", disables running goose configure interactively
 #   ** other provider specific environment variables (eg. DATABRICKS_HOST)
 ##############################################################################
 
@@ -33,6 +34,7 @@ OUT_FILE="goose"
 GOOSE_BIN_DIR="${GOOSE_BIN_DIR:-"$HOME/.local/bin"}"
 RELEASE="${CANARY:-false}"
 RELEASE_TAG="$([[ "$RELEASE" == "true" ]] && echo "canary" || echo "stable")"
+CONFIGURE="${CONFIGURE:-true}"
 
 # --- 3) Detect OS/Architecture ---
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
@@ -40,7 +42,7 @@ ARCH=$(uname -m)
 
 case "$OS" in
   linux|darwin) ;;
-  *) 
+  *)
     echo "Error: Unsupported OS '$OS'. Goose currently only supports Linux and macOS."
     exit 1
     ;;
@@ -92,11 +94,16 @@ fi
 echo "Moving goose to $GOOSE_BIN_DIR/$OUT_FILE"
 mv goose "$GOOSE_BIN_DIR/$OUT_FILE"
 
-# --- 6) Configure Goose (Optional) ---
-echo ""
-echo "Configuring Goose"
-echo ""
-"$GOOSE_BIN_DIR/$OUT_FILE" configure
+# skip configuration for non-interactive installs e.g. automation, docker
+if [ "$CONFIGURE" = true ]; then
+  # --- 6) Configure Goose (Optional) ---
+  echo ""
+  echo "Configuring Goose"
+  echo ""
+  "$GOOSE_BIN_DIR/$OUT_FILE" configure
+else
+  echo "Skipping 'goose configure', you may need to run this manually later"
+fi
 
 # --- 7) Check PATH and give instructions if needed ---
 if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then


### PR DESCRIPTION
# add CONFIGURE=false option in install script
* allow users to set ` | CONFIGURE=false bash` when running the automated installer, to skip the interactive `goose configure` step
* add "Tip" sections to the quickstart/installation docs
* cleanup trailing whitespaces

see https://github.com/block/goose/issues/918 