### PR TITLE
Fix tool call arguments for sonnet openrouter model

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -195,6 +195,11 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                     ));
                     content.push(MessageContent::tool_request(id, Err(error)));
                 } else {
+                    let arguments = if arguments.is_empty() {
+                        "{}".to_string()
+                    } else {
+                        arguments
+                    };
                     match serde_json::from_str::<Value>(&arguments) {
                         Ok(params) => {
                             content.push(MessageContent::tool_request(


### PR DESCRIPTION
Fixes #1079

Update `response_to_message` and `create_request_based_on_model` functions to handle empty arguments for tool calls.

* **`crates/goose/src/providers/formats/openai.rs`**:
  - Update the `response_to_message` function to handle empty arguments for tool calls.
  - Add a check for empty arguments and set them to an empty JSON object if they are empty.

* **`crates/goose/src/providers/openrouter.rs`**:
  - Update the `create_request_based_on_model` function to ensure tool call arguments are properly formatted.
  - Add a check to format tool call arguments as an empty JSON object if they are empty.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1101?shareId=9b907ab0-083b-4603-946b-e830126cacde).