### PR TITLE
feat: allow for multiple values in cli options for adding extensions

### DIFF
--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -16,7 +16,7 @@ pub async fn build_session(
     name: Option<String>,
     resume: bool,
     extension: Option<String>,
-    builtin: Option<String>,
+    builtin: Vec<String>,
 ) -> Session<'static> {
     // Load config and get provider/model
     let config = Config::global();
@@ -104,8 +104,8 @@ pub async fn build_session(
         });
     }
 
-    // Add builtin extension if provided
-    if let Some(name) = builtin {
+    // Add builtin extensions
+    for name in builtin {
         let config = ExtensionConfig::Builtin { name };
         agent.add_extension(config).await.unwrap_or_else(|e| {
             eprintln!("Failed to start builtin extension: {}", e);

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -15,7 +15,7 @@ use mcp_client::transport::Error as McpClientError;
 pub async fn build_session(
     name: Option<String>,
     resume: bool,
-    extension: Option<String>,
+    extensions: Vec<String>,
     builtin: Vec<String>,
 ) -> Session<'static> {
     // Load config and get provider/model
@@ -64,8 +64,8 @@ pub async fn build_session(
         }
     }
 
-    // Add extension if provided
-    if let Some(extension_str) = extension {
+    // Add extensions if provided
+    for extension_str in extensions {
         let mut parts: Vec<&str> = extension_str.split_whitespace().collect();
         let mut envs = std::collections::HashMap::new();
 

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -16,7 +16,7 @@ pub async fn build_session(
     name: Option<String>,
     resume: bool,
     extensions: Vec<String>,
-    builtin: Vec<String>,
+    builtins: Vec<String>,
 ) -> Session<'static> {
     // Load config and get provider/model
     let config = Config::global();
@@ -105,7 +105,7 @@ pub async fn build_session(
     }
 
     // Add builtin extensions
-    for name in builtin {
+    for name in builtins {
         let config = ExtensionConfig::Builtin { name };
         agent.add_extension(config).await.unwrap_or_else(|e| {
             eprintln!("Failed to start builtin extension: {}", e);

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -62,14 +62,15 @@ enum Command {
         )]
         resume: bool,
 
-        /// Add a stdio extension with environment variables and command
+        /// Add stdio extensions with environment variables and commands
         #[arg(
             long = "with-extension",
             value_name = "COMMAND",
-            help = "Add a stdio extension (e.g., 'GITHUB_TOKEN=xyz npx -y @modelcontextprotocol/server-github')",
-            long_help = "Add a stdio extension from a full command with environment variables. Format: 'ENV1=val1 ENV2=val2 command args...'"
+            help = "Add stdio extensions (can be specified multiple times)",
+            long_help = "Add stdio extensions from full commands with environment variables. Can be specified multiple times. Format: 'ENV1=val1 ENV2=val2 command args...'",
+            action = clap::ArgAction::Append
         )]
-        extension: Option<String>,
+        extension: Vec<String>,
 
         /// Add builtin extensions by name
         #[arg(
@@ -126,14 +127,15 @@ enum Command {
         )]
         resume: bool,
 
-        /// Add a stdio extension with environment variables and command
+        /// Add stdio extensions with environment variables and commands
         #[arg(
             long = "with-extension",
             value_name = "COMMAND",
-            help = "Add a stdio extension with environment variables and command (e.g., 'GITHUB_TOKEN=xyz npx -y @modelcontextprotocol/server-github')",
-            long_help = "Add a stdio extension with environment variables and command. Format: 'ENV1=val1 ENV2=val2 command args...'"
+            help = "Add stdio extensions (can be specified multiple times)",
+            long_help = "Add stdio extensions from full commands with environment variables. Can be specified multiple times. Format: 'ENV1=val1 ENV2=val2 command args...'",
+            action = clap::ArgAction::Append
         )]
-        extension: Option<String>,
+        extension: Vec<String>,
 
         /// Add builtin extensions by name
         #[arg(

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -71,14 +71,15 @@ enum Command {
         )]
         extension: Option<String>,
 
-        /// Add a builtin extension by name
+        /// Add builtin extensions by name
         #[arg(
             long = "with-builtin",
             value_name = "NAME",
-            help = "Add a builtin extension by name (e.g., 'developer')",
-            long_help = "Add a builtin extension that is bundled with goose by specifying its name"
+            help = "Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')",
+            long_help = "Add one or more builtin extensions that are bundled with goose by specifying their names, comma-separated",
+            value_delimiter = ','
         )]
-        builtin: Option<String>,
+        builtin: Vec<String>,
     },
 
     /// Execute commands from an instruction file
@@ -134,14 +135,15 @@ enum Command {
         )]
         extension: Option<String>,
 
-        /// Add a builtin extension by name
+        /// Add builtin extensions by name
         #[arg(
             long = "with-builtin",
             value_name = "NAME",
-            help = "Add a builtin extension by name (e.g., 'developer')",
-            long_help = "Add a builtin extension that is compiled into goose by specifying its name"
+            help = "Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')",
+            long_help = "Add one or more builtin extensions that are bundled with goose by specifying their names, comma-separated",
+            value_delimiter = ','
         )]
-        builtin: Option<String>,
+        builtin: Vec<String>,
     },
 
     /// List available agent versions

--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -251,13 +251,21 @@ You can remove installed extensions.
 You can start a tailored goose session with specific extensions directly from the CLI. To do this, run the following command:
 
 ```bash
-goose session --with-extension "{extension command}"
+goose session --with-extension "{extension command}" --with-extension "{antoher extension command}"
 ```
 
 :::info
 You may need to set necessary environment variables for the extension to work correctly.
 ```bash
 goose session --with-extension "VAR=value command arg1 arg2"
+```
+:::
+
+:::tip
+You can also start a session with built-in extensions by using the `--with-builtin` flag.
+```bash
+goose session --with-builtin "developer,memory"
+goose session --with-builtin developer --with-builtin memory
 ```
 :::
 


### PR DESCRIPTION
Currently, you can only specify one extension on the cli through each of the `--with-builtin` and `--with-extension` options: `goose session --with-extension "npx -y @modelcontextprotocol/server-memory" --with-builtin "developer"`. This PR extends the cli to allow for multiple values to be specified for each of these options: 
`goose session --with-builtin developer,memory --with-extension "npx -y @modelcontextprotocol/server-memory" --with-extension "npx -y @modelcontextprotocol/server-github"`

This enables running goose in "headless" mode without modifying configurations and adding extensions on the fly