### PR TITLE
feat: allow users to configure openai host

### DIFF
--- a/crates/goose-server/src/routes/providers_and_keys.json
+++ b/crates/goose-server/src/routes/providers_and_keys.json
@@ -3,7 +3,7 @@
         "name": "OpenAI",
         "description": "Use GPT-4 and other OpenAI models",
         "models": ["gpt-4o", "gpt-4-turbo","o1"],
-        "required_keys": ["OPENAI_API_KEY"]
+        "required_keys": ["OPENAI_API_KEY", "OPENAI_HOST"]
     },
     "anthropic": {
         "name": "Anthropic",

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -98,7 +98,7 @@ impl Provider for OpenAiProvider {
         ProviderMetadata::new(
             "openai",
             "OpenAI",
-            "GPT-4 and other OpenAI models",
+            "GPT-4 and other OpenAI models, including OpenAI compatible ones",
             OPEN_AI_DEFAULT_MODEL,
             OPEN_AI_KNOWN_MODELS
                 .iter()
@@ -107,7 +107,7 @@ impl Provider for OpenAiProvider {
             OPEN_AI_DOC_URL,
             vec![
                 ConfigKey::new("OPENAI_API_KEY", true, true, None),
-                ConfigKey::new("OPENAI_HOST", false, false, Some("https://api.openai.com")),
+                ConfigKey::new("OPENAI_HOST", true, false, Some("https://api.openai.com")),
                 ConfigKey::new("OPENAI_ORGANIZATION", false, false, None),
                 ConfigKey::new("OPENAI_PROJECT", false, false, None),
             ],

--- a/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
+++ b/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
@@ -65,7 +65,7 @@ export function getDefaultModel(key: string): string | undefined {
 export const short_list = ['gpt-4o', 'claude-3-5-sonnet-latest'];
 
 export const required_keys = {
-  OpenAI: ['OPENAI_API_KEY'],
+  OpenAI: ['OPENAI_API_KEY', 'OPENAI_HOST'],
   Anthropic: ['ANTHROPIC_API_KEY'],
   Databricks: ['DATABRICKS_HOST'],
   Groq: ['GROQ_API_KEY'],

--- a/ui/desktop/src/components/settings/providers/BaseProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/BaseProviderGrid.tsx
@@ -38,7 +38,7 @@ function getArticle(word: string): string {
 
 export function getProviderDescription(provider) {
   const descriptions = {
-    OpenAI: 'Access GPT-4, GPT-3.5 Turbo, and other OpenAI models',
+    OpenAI: 'Access GPT-4 and other OpenAI models, including OpenAI compatible ones',
     Anthropic: 'Access Claude and other Anthropic models',
     Google: 'Access Gemini and other Google AI models',
     Groq: 'Access Mixtral and other Groq-hosted models',


### PR DESCRIPTION
fix #1198 

Requires users to input the openai host, for existing users, it will still use the default value

Test:
CLI
```┌   goose-configure 
│
◇  What would you like to configure?
│  Configure Providers 
│
◇  Which model provider should we use?
│  OpenAI 
│
●  OPENAI_API_KEY is already configured
│  
◇  Would you like to update this value?
│  Yes 
│
◇  Enter new value for OPENAI_API_KEY
│  ▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
│
◇  Provider OpenAI requires OPENAI_HOST, please enter a value
│  https://api.openai.com
│
◆  Enter a model from that provider:
│  gpt-4o (default)
└  
```

UI
![image](https://github.com/user-attachments/assets/18dc4716-717c-429d-9172-9b28e49bc556)
