### PR TITLE
docs: Add Mac M3 Permission Troubleshooting to Documentation

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -47,7 +47,7 @@ import RateLimits from '@site/src/components/RateLimits';
           1. Unzip the downloaded `Goose.zip` file.
           2. Run the executable file to launch the Goose desktop application.
 
-          :::note Permissions Note for Mac M3
+          :::note Permissions
             If you’re on an Apple Mac M3 and the Goose desktop app shows no window on launch, check and update the following:
 
             Ensure the `~/.config` directory has read and write access.

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -46,6 +46,14 @@ import RateLimits from '@site/src/components/RateLimits';
         <div style={{ marginTop: '1rem' }}>
           1. Unzip the downloaded `Goose.zip` file.
           2. Run the executable file to launch the Goose desktop application.
+
+          :::note Permissions Note for Mac M3
+            If you’re on an Apple Mac M3 and the Goose desktop app shows no window on launch, check and update the following:
+
+            Ensure the `~/.config` directory has read and write access.
+
+            Goose needs this access to create the log directory and file. Once permissions are granted, the app should load correctly. For steps on how to do this, refer to the  [Troubleshooting Guide](/docs/troubleshooting.md#macos-permission-issues-m3-macs)
+          :::
         </div>
 
       </TabItem>

--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -172,6 +172,40 @@ An example is the GitHub extension whose command is `npx -y @modelcontextprotoco
 
 ---
 
+### macOS Permission Issues (M3 Macs)
+
+If you encounter an issue where the Goose desktop app shows no window on launch, it may be due to file and folder permissions. This typically happens because Goose needs read and write access to the `~/.config` directory to create its log directory and file.
+
+#### How to Check and Fix Permissions:
+
+1. Open Terminal.
+2. Run the following command to check the current permissions for ~/.config:
+  ```sh
+  ls -ld ~/.config
+  ```
+**Example output:**
+  ```sh
+  drwx------  7 yourusername  staff  224 Jan 15 12:00 /Users/yourusername/.config
+  ```
+`rwx` indicates you have read (r), write (w), and execute (x) permissions for your user. If you do not see `rwx` for your user, follow the steps below.
+
+#### How to Grant Read and Write Permissions:
+
+1. To add the correct permissions, run the following commands:
+    ```sh
+    chmod u+rw ~/.config
+    ```
+    If the ~/.config directory does not exist, create it and then assign permissions:
+      ```sh
+      mkdir -p ~/.config
+      chmod u+rw ~/.config
+      ```
+2. Verify the change:
+    ```sh
+    ls -ld ~/.config
+    ```
+---
+
 ### Need Further Help? 
 If you have questions, run into issues, or just need to brainstorm ideas join the [Discord Community][discord]!
 


### PR DESCRIPTION
This PR updates the **Installation** and **Troubleshooting** guides to address a community raised issue for Mac M3 users where the Goose desktop app fails to launch with no visible window. The root cause is related to file and folder permissions for the `~/.config` directory.

### **Changes Made:**
- **Installation Guide**
  - Added a **Permissions Note for Mac M3** users under the Goose Desktop installation instructions.
  - Linked to the new **macOS Permission Issues** section in the Troubleshooting Guide for detailed steps on how to check and fix permissions.

- **Troubleshooting Guide**
  - Added a new **macOS Permission Issues (M3 Macs)** section with:
    - Steps to check current directory permissions using the `ls -ld ~/.config` command.
    - Instructions on how to grant read and write permissions using `chmod` and `mkdir` commands.
    - An additional note on enabling **Screen Recording Permission** in macOS settings, if needed.

