### PR TITLE
fix: add fallback sans-serif font to desktop app

### DIFF
--- a/ui/desktop/tailwind.config.ts
+++ b/ui/desktop/tailwind.config.ts
@@ -6,7 +6,7 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        sans: ['Cash Sans'],
+        sans: ['Cash Sans', 'sans-serif'],
       },
       keyframes: {
         shimmer: {


### PR DESCRIPTION
Link to font https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSans-Regular.woff2 gives 403 whenever I try to access it

![image](https://github.com/user-attachments/assets/b3626d23-df57-48f7-af66-531b027a3457)

That gives us not so good looking window with default font.

<img src="https://github.com/user-attachments/assets/bdbe9e20-82f5-4565-83c5-f7df78e2dafd" height="400" />

I have noticed website uses "sans-serif" as fallback font and have added it to desktop app too.
