### PR TITLE
fix: Fixed a problem with IME's(i.e. Japanese IME input) Enter to Co…

### DIFF
--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -17,6 +17,8 @@ export default function Input({
   onStop,
 }: InputProps) {
   const [value, setValue] = useState('');
+  // State to track if the IME is composing (i.e., in the middle of Japanese IME input)
+  const [isComposing, setIsComposing] = useState(false);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
@@ -41,12 +43,22 @@ export default function Input({
   useAutosizeTextArea(textAreaRef.current, value);
 
   const handleChange = (evt: React.ChangeEvent<HTMLTextAreaElement>) => {
-    const val = evt.target?.value;
+    const val = evt.target.value;
     setValue(val);
   };
 
+  // Handlers for composition events, which are crucial for proper IME behavior
+  const handleCompositionStart = (evt: React.CompositionEvent<HTMLTextAreaElement>) => {
+    setIsComposing(true);
+  };
+
+  const handleCompositionEnd = (evt: React.CompositionEvent<HTMLTextAreaElement>) => {
+    setIsComposing(false);
+  };
+
   const handleKeyDown = (evt: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (evt.key === 'Enter' && !evt.shiftKey) {
+    // Only trigger submit on Enter if not composing (IME input in progress) and shift is not pressed
+    if (evt.key === 'Enter' && !evt.shiftKey && !isComposing) {
       evt.preventDefault();
       if (value.trim()) {
         handleSubmit(new CustomEvent('submit', { detail: { value } }));
@@ -76,18 +88,14 @@ export default function Input({
       onSubmit={onFormSubmit}
       className="flex relative h-auto px-[16px] pr-[68px] py-[1rem] border-t border-borderSubtle"
     >
-      {/* loading */}
-      {/* {isLoading && (
-        <div className="absolute top-[-2px] left-0 w-full h-[2px]">
-          <div className="absolute w-[300px] h-[2px] bg-gradient-to-r from-blockTeal to-blockOrange animate-gradient-loader"></div>
-        </div>
-      )} */}
       <textarea
         autoFocus
         id="dynamic-textarea"
         placeholder="What can goose help with?"
         value={value}
         onChange={handleChange}
+        onCompositionStart={handleCompositionStart}
+        onCompositionEnd={handleCompositionEnd}
         onKeyDown={handleKeyDown}
         disabled={disabled}
         ref={textAreaRef}


### PR DESCRIPTION
Fixed an issue with IME input in the input form when typing in Japanese.

## Before

```
k o n n n i t i w a <space> <enter>
```

The message was sent immediately.

https://github.com/user-attachments/assets/4bb84711-7c7b-4f0e-993f-57e9f41db8fc

## After



```
k o n n n i t i w a <space> <enter> <enter>
```
Now, the first `<enter>` confirms the IME input, and the second `<enter>` sends the message to Goose.

https://github.com/user-attachments/assets/52892cbc-6def-4af3-a993-1e89aa3ee865
