### PR TITLE
Fix custom certificates handling for internal company setup

### DIFF
--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -1,9 +1,11 @@
 use super::base::Usage;
 use anyhow::Result;
 use regex::Regex;
-use reqwest::{Response, StatusCode};
+use reqwest::{Response, StatusCode, Certificate};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Map, Value};
+use std::fs::File;
+use std::io::Read;
 
 use crate::providers::errors::ProviderError;
 use mcp_core::content::ImageContent;
@@ -157,6 +159,14 @@ pub fn emit_debug_trace<T: serde::Serialize>(
         output_tokens = ?usage.output_tokens.unwrap_or_default(),
         total_tokens = ?usage.total_tokens.unwrap_or_default(),
     );
+}
+
+/// Load custom certificates from environment variables
+pub fn load_custom_certificates(cert_path: &str) -> Result<Certificate> {
+    let mut buf = Vec::new();
+    File::open(cert_path)?.read_to_end(&mut buf)?;
+    let cert = Certificate::from_pem(&buf)?;
+    Ok(cert)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #1086

Add support for custom certificates for internal company setup in `OpenAiProvider`.

* **`crates/goose/src/providers/openai.rs`**
  - Add logic to handle custom certificates for internal company setup.
  - Update `post` method to use custom certificates if provided.
  - Add `OPENAI_CERT_PATH` configuration key to `OpenAiProvider`.

* **`crates/goose/src/providers/utils.rs`**
  - Add utility function `load_custom_certificates` to load custom certificates from environment variables.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1091?shareId=32f44f67-8244-4b22-bf31-5b1b02a689e2).