### PR TITLE
fix: minor CSS change to extensions

### DIFF
--- a/ui/desktop/README.md
+++ b/ui/desktop/README.md
@@ -28,7 +28,7 @@ see `package.json`:
 This allows you to set for example GOOSE_PROVIDER__TYPE to be "databricks" by default if you want (so when people start Goose.app - they will get that out of the box). There is no way to set an api key in that bundling as that would be a terrible idea, so only use providers that can do oauth (like databricks can), otherwise stick to default goose.
 
 
-# Runninng with goosed server from source
+# Running with goosed server from source
 
 Set `VITE_START_EMBEDDED_SERVER=yes` to no in `.env.
 Run `cargo run -p goose-server` from parent dir.

--- a/ui/desktop/src/components/settings/extensions/ConfigureBuiltInExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ConfigureBuiltInExtensionModal.tsx
@@ -83,10 +83,10 @@ export function ConfigureBuiltInExtensionModal({
 
   return (
     <div className="fixed inset-0 bg-black/20 backdrop-blur-sm">
-      <Card className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[440px] bg-white dark:bg-gray-800 rounded-xl shadow-xl overflow-hidden p-[16px] pt-[24px] pb-0">
-        <div className="px-8 pb-0 space-y-8">
+      <Card className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[440px] bg-white dark:bg-gray-800 rounded-xl shadow-xl overflow-hidden pt-[24px]">
+        <div className="pb-0 space-y-8">
           {/* Header */}
-          <div className="flex">
+          <div className="flex px-8">
             <h2 className="text-2xl font-regular dark:text-white text-gray-900">
               Configure {extension.name}
             </h2>
@@ -94,7 +94,7 @@ export function ConfigureBuiltInExtensionModal({
 
           {/* Form */}
           <form onSubmit={handleExtensionConfigSubmit}>
-            <div className="mt-[24px]">
+            <div className="mt-[24px] px-8">
               {extension.env_keys?.length > 0 ? (
                 <>
                   <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">

--- a/ui/desktop/src/components/settings/extensions/ConfigureExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ConfigureExtensionModal.tsx
@@ -85,10 +85,10 @@ export function ConfigureExtensionModal({
 
   return (
     <div className="fixed inset-0 bg-black/20 backdrop-blur-sm">
-      <Card className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[440px] bg-white dark:bg-gray-800 rounded-xl shadow-xl overflow-hidden p-[16px] pt-[24px] pb-0">
-        <div className="px-8 pb-0 space-y-8">
+      <Card className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[440px] bg-white dark:bg-gray-800 rounded-xl shadow-xl overflow-hidden pt-[24px]">
+        <div className="pb-0 space-y-8">
           {/* Header */}
-          <div className="flex">
+          <div className="flex px-8">
             <h2 className="text-2xl font-regular dark:text-white text-gray-900">
               Configure {extension.name}
             </h2>
@@ -96,7 +96,7 @@ export function ConfigureExtensionModal({
 
           {/* Form */}
           <form onSubmit={handleExtensionConfigSubmit}>
-            <div className="mt-[24px]">
+            <div className="mt-[24px] px-8">
               {extension.env_keys?.length > 0 ? (
                 <>
                   <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">


### PR DESCRIPTION
Add some more padding. 

# Before

<img width="567" alt="Screenshot 2025-02-18 at 11 59 36 am" src="https://github.com/user-attachments/assets/0a86df4e-891e-468e-81d5-a5dc5beff50a" />

# After 

https://github.com/user-attachments/assets/03876f6d-4534-4cd6-8688-aba673ee1ae8


