### PR TITLE
add mcpx MCP server to servers.json

### DIFF
--- a/extensions-site/public/servers.json
+++ b/extensions-site/public/servers.json
@@ -118,5 +118,17 @@
         "required": true
       }
     ]
+  },
+  {
+    "id": "mcpx",
+    "name": "mcp.run",
+    "description": "Secure & portable MCP tools, managed on mcp.run",
+    "command": "npx --yes @dylibso/mcpx@latest",
+    "link": "https://www.mcp.run",
+    "installation_notes": "Install & prompt Goose with 'log me into mcp.run' to get started.",
+    "is_builtin": false,
+    "endorsed": true,
+    "githubStars": 0,
+    "environmentVariables": []
   }
 ]


### PR DESCRIPTION
Our free registry provides highly secure & portable MCP tools to Goose without exposing your system to untrusted file/network access. All "servlets" on mcp.run get installed on demand via mcp.run, and are small WebAssembly modules - totally isolated from the user's system. 

Some examples: https://x.com/nilslice/status/1884360731694620739