### PR TITLE
fix: deep link installs of extensions

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -13,12 +13,13 @@ import { extractExtensionName } from './components/settings/extensions/utils';
 
 import WelcomeView from './components/WelcomeView';
 import ChatView from './components/ChatView';
-import SettingsView from './components/settings/SettingsView';
+import SettingsView, { type SettingsViewOptions } from './components/settings/SettingsView';
 import MoreModelsView from './components/settings/models/MoreModelsView';
 import ConfigureProvidersView from './components/settings/providers/ConfigureProvidersView';
 
 import 'react-toastify/dist/ReactToastify.css';
 
+// Views and their options
 export type View =
   | 'welcome'
   | 'chat'
@@ -27,15 +28,27 @@ export type View =
   | 'configureProviders'
   | 'configPage';
 
+export type ViewConfig = {
+  view: View;
+  viewOptions?: SettingsViewOptions | Record<any, any>;
+};
+
 export default function App() {
   const [fatalError, setFatalError] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [pendingLink, setPendingLink] = useState<string | null>(null);
   const [modalMessage, setModalMessage] = useState<string>('');
   const [isInstalling, setIsInstalling] = useState(false);
-  const [view, setView] = useState<View>('welcome');
+  const [{ view, viewOptions }, setInternalView] = useState<ViewConfig>({
+    view: 'welcome',
+    viewOptions: {},
+  });
+
   const { switchModel } = useModel();
   const { addRecentModel } = useRecentModels();
+  const setView = (view: View, viewOptions: Record<any, any> = {}) => {
+    setInternalView({ view, viewOptions });
+  };
 
   // Utility function to extract the command from the link
   function extractCommand(link: string): string {
@@ -193,6 +206,7 @@ export default function App() {
                 setView('chat');
               }}
               setView={setView}
+              viewOptions={viewOptions as SettingsViewOptions}
             />
           )}
           {view === 'moreModels' && (

--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -46,15 +46,20 @@ const DEFAULT_SETTINGS: SettingsType = {
   extensions: BUILT_IN_EXTENSIONS,
 };
 
+export type SettingsViewOptions = {
+  extensionId: string;
+  showEnvVars: boolean;
+};
+
 export default function SettingsView({
   onClose,
   setView,
+  viewOptions,
 }: {
   onClose: () => void;
   setView: (view: View) => void;
+  viewOptions: SettingsViewOptions;
 }) {
-  const [searchParams] = useState(() => new URLSearchParams(window.location.search));
-
   const [settings, setSettings] = React.useState<SettingsType>(() => {
     const saved = localStorage.getItem('user_settings');
     window.electron.logInfo('Settings: ' + saved);
@@ -101,10 +106,10 @@ export default function SettingsView({
 
   // Handle URL parameters for auto-opening extension configuration
   useEffect(() => {
-    const extensionId = searchParams.get('extensionId');
-    const showEnvVars = searchParams.get('showEnvVars');
+    const extensionId = viewOptions.extensionId;
+    const showEnvVars = viewOptions.showEnvVars;
 
-    if (extensionId && showEnvVars === 'true') {
+    if (extensionId && showEnvVars === true) {
       // Find the extension in settings
       const extension = settings.extensions.find((ext) => ext.id === extensionId);
       if (extension) {

--- a/ui/desktop/src/extensions.ts
+++ b/ui/desktop/src/extensions.ts
@@ -1,5 +1,6 @@
 import { getApiUrl, getSecretKey } from './config';
 import { type View } from './App';
+import { type SettingsViewOptions } from './components/settings/SettingsView';
 import { toast } from 'react-toastify';
 
 // ExtensionConfig type matching the Rust version
@@ -194,7 +195,7 @@ function storeExtensionConfig(config: FullExtensionConfig) {
       localStorage.setItem('user_settings', JSON.stringify(userSettings));
       console.log('Extension config stored successfully in user_settings');
       // Notify settings update through electron IPC
-      window.electron.send('settings-updated');
+      window.electron.emit('settings-updated');
     } else {
       console.log('Extension config already exists in user_settings');
     }
@@ -258,7 +259,10 @@ function handleError(message: string, shouldThrow = false): void {
   }
 }
 
-export async function addExtensionFromDeepLink(url: string, setView: (view: View) => void) {
+export async function addExtensionFromDeepLink(
+  url: string,
+  setView: (view: View, options: SettingsViewOptions) => void
+) {
   if (!url.startsWith('goose://extension')) {
     handleError(
       'Failed to install extension: Invalid URL: URL must use the goose://extension scheme'
@@ -344,9 +348,7 @@ export async function addExtensionFromDeepLink(url: string, setView: (view: View
   // Check if extension requires env vars and go to settings if so
   if (envVarsRequired(config)) {
     console.log('Environment variables required, redirecting to settings');
-    setView('settings');
-    // TODO - add code which can auto-open the modal on the settings view
-    // navigate(`/settings?extensionId=${config.id}&showEnvVars=true`);
+    setView('settings', { extensionId: config.id, showEnvVars: true });
     return;
   }
 

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -26,6 +26,7 @@ type ElectronAPI = {
     channel: string,
     callback: (event: Electron.IpcRendererEvent, ...args: any[]) => void
   ) => void;
+  emit: (channel: string, ...args: any[]) => void;
 };
 
 type AppConfigAPI = {
@@ -54,6 +55,9 @@ const electronAPI: ElectronAPI = {
   },
   off: (channel: string, callback: (event: Electron.IpcRendererEvent, ...args: any[]) => void) => {
     ipcRenderer.off(channel, callback);
+  },
+  emit: (channel: string, ...args: any[]) => {
+    ipcRenderer.emit(channel, ...args);
   },
 };
 


### PR DESCRIPTION
Deep link installs of extensions were completely broken. This fixes the feature by:

* Resetting much of the code related to handling the `goose://` protocol in `main.ts`
* Adding a new concept of `View` and `ViewOptions` which can be used to populate options when routing to a certain view (used to navigate to settings and open the env var entry modal dialog if env vars are needed to configure and enable an extension)

![Screenshot 2025-02-21 at 15 08 02](https://github.com/user-attachments/assets/088024f5-757a-475d-a445-1aa1e09e80e2)
![Screenshot 2025-02-21 at 15 08 07](https://github.com/user-attachments/assets/8c9c5539-9cfb-4134-83c9-a8a5161da5fa)
