### PR TITLE
fix: ./add-macos-cert.sh: No such file or directory

### DIFF
--- a/.github/workflows/bundle-desktop.yml
+++ b/.github/workflows/bundle-desktop.yml
@@ -124,7 +124,7 @@ jobs:
 
       - name: Add MacOS certs for signing and notarization
         if: ${{ inputs.signing }}
-        run: ./add-macos-cert.sh
+        run: ./scripts/add-macos-cert.sh
         working-directory: ui/desktop
         env:
           CERTIFICATE_OSX_APPLICATION: ${{ secrets.CERTIFICATE_OSX_APPLICATION }}


### PR DESCRIPTION
The script was moved in https://github.com/block/goose/pull/1319