### PR TITLE
remove provider settings from dev mode it does nothing

### DIFF
--- a/ui/desktop/src/components/MoreMenu.tsx
+++ b/ui/desktop/src/components/MoreMenu.tsx
@@ -267,22 +267,6 @@ export default function MoreMenu({ setView }: { setView?: (view: View) => void }
             >
               Reset Provider
             </button>
-
-            {/* Provider keys settings */}
-            {process.env.NODE_ENV === 'development' && (
-              <button
-                onClick={() => {
-                  setOpen(false);
-                  // Instead of navigate('/keys'), we might do setView('someKeysView') or open new window.
-                  // For now, just do nothing or set to some placeholder.
-                  // setView?.('keys');
-                  window.electron.createChatWindow();
-                }}
-                className="w-full text-left p-2 text-sm hover:bg-bgSubtle transition-colors"
-              >
-                Provider Settings (alpha)
-              </button>
-            )}
           </div>
         </PopoverContent>
       </PopoverPortal>


### PR DESCRIPTION
<img width="749" alt="Screenshot 2025-02-11 at 1 02 49 PM" src="https://github.com/user-attachments/assets/cf43cbf4-5d2e-45c9-8250-b9c1faf31773" />

removes provider settings from moreMenu in dev mode... does nothing 