### PR TITLE
chore: re-add tests, tidy up goose-cli/Cargo.toml, send + sync logic

### DIFF
--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -47,7 +47,6 @@ chrono = "0.4"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json", "time"] }
 tracing-appender = "0.2"
 once_cell = "1.20.2"
-winapi = { version = "0.3", features = ["wincred"], optional = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose-mcp/src/computercontroller/platform/macos.rs
+++ b/crates/goose-mcp/src/computercontroller/platform/macos.rs
@@ -4,10 +4,6 @@ use std::process::Command;
 
 pub struct MacOSAutomation;
 
-// MacOSAutomation is Send + Sync because it contains no shared state
-unsafe impl Send for MacOSAutomation {}
-unsafe impl Sync for MacOSAutomation {}
-
 impl SystemAutomation for MacOSAutomation {
     fn execute_system_script(&self, script: &str) -> std::io::Result<String> {
         let output = Command::new("osascript").arg("-e").arg(script).output()?;

--- a/crates/goose-mcp/src/computercontroller/platform/windows.rs
+++ b/crates/goose-mcp/src/computercontroller/platform/windows.rs
@@ -4,10 +4,6 @@ use std::process::Command;
 
 pub struct WindowsAutomation;
 
-// WindowsAutomation is Send + Sync because it contains no shared state
-unsafe impl Send for WindowsAutomation {}
-unsafe impl Sync for WindowsAutomation {}
-
 impl SystemAutomation for WindowsAutomation {
     fn execute_system_script(&self, script: &str) -> std::io::Result<String> {
         let output = Command::new("powershell")


### PR DESCRIPTION
a few missed things after #880 
* remove redundant winapi dependency, and keep the one in the `target.cfg` block
* remove manual `unsafe impl Send/Send` since the structs are empty and `Send` + `Sync` are [auto derived traits](https://doc.rust-lang.org/nomicon/send-and-sync.html#:~:text=Send%20and%20Sync%20are%20also,with%20are%20Send%20and%20Sync.)
* add back in `test_text_editor_size_limits` in developer tests