### PR TITLE
ci: run git tag commands when just tag-push

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -56,6 +56,7 @@ ensure-main:
     fi
 
     # check that main is up to date with upstream main
+    git fetch
     # @{u} refers to upstream branch of current branch
     if [ "$(git rev-parse HEAD)" != "$(git rev-parse @{u})" ]; then \
         echo "Error: Your branch is not up to date with the upstream main branch"; \

--- a/Justfile
+++ b/Justfile
@@ -89,12 +89,12 @@ get-tag-version:
 
 # create the git tag from Cargo.toml, must be on main
 tag: ensure-main
-    echo git tag v$(just get-tag-version)
+    git tag v$(just get-tag-version)
 
 # create tag and push to origin (use this when release branch is merged to main)
 tag-push: tag
     # this will kick of ci for release
-    echo git push origin tag v$(just get-tag-version)
+    git push origin tag v$(just get-tag-version)
 
 # generate release notes from git commits
 release-notes:

--- a/Justfile
+++ b/Justfile
@@ -55,6 +55,14 @@ ensure-main:
         exit 1; \
     fi
 
+    # check that main is up to date with upstream main
+    # @{u} refers to upstream branch of current branch
+    if [ "$(git rev-parse HEAD)" != "$(git rev-parse @{u})" ]; then \
+        echo "Error: Your branch is not up to date with the upstream main branch"; \
+        echo "  ensure your branch is up to date (git pull)"; \
+        exit 1; \
+    fi
+
 # validate the version is semver, and not the current version
 validate version:
     #!/usr/bin/env bash


### PR DESCRIPTION
had `echo` when testing to ensure no false tags were pushed, forgot to remove it