### PR TITLE
Respect the terminal emulator's base colors

### DIFF
--- a/crates/goose-cli/src/prompt.rs
+++ b/crates/goose-cli/src/prompt.rs
@@ -35,4 +35,5 @@ pub enum InputType {
 pub enum Theme {
     Light,
     Dark,
+    Ansi, // Use terminal's ANSI/base16 colors directly.
 }

--- a/crates/goose-cli/src/prompt/renderer.rs
+++ b/crates/goose-cli/src/prompt/renderer.rs
@@ -231,6 +231,7 @@ pub fn render(message: &Message, theme: &Theme, renderers: HashMap<String, Box<d
     let theme = match theme {
         Theme::Light => "GitHub",
         Theme::Dark => "zenburn",
+        Theme::Ansi => "base16",
     };
 
     let mut last_tool_name: &str = "default";

--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -57,6 +57,8 @@ impl RustylinePrompt {
                 .map(|val| {
                     if val.eq_ignore_ascii_case("light") {
                         Theme::Light
+                    } else if val.eq_ignore_ascii_case("ansi") {
+                        Theme::Ansi
                     } else {
                         Theme::Dark
                     }
@@ -122,6 +124,10 @@ impl Prompt for RustylinePrompt {
                     Theme::Dark
                 }
                 Theme::Dark => {
+                    println!("Switching to Ansi theme");
+                    Theme::Ansi
+                }
+                Theme::Ansi => {
                     println!("Switching to Light theme");
                     Theme::Light
                 }
@@ -135,7 +141,7 @@ impl Prompt for RustylinePrompt {
         {
             println!("Commands:");
             println!("/exit - Exit the session");
-            println!("/t - Toggle Light/Dark theme");
+            println!("/t - Toggle Light/Dark/Ansi theme");
             println!("/? | /help - Display this help message");
             println!("Ctrl+C - Interrupt goose (resets the interaction to before the interrupted user request)");
             println!("Ctrl+j - Adds a newline");

--- a/crates/goose-cli/src/prompt/rustyline.rs
+++ b/crates/goose-cli/src/prompt/rustyline.rs
@@ -10,11 +10,14 @@ use super::{
 
 use anyhow::Result;
 use cliclack::spinner;
+use console::style;
 use goose::message::Message;
 use mcp_core::Role;
 use rustyline::{DefaultEditor, EventHandler, KeyCode, KeyEvent, Modifiers};
 
-const PROMPT: &str = "\x1b[1m\x1b[38;5;30m( O)> \x1b[0m";
+fn get_prompt() -> String {
+    format!("{} ", style("( O)>").cyan().bold())
+}
 
 pub struct RustylinePrompt {
     spinner: cliclack::ProgressBar,
@@ -81,7 +84,7 @@ impl Prompt for RustylinePrompt {
     }
 
     fn get_input(&mut self) -> Result<Input> {
-        let input = self.editor.readline(PROMPT);
+        let input = self.editor.readline(&get_prompt());
         let mut message_text = match input {
             Ok(text) => {
                 // Add valid input to history


### PR DESCRIPTION
This patch contains two changes to the CLI app which allows it to respect the base 16 colors of a terminal emulator. While a handful of dependencies print output, most are respecting the console settings already.

The first commit contains a tweak to the hard-coded goose prompt to instead use the console style. I am not sure how controversial this is, if there is special meaning to the teal color currently used. The following commit adds a variant that could be referenced to switch between them.

The second commit adds an `Ansi` variant to the theme. This is only used by the underlying bat renderer for now, but could be a spot for other renderers to hook into in the future if necessary.

Closes https://github.com/block/goose/issues/1089