### PR TITLE
ci: per semver build metadata should be after +

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           # TODO: fix this to be dynamic - extract version from repo
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
-          VERSION="1.0.3-canary.${SHORT_SHA}"
+          VERSION="1.0.3-canary+${SHORT_SHA}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   # ------------------------------------


### PR DESCRIPTION
# ci: fix semver build metadata
per: https://semver.org/#spec-item-10, build metadata should be after `+` and not `.`


```
❯ cargo build
error: invalid leading zero in pre-release identifier
 --> Cargo.toml:7:11
  |
7 | version = "1.0.3-canary.0020123"
  |           ^^^^^^^^^^^^^^^^^^^^^^
  |
```
vs
```
❯ cargo build
   Compiling goose v1.0.3-canary+0020123)
   Compiling goose-mcp v1.0.3-canary+0020123 
```