### PR TITLE
chore: remove o1-mini suggestion from UI add model view

### DIFF
--- a/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
+++ b/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
@@ -7,7 +7,6 @@ export const goose_models: Model[] = [
   { id: 3, name: 'gpt-4-turbo', provider: 'OpenAI' },
   { id: 4, name: 'gpt-3.5-turbo', provider: 'OpenAI' },
   { id: 5, name: 'o1', provider: 'OpenAI' },
-  { id: 6, name: 'o1-mini', provider: 'OpenAI' },
   { id: 7, name: 'claude-3-5-sonnet-latest', provider: 'Anthropic' },
   { id: 8, name: 'claude-3-5-haiku-latest', provider: 'Anthropic' },
   { id: 9, name: 'claude-3-opus-latest', provider: 'Anthropic' },
@@ -21,14 +20,7 @@ export const goose_models: Model[] = [
   { id: 17, name: 'anthropic/claude-3.5-sonnet', provider: 'OpenRouter' },
 ];
 
-export const openai_models = [
-  'gpt-4o-mini',
-  'gpt-4o',
-  'gpt-4-turbo',
-  'gpt-3.5-turbo',
-  'o1',
-  'o1-mini',
-];
+export const openai_models = ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo', 'gpt-3.5-turbo', 'o1'];
 
 export const anthropic_models = [
   'claude-3-5-sonnet-latest',


### PR DESCRIPTION
# remove o1-mini suggestion from UI add model view

remove the o1-mini suggestion from the "Add Model" page since it is not supported (see https://github.com/block/goose/pull/921)

<img width="528" alt="image" src="https://github.com/user-attachments/assets/d6b7f838-7170-423f-9a30-fb9924d61ac4" />
