### PR TITLE
feat: consolidate goose settings config 

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -151,9 +151,9 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
             )
             .item("remove", "Remove Extension", "Remove an extension")
             .item(
-                "tool_output",
-                "Adjust Tool Output",
-                "Show more or less tool output",
+                "settings",
+                "Adjust Goose Settings",
+                "Set the Goose Mode, Tool Output, and more",
             )
             .interact()?;
 
@@ -161,7 +161,7 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
             "toggle" => toggle_extensions_dialog(),
             "add" => configure_extensions_dialog(),
             "remove" => remove_extension_dialog(),
-            "tool_output" => configure_tool_output_dialog(),
+            "settings" => configure_settings_dialog(),
             "providers" => configure_provider_dialog().await.and(Ok(())),
             _ => unreachable!(),
         }
@@ -621,12 +621,77 @@ pub fn remove_extension_dialog() -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
+pub fn configure_settings_dialog() -> Result<(), Box<dyn Error>> {
+    let setting_type = cliclack::select("What setting would you like to configure?")
+        .item(
+            "goose_mode",
+            "Goose Mode",
+            "Configure Goose mode",
+        )
+        .item(
+            "tool_output",
+            "Tool Output",
+            "Show more or less tool output",
+        )
+        .interact()?;
+
+    match setting_type {
+        "goose_mode" => {
+            configure_goose_mode_dialog()?;
+        }
+        "tool_output" => {
+            configure_tool_output_dialog()?;
+        }
+        _ => unreachable!(),
+    };
+ 
+    Ok(())
+}
+
+pub fn configure_goose_mode_dialog() -> Result<(), Box<dyn Error>> {
+    let config = Config::global();
+    let mode = cliclack::select("Which Goose mode would you like to configure?")
+        .item(
+            "auto",
+            "Auto Mode", 
+            "Full file modification, extension usage, edit, create and delete files freely"
+        )
+        .item(
+            "approve",
+            "Approve Mode",
+            "Editing, creating, deleting files and using extensions will require human approval"
+        )
+        .item(
+            "chat",
+            "Chat Mode",
+            "Engage with the selected provider without using tools, extensions, or file modification"
+        )
+        .interact()?;
+
+    match mode {
+        "auto" => {
+            config.set("GOOSE_MODE", Value::String("auto".to_string()))?;
+            cliclack::outro("Set to Auto Mode - full file modification enabled")?;
+        }
+        "approve" => {
+            config.set("GOOSE_MODE", Value::String("approve".to_string()))?;
+            cliclack::outro("Set to Approve Mode - modifications require approval")?;
+        }
+        "chat" => {
+            config.set("GOOSE_MODE", Value::String("chat".to_string()))?;
+            cliclack::outro("Set to Chat Mode - no tools or modifications enabled")?;
+        }
+        _ => unreachable!(),
+    };
+    Ok(())
+}
+
 pub fn configure_tool_output_dialog() -> Result<(), Box<dyn Error>> {
     let config = Config::global();
     let tool_log_level = cliclack::select("Which tool output would you like to show?")
         .item("high", "High Importance", "")
         .item("medium", "Medium Importance", "Ex. results of file-writes")
-        .item("all", "All", "Ex. shell command output")
+        .item("all", "All (default)", "Ex. shell command output")
         .interact()?;
 
     match tool_log_level {

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -152,7 +152,7 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
             .item("remove", "Remove Extension", "Remove an extension")
             .item(
                 "settings",
-                "Adjust Goose Settings",
+                "Goose Settings",
                 "Set the Goose Mode, Tool Output, and more",
             )
             .interact()?;


### PR DESCRIPTION
Goose config: consolidate `tool output` and `goose modes` into `Goose Settings`

<img width="749" alt="image" src="https://github.com/user-attachments/assets/b77906b3-859f-4f0a-a4ff-3d130d5d0819" />
