### PR TITLE
feat: cfg electron to open links in new window

### DIFF
--- a/ui/desktop/src/components/LinkPreview.tsx
+++ b/ui/desktop/src/components/LinkPreview.tsx
@@ -116,38 +116,35 @@ export default function LinkPreview({ url }: LinkPreviewProps) {
   }
 
   return (
-    <Card
-      className="max-w-[300px] truncate flex items-center bg-link-preview dark:bg-link-preview-dark p-3 transition-colors cursor-pointer"
-      onClick={() => {
-        window.electron.openInChrome(url);
-      }}
-    >
-      {metadata.favicon && (
-        <img
-          src={metadata.favicon}
-          alt="Site favicon"
-          className="w-4 h-4 mr-2"
-          onError={(e) => {
-            e.currentTarget.style.display = 'none';
-          }}
-        />
-      )}
-      <div className="flex-1 min-w-0">
-        <h4 className="text-sm font-medium truncate">{metadata.title || url}</h4>
-        {metadata.description && (
-          <p className="text-xs text-gray-500 truncate">{metadata.description}</p>
+    <a href={url} target="_blank" rel="noreferrer">
+      <Card className="max-w-[300px] truncate flex items-center bg-link-preview dark:bg-link-preview-dark p-3 transition-colors cursor-pointer">
+        {metadata.favicon && (
+          <img
+            src={metadata.favicon}
+            alt="Site favicon"
+            className="w-4 h-4 mr-2"
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+            }}
+          />
         )}
-      </div>
-      {metadata.image && (
-        <img
-          src={metadata.image}
-          alt="Preview"
-          className="w-16 h-16 object-cover rounded ml-3"
-          onError={(e) => {
-            e.currentTarget.style.display = 'none';
-          }}
-        />
-      )}
-    </Card>
+        <div className="flex-1 min-w-0">
+          <h4 className="text-sm font-medium truncate">{metadata.title || url}</h4>
+          {metadata.description && (
+            <p className="text-xs text-gray-500 truncate">{metadata.description}</p>
+          )}
+        </div>
+        {metadata.image && (
+          <img
+            src={metadata.image}
+            alt="Preview"
+            className="w-16 h-16 object-cover rounded ml-3"
+            onError={(e) => {
+              e.currentTarget.style.display = 'none';
+            }}
+          />
+        )}
+      </Card>
+    </a>
   );
 }

--- a/ui/desktop/src/components/settings/Settings.tsx
+++ b/ui/desktop/src/components/settings/Settings.tsx
@@ -234,12 +234,14 @@ export default function Settings() {
                       Add
                     </button>
 
-                    <button
-                      onClick={() => window.electron.openInChrome(EXTENSIONS_SITE_LINK)}
+                    <a
+                      href={EXTENSIONS_SITE_LINK}
+                      target="_blank"
                       className="text-indigo-500 hover:text-indigo-600 text-sm"
+                      rel="noreferrer"
                     >
                       Browse
-                    </button>
+                    </a>
                   </div>
                 </div>
 

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -171,6 +171,16 @@ const createChat = async (app, query?: string, dir?: string, version?: string) =
     },
   });
 
+  // Handle new window creation for links
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    // Open all links in external browser
+    if (url.startsWith('http:') || url.startsWith('https:')) {
+      require('electron').shell.openExternal(url);
+      return { action: 'deny' };
+    }
+    return { action: 'allow' };
+  });
+
   // Load the index.html of the app.
   const queryParam = query ? `?initialQuery=${encodeURIComponent(query)}` : '';
   const { screen } = require('electron');


### PR DESCRIPTION
This PR addresses the linked issue by forcing links to open in a new browser window, via an electron configuration change.

Tested by asking Goose variants of "give me a link|hyperlink|source to learn more about kadane" with the expectation being a response either solely or containing a clickable link, which, when clicked opens in a new browser window and not the primary electron window for Goose"