### PR TITLE
feat(openai): Add organization and project support for OpenAI provider

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -29,6 +29,8 @@ pub struct OpenAiProvider {
     client: Client,
     host: String,
     api_key: String,
+    organization: Option<String>,
+    project: Option<String>,
     model: ModelConfig,
 }
 
@@ -46,6 +48,8 @@ impl OpenAiProvider {
         let host: String = config
             .get("OPENAI_HOST")
             .unwrap_or_else(|_| "https://api.openai.com".to_string());
+        let organization: Option<String> = config.get("OPENAI_ORGANIZATION").ok();
+        let project: Option<String> = config.get("OPENAI_PROJECT").ok();
         let client = Client::builder()
             .timeout(Duration::from_secs(600))
             .build()?;
@@ -54,6 +58,8 @@ impl OpenAiProvider {
             client,
             host,
             api_key,
+            organization,
+            project,
             model,
         })
     }
@@ -65,10 +71,22 @@ impl OpenAiProvider {
             ProviderError::RequestFailed(format!("Failed to construct endpoint URL: {e}"))
         })?;
 
-        let response = self
+        let mut request = self
             .client
             .post(url)
-            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("Authorization", format!("Bearer {}", self.api_key));
+
+        // Add organization header if present
+        if let Some(org) = &self.organization {
+            request = request.header("OpenAI-Organization", org);
+        }
+
+        // Add project header if present
+        if let Some(project) = &self.project {
+            request = request.header("OpenAI-Project", project);
+        }
+
+        let response = request
             .json(&payload)
             .send()
             .await?;
@@ -93,6 +111,8 @@ impl Provider for OpenAiProvider {
             vec![
                 ConfigKey::new("OPENAI_API_KEY", true, true, None),
                 ConfigKey::new("OPENAI_HOST", false, false, Some("https://api.openai.com")),
+                ConfigKey::new("OPENAI_ORGANIZATION", false, false, None),
+                ConfigKey::new("OPENAI_PROJECT", false, false, None),
             ],
         )
     }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -86,10 +86,7 @@ impl OpenAiProvider {
             request = request.header("OpenAI-Project", project);
         }
 
-        let response = request
-            .json(&payload)
-            .send()
-            .await?;
+        let response = request.json(&payload).send().await?;
 
         handle_response_openai_compat(response).await
     }

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -26,7 +26,7 @@ Goose relies heavily on tool calling capabilities and currently works best with 
 | [Gemini](https://ai.google.dev/gemini-api/docs) | Advanced LLMs by Google with multimodal capabilities (text, images).    | `GOOGLE_API_KEY`                      |
 | [Groq](https://groq.com/)                     | High-performance inference hardware and tools for LLMs.    | `GROQ_API_KEY`                        |
 | [Ollama](https://ollama.com/)                 | Local model runner supporting Qwen, Llama, DeepSeek, and other open-source models. **Because this provider runs locally, you must first [download and run a model](/docs/getting-started/providers#local-llms-ollama).** | `OLLAMA_HOST`                                 |
-| [OpenAI](https://platform.openai.com/api-keys) | Provides gpt-4o, o1, and other advanced language models. **o1-mini and o1-preview are not supported because Goose uses tool calling.**                                                                                  | `OPENAI_API_KEY`                      |
+| [OpenAI](https://platform.openai.com/api-keys) | Provides gpt-4o, o1, and other advanced language models. **o1-mini and o1-preview are not supported because Goose uses tool calling.**                                                                                  | `OPENAI_API_KEY`, `OPENAI_HOST` (optional, defaults to api.openai.com)                      |
 | [OpenRouter](https://openrouter.ai/)          | API gateway for unified access to various models with features like rate-limiting management.  | `OPENROUTER_API_KEY`                  |
 
 
@@ -105,9 +105,31 @@ To configure your chosen provider or see available options, run `goose configure
   5. Select a Provider from drop down menu
   6. Enter Model name and press `+ Add Model`
 
-  You can explore more models by selecting a `provider` name under `Browse by Provider`. A link will appear, directing you to the provider’s website. Once you've found the model you want, return to step 6 and paste the model name.
+  You can explore more models by selecting a `provider` name under `Browse by Provider`. A link will appear, directing you to the provider's website. Once you've found the model you want, return to step 6 and paste the model name.
   </TabItem>
 
+</Tabs>
+
+## Using Custom OpenAI Endpoints
+
+If you need to use a custom OpenAI-compatible endpoint (for example, a private server or proxy), you can configure this using the `OPENAI_HOST` environment variable:
+
+<Tabs groupId="interface">
+  <TabItem value="cli" label="Goose CLI" default>
+    1. Run `goose configure`
+    2. Select `Configure Providers`
+    3. Choose `OpenAI` as the provider
+    4. Enter your API key when prompted
+    5. When asked for additional configuration, set `OPENAI_HOST` to your custom endpoint (e.g., `https://your-custom-endpoint.com`)
+  </TabItem>
+  <TabItem value="ui" label="Goose Desktop">
+    1. Click `...` in the upper right corner
+    2. Click `Settings`
+    3. Next to `Models`, click the `browse` link
+    4. Click the `configure` link in the upper right corner
+    5. Press the `+` button next to OpenAI
+    6. Add your API key and custom host URL, then press `submit`
+  </TabItem>
 </Tabs>
 
 ## Using Goose for Free

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -26,7 +26,7 @@ Goose relies heavily on tool calling capabilities and currently works best with 
 | [Gemini](https://ai.google.dev/gemini-api/docs) | Advanced LLMs by Google with multimodal capabilities (text, images).    | `GOOGLE_API_KEY`                      |
 | [Groq](https://groq.com/)                     | High-performance inference hardware and tools for LLMs.    | `GROQ_API_KEY`                        |
 | [Ollama](https://ollama.com/)                 | Local model runner supporting Qwen, Llama, DeepSeek, and other open-source models. **Because this provider runs locally, you must first [download and run a model](/docs/getting-started/providers#local-llms-ollama).** | `OLLAMA_HOST`                                 |
-| [OpenAI](https://platform.openai.com/api-keys) | Provides gpt-4o, o1, and other advanced language models. **o1-mini and o1-preview are not supported because Goose uses tool calling.**                                                                                  | `OPENAI_API_KEY`, `OPENAI_HOST` (optional, defaults to api.openai.com)                      |
+| [OpenAI](https://platform.openai.com/api-keys) | Provides gpt-4o, o1, and other advanced language models. Also supports OpenAI-compatible endpoints (e.g., self-hosted LLaMA, vLLM, KServe). **o1-mini and o1-preview are not supported because Goose uses tool calling.** | `OPENAI_API_KEY`, `OPENAI_HOST` (optional), `OPENAI_ORGANIZATION` (optional), `OPENAI_PROJECT` (optional) |
 | [OpenRouter](https://openrouter.ai/)          | API gateway for unified access to various models with features like rate-limiting management.  | `OPENROUTER_API_KEY`                  |
 
 
@@ -112,15 +112,62 @@ To configure your chosen provider or see available options, run `goose configure
 
 ## Using Custom OpenAI Endpoints
 
-If you need to use a custom OpenAI-compatible endpoint (for example, a private server or proxy), you can configure this using the `OPENAI_HOST` environment variable:
+Goose supports using custom OpenAI-compatible endpoints, which is particularly useful for:
+- Self-hosted LLMs (e.g., LLaMA, Mistral) using vLLM or KServe
+- Private OpenAI-compatible API servers
+- Enterprise deployments requiring data governance and security compliance
+- OpenAI API proxies or gateways
+
+### Configuration Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `OPENAI_API_KEY` | Yes | Authentication key for the API |
+| `OPENAI_HOST` | No | Custom endpoint URL (defaults to api.openai.com) |
+| `OPENAI_ORGANIZATION` | No | Organization ID for usage tracking and governance |
+| `OPENAI_PROJECT` | No | Project identifier for resource management |
+
+### Example Configurations
+
+<Tabs groupId="deployment">
+  <TabItem value="vllm" label="vLLM Self-Hosted" default>
+    If you're running LLaMA or other models using vLLM with OpenAI compatibility:
+    ```sh
+    OPENAI_HOST=https://your-vllm-endpoint.internal
+    OPENAI_API_KEY=your-internal-api-key
+    ```
+  </TabItem>
+  <TabItem value="kserve" label="KServe Deployment">
+    For models deployed on Kubernetes using KServe:
+    ```sh
+    OPENAI_HOST=https://kserve-gateway.your-cluster
+    OPENAI_API_KEY=your-kserve-api-key
+    OPENAI_ORGANIZATION=your-org-id
+    OPENAI_PROJECT=ml-serving
+    ```
+  </TabItem>
+  <TabItem value="enterprise" label="Enterprise OpenAI">
+    For enterprise OpenAI deployments with governance:
+    ```sh
+    OPENAI_API_KEY=your-api-key
+    OPENAI_ORGANIZATION=org-id123
+    OPENAI_PROJECT=compliance-approved
+    ```
+  </TabItem>
+</Tabs>
+
+### Setup Instructions
 
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
     1. Run `goose configure`
     2. Select `Configure Providers`
     3. Choose `OpenAI` as the provider
-    4. Enter your API key when prompted
-    5. When asked for additional configuration, set `OPENAI_HOST` to your custom endpoint (e.g., `https://your-custom-endpoint.com`)
+    4. Enter your configuration when prompted:
+       - API key
+       - Host URL (if using custom endpoint)
+       - Organization ID (if using organization tracking)
+       - Project identifier (if using project management)
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
     1. Click `...` in the upper right corner
@@ -128,9 +175,18 @@ If you need to use a custom OpenAI-compatible endpoint (for example, a private s
     3. Next to `Models`, click the `browse` link
     4. Click the `configure` link in the upper right corner
     5. Press the `+` button next to OpenAI
-    6. Add your API key and custom host URL, then press `submit`
+    6. Fill in your configuration details:
+       - API Key (required)
+       - Host URL (for custom endpoints)
+       - Organization ID (for usage tracking)
+       - Project (for resource management)
+    7. Press `submit`
   </TabItem>
 </Tabs>
+
+:::tip Enterprise Deployment
+For enterprise deployments, you can pre-configure these values using environment variables or configuration files to ensure consistent governance across your organization.
+:::
 
 ## Using Goose for Free
 


### PR DESCRIPTION
**Add organization and project support for OpenAI provider**
 
What was done:
- Extended the provider configuration to support optional `organization` and `project` headers  
- Updated the provider struct to include the new optional fields  
- Modified the request construction so it conditionally adds these headers when configured  
- Expanded the documentation to explain how to set up these fields for custom OpenAI endpoints  