### PR TITLE
fix: apply cache control correctly to tools

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -131,6 +131,23 @@ fn update_request_for_anthropic(original_payload: &Value) -> Value {
             }
         }
     }
+
+    if let Some(tools_spec) = payload
+        .as_object_mut()
+        .and_then(|obj| obj.get_mut("tools"))
+        .and_then(|tools| tools.as_array_mut())
+    {
+        // Add "cache_control" to the last tool spec, if any. This means that all tool definitions,
+        // will be cached as a single prefix.
+        if let Some(last_tool) = tools_spec.last_mut() {
+            if let Some(function) = last_tool.get_mut("function") {
+                function
+                    .as_object_mut()
+                    .unwrap()
+                    .insert("cache_control".to_string(), json!({ "type": "ephemeral" }));
+            }
+        }
+    }
     payload
 }
 


### PR DESCRIPTION
fix #1066 

Test:

Enable tools and see higher cache_discount

```
{
  "data": {
    "id": "gen-1738712804-5wvhsREvgvXR99HBpioS",
    "upstream_id": "msg_01GQ8Vs5vVjo3C5viSgEYjsm",
    "total_cost": 0.0028803,
    "cache_discount": 0.0042687,
    "provider_name": "Anthropic",
    "created_at": "2025-02-04T23:46:48.29004+00:00",
    "model": "anthropic/claude-3.5-sonnet",
    "app_id": 1784029,
    "streamed": true,
    "cancelled": false,
    "latency": 1191,
    "moderation_latency": 205,
    "generation_time": 1780,
    "tokens_prompt": 1099,
    "tokens_completion": 103,
    "native_tokens_prompt": 1758,
    "native_tokens_completion": 125,
    "native_tokens_reasoning": 0,
    "is_byok": false,
    "finish_reason": "stop",
    "native_finish_reason": "stop",
    "usage": 0.0028803
  }
}
```