### PR TITLE
Fix conda environment shell output capture

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -227,11 +227,13 @@ impl DeveloperRouter {
                     "The command string is required".to_string(),
                 ))?;
 
-        // TODO consider command suggestions and safety rails
-
-        // TODO be more careful about backgrounding, revisit interleave
-        // Redirect stderr to stdout to interleave outputs
-        let cmd_with_redirect = format!("{} 2>&1", command);
+        // Detect if the command is to be run within a conda environment
+        let conda_env = std::env::var("CONDA_DEFAULT_ENV").ok();
+        let cmd_with_redirect = if let Some(env) = conda_env {
+            format!("conda run -n {} {} 2>&1", env, command)
+        } else {
+            format!("{} 2>&1", command)
+        };
 
         // Execute the command
         let child = Command::new("bash")


### PR DESCRIPTION
Fixes #1060

Update the `bash` method in `DeveloperRouter` to handle conda environments.

* Detect if the command is to be run within a conda environment by checking the `CONDA_DEFAULT_ENV` environment variable.
* Modify the command to use `conda run -n <env>` if a conda environment is detected, ensuring proper output capture.
* Redirect stderr to stdout for interleaving outputs.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1117?shareId=6ddc2d7d-a812-45af-86ab-8d4257170444).