### PR TITLE
fix: handle empty arguments in tool call

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -191,7 +191,7 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                 if arguments.is_empty() {
                     arguments = "{}".to_string();
                 }
-                
+
                 if !is_valid_function_name(&function_name) {
                     let error = ToolError::NotFound(format!(
                         "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -585,4 +585,23 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_response_to_message_empty_argument() -> anyhow::Result<()> {
+        let mut response: Value = serde_json::from_str(OPENAI_TOOL_USE_RESPONSE)?;
+        response["choices"][0]["message"]["tool_calls"][0]["function"]["arguments"] =
+            serde_json::Value::String("".to_string());
+
+        let message = response_to_message(response)?;
+
+        if let MessageContent::ToolRequest(request) = &message.content[0] {
+            let tool_call = request.tool_call.as_ref().unwrap();
+            assert_eq!(tool_call.name, "example_fn");
+            assert_eq!(tool_call.arguments, json!({}));
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+
+        Ok(())
+    }
 }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -183,11 +183,15 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                     .as_str()
                     .unwrap_or_default()
                     .to_string();
-                let arguments = tool_call["function"]["arguments"]
+                let mut arguments = tool_call["function"]["arguments"]
                     .as_str()
                     .unwrap_or_default()
                     .to_string();
-
+                // If arguments is empty, we will have invalid json parsing error later.
+                if arguments.is_empty() {
+                    arguments = "{}".to_string();
+                }
+                
                 if !is_valid_function_name(&function_name) {
                     let error = ToolError::NotFound(format!(
                         "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",

--- a/crates/goose/tests/truncate_agent.rs
+++ b/crates/goose/tests/truncate_agent.rs
@@ -13,7 +13,7 @@ use goose::providers::{
 };
 use goose::providers::{google::GoogleProvider, groq::GroqProvider};
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 enum ProviderType {
     Azure,
     OpenAi,
@@ -136,6 +136,14 @@ async fn run_truncate_test(
 
     println!("Responses: {responses:?}\n");
     assert_eq!(responses.len(), 1);
+
+    // Ollama and OpenRouter truncate by default even when the context window is exceeded
+    // We don't have control over the truncation behavior in these providers
+    if provider_type == ProviderType::Ollama || provider_type == ProviderType::OpenRouter {
+        println!("WARNING: Skipping test for {:?} because it truncates by default when the context window is exceeded", provider_type);
+        return Ok(());
+    }
+
     assert_eq!(responses[0].content.len(), 1);
 
     let response_text = responses[0].content[0].as_text().unwrap();


### PR DESCRIPTION
fix #1108 

Sometimes the arguments can be empty and it will cause invalid json parsing error. We apply empty `{}` to avoid it.

Test:

Before:
```
( O)> list the window titles

I'll use the list_windows tool to show you all available window titles.
Invalid parameters: Could not interpret tool use parameters for id toolu_01CA9USw485HtvPTp53RXT68: EOF while parsing a value at line
 1 column 0


◓  Designing data dreams...            
2025-02-06T07:21:55.459232Z  WARN goose::providers::openrouter: Failed to get usage data: No usage data in response
    at crates/goose/src/providers/openrouter.rs:228


( O)> 

```

After
```
( O)> list the window titles
I'll help you list all available window titles using the `developer__list_windows` tool.

─── list_windows | developer ──────────────────────────



Here are all the available window titles that could be used with the screen capture tool. The list includes:
1. Several "Item-0" entries
2. System elements like Battery, WiFi, Clock, Menubar, and Dock
3. Application windows like:
   - "goose — goose session ▸ goose — 132×38"
   - "Threads - Block, Inc. - Slack"
   - "Downloads"
   - "BentoBox"

You can use any of these window titles with the screen_capture tool if you want to capture a specific window.

``