### PR TITLE
Fix certificate issue for internal company setup

### DIFF
--- a/ui/desktop/src/config.ts
+++ b/ui/desktop/src/config.ts
@@ -1,3 +1,6 @@
+import { Certificate } from 'electron';
+import fs from 'fs';
+
 // Helper to construct API endpoints
 export const getApiUrl = (endpoint: string): string => {
   const baseUrl = window.appConfig.get('GOOSE_API_HOST') + ':' + window.appConfig.get('GOOSE_PORT');
@@ -7,4 +10,15 @@ export const getApiUrl = (endpoint: string): string => {
 
 export const getSecretKey = (): string => {
   return window.appConfig.get('secretKey');
+};
+
+// Function to load custom certificate
+export const loadCustomCertificate = (certPath: string): Certificate | null => {
+  try {
+    const cert = fs.readFileSync(certPath);
+    return Certificate.fromPEM(cert);
+  } catch (error) {
+    console.error('Failed to load custom certificate:', error);
+    return null;
+  }
 };


### PR DESCRIPTION
Fixes #1086

Add logic to handle custom certificates for internal company setup.

* **crates/goose/src/providers/openai.rs**
  - Import `Certificate` from `reqwest` and `fs` module.
  - Add logic to load custom certificate from a specified path.
  - Update `Client::builder()` to include custom certificate configuration if specified.
  - Add `OPENAI_CERT_PATH` to the list of configuration keys.

* **ui/desktop/src/config.ts**
  - Import `Certificate` from `electron` and `fs` module.
  - Add `loadCustomCertificate` function to load custom certificate from a specified path.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1088?shareId=ed08f824-3389-4e02-b79e-a0f0ea2d9a9b).