### PR TITLE
feat: Make CLI session command alias visible

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -41,7 +41,10 @@ enum Command {
     Mcp { name: String },
 
     /// Start or resume interactive chat sessions
-    #[command(about = "Start or resume interactive chat sessions", alias = "s")]
+    #[command(
+        about = "Start or resume interactive chat sessions",
+        visible_alias = "s"
+    )]
     Session {
         /// Name for the chat session
         #[arg(


### PR DESCRIPTION
Before:

```bash
An AI agent

Usage: goose-cli [COMMAND]

Commands:
  ...
  session    Start or resume interactive chat sessions
  ...

Options:
  -v, --version  
  -h, --help     Print help


  Tip: Run 'goose configure' to setup goose for the first time
```
  
After: 

```bash
An AI agent

Usage: goose-cli [COMMAND]

Commands:
  ...
  session    Start or resume interactive chat sessions [aliases: s]
  ...

Options:
  -v, --version  
  -h, --help     Print help


  Tip: Run 'goose configure' to setup goose for the first time
```