### PR TITLE
fix: Only run husky precommit hooks when relevant

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,7 @@
 #!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
 
-cd ui/desktop && npx lint-staged
+# Only auto-format desktop TS code if relevant files are modified
+if git diff --cached --name-only | grep -q "^ui/desktop/"; then
+  . "$(dirname -- "$0")/_/husky.sh"
+  cd ui/desktop && npx lint-staged
+fi


### PR DESCRIPTION
Only run husky pre-commit hook for auto-formatting app code if app code has been changed