### PR TITLE
fix: use in_state_dir to match logs directory

### DIFF
--- a/crates/goose-cli/src/commands/info.rs
+++ b/crates/goose-cli/src/commands/info.rs
@@ -10,7 +10,9 @@ fn print_aligned(label: &str, value: &str, width: usize) {
 
 pub fn handle_info(verbose: bool) -> Result<()> {
     let data_dir = choose_app_strategy(crate::APP_STRATEGY.clone())?;
-    let logs_dir = data_dir.in_data_dir("logs");
+    let logs_dir = data_dir
+        .in_state_dir("logs")
+        .unwrap_or_else(|| data_dir.in_data_dir("logs"));
     let sessions_dir = data_dir.in_data_dir("sessions");
 
     // Get paths using a stored reference to the global config


### PR DESCRIPTION
* fix the usage of the state_dir for logs