### PR TITLE
fix: missing field in request

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -215,8 +215,12 @@ pub async fn configure_provider_dialog() -> Result<bool, Box<dyn Error>> {
                                     .mask('▪')
                                     .interact()?
                             } else {
-                                cliclack::input(format!("Enter new value for {}", key.name))
-                                    .interact()?
+                                let mut input =
+                                    cliclack::input(format!("Enter new value for {}", key.name));
+                                if key.default.is_some() {
+                                    input = input.default_input(&key.default.clone().unwrap());
+                                }
+                                input.interact()?
                             };
 
                             if key.secret {

--- a/ui/desktop/src/components/settings/providers/ConfigureProvidersGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ConfigureProvidersGrid.tsx
@@ -86,6 +86,8 @@ export function ConfigureProvidersGrid() {
       return;
     }
 
+    const isSecret = isSecretKey(keyName);
+
     try {
       // Delete existing key if provider is already configured
       const isUpdate = providers.find((p) => p.id === selectedForSetup)?.isConfigured;
@@ -96,7 +98,10 @@ export function ConfigureProvidersGrid() {
             'Content-Type': 'application/json',
             'X-Secret-Key': getSecretKey(),
           },
-          body: JSON.stringify({ key: keyName }),
+          body: JSON.stringify({ 
+            key: keyName, 
+            isSecret,
+          }),
         });
 
         if (!deleteResponse.ok) {
@@ -107,7 +112,6 @@ export function ConfigureProvidersGrid() {
       }
 
       // Store new key
-      const isSecret = isSecretKey(keyName);
       const storeResponse = await fetch(getApiUrl('/configs/store'), {
         method: 'POST',
         headers: {

--- a/ui/desktop/src/components/welcome_screen/ProviderGrid.tsx
+++ b/ui/desktop/src/components/welcome_screen/ProviderGrid.tsx
@@ -81,6 +81,7 @@ export function ProviderGrid({ onSubmit }: ProviderGridProps) {
       return;
     }
 
+    const isSecret = isSecretKey(keyName);
     try {
       if (selectedId && providers.find((p) => p.id === selectedId)?.isConfigured) {
         const deleteResponse = await fetch(getApiUrl('/configs/delete'), {
@@ -89,7 +90,10 @@ export function ProviderGrid({ onSubmit }: ProviderGridProps) {
             'Content-Type': 'application/json',
             'X-Secret-Key': getSecretKey(),
           },
-          body: JSON.stringify({ key: keyName }),
+          body: JSON.stringify({ 
+            key: keyName, 
+            isSecret,
+          }),
         });
 
         if (!deleteResponse.ok) {
@@ -99,7 +103,6 @@ export function ProviderGrid({ onSubmit }: ProviderGridProps) {
         }
       }
 
-      const isSecret = isSecretKey(keyName);
       const storeResponse = await fetch(getApiUrl('/configs/store'), {
         method: 'POST',
         headers: {


### PR DESCRIPTION
Also improve the CLI configuration by providing default value for ollama host

Test:

CLI configuration with default value: 
```
┌   goose-configure 
│
◇  What would you like to configure?
│  Configure Providers 
│
◇  Which model provider should we use?
│  Ollama 
│
●  OLLAMA_HOST is already configured
│  
◇  Would you like to update this value?
│  Yes 
│
◆  Enter new value for OLLAMA_HOST
│  http://localhost:11434 (default)
└  
```
without default value:

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Configure Providers 
│
◇  Which model provider should we use?
│  Databricks 
│
●  DATABRICKS_HOST is already configured
│  
◇  Would you like to update this value?
│  Yes 
│
◆  Enter new value for DATABRICKS_HOST
│   
└ 
```