### PR TITLE
feat:[goose-cli] Added commands to remove configured extensions & list all configured extensions

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -132,8 +132,16 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
                 "Enable or disable connected extensions",
             )
             .item("add", "Add Extension", "Connect to a new extension")
-            .item("remove", "Remove Extension", "Remove existing extensions from the configuration")
-            .item("list_configured_extensions", "List Configured Extensions", "List all configured extensions")
+            .item(
+                "remove",
+                "Remove Extension",
+                "Remove existing extensions from the configuration",
+            )
+            .item(
+                "list_configured_extensions",
+                "List Configured Extensions",
+                "List all configured extensions",
+            )
             .interact()?;
 
         match action {
@@ -573,7 +581,11 @@ pub fn list_configured_extensions() -> Result<(), Box<dyn Error>> {
     // Display the list of currently configured extensions
     cliclack::outro("Currently configured extensions:")?;
     for (name, is_enabled) in &configured_extensions {
-        let status = if *is_enabled { "[Enabled]" } else { "[Disabled]" };
+        let status = if *is_enabled {
+            "[Enabled]"
+        } else {
+            "[Disabled]"
+        };
         cliclack::outro(format!("{} - {}", status, name))?;
     }
     cliclack::outro("")?;
@@ -602,14 +614,14 @@ pub fn remove_extensions_dialog() -> Result<(), Box<dyn Error>> {
     let selected_to_remove = cliclack::multiselect(
         "Select extensions to remove (use \"space\" to select and \"enter\" to submit):",
     )
-        .required(false)
-        .items(
-            &configured_extensions
-                .iter()
-                .map(|name| (name, name.as_str(), ""))
-                .collect::<Vec<_>>(),
-        )
-        .interact()?;
+    .required(false)
+    .items(
+        &configured_extensions
+            .iter()
+            .map(|name| (name, name.as_str(), ""))
+            .collect::<Vec<_>>(),
+    )
+    .interact()?;
 
     // Remove extension from configuration
     for name in selected_to_remove {


### PR DESCRIPTION
Added two simple functions in configure.rs, majority of the functionalities are already present in the code, this change simply exposes them to the end users.

1. Remove configured extensions
2. List configured extensions (Toggle extensions does the similar thing but it kinda forces the user to update the configuration every time)

<img width="683" alt="Screenshot 2025-02-03 at 1 08 27 PM" src="https://github.com/user-attachments/assets/e6dd7667-50f5-4b4c-9c52-d6ba7cf7c834" />
<img width="713" alt="Screenshot 2025-02-03 at 1 08 15 PM" src="https://github.com/user-attachments/assets/c8331ed6-c555-480f-a50a-fa4fc75755ca" />
<img width="690" alt="Screenshot 2025-02-03 at 1 08 05 PM" src="https://github.com/user-attachments/assets/24a8a39a-ed15-4f1f-a298-6b945daf60f8" />
