### PR TITLE
fix: explicitly add remember_memory tool in the instructions/system prompt

### DIFF
--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -100,6 +100,13 @@ impl MemoryRouter {
              2. Search memories by content or specific tags to find relevant information.
              3. List all available memory categories for easy navigation.
              4. Remove entire categories of memories when they are no longer needed.
+             When to call memory tools:
+             - These are examples where the assistant should proactively call the memory tool because the user is providing recurring preferences, project details, or workflow habits that they may expect to be remembered.
+             - Preferred Development Tools & Conventions
+             - User-specific data (e.g., name, preferences)
+             - Project-related configurations
+             - Workflow descriptions
+             - Other critical settings
              Interaction Protocol:
              When important information is identified, such as:
              - User-specific data (e.g., name, preferences)
@@ -115,6 +122,8 @@ impl MemoryRouter {
                 - Confirm the desired storage location:
                   - Local storage (.goose/memory) for project-specific details.
                   - Global storage (~/.config/goose/memory) for user-wide data.
+                - Use the remember_memory tool to store the information.
+                  - `remember_memory(category, data, tags, is_global)`
              Example Interaction for Storing Information:
              User: "For this project, we use black for code formatting"
              Assistant: "You've mentioned a development preference. Would you like to remember this for future conversations?

--- a/crates/goose/src/truncate.rs
+++ b/crates/goose/src/truncate.rs
@@ -23,6 +23,8 @@ pub trait TruncationStrategy {
 
 /// Strategy to truncate messages by removing the oldest first
 pub struct OldestFirstTruncation;
+/// Strategy to truncate messages explicitly
+pub struct ExplicitTruncation;
 
 impl TruncationStrategy for OldestFirstTruncation {
     fn determine_indices_to_remove(


### PR DESCRIPTION
We didn't have `remember_memory` the tool in the instructions explicitly. Explicitly tell llm provider to use the `remember_memory` tool to store the information.