### PR TITLE
Add Docker image for Goose

### DIFF
--- a/.github/workflows/build-docker-image.yml
+++ b/.github/workflows/build-docker-image.yml
@@ -1,0 +1,32 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches:
+      - main
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          push: true
+          tags: ${{ secrets.DOCKER_HUB_USERNAME }}/goose:latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# Use a multi-stage build to minimize the final image size
+
+# Stage 1: Build the Goose binary
+FROM rust:latest AS builder
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the Cargo.toml and Cargo.lock files
+COPY Cargo.toml Cargo.lock ./
+
+# Copy the source code
+COPY . .
+
+# Build the Goose binary
+RUN cargo build --release --package goose-cli
+
+# Stage 2: Create the final image
+FROM debian:buster-slim
+
+# Set the working directory
+WORKDIR /app
+
+# Copy the Goose binary from the build stage
+COPY --from=builder /app/target/release/goose /usr/local/bin/goose
+
+# Set the entrypoint to the Goose binary
+ENTRYPOINT ["goose"]

--- a/README.md
+++ b/README.md
@@ -20,3 +20,32 @@ codename goose
 
 Check out our [documentation](https://block.github.io/goose), or to try it out head to the [installation](https://block.github.io/goose/docs/getting-started/installation) instructions!
 
+## Using the Goose Docker Image
+
+You can now use the official Goose Docker image to run Goose in a containerized environment. Follow the instructions below to build and run the Goose Docker image.
+
+### Building the Docker Image
+
+To build the Goose Docker image, run the following command in the root directory of the repository:
+
+```sh
+docker build -t goose:latest .
+```
+
+### Running the Docker Image
+
+To run the Goose Docker image, use the following command:
+
+```sh
+docker run --rm -it goose:latest
+```
+
+This will start the Goose CLI in an interactive terminal session.
+
+You can also pass additional arguments to the Goose CLI by appending them to the `docker run` command. For example, to run a specific Goose command, use:
+
+```sh
+docker run --rm -it goose:latest <command>
+```
+
+Replace `<command>` with the desired Goose command and its arguments.


### PR DESCRIPTION
Fixes #1072

Add Docker support for Goose.

* **Dockerfile**
  - Create a `Dockerfile` to build the Goose Docker image using a multi-stage build.
  - Set the entrypoint to the Goose binary.

* **GitHub Actions Workflow**
  - Add `.github/workflows/build-docker-image.yml` to build and publish the Docker image.
  - Trigger the workflow on push to the main branch and on release tags.
  - Use Docker build and push action to build and publish the image.
  - Set up Docker Hub credentials as secrets in the repository.

* **README.md**
  - Add instructions on how to build and run the Goose Docker image.
  - Include a section on using the Docker image for Goose.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1119?shareId=a51abb31-1f22-4ac8-8342-2a31d0fa76dc).