### PR TITLE
fix: Update help docs for resume CLI arg

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -47,8 +47,8 @@ enum Command {
         #[arg(
             short,
             long,
-            help = "Resume a previous session (last used or specified by --session)",
-            long_help = "Continue from a previous chat session. If --session is provided, resumes that specific session. Otherwise resumes the last used session."
+            help = "Resume a previous session (last used or specified by --name)",
+            long_help = "Continue from a previous chat session. If --name is provided, resumes that specific session. Otherwise resumes the last used session."
         )]
         resume: bool,
 


### PR DESCRIPTION
Fixes https://github.com/block/goose/issues/1209

---

### Testing

Verified that the CLI args help for `--resume` references `--name` instead of `--session`

```
❯ ./target/debug/goose session -h
Start or resume interactive chat sessions

Usage: goose session [OPTIONS]

Options:
  -n, --name <NAME>               Name for the chat session (e.g., 'project-x')
  -r, --resume                    Resume a previous session (last used or specified by --name)
      --with-extension <COMMAND>  Add stdio extensions (can be specified multiple times)
      --with-builtin <NAME>       Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')
  -h, --help                      Print help (see more with '--help')
```