### PR TITLE
ci: update release processes using Justfile, make reusable workflows have optional version param

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -6,7 +6,8 @@ on:
   workflow_call:
     inputs:
       version:
-        required: true
+        required: false
+        default: ""
         type: string
       # Let's allow overriding the OSes and architectures in JSON array form:
       # e.g. '["ubuntu-latest","macos-latest"]'
@@ -42,6 +43,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Update version in Cargo.toml
+        if: ${{ inputs.version != '' }}
         run: |
           sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version }}'"/' Cargo.toml
           rm -f Cargo.toml.bak

--- a/.github/workflows/bundle-desktop.yml
+++ b/.github/workflows/bundle-desktop.yml
@@ -8,7 +8,8 @@ on:
     inputs:
       version:
         description: 'Version to set for the build'
-        required: true
+        required: false
+        default: ""
         type: string
       signing:
         description: 'Whether to perform signing and notarization'
@@ -75,6 +76,7 @@ jobs:
 
       # Update versions before build
       - name: Update versions
+        if: ${{ inputs.version != '' }}
         run: |
           # Update version in Cargo.toml
           sed -i.bak 's/^version = ".*"/version = "'${{ inputs.version }}'"/' Cargo.toml

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -5,7 +5,7 @@
 on:
   push:
     paths-ignore:
-      - 'documentation/**'
+      - "documentation/**"
     branches:
       - main
 
@@ -28,9 +28,10 @@ jobs:
       - name: Generate a canary version
         id: set-version
         run: |
-          # TODO: fix this to be dynamic - extract version from repo
+          # Extract the version from Cargo.toml
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-7)
-          VERSION="1.0.3-canary+${SHORT_SHA}"
+          VERSION=$(grep '^version\s*=' Cargo.toml | head -n 1 | cut -d\" -f2)
+          VERSION="${VERSION}-canary+${SHORT_SHA}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
   # ------------------------------------
@@ -48,7 +49,7 @@ jobs:
   install-script:
     name: Upload Install Script
     runs-on: ubuntu-latest
-    needs: [ build-cli ]
+    needs: [build-cli]
     steps:
       - uses: actions/checkout@v4
       - uses: actions/upload-artifact@v4
@@ -71,14 +72,14 @@ jobs:
       APPLE_ID: ${{ secrets.APPLE_ID }}
       APPLE_ID_PASSWORD: ${{ secrets.APPLE_ID_PASSWORD }}
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-  
+
   # ------------------------------------
   # 5) Create/Update GitHub Release
   # ------------------------------------
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [ build-cli, install-script, bundle-desktop ]
+    needs: [build-cli, install-script, bundle-desktop]
     permissions:
       contents: write
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 on:
   push:
     paths-ignore:
-      - 'documentation/**'
+      - "documentation/**"
     branches:
       - main
   pull_request:
     paths-ignore:
-      - 'documentation/**'
+      - "documentation/**"
     branches:
       - main
   workflow_dispatch:
@@ -89,7 +89,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v2
         with:
-          node-version: 'lts/*'
+          node-version: "lts/*"
 
       - name: Install Dependencies
         run: npm ci
@@ -104,5 +104,4 @@ jobs:
     uses: ./.github/workflows/bundle-desktop.yml
     if: github.event_name == 'pull_request'
     with:
-      version: 1.0.3 # TODO: fix this to be dynamic
       signing: false

--- a/.github/workflows/pr-comment-bundle-desktop.yml
+++ b/.github/workflows/pr-comment-bundle-desktop.yml
@@ -43,7 +43,6 @@ jobs:
     if: ${{ needs.trigger-on-command.outputs.continue == 'true' }}
     uses: ./.github/workflows/bundle-desktop.yml
     with:
-      version: 1.0.3 # TODO: fix this to be dynamic
       signing: true
     secrets:
       CERTIFICATE_OSX_APPLICATION: ${{ secrets.CERTIFICATE_OSX_APPLICATION }}
@@ -71,11 +70,11 @@ jobs:
           issue-number: ${{ needs.trigger-on-command.outputs.pr_number }}
           body: |
             ### Desktop App for this PR
-            
+
             The following build is available for testing:
-            
+
             - [📱 macOS Desktop App (arm64, signed)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/Goose-darwin-arm64.zip)
 
             After downloading, unzip the file and drag the Goose.app to your Applications folder. The app is signed and notarized for macOS.
-            
+
             This link is provided by nightly.link and will work even if you're not logged into GitHub.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 on:
   push:
     paths-ignore:
-      - 'documentation/**'
+      - "documentation/**"
     tags:
       - "v1.*"
 
@@ -13,22 +13,7 @@ concurrency:
 
 jobs:
   # ------------------------------------
-  # 1) Set version variables first
-  # ------------------------------------
-  prepare-version:
-    name: Prepare Version
-    runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.set-version.outputs.version }}
-    steps:
-      - name: Extract version
-        id: set-version
-        run: |
-          VERSION=${GITHUB_REF#refs/tags/v}
-          echo "version=$VERSION" >> $GITHUB_OUTPUT
-
-  # ------------------------------------
-  # 3) Build CLI for multiple OS/Arch
+  # 1) Build CLI for multiple OS/Arch
   # ------------------------------------
   build-cli:
     needs: [prepare-version]
@@ -37,7 +22,7 @@ jobs:
       version: ${{ needs.prepare-version.outputs.version }}
 
   # ------------------------------------
-  # 4) Upload Install CLI Script
+  # 2) Upload Install CLI Script
   # ------------------------------------
   install-script:
     name: Upload Install Script
@@ -51,7 +36,7 @@ jobs:
           path: download_cli.sh
 
   # ------------------------------------------------------------
-  # 5) Bundle Desktop App (macOS only)
+  # 3) Bundle Desktop App (macOS only)
   # ------------------------------------------------------------
   bundle-desktop:
     needs: [prepare-version]
@@ -67,7 +52,7 @@ jobs:
       APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
 
   # ------------------------------------
-  # 6) Create/Update GitHub Release
+  # 4) Create/Update GitHub Release
   # ------------------------------------
   release:
     name: Release
@@ -80,7 +65,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           merge-multiple: true
-          
+
       # Create/update the versioned release
       - name: Release versioned
         uses: ncipollo/release-action@v1
@@ -108,4 +93,3 @@ jobs:
           allowUpdates: true
           omitBody: true
           omitPrereleaseDuringUpdate: true
-      

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,10 +16,7 @@ jobs:
   # 1) Build CLI for multiple OS/Arch
   # ------------------------------------
   build-cli:
-    needs: [prepare-version]
     uses: ./.github/workflows/build-cli.yml
-    with:
-      version: ${{ needs.prepare-version.outputs.version }}
 
   # ------------------------------------
   # 2) Upload Install CLI Script
@@ -39,10 +36,8 @@ jobs:
   # 3) Bundle Desktop App (macOS only)
   # ------------------------------------------------------------
   bundle-desktop:
-    needs: [prepare-version]
     uses: ./.github/workflows/bundle-desktop.yml
     with:
-      version: ${{ needs.prepare-version.outputs.version }}
       signing: true
     secrets:
       CERTIFICATE_OSX_APPLICATION: ${{ secrets.CERTIFICATE_OSX_APPLICATION }}

--- a/Justfile
+++ b/Justfile
@@ -1,7 +1,7 @@
 # Justfile
 
 # Default release command
-release:
+release-binary:
     @echo "Building release version..."
     cargo build --release
     @just copy-binary
@@ -18,7 +18,7 @@ copy-binary:
 
 # Run UI with latest
 run-ui:
-    @just release
+    @just release-binary
     @echo "Running UI..."
     cd ui/desktop && npm install && npm run start-gui
 
@@ -34,10 +34,61 @@ run-server:
 
 # make GUI with latest binary
 make-ui:
-    @just release
+    @just release-binary
     cd ui/desktop && npm run bundle:default
 
 # Setup langfuse server
 langfuse-server:
     #!/usr/bin/env bash
     ./scripts/setup_langfuse.sh
+
+
+# validate the version is semver, and not the current version
+validate version:
+    #!/usr/bin/env bash
+    if [[ ! "{{ version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+      echo "[error]: invalid version '{{ version }}'."
+      echo "  expected: semver format major.minor.patch or major.minor.patch-<suffix>"
+      exit 1
+    fi
+
+    current_version=$(just get-tag-version)
+    if [[ "{{ version }}" == "$current_version" ]]; then
+      echo "[error]: current_version '$current_version' is the same as target version '{{ version }}'"
+      echo "  expected: new version in semver format"
+      exit 1
+    fi
+
+release version:
+    @just validate {{ version }} || exit 1
+
+    @git switch -c "release/{{ version }}"
+    @uvx --from=toml-cli toml set --toml-path=Cargo.toml "workspace.package.version" {{ version }}
+
+    @cd ui/desktop && npm version {{ version }} --no-git-tag-version --allow-same-version
+
+    # TODO: Cargo.lock?
+    @git add Cargo.toml ui/desktop/package.json ui/desktop/package-lock.json
+    @git commit --message "chore(release): release version {{ version }}"
+
+# extract version from Cargo.toml
+get-tag-version:
+    @uvx --from=toml-cli toml get --toml-path=Cargo.toml "workspace.package.version"
+
+tag:
+    #!/usr/bin/env bash
+    branch=$(git rev-parse --abbrev-ref HEAD); \
+    if [ "$branch" != "main" ]; then \
+        echo "Error: You are not on the main branch (current: $branch)"; \
+        exit 1; \
+    fi
+    git tag v$(just get-tag-version)
+
+# create tag and push to origin (use this when release branch is merged to main)
+tag-push: tag
+    # this will kick of ci for release
+    git push origin tag v$(just get-tag-version)
+
+release-notes:
+    #!/usr/bin/env bash
+    git log --pretty=format:"- %s" v$(just get-tag-version)..HEAD

--- a/Justfile
+++ b/Justfile
@@ -46,7 +46,6 @@ langfuse-server:
     #!/usr/bin/env bash
     ./scripts/setup_langfuse.sh
 
-
 # validate the version is semver, and not the current version
 validate version:
     #!/usr/bin/env bash

--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,9 @@
 # Justfile
 
+# list all tasks
+default:
+  @just --list
+
 # Default release command
 release-binary:
     @echo "Building release version..."
@@ -59,6 +63,7 @@ validate version:
       exit 1
     fi
 
+# set cargo and app versions, must be semver
 release version:
     @just validate {{ version }} || exit 1
 
@@ -75,6 +80,7 @@ release version:
 get-tag-version:
     @uvx --from=toml-cli toml get --toml-path=Cargo.toml "workspace.package.version"
 
+# create the git tag from Cargo.toml, must be on main
 tag:
     #!/usr/bin/env bash
     branch=$(git rev-parse --abbrev-ref HEAD); \
@@ -89,6 +95,7 @@ tag-push: tag
     # this will kick of ci for release
     git push origin tag v$(just get-tag-version)
 
+# generate release notes from git commits
 release-notes:
     #!/usr/bin/env bash
     git log --pretty=format:"- %s" v$(just get-tag-version)..HEAD


### PR DESCRIPTION
# ci workflow overhaul

* `Justfile` updates to help automate the release process, modeled after [goose python justfile release](https://github.com/block/goose/blob/eccb1b22614f39b751db4e5efd73d728d9ca40fc/justfile#L90-L122)
  * `just release $VERSION` - use this to set the next version we want to release, will create a new branch and set the commit ready to go
  * `just tag-push` once the above command has been run + pr merged, run this to set the newest tag and kick off the CI for release process
* removes setting the version based on the pushed tag and instead uses the version already committed, and we can follow https://github.com/block/goose/pull/967 for version bumping
* extract the version from `Cargo.toml` for the canary step 
* makes `version` an optional parameter for the re-usable workflows, will primarily be used by the canary to generate canary versions (1.0.3-canary+SHA)
* remove `version` parameters from `ci` and `bundle` workflows, they'll just use defaults
* some autoformatting and trailing whitespace cleaning

### example output
some examples of running the commands (truncated)
```bash
❯ just release 1.0.4
Switched to a new branch 'release/1.0.4'
v1.0.4
→ No staged files match any configured task.
[release/1.0.4 402e961d] chore(release): release version 1.0.4
 3 files changed, 4 insertions(+), 4 deletions(-)

❯ git show
commit 402e961d7f0afb784f4a6c34dc2d4f489c1fb328 (HEAD -> release/1.0.4)
...
    chore(release): release version 1.0.4

diff --git a/Cargo.toml b/Cargo.toml
...
 [workspace.package]
 edition = "2021"
-version = "1.0.3"
+version = "1.0.4"
diff --git a/ui/desktop/package-lock.json b/ui/desktop/package-lock.json
...
   "name": "goose-app",
-  "version": "1.0.3",
+  "version": "1.0.4",
...
       "name": "goose-app",
-      "version": "1.0.3",
+      "version": "1.0.4",
diff --git a/ui/desktop/package.json b/ui/desktop/package.json
index 84026c77..5b4d7c7f 100644
...
   "name": "goose-app",
   "productName": "Goose",
-  "version": "1.0.3",
+  "version": "1.0.4",

```

```
❯ just release 1.0.3
[error]: current_version '1.0.3' is the same as target version '1.0.3'
  expected: new version in semver format
```
