### PR TITLE
feat: add experiment manager to control whether we enable a feature

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1,7 +1,7 @@
 use cliclack::spinner;
 use console::style;
 use goose::agents::{extension::Envs, ExtensionConfig};
-use goose::config::{Config, ConfigError, ExtensionEntry, ExtensionManager};
+use goose::config::{Config, ConfigError, ExperimentManager, ExtensionEntry, ExtensionManager};
 use goose::message::Message;
 use goose::providers::{create, providers};
 use mcp_core::Tool;
@@ -622,14 +622,24 @@ pub fn remove_extension_dialog() -> Result<(), Box<dyn Error>> {
 }
 
 pub fn configure_settings_dialog() -> Result<(), Box<dyn Error>> {
-    let setting_type = cliclack::select("What setting would you like to configure?")
+    let mut setting_select_builder = cliclack::select("What setting would you like to configure?")
         .item("goose_mode", "Goose Mode", "Configure Goose mode")
         .item(
             "tool_output",
             "Tool Output",
             "Show more or less tool output",
-        )
-        .interact()?;
+        );
+
+    // Conditionally add the "Toggle Experiment" option
+    if ExperimentManager::is_enabled("EXPERIMENT_CONFIG")? {
+        setting_select_builder = setting_select_builder.item(
+            "experiment",
+            "Toggle Experiment",
+            "Enable or disable an experiment feature",
+        );
+    }
+
+    let setting_type = setting_select_builder.interact()?;
 
     match setting_type {
         "goose_mode" => {
@@ -637,6 +647,9 @@ pub fn configure_settings_dialog() -> Result<(), Box<dyn Error>> {
         }
         "tool_output" => {
             configure_tool_output_dialog()?;
+        }
+        "experiment" => {
+            toggle_experiments_dialog()?;
         }
         _ => unreachable!(),
     };
@@ -716,5 +729,45 @@ pub fn configure_tool_output_dialog() -> Result<(), Box<dyn Error>> {
         _ => unreachable!(),
     };
 
+    Ok(())
+}
+
+/// Configure experiment features that can be used with goose
+/// Dialog for toggling which experiments are enabled/disabled
+pub fn toggle_experiments_dialog() -> Result<(), Box<dyn Error>> {
+    let experiments = ExperimentManager::get_all()?;
+
+    if experiments.is_empty() {
+        cliclack::outro("No experiments supported yet.")?;
+        return Ok(());
+    }
+
+    // Get currently enabled experiments for the selection
+    let enabled_experiments: Vec<&String> = experiments
+        .iter()
+        .filter(|(_, enabled)| *enabled)
+        .map(|(name, _)| name)
+        .collect();
+
+    // Let user toggle experiments
+    let selected = cliclack::multiselect(
+        "enable experiments: (use \"space\" to toggle and \"enter\" to submit)",
+    )
+    .required(false)
+    .items(
+        &experiments
+            .iter()
+            .map(|(name, _)| (name, name.as_str(), ""))
+            .collect::<Vec<_>>(),
+    )
+    .initial_values(enabled_experiments)
+    .interact()?;
+
+    // Update enabled status for each experiments
+    for name in experiments.iter().map(|(name, _)| name) {
+        ExperimentManager::set_enabled(name, selected.iter().any(|&s| s.as_str() == name))?;
+    }
+
+    cliclack::outro("Experiments settings updated successfully")?;
     Ok(())
 }

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -153,7 +153,7 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
             .item(
                 "settings",
                 "Goose Settings",
-                "Set the Goose Mode, Tool Output, and more",
+                "Set the Goose Mode, Tool Output, Experiment and more",
             )
             .interact()?;
 

--- a/crates/goose/src/config/experiments.rs
+++ b/crates/goose/src/config/experiments.rs
@@ -1,0 +1,55 @@
+use super::base::Config;
+use anyhow::Result;
+use std::collections::HashMap;
+
+const ALL_EXPERIMENTS: &[(&str, bool)] = &[
+    // TODO(yingjiehe): Cleanup EXPERIMENT_CONFIG once experiment is fully ready.
+    ("EXPERIMENT_CONFIG", false),
+];
+
+/// Experiment configuration management
+pub struct ExperimentManager;
+
+impl ExperimentManager {
+    /// Get all experiments and their configurations
+    pub fn get_all() -> Result<Vec<(String, bool)>> {
+        let config = Config::global();
+        let experiments: HashMap<String, bool> = config.get("experiments").unwrap_or_default();
+        if experiments.is_empty() {
+            Ok(experiments.iter().map(|(k, v)| (k.clone(), *v)).collect())
+        } else {
+            Ok(ALL_EXPERIMENTS
+                .iter()
+                .map(|(k, v)| (k.to_string(), *v))
+                .collect())
+        }
+    }
+
+    /// Enable or disable an experiment
+    pub fn set_enabled(name: &str, enabled: bool) -> Result<()> {
+        let config = Config::global();
+
+        // Load existing experiments or initialize a new map
+        let mut experiments: HashMap<String, bool> =
+            config.get("experiments").unwrap_or_else(|_| HashMap::new());
+
+        // Update the status of the experiment
+        experiments.insert(name.to_string(), enabled);
+
+        // Save the updated experiments map
+        config.set("experiments", serde_json::to_value(experiments)?)?;
+        Ok(())
+    }
+
+    /// Check if an experiment is enabled
+    pub fn is_enabled(name: &str) -> Result<bool> {
+        let config = Config::global();
+
+        // Load existing experiments or initialize a new map
+        let experiments: HashMap<String, bool> =
+            config.get("experiments").unwrap_or_else(|_| HashMap::new());
+
+        // Return whether the experiment is enabled, defaulting to false
+        Ok(*experiments.get(name).unwrap_or(&false))
+    }
+}

--- a/crates/goose/src/config/mod.rs
+++ b/crates/goose/src/config/mod.rs
@@ -1,6 +1,8 @@
 mod base;
+mod experiments;
 mod extensions;
 
 pub use crate::agents::ExtensionConfig;
 pub use base::{Config, ConfigError, APP_STRATEGY};
+pub use experiments::ExperimentManager;
 pub use extensions::{ExtensionEntry, ExtensionManager};


### PR DESCRIPTION
Add experiment manager to control whether a feature enabled. Right now for dev, we can manually update our config.yaml to set the experiment. 

It is not enabled by default


Before:

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Goose Settings 
│
◆  What setting would you like to configure?
│  ● Goose Mode (Configure Goose mode)
│  ○ Tool Output 
└  
```

After:

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Goose Settings 
│
◆  What setting would you like to configure?
│  ● Goose Mode (Configure Goose mode)
│  ○ Tool Output 
│  ○ Toggle Experiment 
└ 
```