### PR TITLE
chore: Change no usage found warning to a debug trace

### DIFF
--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -124,7 +124,7 @@ impl Provider for AzureProvider {
         let usage = match get_usage(&response) {
             Ok(usage) => usage,
             Err(ProviderError::UsageError(e)) => {
-                tracing::warn!("Failed to get usage data: {}", e);
+                tracing::debug!("Failed to get usage data: {}", e);
                 Usage::default()
             }
             Err(e) => return Err(e),

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -253,7 +253,7 @@ impl Provider for DatabricksProvider {
         let usage = match get_usage(&response) {
             Ok(usage) => usage,
             Err(ProviderError::UsageError(e)) => {
-                tracing::warn!("Failed to get usage data: {}", e);
+                tracing::debug!("Failed to get usage data: {}", e);
                 Usage::default()
             }
             Err(e) => return Err(e),

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -202,7 +202,7 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
 
         Ok(Usage::new(input_tokens, output_tokens, total_tokens))
     } else {
-        tracing::warn!(
+        tracing::debug!(
             "Failed to get usage data: {}",
             ProviderError::UsageError("No usage data found in response".to_string())
         );

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -255,7 +255,7 @@ pub fn get_usage(data: &Value) -> Result<Usage> {
             .map(|v| v as i32);
         Ok(Usage::new(input_tokens, output_tokens, total_tokens))
     } else {
-        tracing::warn!(
+        tracing::debug!(
             "Failed to get usage data: {}",
             ProviderError::UsageError("No usage data found in response".to_string())
         );

--- a/crates/goose/src/providers/groq.rs
+++ b/crates/goose/src/providers/groq.rs
@@ -142,7 +142,7 @@ impl Provider for GroqProvider {
         let usage = match get_usage(&response) {
             Ok(usage) => usage,
             Err(ProviderError::UsageError(e)) => {
-                tracing::warn!("Failed to get usage data: {}", e);
+                tracing::debug!("Failed to get usage data: {}", e);
                 Usage::default()
             }
             Err(e) => return Err(e),

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -129,7 +129,7 @@ impl Provider for OllamaProvider {
         let usage = match get_usage(&response) {
             Ok(usage) => usage,
             Err(ProviderError::UsageError(e)) => {
-                tracing::warn!("Failed to get usage data: {}", e);
+                tracing::debug!("Failed to get usage data: {}", e);
                 Usage::default()
             }
             Err(e) => return Err(e),

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -121,7 +121,7 @@ impl Provider for OpenAiProvider {
         let usage = match get_usage(&response) {
             Ok(usage) => usage,
             Err(ProviderError::UsageError(e)) => {
-                tracing::warn!("Failed to get usage data: {}", e);
+                tracing::debug!("Failed to get usage data: {}", e);
                 Usage::default()
             }
             Err(e) => return Err(e),

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -208,7 +208,7 @@ impl Provider for OpenRouterProvider {
         let usage = match get_usage(&response) {
             Ok(usage) => usage,
             Err(ProviderError::UsageError(e)) => {
-                tracing::warn!("Failed to get usage data: {}", e);
+                tracing::debug!("Failed to get usage data: {}", e);
                 Usage::default()
             }
             Err(e) => return Err(e),


### PR DESCRIPTION
It can be confusing when "no usage found" warning is emitted in the CLI. It doesn't interrupt Goose's execution but has led some users to thinking it is the cause behind other issues they're seeing (such as no content returned from the provider e.g., https://github.com/block/goose/issues/1170 or another provider error e.g., in https://github.com/block/goose/issues/899). 

I am personally unable to repro these issues (I created a session that I manually edited to contain an empty content array from the assistant in one message, but Goose with OpenAI and OpenRouter+Anthropic continued the session just fine). 