### PR TITLE
Fix tool result order

### DIFF
--- a/crates/goose-cli/src/prompt/renderer.rs
+++ b/crates/goose-cli/src/prompt/renderer.rs
@@ -251,11 +251,18 @@ pub fn render(message: &Message, theme: &Theme, renderers: HashMap<String, Box<d
                     .unwrap()
                     .request(tool_request, theme),
             },
-            MessageContent::ToolResponse(tool_response) => renderers
-                .get(last_tool_name)
-                .or_else(|| renderers.get("default"))
-                .unwrap()
-                .response(tool_response, theme),
+            MessageContent::ToolResponse(tool_response) => {
+                // Add a check to ensure the order of tool requests and responses
+                if !message.enforce_tool_call_order() {
+                    println!("Error: Tool result is not preceded by a tool call");
+                    return;
+                }
+                renderers
+                    .get(last_tool_name)
+                    .or_else(|| renderers.get("default"))
+                    .unwrap()
+                    .response(tool_response, theme)
+            },
             MessageContent::Image(image) => {
                 println!("Image: [data: {}, type: {}]", image.data, image.mime_type);
             }

--- a/crates/goose/src/agents/reference.rs
+++ b/crates/goose/src/agents/reference.rs
@@ -172,6 +172,11 @@ impl Agent for ReferenceAgent {
                     );
                 }
 
+                // Add a check to ensure tool results are always preceded by tool calls
+                if !messages.iter().any(|msg| msg.get_tool_request_ids().contains(request.id.as_str())) {
+                    return Err(anyhow::anyhow!("Tool result is not preceded by a tool call"));
+                }
+
                 yield message_tool_response.clone();
 
                 messages.push(response);

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -238,6 +238,11 @@ impl Agent for TruncateAgent {
                             );
                         }
 
+                        // Add a check to ensure tool results are always preceded by tool calls
+                        if !messages.iter().any(|msg| msg.get_tool_request_ids().contains(request.id.as_str())) {
+                            return Err(anyhow::anyhow!("Tool result is not preceded by a tool call"));
+                        }
+
                         yield message_tool_response.clone();
 
                         messages.push(response);

--- a/crates/goose/src/message.rs
+++ b/crates/goose/src/message.rs
@@ -247,4 +247,12 @@ impl Message {
             .iter()
             .all(|c| matches!(c, MessageContent::Text(_)))
     }
+
+    /// Ensure tool results are always preceded by tool calls
+    pub fn enforce_tool_call_order(&self) -> bool {
+        let tool_request_ids = self.get_tool_request_ids();
+        let tool_response_ids = self.get_tool_response_ids();
+
+        tool_response_ids.is_subset(&tool_request_ids)
+    }
 }


### PR DESCRIPTION
Fixes #1056

Add checks to ensure tool results are always preceded by tool calls.

* **`crates/goose/src/agents/reference.rs`**
  - Add a check in the `reply` function to ensure tool results are always preceded by tool calls.

* **`crates/goose/src/agents/truncate.rs`**
  - Add a check in the `reply` function to ensure tool results are always preceded by tool calls.

* **`crates/goose/src/message.rs`**
  - Add a method to the `Message` struct to enforce the order of tool calls and results.

* **`crates/goose-cli/src/prompt/renderer.rs`**
  - Add a check in the `render` function to ensure the order of tool requests and responses.
  - Print an error message if the tool result is not preceded by a tool call.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1087?shareId=ad5f4338-6916-48b5-bae7-cf08edd399a5).