### PR TITLE
docs: updated spelling in documentation

### DIFF
--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -70,7 +70,7 @@ To configure your chosen provider or see available options, run `goose configure
    │  ○ OpenRouter 
    └  
    ```
-   4. Enter you API key (and any other configuration details) when prompted
+   4. Enter your API key (and any other configuration details) when prompted
 
    ```
    ┌   goose-configure 

--- a/documentation/docs/goose-architecture/goose-architecture.md
+++ b/documentation/docs/goose-architecture/goose-architecture.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Goose Architecture
 
-Goose, an open source AI Agent, builds upon the basic interaction framework of Large Language Models (LLMs), which primarily functions as a text-based conversational interface. It processes text input and generates text output. This "text in, text out" approach is enhanced with tool integrations, which allows the AI agent to complete task, creating Goose.
+Goose, an open source AI Agent, builds upon the basic interaction framework of Large Language Models (LLMs), which primarily functions as a text-based conversational interface. It processes text input and generates text output. This "text in, text out" approach is enhanced with tool integrations, which allows the AI agent to complete tasks, creating Goose.
 
 ## Goose Components
 Goose operates using three main components, the **interface**, the **agent**, and the **connected [extensions](/docs/getting-started/using-extensions)**.
@@ -20,7 +20,7 @@ In a typical session, the interface spins up an instance of the agent, which the
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) is an open standard that allows for interoperability between data sources and AI agents. Goose utilizes MCP to connect to [MCP systems/servers](https://github.com/modelcontextprotocol/servers?tab=readme-ov-file#model-context-protocol-servers). In Goose, these systems/servers are referred to as extensions.
 
 
-Extensions expose their functionality to Goose through tools. Tools are the functions that allow extensions to perfrom specific actions, such as running commands, or performing file operations. For example, the Google Drive extension includes a tool for searching documents. That tool is what gives Goose the ability to perform that action.
+Extensions expose their functionality to Goose through tools. Tools are the functions that allow extensions to perform specific actions, such as running commands, or performing file operations. For example, the Google Drive extension includes a tool for searching documents. That tool is what gives Goose the ability to perform that action.
 
 
 Goose comes with a set of [built-in extensions](/docs/getting-started/using-extensions#built-in-extensions), each designed to enhance your interaction. These include tools for development, web scraping, automation, memory, and integrations with JetBrains and Google Drive. Goose also supports [connecting to external extensions](/docs/getting-started/using-extensions#adding-extensions) or [creating custom extensions](/docs/tutorials/custom-extensions) as MCP servers. 
@@ -30,16 +30,16 @@ To learn more about the design and implementation of extensions and tools, refer
 ## Interactive Loop
 ![interactive loop](../assets/guides/interactive-loop.png)
 
-Lets take a closer look at the interactive loop shown above.  
+Let's take a closer look at the interactive loop shown above.  
 
 1. **Human Request** 
 The process begins and ends with you. Once you give Goose a request, question, command, or problem to solve, the flow begins.
 
 2. **Provider Chat** 
-Goose sends your request along with a list of available tools to the [LLM provider](/docs/getting-started/providers) you've connected. The provider processes it, and if necesarry, creates a tool call as part of its response.  
+Goose sends your request along with a list of available tools to the [LLM provider](/docs/getting-started/providers) you've connected. The provider processes it, and if necessary, creates a tool call as part of its response.  
 
 3. **Model Extension Call** 
-The LLM is capable of creating a tool call request but not able to execute it, that's when Goose steps in. Goose takes the tool call which is formattted in JSON, runs it, and gathers the results.
+The LLM is capable of creating a tool call request but not able to execute it, that's when Goose steps in. Goose takes the tool call which is formatted in JSON, runs it, and gathers the results.
 
 4. **Response to Model**
 After executing the tool call, Goose sends the results back to the model. If more extensions are needed, those steps will repeat.
@@ -62,7 +62,7 @@ For more details on how Goose handles errors, refer to the [Error Handling in Go
 While Goose is free and open source, there is typically a cost associated with LLM token usage. Everything competes for token usage including messages, tool requests, resources, file content, instructions, etc. This is where Content Revision comes into play to help reduce some of those costs. There are a few things that are done to assist with this:
 * Goose summarizes with faster and smaller LLMs
 * Goose includes everything versus a semantic search
-* Goose uses algorithims to delete old or irrelevant content
+* Goose uses algorithms to delete old or irrelevant content
 * Goose will use find and replace instead of rewriting large files, use ripgrep to skip system files, and summarize verbose command outputs 
 
 

--- a/documentation/docs/guides/tips.md
+++ b/documentation/docs/guides/tips.md
@@ -8,7 +8,7 @@ Here is a collection of tips for working with Goose:
 Use a git strategy to avoid losing anything - such as staging your personal edits and leaving Goose edits unstaged until reviewed. Consider using individual commits which can be reverted. See more on [File Management](/docs/guides/file-management).
 
 ### Goose can and will run commands
-Goose will check commands for satefy, however, you can also ask Goose to check with you before running commands if you are concerned.
+Goose will check commands for safety, however, you can also ask Goose to check with you before running commands if you are concerned.
 
 ### You can interrupt Goose with `CTRL+C`
 Use this command to stop Goose in the event that you need to correct it or give it more info.

--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -32,13 +32,13 @@ For particularly large or complex tasks, consider breaking them into smaller ses
 
 ### Context Length Exceeded Error
 
-This error occurs when the input provided to Goose exceeds the maximum token limit of the LLM being used. To resolve this try breaking down your input into smaller parts. You can also use `.goosehints` as a way to provide goose with detailed context. Refer to the [Using Goosehints Guide][goosehints] for more information.
+This error occurs when the input provided to Goose exceeds the maximum token limit of the LLM being used. To resolve this, try breaking down your input into smaller parts. You can also use `.goosehints` as a way to provide goose with detailed context. Refer to the [Using Goosehints Guide][goosehints] for more information.
 
 ---
 
 ### Using Ollama Provider
 
-Ollama provides local LLMs, which means you must first [download Ollama and run a model](/docs/getting-started/providers#local-llms-ollama) before attempting to use this provider with Goose. If you do not have the model downloaded, you'll run into the follow error:
+Ollama provides local LLMs, which means you must first [download Ollama and run a model](/docs/getting-started/providers#local-llms-ollama) before attempting to use this provider with Goose. If you do not have the model downloaded, you'll run into the following error:
 
 > ExecutionError("error sending request for url (http://localhost:11434/v1/chat/completions)")
 
@@ -108,7 +108,7 @@ You can remove all of this data by following these steps.
   * consider confirming you've stopped them all via the activity monitor
 * open the keychain and delete the credential called "goose", which contains all secrets stored by goose
 * `rm -rf ~/.config/goose`
-* For the App on macos, `rm -rf ~/Library/Application Support/Goose`
+* For the App on macOS, `rm -rf ~/Library/Application Support/Goose`
 * Delete the "Goose" app from your Applications folder
 
 After this cleanup, if you are looking to try out a fresh install of Goose, you can now start from the usual


### PR DESCRIPTION
Asked goose to point out and fix spelling errors in the documentation. I did not include any suggested grammatical changes that I thought were superfluous (It wanted to capitalize a lot of the documentation).