### PR TITLE
fix: temp fix to make CI workflow pass

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -28,9 +28,9 @@ jobs:
       - name: Generate a canary version
         id: set-version
         run: |
-          # Something like "1.0.0-canary.<short sha>"
+          # TODO: fix this to be dynamic - extract version from repo
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
-          VERSION="1.0.0-canary.${SHORT_SHA}"
+          VERSION="1.0.3-canary.${SHORT_SHA}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   # ------------------------------------

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,4 +104,5 @@ jobs:
     uses: ./.github/workflows/bundle-desktop.yml
     if: github.event_name == 'pull_request'
     with:
+      version: 1.0.3 # TODO: fix this to be dynamic
       signing: false

--- a/.github/workflows/pr-comment-bundle-desktop.yml
+++ b/.github/workflows/pr-comment-bundle-desktop.yml
@@ -43,6 +43,7 @@ jobs:
     if: ${{ needs.trigger-on-command.outputs.continue == 'true' }}
     uses: ./.github/workflows/bundle-desktop.yml
     with:
+      version: 1.0.3 # TODO: fix this to be dynamic
       signing: true
     secrets:
       CERTIFICATE_OSX_APPLICATION: ${{ secrets.CERTIFICATE_OSX_APPLICATION }}


### PR DESCRIPTION
we need to clean up how we do versioning in the release, canary workflows in a later PR. `version` should not be required. if its not passed, it should be extracted from the repo.