### PR TITLE
feat: support OpenAI reasoning effort configuration for O1/O3 models

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -330,6 +330,26 @@ pub fn create_request(
     let is_o1 = model_config.model_name.starts_with("o1");
     let is_o3 = model_config.model_name.starts_with("o3");
 
+    // Only extract reasoning effort for O1/O3 models
+    let (model_name, reasoning_effort) = if is_o1 || is_o3 {
+        let parts: Vec<&str> = model_config.model_name.split('-').collect();
+        let last_part = parts.last().unwrap();
+
+        match *last_part {
+            "low" | "medium" | "high" => {
+                let base_name = parts[..parts.len() - 1].join("-");
+                (base_name, Some(last_part.to_string()))
+            }
+            _ => (
+                model_config.model_name.to_string(),
+                Some("medium".to_string()),
+            ),
+        }
+    } else {
+        // For non-O family models, use the model name as is and no reasoning effort
+        (model_config.model_name.to_string(), None)
+    };
+
     let system_message = json!({
         "role": if is_o1 { "developer" } else { "system" },
         "content": system
@@ -349,9 +369,16 @@ pub fn create_request(
     messages_array.extend(messages_spec);
 
     let mut payload = json!({
-        "model": model_config.model_name,
+        "model": model_name,
         "messages": messages_array
     });
+
+    if let Some(effort) = reasoning_effort {
+        payload
+            .as_object_mut()
+            .unwrap()
+            .insert("reasoning_effort".to_string(), json!(effort));
+    }
 
     if !tools_spec.is_empty() {
         payload
@@ -775,6 +802,66 @@ mod tests {
         } else {
             panic!("Expected ToolRequest content");
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_gpt_4o() -> anyhow::Result<()> {
+        // Test default medium reasoning effort for O3 model
+        let model_config = ModelConfig {
+            model_name: "gpt-4o".to_string(),
+            tokenizer_name: "gpt-4o".to_string(),
+            context_limit: Some(4096),
+            temperature: None,
+            max_tokens: Some(1024),
+        };
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+        let obj = request.as_object().unwrap();
+        assert_eq!(obj.get("model").unwrap(), "gpt-4o");
+        assert!(obj.get("reasoning_effort").is_none());
+        assert!(obj.get("max_completion_tokens").is_none());
+        assert_eq!(obj.get("max_tokens").unwrap(), 1024);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_o1_default() -> anyhow::Result<()> {
+        // Test default medium reasoning effort for O1 model
+        let model_config = ModelConfig {
+            model_name: "o1".to_string(),
+            tokenizer_name: "o1".to_string(),
+            context_limit: Some(4096),
+            temperature: None,
+            max_tokens: Some(1024),
+        };
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+        let obj = request.as_object().unwrap();
+        assert_eq!(obj.get("model").unwrap(), "o1");
+        assert_eq!(obj.get("reasoning_effort").unwrap(), "medium");
+        assert_eq!(obj.get("max_completion_tokens").unwrap(), 1024);
+        assert!(obj.get("max_tokens").is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_create_request_o3_custom_reasoning_effort() -> anyhow::Result<()> {
+        // Test custom reasoning effort for O3 model
+        let model_config = ModelConfig {
+            model_name: "o3-mini-high".to_string(),
+            tokenizer_name: "o3-mini".to_string(),
+            context_limit: Some(4096),
+            temperature: None,
+            max_tokens: Some(1024),
+        };
+        let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
+        let obj = request.as_object().unwrap();
+        assert_eq!(obj.get("model").unwrap(), "o3-mini");
+        assert_eq!(obj.get("reasoning_effort").unwrap(), "high");
+        assert_eq!(obj.get("max_completion_tokens").unwrap(), 1024);
+        assert!(obj.get("max_tokens").is_none());
 
         Ok(())
     }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -351,7 +351,7 @@ pub fn create_request(
     };
 
     let system_message = json!({
-        "role": if is_o1 { "developer" } else { "system" },
+        "role": if is_o1 || is_o3 { "developer" } else { "system" },
         "content": system
     });
 
@@ -818,10 +818,20 @@ mod tests {
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
         let obj = request.as_object().unwrap();
-        assert_eq!(obj.get("model").unwrap(), "gpt-4o");
-        assert!(obj.get("reasoning_effort").is_none());
-        assert!(obj.get("max_completion_tokens").is_none());
-        assert_eq!(obj.get("max_tokens").unwrap(), 1024);
+        let expected = json!({
+            "model": "gpt-4o",
+            "messages": [
+                {
+                    "role": "system",
+                    "content": "system"
+                }
+            ],
+            "max_tokens": 1024
+        });
+
+        for (key, value) in expected.as_object().unwrap() {
+            assert_eq!(obj.get(key).unwrap(), value);
+        }
 
         Ok(())
     }
@@ -838,10 +848,21 @@ mod tests {
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
         let obj = request.as_object().unwrap();
-        assert_eq!(obj.get("model").unwrap(), "o1");
-        assert_eq!(obj.get("reasoning_effort").unwrap(), "medium");
-        assert_eq!(obj.get("max_completion_tokens").unwrap(), 1024);
-        assert!(obj.get("max_tokens").is_none());
+        let expected = json!({
+            "model": "o1",
+            "messages": [
+                {
+                    "role": "developer",
+                    "content": "system"
+                }
+            ],
+            "reasoning_effort": "medium",
+            "max_completion_tokens": 1024
+        });
+
+        for (key, value) in expected.as_object().unwrap() {
+            assert_eq!(obj.get(key).unwrap(), value);
+        }
 
         Ok(())
     }
@@ -858,10 +879,21 @@ mod tests {
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
         let obj = request.as_object().unwrap();
-        assert_eq!(obj.get("model").unwrap(), "o3-mini");
-        assert_eq!(obj.get("reasoning_effort").unwrap(), "high");
-        assert_eq!(obj.get("max_completion_tokens").unwrap(), 1024);
-        assert!(obj.get("max_tokens").is_none());
+        let expected = json!({
+            "model": "o3-mini",
+            "messages": [
+                {
+                    "role": "developer",
+                    "content": "system"
+                }
+            ],
+            "reasoning_effort": "high",
+            "max_completion_tokens": 1024
+        });
+
+        for (key, value) in expected.as_object().unwrap() {
+            assert_eq!(obj.get(key).unwrap(), value);
+        }
 
         Ok(())
     }

--- a/crates/goose/tests/truncate_agent.rs
+++ b/crates/goose/tests/truncate_agent.rs
@@ -185,7 +185,7 @@ mod tests {
     async fn test_truncate_agent_with_openai() -> Result<()> {
         run_test_with_config(TestConfig {
             provider_type: ProviderType::OpenAi,
-            model: "o3-mini",
+            model: "o3-mini-low",
             context_window: 200_000,
         })
         .await

--- a/crates/goose/tests/truncate_agent.rs
+++ b/crates/goose/tests/truncate_agent.rs
@@ -185,8 +185,8 @@ mod tests {
     async fn test_truncate_agent_with_openai() -> Result<()> {
         run_test_with_config(TestConfig {
             provider_type: ProviderType::OpenAi,
-            model: "gpt-4o-mini",
-            context_window: 128_000,
+            model: "o3-mini",
+            context_window: 200_000,
         })
         .await
     }


### PR DESCRIPTION
extract reasoning effort from o1 & o3 model name's last part

duplicate of - https://github.com/block/goose/pull/1045/files (without the comments, and refactoring into different functions)