### PR TITLE
fix: show default value when adding new one

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -242,7 +242,6 @@ pub async fn configure_provider_dialog() -> Result<bool, Box<dyn Error>> {
                             let mut input = cliclack::input(format!(
                                 "Provider {} requires {}, please enter a value",
                                 provider_meta.display_name, key.name
-
                             ));
                             if key.default.is_some() {
                                 input = input.default_input(&key.default.clone().unwrap());

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -239,11 +239,15 @@ pub async fn configure_provider_dialog() -> Result<bool, Box<dyn Error>> {
                             .mask('▪')
                             .interact()?
                         } else {
-                            cliclack::input(format!(
+                            let mut input = cliclack::input(format!(
                                 "Provider {} requires {}, please enter a value",
                                 provider_meta.display_name, key.name
-                            ))
-                            .interact()?
+
+                            ));
+                            if key.default.is_some() {
+                                input = input.default_input(&key.default.clone().unwrap());
+                            }
+                            input.interact()?
                         };
 
                         if key.secret {


### PR DESCRIPTION
Show the default value when adding a new value

Test:

Before

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Configure Providers 
│
◇  Which model provider should we use?
│  Ollama 
│
◆  Provider Ollama requires OLLAMA_HOST, please enter a value
│  
└  
```

After:

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Configure Providers 
│
◇  Which model provider should we use?
│  Ollama 
│
◆  Provider Ollama requires OLLAMA_HOST, please enter a value
│  localhost (default)
└  
```