### PR TITLE
docs: noting Fetch limitation with Gemini

### DIFF
--- a/documentation/docs/tutorials/fetch-mcp.md
+++ b/documentation/docs/tutorials/fetch-mcp.md
@@ -6,6 +6,9 @@ description: Add Fetch MCP Server as a Goose Extension
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+:::warning Known Limitation
+The Fetch extension does not work with Google models (e.g. gemini-2.0-flash-exp) because this extension uses `format: uri` in its JSON schema which Google doesn't support.
+:::
 
 This tutorial covers how to add the [Fetch MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) as a Goose extension to retrieve and process content from the web.
 


### PR DESCRIPTION
Noting limitation

![image](https://github.com/user-attachments/assets/7da413d3-d0f0-4837-84be-a991a9a8bdf3)

> Request failed: Request failed with status: 400 Bad Request. Message: * GenerateContentRequest.tools[0].function_declarations[22].parameters.properties[url].format: only 'enum' is supported for STRING type .
Please retry if you think this is a transient or recoverable error.