### PR TITLE
Fix background process termination on stop button

### DIFF
--- a/ui/desktop/src/ChatWindow.tsx
+++ b/ui/desktop/src/ChatWindow.tsx
@@ -189,6 +189,9 @@ export function ChatContent({
       const updatedMessages = [...messages.slice(0, -1), newLastMessage];
       setMessages(updatedMessages);
     }
+
+    // Terminate any background processes
+    window.electron.terminateBackgroundProcesses();
   };
 
   return (

--- a/ui/desktop/src/ai-sdk-fork/call-custom-chat-api.ts
+++ b/ui/desktop/src/ai-sdk-fork/call-custom-chat-api.ts
@@ -90,3 +90,12 @@ export async function callCustomChatApi({
     }
   }
 }
+
+export function stop() {
+  const abortController = abortController?.();
+  if (abortController) {
+    abortController.abort();
+  }
+  // Terminate any background processes
+  window.electron.terminateBackgroundProcesses();
+}

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -594,6 +594,8 @@ app.whenReady().then(async () => {
       log.info('Stopped power save blocker');
       return true;
     }
+    // Terminate any background processes
+    window.electron.terminateBackgroundProcesses();
     return false;
   });
 


### PR DESCRIPTION
Fixes #1062

Add logic to terminate background processes when the stop button is clicked.

* **ui/desktop/src/ChatWindow.tsx**
  - Add logic to terminate background processes in the `onStopGoose` function.
  - Update the `stop` function to include background process termination.

* **ui/desktop/src/ai-sdk-fork/call-custom-chat-api.ts**
  - Add a `stop` function to terminate background processes.

* **ui/desktop/src/main.ts**
  - Update the `stop-power-save-blocker` function to stop background processes.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1090?shareId=a7b1b482-e567-4724-a76a-fe44b7882447).