### PR TITLE
fix: global .goosehints configuration not working

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -205,7 +205,7 @@ impl DeveloperRouter {
             }
         }
 
-        // Combine base instructions with any hints found
+        // Return base instructions directly if no hints, otherwise combine with hints
         let instructions = if hints.is_empty() {
             base_instructions
         } else {

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -733,9 +733,15 @@ mod tests {
         // copy the existing global hints file to a .bak file
         let global_hints_path =
             PathBuf::from(shellexpand::tilde("~/.config/goose/.goosehints").to_string());
-        let global_hints_bak_path =
-            PathBuf::from(shellexpand::tilde("~/.config/goose/.goosehints.bak").to_string());
-        fs::copy(&global_hints_path, &global_hints_bak_path).unwrap();
+        let globalhints_existed = false;
+
+        if global_hints_path.is_file() {
+            globalhints_existed = true;
+            let global_hints_bak_path =
+                PathBuf::from(shellexpand::tilde("~/.config/goose/.goosehints.bak").to_string());
+            fs::copy(&global_hints_path, &global_hints_bak_path).unwrap();
+        }
+
         fs::write(&global_hints_path, "These are my global goose hints.").unwrap();
 
         let dir = TempDir::new().unwrap();
@@ -747,9 +753,11 @@ mod tests {
         assert!(instructions.contains("### Global Hints"));
         assert!(instructions.contains("my global goose hints."));
 
-        // restore backup
-        fs::copy(&global_hints_bak_path, &global_hints_path).unwrap();
-        fs::remove_file(&global_hints_bak_path).unwrap();
+        // restore backup if globalhints previously existed
+        if globalhints_existed {
+            fs::copy(&global_hints_bak_path, &global_hints_path).unwrap();
+            fs::remove_file(&global_hints_bak_path).unwrap();
+        }
     }
 
     #[test]

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -179,7 +179,7 @@ impl DeveloperRouter {
         let global_hints_path =
             PathBuf::from(shellexpand::tilde("~/.config/goose/.goosehints").to_string());
         // Create the directory if it doesn't exist
-        std::fs::create_dir_all(global_hints_path.parent().unwrap());
+        let _ = std::fs::create_dir_all(global_hints_path.parent().unwrap());
 
         // Check for local hints in current directory
         let local_hints_path = cwd.join(".goosehints");
@@ -733,12 +733,12 @@ mod tests {
         // copy the existing global hints file to a .bak file
         let global_hints_path =
             PathBuf::from(shellexpand::tilde("~/.config/goose/.goosehints").to_string());
-        let globalhints_existed = false;
+        let global_hints_bak_path =
+            PathBuf::from(shellexpand::tilde("~/.config/goose/.goosehints.bak").to_string());
+        let mut globalhints_existed = false;
 
         if global_hints_path.is_file() {
             globalhints_existed = true;
-            let global_hints_bak_path =
-                PathBuf::from(shellexpand::tilde("~/.config/goose/.goosehints.bak").to_string());
             fs::copy(&global_hints_path, &global_hints_bak_path).unwrap();
         }
 

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -178,6 +178,8 @@ impl DeveloperRouter {
         // Check for global hints in ~/.config/goose/.goosehints
         let global_hints_path =
             PathBuf::from(shellexpand::tilde("~/.config/goose/.goosehints").to_string());
+        // Create the directory if it doesn't exist
+        std::fs::create_dir_all(global_hints_path.parent().unwrap());
 
         // Check for local hints in current directory
         let local_hints_path = cwd.join(".goosehints");

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -205,7 +205,7 @@ impl DeveloperRouter {
             }
         }
 
-        // Return base instructions directly if no hints, otherwise combine with hints
+        // Return base instructions directly when no hints are found
         let instructions = if hints.is_empty() {
             base_instructions
         } else {

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -177,11 +177,14 @@ impl DeveloperRouter {
 
         // Check for global hints in ~/.config/goose/.goosehints
         let home = std::env::var("HOME").unwrap_or_else(|_| "~".to_string());
-        let global_hints_path = PathBuf::from(home).join(".config").join("goose").join(".goosehints");
-        
+        let global_hints_path = PathBuf::from(home)
+            .join(".config")
+            .join("goose")
+            .join(".goosehints");
+
         // Check for local hints in current directory
         let local_hints_path = cwd.join(".goosehints");
-        
+
         // Read global hints if they exist
         let mut hints = String::new();
         if global_hints_path.is_file() {
@@ -190,7 +193,7 @@ impl DeveloperRouter {
                 hints.push_str(&global_hints);
             }
         }
-        
+
         // Read local hints if they exist
         if local_hints_path.is_file() {
             if let Ok(local_hints) = std::fs::read_to_string(&local_hints_path) {
@@ -201,7 +204,7 @@ impl DeveloperRouter {
                 hints.push_str(&local_hints);
             }
         }
-        
+
         // Combine base instructions with any hints found
         let instructions = if hints.is_empty() {
             base_instructions


### PR DESCRIPTION
Fixes #1022

The issue was that Goose was only checking for .goosehints in the current working directory, but not in the global configuration location (~/.config/goose/.goosehints).

Changes made:
- Added support for reading global hints from ~/.config/goose/.goosehints
- Maintains existing support for local .goosehints in project directories
- Both global and local hints will be combined if they exist
- Added clear section headers to distinguish between global and local hints

This allows users to set global hints that apply across all projects while still allowing project-specific overrides.