### PR TITLE
fixes: #987 by ignoring when user submits empty message

### DIFF
--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -138,6 +138,7 @@ impl<'a> Session<'a> {
             match input.input_type {
                 InputType::Message => {
                     if let Some(content) = &input.content {
+                        if content.is_empty() { continue; }
                         self.messages.push(Message::user().with_text(content));
                         persist_messages(&self.session_file, &self.messages)?;
                     }

--- a/crates/goose-cli/src/session.rs
+++ b/crates/goose-cli/src/session.rs
@@ -138,7 +138,9 @@ impl<'a> Session<'a> {
             match input.input_type {
                 InputType::Message => {
                     if let Some(content) = &input.content {
-                        if content.is_empty() { continue; }
+                        if content.is_empty() {
+                            continue;
+                        }
                         self.messages.push(Message::user().with_text(content));
                         persist_messages(&self.session_file, &self.messages)?;
                     }


### PR DESCRIPTION
the cli should now skip processing entirely if the user message was empty

question for reviewers, should this be applied to headless sessions as well?