### PR TITLE
feat: removed minHeight

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -153,7 +153,7 @@ const createChat = async (app, query?: string, dir?: string, version?: string) =
     width: 750,
     height: 800,
     minWidth: 650,
-    minHeight: 800,
+    resizable: true,
     transparent: false,
     useContentSize: true,
     icon: path.join(__dirname, '../images/icon'),


### PR DESCRIPTION
This removes the minHeight which allows one to resize the window under the previously set amount. Useful for folks using accessibility settings and larger type. 

<img width="1166" alt="Screenshot 2025-01-30 at 10 27 06 AM" src="https://github.com/user-attachments/assets/99a7a274-1aaf-4e58-9376-f481ef805e56" />
