### PR TITLE
fix: Allow port 443 to be used with https (ollama provider)

### DIFF
--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -65,7 +65,8 @@ impl OllamaProvider {
             .map_err(|e| ProviderError::RequestFailed(format!("Invalid base URL: {e}")))?;
 
         // Set the default port if missing
-        if base_url.port().is_none() {
+        let explicit_default_port = self.host.ends_with(":80") || self.host.ends_with(":443");
+        if base_url.port().is_none() && !explicit_default_port {
             base_url.set_port(Some(OLLAMA_DEFAULT_PORT)).map_err(|_| {
                 ProviderError::RequestFailed("Failed to set default port".to_string())
             })?;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "goose",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "goose",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}


### PR DESCRIPTION
**Overview**:

With this change I am able to use Goose with Ollama over https on 443, before this change it would always use port 11434 even if the scheme was https.

**Findings**:

Per Url docs port() will return None if the scheme is https, even if the port is explicitly provided. This causes the port to always be set to 11434 when trying to use https on 443.

This change will:
  - use 11434 for http by default
  - always use the port provided
