### PR TITLE
log tokenizer download status

### DIFF
--- a/crates/goose/build.rs
+++ b/crates/goose/build.rs
@@ -42,7 +42,12 @@ async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     // Download the file
     let response = reqwest::get(&file_url).await?;
     if !response.status().is_success() {
-        return Err(format!("Failed to download tokenizer for {}, status: {}", repo_id, response.status()).into());
+        return Err(format!(
+            "Failed to download tokenizer for {}, status: {}",
+            repo_id,
+            response.status()
+        )
+        .into());
     }
 
     let content = response.bytes().await?;

--- a/crates/goose/build.rs
+++ b/crates/goose/build.rs
@@ -42,7 +42,7 @@ async fn download_tokenizer(repo_id: &str) -> Result<(), Box<dyn Error>> {
     // Download the file
     let response = reqwest::get(&file_url).await?;
     if !response.status().is_success() {
-        return Err(format!("Failed to download tokenizer for {}", repo_id).into());
+        return Err(format!("Failed to download tokenizer for {}, status: {}", repo_id, response.status()).into());
     }
 
     let content = response.bytes().await?;


### PR DESCRIPTION
Sometimes the download failed without any detail: https://github.com/block/goose/actions/runs/13395267770/job/37412606892

```
--- stdout
  cargo:rerun-if-changed=build.rs
  cargo:rerun-if-changed=../../tokenizer_files
  Downloading tokenizer for Xenova/gpt-4o...
  Downloaded Xenova/gpt-4o to ../../tokenizer_files/Xenova--gpt-4o/tokenizer.json
  Downloading tokenizer for Xenova/claude-tokenizer...

  --- stderr
  Error: "Failed to download tokenizer for Xenova/claude-tokenizer"
```