### PR TITLE
docs: Add WSL Localhost Connection Error to Troubleshooting Guide

### DIFF
--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -206,6 +206,26 @@ If you encounter an issue where the Goose desktop app shows no window on launch,
     ```
 ---
 
+### Connection Error with Ollama Provider on WSL
+
+If you encounter an error like this when setting up Ollama as the provider in Goose:
+    ```
+    Execution error: error sending request for url (http://localhost:11434/v1/chat/completions)
+    ```
+This likely means that the local host address is not accessible from WSL.
+1. Check if the service is running:
+    ```
+    curl http://localhost:11434/api/tags
+    ```
+    If you receive a `failed to connect` error, it’s possible that WSL is using a different IP for localhost. In that case, run the following command to find the correct IP address for WSL:
+    ```
+    ip route show | grep -i default | awk '{ print $3 }'
+    ```
+2. Once you get the IP address, use it in your Goose configuration instead of localhost. For example:
+    ```
+    http://172.24.80.1:11434
+    ```
+---
 ### Need Further Help? 
 If you have questions, run into issues, or just need to brainstorm ideas join the [Discord Community][discord]!
 


### PR DESCRIPTION
This PR updates the **Troubleshooting Guide** with a new section addressing connection errors when using **Ollama** as the provider on **WSL (Windows Subsystem for Linux)**.

#### Changes:
- Added a new troubleshooting entry for **"Connection Error with Ollama Provider on WSL"**.
- Provided steps to diagnose and resolve the error, including how to:
  - Check if the service is running using `curl`.
  - Find and use the correct WSL IP address in Goose configuration.
- Included an example command (`ip route show | grep -i default | awk '{ print $3 }'`) to retrieve the correct WSL IP address.

#### Why This Matters:
community members running Goose with Ollama on WSL have encountered this connection issue due to WSL’s handling of localhost. 



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209398868448861