### PR TITLE
feat: propagate external_model_message upwards on errors

### DIFF
--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -181,7 +181,16 @@ impl DatabricksProvider {
 
                 let mut error_msg = "Unknown error".to_string();
                 if let Some(payload) = &payload {
-                    error_msg = payload.get("message").and_then(|m| m.as_str()).unwrap_or("Unknown error").to_string();
+                    // try to convert message to string, if that fails use external_model_message
+                    error_msg = payload
+                        .get("message")
+                        .and_then(|m| m.as_str())
+                        .or_else(|| {
+                            payload.get("external_model_message")
+                                .and_then(|ext| ext.get("message"))
+                                .and_then(|m| m.as_str())
+                        })
+                        .unwrap_or("Unknown error").to_string();
                 }
 
                 tracing::debug!(


### PR DESCRIPTION
* Attempt to propagate `external_model_message.message` when we get a `400 Bad Request` from databricks provider

ex:
```
( O)> hi
◓  Evolving ethereal entities...                                                                                                                                          
  2025-02-19T18:48:21.799301Z ERROR goose::agents::truncate: Error: Request failed: Request failed with status: 400 Bad Request. Message: Unknown error
    at crates/goose/src/agents/truncate.rs:279

```
becomes:
```
  2025-02-19T18:53:32.354126Z ERROR goose::agents::truncate: Error: Request failed: Request failed with status: 400 Bad Request. Message: Malformed input request: #: subject must not be valid against schema {"required":["messages"]}#/tools/4/name: string [6kr06od8__add nums] does not match pattern ^[a-zA-Z0-9_-]{1,64}$#/tools/4: required key [type] not found#/tools/4: extraneous key [input_schema] is not permitted#/tools/4: extraneous key [description] is not permitted#/tools/4/name: #/tools/4/name: 6kr06od8__add nums is not a valid enum value#/tools/4: required key [type] not found#/tools/4: required key [display_height_px] not found#/tools/4: required key [display_width_px] not found#/tools/4: extraneous key [input_schema] is not permitted#/tools/4: extraneous key [description] is not permitted#/tools/4/name: #/tools/4/name: 6kr06od8__add nums is not a valid enum value#/tools/4: required key [type] not found#/tools/4: extraneous key [input_schema] is not permitted#/tools/4: extraneous key [description] is not permitted#/tools/4/name: 6kr06od8__add nums is not a valid enum value#/tools/4/name: , please reformat your input and try again.
    at crates/goose/src/agents/truncate.rs:279
```