### PR TITLE
feat: Add link to github project on extension cards

### DIFF
--- a/extensions-site/app/components/server-card.tsx
+++ b/extensions-site/app/components/server-card.tsx
@@ -100,10 +100,10 @@ export function ServerCard({ server }: { server: MCPServer }) {
           </div>
 
           <div className="flex items-center justify-between">
-            <div className="flex items-center text-textSubtle text-xs leading-[14px]">
+            <a href={server.link} target="_blank" rel="noopener noreferrer" className="flex items-center text-textSubtle text-xs leading-[14px] hover:text-textProminent transition-colors">
               <Star className="h-4 w-4" />
               <span className="ml-1">{server.githubStars} on Github</span>
-            </div>
+            </a>
             {server.is_builtin ? (
               <div
                 className="inline-block"


### PR DESCRIPTION
Adds links to github page for extension the Github stats on extension cards (https://github.com/block/goose/issues/791)

https://github.com/user-attachments/assets/ef359816-664f-4940-8372-1d0cb61ce0e9


