### PR TITLE
fix: fixing UI styling of modals

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.7"
+    "version": "1.0.8"
   },
   "paths": {
     "/config": {

--- a/ui/desktop/src/components/settings/ProviderSetupModal.tsx
+++ b/ui/desktop/src/components/settings/ProviderSetupModal.tsx
@@ -45,7 +45,7 @@ export function ProviderSetupModal({
 
   return (
     <div className="fixed inset-0 bg-black/20 dark:bg-white/20 backdrop-blur-sm transition-colors animate-[fadein_200ms_ease-in_forwards]">
-      <Card className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[800px] bg-bgApp rounded-xl overflow-hidden shadow-none p-[16px] pt-[24px] pb-0">
+      <Card className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] bg-bgApp rounded-xl overflow-hidden shadow-none p-[16px] pt-[24px] pb-0">
         <div className="px-4 pb-0 space-y-8">
           {/* Header */}
           <div className="flex">


### PR DESCRIPTION
UI styling of modals was broken by changing the width to 800px from 500px [here](https://github.com/block/goose/pull/1201/files#diff-978d31b4e329a4fbc88baaffe0bb2d19e3529ac38bc9285822036b347e6e8f97R48)

In this change, it is fixed

Before

![Screenshot 2025-02-21 at 11 17 02](https://github.com/user-attachments/assets/6a86b140-d12a-4bfa-97ab-22dbcd2fbece)

After

![Screenshot 2025-02-21 at 11 17 21](https://github.com/user-attachments/assets/b3ea184c-0e53-491a-89d7-b005f76b915c)



