### PR TITLE
fix: use SSL_CERT_FILE to point to CA bundle, not for mTLS client cert

### DIFF
--- a/ui/desktop/src/bin/uvx
+++ b/ui/desktop/src/bin/uvx
@@ -79,9 +79,9 @@ if [ -n "${GOOSE_UV_REGISTRY:-}" ] && curl -s --head --fail "$GOOSE_UV_REGISTRY"
         curl -sSL -o ~/.config/goose/mcp-hermit/cert.pem "$GOOSE_UV_CERT"
         if [ $? -eq 0 ]; then
             log "Certificate downloaded successfully."
-            export SSL_CLIENT_CERT=~/.config/goose/mcp-hermit/cert.pem
+            export SSL_CERT_FILE=~/.config/goose/mcp-hermit/cert.pem
         else
-            log "Unable to download the certificate. Skipping certificate setup."        
+            log "Unable to download the certificate. Skipping certificate setup."
         fi
     else
         log "GOOSE_UV_CERT is either not set or not accessible. Skipping certificate setup."


### PR DESCRIPTION
# use SSL_CERT_FILE to point to the CA cert bundle

https://docs.astral.sh/uv/configuration/authentication/#custom-ca-certificates

>If client certificate authentication (mTLS) is desired, set the SSL_CLIENT_CERT

but we want:
> If a direct path to the certificate is required (e.g., in CI), set the SSL_CERT_FILE environment variable to the path of the certificate bundle, to instruct uv to use that file instead of the system's trust store.