### PR TITLE
Add telemetry toggle to langfuse services

### DIFF
--- a/scripts/langfuse-docker-compose.yaml
+++ b/scripts/langfuse-docker-compose.yaml
@@ -65,6 +65,7 @@ services:
       LANGFUSE_READ_FROM_POSTGRES_ONLY: ${LANGFUSE_READ_FROM_POSTGRES_ONLY:-false}
       LANGFUSE_READ_FROM_CLICKHOUSE_ONLY: ${LANGFUSE_READ_FROM_CLICKHOUSE_ONLY:-true}
       LANGFUSE_RETURN_FROM_CLICKHOUSE: ${LANGFUSE_RETURN_FROM_CLICKHOUSE:-true}
+      TELEMETRY_ENABLED: ${TELEMETRY_ENABLED:-true}
 
   clickhouse:
     image: clickhouse/clickhouse-server
@@ -76,6 +77,7 @@ services:
       CLICKHOUSE_DB: default
       CLICKHOUSE_USER: clickhouse
       CLICKHOUSE_PASSWORD: clickhouse
+      TELEMETRY_ENABLED: ${TELEMETRY_ENABLED:-true}
     volumes:
       - langfuse_clickhouse_data:/var/lib/clickhouse
       - langfuse_clickhouse_logs:/var/log/clickhouse-server


### PR DESCRIPTION
Fixes #1026

Add `TELEMETRY_ENABLED` environment variable to `langfuse-web` and `clickhouse` services in `scripts/langfuse-docker-compose.yaml`.

* Add `TELEMETRY_ENABLED` environment variable to `langfuse-web` service.
* Add `TELEMETRY_ENABLED` environment variable to `clickhouse` service.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/block/goose/pull/1120?shareId=125145d5-64cc-4ac3-a6db-309f96478094).