### PR TITLE
Improve docs & extensions deploy workflow

### DIFF
--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+  
+  pull_request:
+    paths:
+      - 'documentation/**'
+      - 'extensions-site/**'
 
 jobs:
   deploy:
@@ -18,6 +23,14 @@ jobs:
         with:
           node-version: 20 
 
+      - name: Cache Node.js modules (documentation)
+        uses: actions/cache@v3
+        with:
+          path: ./documentation/node_modules
+          key: ${{ runner.os }}-documentation-${{ hashFiles('./documentation/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-documentation-
+
       - name: Install dependencies and build docs
         working-directory: ./documentation
         env:
@@ -27,6 +40,14 @@ jobs:
         run: |
           npm install
           npm run build
+
+      - name: Cache Node.js modules (extensions-site)
+        uses: actions/cache@v3
+        with:
+          path: ./extensions-site/node_modules
+          key: ${{ runner.os }}-extensions-${{ hashFiles('./extensions-site/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-extensions-
 
       - name: Install dependencies and build extensions-site
         working-directory: ./extensions-site
@@ -44,9 +65,8 @@ jobs:
           cp -r extensions-site/build/client/* combined-build/v1/extensions/
 
       - name: Deploy to /gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: combined-build
-          destination_dir: . # Deploy the site to the root /goose directory
-      


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow to improve the deployment process for documentation and the extensions site. The main changes include adding caching for Node.js modules and conditional deployment to the `gh-pages` branch.

Improvements to deployment workflow:

* [`.github/workflows/deploy-docs-and-extensions.yml`](diffhunk://#diff-f4f5e7e1f608be6cd836684bc3c5094e63edbedfb2baee8512005bf9fb7450d3R8-R12): Added `pull_request` trigger to run the workflow when changes are made to the `documentation` or `extensions-site` directories.
* [`.github/workflows/deploy-docs-and-extensions.yml`](diffhunk://#diff-f4f5e7e1f608be6cd836684bc3c5094e63edbedfb2baee8512005bf9fb7450d3R26-R33): Added caching for Node.js modules in the `documentation` directory to speed up the workflow.
* [`.github/workflows/deploy-docs-and-extensions.yml`](diffhunk://#diff-f4f5e7e1f608be6cd836684bc3c5094e63edbedfb2baee8512005bf9fb7450d3R44-R51): Added caching for Node.js modules in the `extensions-site` directory to speed up the workflow.
* [`.github/workflows/deploy-docs-and-extensions.yml`](diffhunk://#diff-f4f5e7e1f608be6cd836684bc3c5094e63edbedfb2baee8512005bf9fb7450d3R68-L52): Added a condition to the deployment step to ensure it only runs on push events to the `main` branch.