### PR TITLE
fix: consistently use LANGFUSE_URL instead of LANGFUSE_HOST

### DIFF
--- a/crates/goose-cli/src/logging.rs
+++ b/crates/goose-cli/src/logging.rs
@@ -200,7 +200,7 @@ mod tests {
         let original_vars = [
             ("LANGFUSE_PUBLIC_KEY", env::var("LANGFUSE_PUBLIC_KEY").ok()),
             ("LANGFUSE_SECRET_KEY", env::var("LANGFUSE_SECRET_KEY").ok()),
-            ("LANGFUSE_HOST", env::var("LANGFUSE_HOST").ok()),
+            ("LANGFUSE_URL", env::var("LANGFUSE_URL").ok()),
             (
                 "LANGFUSE_INIT_PROJECT_PUBLIC_KEY",
                 env::var("LANGFUSE_INIT_PROJECT_PUBLIC_KEY").ok(),

--- a/documentation/docs/tutorials/langfuse.md
+++ b/documentation/docs/tutorials/langfuse.md
@@ -22,7 +22,7 @@ Set the environment variables so that Goose (written in Rust) can connect to the
 ```bash
 export LANGFUSE_INIT_PROJECT_PUBLIC_KEY=pk-lf-...
 export LANGFUSE_INIT_PROJECT_SECRET_KEY=sk-lf-...
-export LANGFUSE_HOST=https://cloud.langfuse.com # EU data region 🇪🇺
+export LANGFUSE_URL=https://cloud.langfuse.com # EU data region 🇪🇺
 
 # https://us.cloud.langfuse.com if you're using the US region 🇺🇸
 # https://localhost:3000 if you're self-hosting


### PR DESCRIPTION
fix: #1191 