### PR TITLE
Fix website preview action

### DIFF
--- a/.github/workflows/pr-website-preview.yml
+++ b/.github/workflows/pr-website-preview.yml
@@ -47,6 +47,7 @@ jobs:
           npm run build
 
       - name: Combine builds into one directory
+        if: github.event.action != 'closed'
         run: |
           mkdir combined-build
           cp -r documentation/build/* combined-build/


### PR DESCRIPTION
## Problem

This workflow was failing because:
- When a PR is closed/merged, the workflow skips building documentation 
- but was still attempting to combine the non-existent build artifacts

## Solution
- I skipped the step to combine builds _if_ closed/merged


## Tried this out on a personal forked repo I created to make sure it worked
<img width="946" alt="Screenshot 2025-02-12 at 12 55 29 PM" src="https://github.com/user-attachments/assets/87b3fca4-2448-446b-966b-1ab9a8dafdeb" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209391518598115