### PR TITLE
Consolidate configuration and logging locations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,6 @@ authors = ["Block <ai-oss-tools@block.xyz>"]
 license = "Apache-2.0"
 repository = "https://github.com/block/goose"
 description = "An AI agent"
+
+[dependencies]
+etcetera = "0.3"

--- a/crates/goose-cli/src/log_usage.rs
+++ b/crates/goose-cli/src/log_usage.rs
@@ -1,4 +1,5 @@
 use goose::providers::base::ProviderUsage;
+use etcetera::base_strategy::{get_config_dir, ConfigLocation};
 
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 struct SessionLog {
@@ -13,8 +14,8 @@ pub fn log_usage(session_file: String, usage: Vec<ProviderUsage>) {
     };
 
     // Ensure log directory exists
-    if let Some(home_dir) = dirs::home_dir() {
-        let log_dir = home_dir.join(".config").join("goose").join("logs");
+    if let Ok(config_dir) = get_config_dir() {
+        let log_dir = config_dir.join("goose").join("logs");
         if let Err(e) = std::fs::create_dir_all(&log_dir) {
             eprintln!("Failed to create log directory: {}", e);
             return;
@@ -43,7 +44,7 @@ pub fn log_usage(session_file: String, usage: Vec<ProviderUsage>) {
             eprintln!("Failed to write to usage log file: {}", e);
         }
     } else {
-        eprintln!("Failed to write to usage log file: Failed to determine home directory");
+        eprintln!("Failed to write to usage log file: Failed to determine configuration directory");
     }
 }
 
@@ -59,9 +60,8 @@ mod tests {
     #[test]
     fn test_session_logging() {
         run_with_tmp_dir(|| {
-            let home_dir = dirs::home_dir().unwrap();
-            let log_file = home_dir
-                .join(".config")
+            let config_dir = etcetera::base_strategy::get_config_dir().unwrap();
+            let log_file = config_dir
                 .join("goose")
                 .join("logs")
                 .join("goose.log");

--- a/crates/goose-server/src/logging.rs
+++ b/crates/goose-server/src/logging.rs
@@ -8,13 +8,13 @@ use tracing_subscriber::{
 };
 
 use goose::tracing::langfuse_layer;
+use etcetera::base_strategy::{get_config_dir, ConfigLocation};
 
 /// Returns the directory where log files should be stored.
 /// Creates the directory structure if it doesn't exist.
 fn get_log_directory() -> Result<PathBuf> {
-    let home = std::env::var("HOME").context("HOME environment variable not set")?;
-    let base_log_dir = PathBuf::from(home)
-        .join(".config")
+    let config_dir = get_config_dir().context("Failed to determine configuration directory")?;
+    let base_log_dir = config_dir
         .join("goose")
         .join("logs")
         .join("server"); // Add server-specific subdirectory


### PR DESCRIPTION
Fixes #1049

Consolidate configuration and logging locations to use the `etcetera` crate.

* **Cargo.toml**
  - Add `etcetera` crate to `[dependencies]` section.

* **crates/goose-cli/src/log_usage.rs**
  - Replace `dirs::home_dir()` with `etcetera::base_strategy::get_config_dir()`.
  - Update log directory path to use `etcetera`.

* **crates/goose-server/src/logging.rs**
  - Replace `std::env::var("HOME")` with `etcetera::base_strategy::get_config_dir()`.
  - Update log directory path to use `etcetera`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1118?shareId=9be8c0da-0833-4e8e-9a19-b9e3fc3b015d).