### PR TITLE
style: use is_none_or instead of map_or per clippy warnings rust >= 1.85.0

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -289,7 +289,7 @@ fn ensure_valid_json_schema(schema: &mut Value) {
         let is_object_type = params_obj
             .get("type")
             .and_then(|t| t.as_str())
-            .map_or(true, |t| t == "object"); // Default to true if no type is specified
+            .is_none_or(|t| t == "object"); // Default to true if no type is specified
 
         // Only apply full schema validation to object types
         if is_object_type {

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -311,7 +311,7 @@ pub trait Router: Send + Sync + 'static {
                         || arguments
                             .get(&arg.name)
                             .and_then(Value::as_str)
-                            .map_or(true, str::is_empty))
+                            .is_none_or(str::is_empty))
                 {
                     return Err(RouterError::InvalidParams(format!(
                         "Missing required argument: '{}'",


### PR DESCRIPTION


see https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_map_or 
the CI process started using rust 1.85.0 which introduced these warnings on `cargo clippy -- -D warnings`