### PR TITLE
Add docker image for goose

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -77,3 +77,27 @@ jobs:
         with:
           name: goose-${{ matrix.architecture }}-${{ matrix.target-suffix }}
           path: ${{ env.ARTIFACT }}
+
+  build-docker:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/goose:${{ inputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,3 +88,31 @@ jobs:
           allowUpdates: true
           omitBody: true
           omitPrereleaseDuringUpdate: true
+
+  # ------------------------------------
+  # 5) Build and Publish Docker Image
+  # ------------------------------------
+  build-docker:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+    needs: [build-cli]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and Push Docker Image
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/goose:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Use a multi-stage build to compile the goose binary and create a minimal image
+
+# Stage 1: Build the goose binary
+FROM rust:1.56 as builder
+
+WORKDIR /app
+
+# Copy the source code
+COPY . .
+
+# Build the goose binary
+RUN cargo build --release --package goose-cli
+
+# Stage 2: Create a minimal image
+FROM debian:buster-slim
+
+WORKDIR /app
+
+# Copy the goose binary from the builder stage
+COPY --from=builder /app/target/release/goose /usr/local/bin/goose
+
+# Set the entrypoint to the goose binary
+ENTRYPOINT ["goose"]

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -97,6 +97,20 @@ import RateLimits from '@site/src/components/RateLimits';
     ```  
   </TabItem>
 
+  <TabItem value="docker" label="Docker">
+    Run the following command to pull the Goose Docker image from Docker Hub:
+
+    ```sh
+    docker pull block/goose:latest
+    ```
+
+    To run Goose in a Docker container, use the following command:
+
+    ```sh
+    docker run --rm -it block/goose:latest
+    ```
+  </TabItem>
+
 </Tabs>
 
   :::tip Updating Goose
@@ -223,6 +237,12 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
         Starting a session in the Goose Desktop is straightforward. After choosing your provider, you’ll see the session interface ready for use.
 
         Type your questions, tasks, or instructions directly into the input field, and Goose will get to work immediately.
+    </TabItem>
+    <TabItem value="docker" label="Docker">
+        To run Goose in a Docker container, use the following command:
+        ```sh
+        docker run --rm -it block/goose:latest
+        ```
     </TabItem>
 </Tabs>
 


### PR DESCRIPTION
Fixes #1072

Add a Docker image for goose and update workflows and documentation.

* **Dockerfile**: Add a `Dockerfile` in the root directory to build the goose docker image using a multi-stage build.
* **GitHub Actions**: 
  - Update `.github/workflows/build-cli.yml` to include a job for building and publishing the goose docker image.
  - Update `.github/workflows/release.yml` to include a step for building and publishing the docker image during the release process.
* **Documentation**: Update `documentation/docs/getting-started/installation.md` to include instructions for using the goose docker image, including commands to pull and run the image from Docker Hub.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1115?shareId=e5f81b2f-7ba2-4e7d-97d0-7585ecaa891b).