### PR TITLE
fix: validate function call json schemas for openai

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -374,7 +374,7 @@ mod tests {
         })];
 
         validate_tool_schemas(&mut tools);
-        
+
         let params = tools[0]["function"]["parameters"].as_object().unwrap();
         assert!(params.contains_key("properties"));
         assert!(params.contains_key("required"));
@@ -395,7 +395,7 @@ mod tests {
         })];
 
         validate_tool_schemas(&mut tools);
-        
+
         let params = tools[0]["function"]["parameters"].as_object().unwrap();
         assert_eq!(params["type"], "object");
 

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -298,10 +298,9 @@ fn ensure_valid_json_schema(schema: &mut Value) {
                 if let Some(properties_obj) = properties.as_object_mut() {
                     for (_key, prop) in properties_obj.iter_mut() {
                         if prop.is_object()
-                            && prop
+                            && (prop
                                 .get("type")
-                                .and_then(|t| t.as_str())
-                                .map_or(false, |t| t == "object")
+                                .and_then(|t| t.as_str()) == Some("object"))
                         {
                             ensure_valid_json_schema(prop);
                         }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -298,9 +298,7 @@ fn ensure_valid_json_schema(schema: &mut Value) {
                 if let Some(properties_obj) = properties.as_object_mut() {
                     for (_key, prop) in properties_obj.iter_mut() {
                         if prop.is_object()
-                            && (prop
-                                .get("type")
-                                .and_then(|t| t.as_str()) == Some("object"))
+                            && (prop.get("type").and_then(|t| t.as_str()) == Some("object"))
                         {
                             ensure_valid_json_schema(prop);
                         }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -271,7 +271,8 @@ pub fn validate_tool_schemas(tools: &mut [Value]) {
 fn ensure_valid_json_schema(schema: &mut Value) {
     if let Some(params_obj) = schema.as_object_mut() {
         // Check if this is meant to be an object type schema
-        let is_object_type = params_obj.get("type")
+        let is_object_type = params_obj
+            .get("type")
             .and_then(|t| t.as_str())
             .map_or(true, |t| t == "object"); // Default to true if no type is specified
 
@@ -296,9 +297,11 @@ fn ensure_valid_json_schema(schema: &mut Value) {
             if let Some(properties) = params_obj.get_mut("properties") {
                 if let Some(properties_obj) = properties.as_object_mut() {
                     for (_key, prop) in properties_obj.iter_mut() {
-                        if prop.is_object() && prop.get("type")
-                            .and_then(|t| t.as_str())
-                            .map_or(false, |t| t == "object")
+                        if prop.is_object()
+                            && prop
+                                .get("type")
+                                .and_then(|t| t.as_str())
+                                .map_or(false, |t| t == "object")
                         {
                             ensure_valid_json_schema(prop);
                         }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -278,20 +278,10 @@ fn ensure_valid_json_schema(schema: &mut Value) {
 
         // Only apply full schema validation to object types
         if is_object_type {
-            // Ensure properties field exists and is an object
-            if !params_obj.contains_key("properties") {
-                params_obj.insert("properties".to_string(), json!({}));
-            }
-
-            // Ensure required field exists and is an array
-            if !params_obj.contains_key("required") {
-                params_obj.insert("required".to_string(), json!([]));
-            }
-
-            // Ensure type field exists
-            if !params_obj.contains_key("type") {
-                params_obj.insert("type".to_string(), json!("object"));
-            }
+            // Ensure required fields exist with default values
+            params_obj.entry("properties").or_insert_with(|| json!({}));
+            params_obj.entry("required").or_insert_with(|| json!([]));
+            params_obj.entry("type").or_insert_with(|| json!("object"));
 
             // Recursively validate properties if it exists
             if let Some(properties) = params_obj.get_mut("properties") {

--- a/documentation/docs/tutorials/jetbrains-mcp.md
+++ b/documentation/docs/tutorials/jetbrains-mcp.md
@@ -10,10 +10,6 @@ The JetBrains extension is designed to work within your IDE. Goose can accomplis
 
 This tutorial covers how to enable and use the JetBrains MCP Server as a built-in Goose extension to integrate with any JetBrains IDE.
 
-:::warning Known Limitation
-The JetBrains extension [does not work](https://github.com/block/goose/issues/933) with OpenAI models (e.g. gpt-4o).
-:::
-
 ## Configuration
 
 1. Add the [MCP Server plugin](https://plugins.jetbrains.com/plugin/26071-mcp-server) to your IDE.


### PR DESCRIPTION
Users reporting openai incompatibility with certain extensions.

Fixes #933, related to #945

Extensions are not providing valid json schemas for openai function tool calling. Adds a function to validate the schema and add missing json schema fields
```
    "function": {
        "name": "get_weather",
        "description": "Get current temperature for a given location.",
        "parameters": {
            "type": "object",
            "properties": {
                "location": {
                    "type": "string",
                    "description": "City and country e.g. Bogotá, Colombia"
                }
            },
            "required": [
                "location"
            ],
            "additionalProperties": False
        },
        "strict": True
    }
```

Databricks likely handled the missing fields on their end.

Tests:
- [x] jetbrains tool call successful with openai, gpt4o, o1, o3-mini
- [x] jetbrains tool call successful with databricks, goose

