### PR TITLE
feat: substitute version in CLI and Desktop App during release

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -41,9 +41,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Update version
+      - name: Update version in Cargo.toml
         run: |
-          sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version}}'"/' Cargo.toml
+          sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version }}'"/' Cargo.toml
           rm -f Cargo.toml.bak
 
       - name: Setup Rust

--- a/.github/workflows/bundle-desktop.yml
+++ b/.github/workflows/bundle-desktop.yml
@@ -76,11 +76,11 @@ jobs:
       # Update versions before build
       - name: Update versions
         run: |
-          # Update Cargo.toml version
-          sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version}}'"/' Cargo.toml
+          # Update version in Cargo.toml
+          sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version }}'"/' Cargo.toml
           rm -f Cargo.toml.bak
           
-          # Update package.json version
+          # Update version in package.json 
           cd ui/desktop
           npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
 

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -17,13 +17,33 @@ concurrency:
 
 jobs:
   # ------------------------------------
-  # 1) Build CLI for multiple OS/Arch
+  # 1) Prepare Version
   # ------------------------------------
-  build-cli:
-    uses: ./.github/workflows/build-cli.yml
+  prepare-version:
+    name: Prepare Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - name: Generate a canary version
+        id: set-version
+        run: |
+          # Something like "1.0.0-canary.<short sha>"
+          SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
+          VERSION="1.0.0-canary.${SHORT_SHA}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   # ------------------------------------
-  # 2) Upload Install CLI Script (we only need to do this once)
+  # 2) Build CLI for multiple OS/Arch
+  # ------------------------------------
+  build-cli:
+    needs: [prepare-version]
+    uses: ./.github/workflows/build-cli.yml
+    with:
+      version: ${{ needs.prepare-version.outputs.version }}
+
+  # ------------------------------------
+  # 3) Upload Install CLI Script (we only need to do this once)
   # ------------------------------------
   install-script:
     name: Upload Install Script
@@ -37,11 +57,13 @@ jobs:
           path: download_cli.sh
 
   # ------------------------------------------------------------
-  # 3) Bundle Desktop App (macOS only) - builds goosed and Electron app
+  # 4) Bundle Desktop App (macOS only) - builds goosed and Electron app
   # ------------------------------------------------------------
   bundle-desktop:
+    needs: [prepare-version]
     uses: ./.github/workflows/bundle-desktop.yml
     with:
+      version: ${{ needs.prepare-version.outputs.version }}
       signing: true
     secrets:
       CERTIFICATE_OSX_APPLICATION: ${{ secrets.CERTIFICATE_OSX_APPLICATION }}
@@ -51,7 +73,7 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
   
   # ------------------------------------
-  # 4) Create/Update GitHub Release
+  # 5) Create/Update GitHub Release
   # ------------------------------------
   release:
     name: Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,19 +96,19 @@ jobs:
           prerelease: true # TODO: remove after testing
           draft: true # TODO: remove after testing
 
-      # Create/update the stable release
-      - name: Release stable
-        uses: ncipollo/release-action@v1
-        with:
-          tag: stable
-          name: Stable
-          token: ${{ secrets.GITHUB_TOKEN }}
-          artifacts: |
-            goose-*.tar.bz2
-            Goose*.zip
-            download_cli.sh
-          allowUpdates: true
-          omitBody: true
-          omitPrereleaseDuringUpdate: true
-          prerelease: true # TODO: remove after testing
-          draft: true # TODO: remove after testing
+      # TODO: uncomment after testing. otherwise, this replaces the assets in the stable release
+      # # Create/update the stable release
+      # - name: Release stable
+      #   uses: ncipollo/release-action@v1
+      #   with:
+      #     tag: stable
+      #     name: Stable
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     artifacts: |
+      #       goose-*.tar.bz2
+      #       Goose*.zip
+      #       download_cli.sh
+      #     allowUpdates: true
+      #     omitBody: true
+      #     omitPrereleaseDuringUpdate: true
+      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
       - 'documentation/**'
     tags:
       - "v1.*"
+      - 'test.*' # TODO: remove after testing
 name: Release
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,37 +24,15 @@ jobs:
       - name: Extract version
         id: set-version
         run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
+          VERSION=${GITHUB_REF#refs/tags/test.} # TODO: remove after testing
+          # VERSION=${GITHUB_REF#refs/tags/v}
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-  # ------------------------------------
-  # 2) Update version in files
-  # ------------------------------------
-  update-version:
-    name: Update Cargo.toml & package.json Version
-    needs: [prepare-version]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-      - name: Update workspace Cargo.toml version
-        run: sed -i 's/^version = ".*"/version = "'${{ needs.prepare-version.outputs.version }}'"/' Cargo.toml
-      - name: Update package.json version
-        run: |
-          npm version ${{ needs.prepare-version.outputs.version }} --no-git-tag-version --allow-same-version
-        working-directory: ui/desktop
-      - name: Commit updated files
-        run: |
-          git config --global user.name "github-actions"
-          git config --global user.email "github-actions@github.com"
-          git commit -am "Update versions to ${{ needs.prepare-version.outputs.version }}"
-          git push
 
   # ------------------------------------
   # 3) Build CLI for multiple OS/Arch
   # ------------------------------------
   build-cli:
-    needs: [prepare-version, update-version]
+    needs: [prepare-version]
     uses: ./.github/workflows/build-cli.yml
     with:
       version: ${{ needs.prepare-version.outputs.version }}
@@ -76,7 +55,7 @@ jobs:
   # 5) Bundle Desktop App (macOS only)
   # ------------------------------------------------------------
   bundle-desktop:
-    needs: [prepare-version, update-version]
+    needs: [prepare-version]
     uses: ./.github/workflows/bundle-desktop.yml
     with:
       version: ${{ needs.prepare-version.outputs.version }}
@@ -114,6 +93,9 @@ jobs:
           allowUpdates: true
           omitBody: true
           omitPrereleaseDuringUpdate: true
+          prerelease: true # TODO: remove after testing
+          draft: true # TODO: remove after testing
+
       # Create/update the stable release
       - name: Release stable
         uses: ncipollo/release-action@v1
@@ -128,3 +110,5 @@ jobs:
           allowUpdates: true
           omitBody: true
           omitPrereleaseDuringUpdate: true
+          prerelease: true # TODO: remove after testing
+          draft: true # TODO: remove after testing


### PR DESCRIPTION
workflow succeeded: https://github.com/block/goose/actions/runs/13045348906
test release (draft) - tagged it as `test.1.0.1` : https://github.com/block/goose/releases/tag/untagged-fe0426d4b3b96b1ddc30

downloaded the CLI and App. looks like the version injections worked: 
<img width="275" alt="Screenshot 2025-01-29 at 11 09 48 PM" src="https://github.com/user-attachments/assets/49511dbe-ba3c-4fbc-98ea-6cfe8edae8c4" />
<img width="334" alt="Screenshot 2025-01-29 at 11 08 12 PM" src="https://github.com/user-attachments/assets/35e5e25a-f3cd-4245-a1ea-6ad49c112c2d" />
