### PR TITLE
feat: add goose info command to display directories in use + config

### DIFF
--- a/crates/goose-cli/src/commands/info.rs
+++ b/crates/goose-cli/src/commands/info.rs
@@ -1,0 +1,63 @@
+use anyhow::Result;
+use console::style;
+use etcetera::{choose_app_strategy, AppStrategy};
+use goose::config::Config;
+use serde_yaml;
+
+fn print_aligned(label: &str, value: &str, width: usize) {
+    println!("  {:<width$} {}", label, value, width = width);
+}
+
+pub fn handle_info(verbose: bool) -> Result<()> {
+    let data_dir = choose_app_strategy(crate::APP_STRATEGY.clone())?;
+    let logs_dir = data_dir.in_data_dir("logs");
+    let sessions_dir = data_dir.in_data_dir("sessions");
+
+    // Get paths using a stored reference to the global config
+    let config = Config::global();
+    let config_file = config.path();
+
+    // Define the labels and their corresponding path values once.
+    let paths = [
+        ("Config file:", config_file.to_string()),
+        ("Sessions dir:", sessions_dir.display().to_string()),
+        ("Logs dir:", logs_dir.display().to_string()),
+    ];
+
+    // Calculate padding: use the max length of the label plus extra space.
+    let basic_padding = paths.iter().map(|(l, _)| l.len()).max().unwrap_or(0) + 4;
+
+    // Print version information
+    println!("{}", style("Goose Version:").cyan().bold());
+    print_aligned("Version:", env!("CARGO_PKG_VERSION"), basic_padding);
+    println!();
+
+    // Print location information
+    println!("{}", style("Goose Locations:").cyan().bold());
+    for (label, path) in &paths {
+        print_aligned(label, path, basic_padding);
+    }
+
+    // Print verbose info if requested
+    if verbose {
+        println!("\n{}", style("Goose Configuration:").cyan().bold());
+        match config.load_values() {
+            Ok(values) => {
+                if values.is_empty() {
+                    println!("  No configuration values set");
+                    println!(
+                        "  Run '{}' to configure goose",
+                        style("goose configure").cyan()
+                    );
+                } else if let Ok(yaml) = serde_yaml::to_string(&values) {
+                    for line in yaml.lines() {
+                        println!("  {}", line);
+                    }
+                }
+            }
+            Err(e) => println!("  Error loading configuration: {}", e),
+        }
+    }
+
+    Ok(())
+}

--- a/crates/goose-cli/src/commands/mod.rs
+++ b/crates/goose-cli/src/commands/mod.rs
@@ -1,3 +1,4 @@
 pub mod agent_version;
 pub mod configure;
+pub mod info;
 pub mod mcp;

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -5,6 +5,7 @@ use console::style;
 use goose::config::Config;
 use goose_cli::commands::agent_version::AgentCommand;
 use goose_cli::commands::configure::handle_configure;
+use goose_cli::commands::info::handle_info;
 use goose_cli::commands::mcp::run_server;
 use goose_cli::logging::setup_logging;
 use goose_cli::session::build_session;
@@ -22,6 +23,14 @@ enum Command {
     /// Configure Goose settings
     #[command(about = "Configure Goose settings")]
     Configure {},
+
+    /// Display Goose configuration information
+    #[command(about = "Display Goose information")]
+    Info {
+        /// Show verbose information including current configuration
+        #[arg(short, long, help = "Show verbose information including config.yaml")]
+        verbose: bool,
+    },
 
     /// Manage system prompts and behaviors
     #[command(about = "Run one of the mcp servers bundled with goose")]
@@ -156,6 +165,10 @@ async fn main() -> Result<()> {
     match cli.command {
         Some(Command::Configure {}) => {
             let _ = handle_configure().await;
+            return Ok(());
+        }
+        Some(Command::Info { verbose }) => {
+            handle_info(verbose)?;
             return Ok(());
         }
         Some(Command::Mcp { name }) => {

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -56,7 +56,7 @@ Name for the new chat session (e.g. `'project-x'`)
 goose session --name <name>
 ```
 
-- **`-r, --resume`** 
+- **`-r, --resume`**
 
 Resume the previous session
 
@@ -64,7 +64,7 @@ Resume the previous session
 goose session --resume --name <name>
 ```
 
-- **`--with-extension <COMMAND>`** 
+- **`--with-extension <COMMAND>`**
 
 Starts the session with the specified extension. Can also include environment variables (e.g., `'GITHUB_TOKEN={your_token} npx -y @modelcontextprotocol/server-github'`).
 
@@ -72,7 +72,7 @@ Starts the session with the specified extension. Can also include environment va
 goose session --name <name> --with-extension <command>
 ```
 
-- **`--with-builtin <NAME>`** 
+- **`--with-builtin <NAME>`**
 
 Starts the session with the specified [built-in extension](/docs/getting-started/using-extensions#built-in-extensions) enabled. (e.g. 'developer')
 
@@ -84,10 +84,10 @@ goose session --with-builtin <id>
 
 Execute commands from an instruction file or stdin
 
-- **`-i, --instructions <FILE>`**: Path to instruction file containing commands  
-- **`-t, --text <TEXT>`**: Input text to provide to Goose directly  
-- **`-n, --name <NAME>`**: Name for this run session (e.g., 'daily-tasks')  
-- **`-r, --resume`**: Resume from a previous run  
+- **`-i, --instructions <FILE>`**: Path to instruction file containing commands
+- **`-t, --text <TEXT>`**: Input text to provide to Goose directly
+- **`-n, --name <NAME>`**: Name for this run session (e.g., 'daily-tasks')
+- **`-r, --resume`**: Resume from a previous run
 
 **Usage:**
 ```bash
@@ -98,9 +98,17 @@ goose run --instructions plan.md
 
 Configure Goose settings - providers, extensions, etc.
 
+**Usage:**
+```bash
+goose configure
+```
 
+### info [options]
+Shows Goose information, where goose will load `config.yaml`, store data and logs.
+
+- **`-v, --verbose`**: Show verbose information including config.yaml
 
 **Usage:**
 ```bash
-goose configure'
+goose info
 ```


### PR DESCRIPTION
# add `goose info [-v]` to cli
adds the `info [-v]` command to print to the user goose's version, file location/dirs, and optionally full configuration (no secrets from keyring)

ex:
```bash
root@97b2604d5258:/ goose info -v
Goose Version:
  Version:          1.0.6

Goose Locations:
  Config file:      /root/.config/goose/config.yaml
  Sessions dir:     /root/.local/share/goose/sessions
  Logs dir:         /root/.local/share/goose/logs

# below only shows up with -v
Goose Configuration:
  extensions:
    developer:
      enabled: true
      name: developer
      type: builtin
  GOOSE_PROVIDER: openai
  GOOSE_MODEL: gpt-4o
```

and an example showing if users have `XDG_` envvars set:
```bash
export XDG_CONFIG_HOME=/test
export XDG_DATA_HOME=/data

root@97b2604d5258:/ goose info
Goose Version:
  Version:          1.0.6

Goose Locations:
  Config file:      /test/goose/config.yaml
  Sessions dir:     /data/goose/sessions
  Logs dir:         /data/goose/logs
```