### PR TITLE
fix: handle OpenAI API errors better

### DIFF
--- a/crates/goose/src/providers/errors.rs
+++ b/crates/goose/src/providers/errors.rs
@@ -74,3 +74,50 @@ impl GoogleErrorCode {
         }
     }
 }
+
+#[derive(serde::Deserialize)]
+pub struct OpenAIError {
+    pub code: Option<String>,
+    pub message: Option<String>,
+    #[serde(rename = "type")]
+    pub error_type: Option<String>,
+}
+
+impl OpenAIError {
+    pub fn is_context_length_exceeded(&self) -> bool {
+        if let Some(code) = &self.code {
+            code == "context_length_exceeded" || code == "string_above_max_length"
+        } else {
+            false
+        }
+    }
+}
+
+impl std::fmt::Display for OpenAIError {
+    /// Format the error for display.
+    /// E.g. {"message": "Invalid API key", "code": "invalid_api_key", "type": "client_error"}
+    /// would be formatted as "Invalid API key (code: invalid_api_key, type: client_error)"
+    /// and {"message": "Foo"} as just "Foo", etc.
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if let Some(message) = &self.message {
+            write!(f, "{}", message)?;
+        }
+        let mut in_parenthesis = false;
+        if let Some(code) = &self.code {
+            write!(f, " (code: {}", code)?;
+            in_parenthesis = true;
+        }
+        if let Some(typ) = &self.error_type {
+            if in_parenthesis {
+                write!(f, ", type: {}", typ)?;
+            } else {
+                write!(f, " (type: {}", typ)?;
+                in_parenthesis = true;
+            }
+        }
+        if in_parenthesis {
+            write!(f, ")")?;
+        }
+        Ok(())
+    }
+}

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -5,12 +5,17 @@ use base64::Engine;
 use regex::Regex;
 use reqwest::{Response, StatusCode};
 use serde::{Deserialize, Serialize};
-use serde_json::{json, Map, Value};
+use serde_json::{from_value, json, Map, Value};
 use std::io::Read;
 use std::path::Path;
 
-use crate::providers::errors::ProviderError;
+use crate::providers::errors::{OpenAIError, ProviderError};
 use mcp_core::content::ImageContent;
+
+#[derive(serde::Deserialize)]
+struct OpenAIErrorResponse {
+    error: OpenAIError,
+}
 
 #[derive(Debug, Copy, Clone, Serialize, Deserialize)]
 pub enum ImageFormat {
@@ -56,25 +61,17 @@ pub async fn handle_response_openai_compat(response: Response) -> Result<Value, 
                 Status: {}. Response: {:?}", status, payload)))
         }
         StatusCode::BAD_REQUEST => {
-            let mut message = "Unknown error".to_string();
-            if let Some(error) = payload.get("error") {
-                tracing::debug!("Bad Request Error: {error:?}");
-                message = error
-                            .get("message")
-                            .and_then(|m| m.as_str())
-                            .unwrap_or("Unknown error")
-                            .to_string();
-
-                if let Some(code) = error.get("code").and_then(|c| c.as_str()) {
-                    if code == "context_length_exceeded" || code == "string_above_max_length" {
-                        return Err(ProviderError::ContextLengthExceeded(message));
-                    }
-                }
-            }
             tracing::debug!(
                 "{}", format!("Provider request failed with status: {}. Payload: {:?}", status, payload)
             );
-            Err(ProviderError::RequestFailed(format!("Request failed with status: {}. Message: {}", status, message)))
+            if let Ok(err_resp) = from_value::<OpenAIErrorResponse>(payload) {
+                let err = err_resp.error;
+                if err.is_context_length_exceeded() {
+                    return Err(ProviderError::ContextLengthExceeded(err.message.unwrap_or("Unknown error".to_string())));
+                }
+                return Err(ProviderError::RequestFailed(format!("{} (status {})", err, status.as_u16())));
+            }
+            Err(ProviderError::RequestFailed(format!("Unknown error (status {})", status)))
         }
         StatusCode::NOT_FOUND => {
             Err(ProviderError::RequestFailed(format!("{:?}", payload)))

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -60,7 +60,7 @@ pub async fn handle_response_openai_compat(response: Response) -> Result<Value, 
             Err(ProviderError::Authentication(format!("Authentication failed. Please ensure your API keys are valid and have the required permissions. \
                 Status: {}. Response: {:?}", status, payload)))
         }
-        StatusCode::BAD_REQUEST => {
+        StatusCode::BAD_REQUEST | StatusCode::NOT_FOUND => {
             tracing::debug!(
                 "{}", format!("Provider request failed with status: {}. Payload: {:?}", status, payload)
             );
@@ -72,9 +72,6 @@ pub async fn handle_response_openai_compat(response: Response) -> Result<Value, 
                 return Err(ProviderError::RequestFailed(format!("{} (status {})", err, status.as_u16())));
             }
             Err(ProviderError::RequestFailed(format!("Unknown error (status {})", status)))
-        }
-        StatusCode::NOT_FOUND => {
-            Err(ProviderError::RequestFailed(format!("{:?}", payload)))
         }
         StatusCode::TOO_MANY_REQUESTS => {
             Err(ProviderError::RateLimitExceeded(format!("{:?}", payload)))


### PR DESCRIPTION
I wanted to try Goose out, so I built it from source and tried configuring it with my local Ollama, only to be met with "Request failed with status: 404 Not Found". While I, knowing Ollama, could guess that meant "that model is not found", not everyone might.

This PR:

* gently cleans up error handling from OpenAI compatible endpoints by introducing a real type for them
* makes that error-handling branch handle 404 as well as 400

with the end result that the "model "qwen2.5" not found, try pulling it first" error is now surfaced.

## Before

```
$ goose configure
Welcome to goose! Let's get you set up with a provider.
  you can rerun this command later to update your configuration

┌   goose-configure
│
◇  Which model provider should we use?
│  Ollama
│
◇  Provider Ollama requires OLLAMA_HOST, please enter a value
│  localhost
│
◇  Enter a model from that provider:
│  qwen2.5
│
◇  Request failed: Request failed with status: 404 Not Found
│
└  Failed to configure provider: init chat completion request with tool did not succeed.

  Warning: We did not save your config, inspect your credentials
   and run 'goose configure' again to ensure goose can connect
```

## After

```
$ goose configure
Welcome to goose! Let's get you set up with a provider.
  you can rerun this command later to update your configuration

┌   goose-configure
│
◇  Which model provider should we use?
│  Ollama
│
◇  Provider Ollama requires OLLAMA_HOST, please enter a value
│  localhost
│
◇  Enter a model from that provider:
│  qwen2.5
│
◇  Request failed: model "qwen2.5" not found, try pulling it first (type: api_error) (status 404)
│
└  Failed to configure provider: init chat completion request with tool did not succeed.

  Warning: We did not save your config, inspect your credentials
   and run 'goose configure' again to ensure goose can connect
```