### PR TITLE
docs: updated bluesky link

### DIFF
--- a/documentation/blog/2025-01-28-introducing-codename-goose/index.md
+++ b/documentation/blog/2025-01-28-introducing-codename-goose/index.md
@@ -57,7 +57,7 @@ Excited for upcoming features and events? Be sure to connect with us!
 - [YouTube](https://www.youtube.com/@blockopensource)
 - [LinkedIn](https://www.linkedin.com/company/block-opensource)
 - [X](https://x.com/blockopensource)
-- [BlueSky](https://bsky.app/profile/block-opensource.bsky.social)
+- [BlueSky](https://bsky.app/profile/opensource.block.xyz)
 
 
 [extensions-directory]: https://block.github.io/goose/v1/extensions

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -171,7 +171,7 @@ const config: Config = {
             },
             {
               label: "BlueSky",
-              href: "https://bsky.app/profile/block-opensource.bsky.social",
+              href: "https://bsky.app/profile/opensource.block.xyz",
             },
           ],
         },


### PR DESCRIPTION
bluesky acct now verified so link has changed to https://bsky.app/profile/opensource.block.xyz