### PR TITLE
bug: Fix env var for openAI

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.8"
+    "version": "1.0.9"
   },
   "paths": {
     "/config": {


### PR DESCRIPTION
Since adding the OPENAI_HOST, OLLAMA_HOST, and other environment variables to the `default_key_value` object in `ui/desktop/src/components/settings/api_keys/utils.tsx`, the `getActiveProviders` function was not registering OpenAI as active if you had a key in `~/.zshrc`. This was because we considered it not configured if we hadn't set OPENAI_HOST.

We now correctly identify providers like openAI where there's 1* needed key, and 1* default key. 

If a provider has N needed keys (such as OpenAI needing OPENAI_API_KEY), and M default keys (such as OPENAI_HOST), the provider is considered active if all N needed keys are set, and the M default keys do not matter.

BUT if a provider has 0 needed keys (such as Ollama), and M default keys (such as OLLAMA_HOST), the provider is considered active if at least one default key is set. This is a necessary check because for cases like Ollama, we don't want to consider it active off the bat unless the user has indicated the host. If we did a blanket filter of default_keys (ie any provider with only 1+ keys that are listed as keys with defaults to fall back to) Ollama would _always_ get shown as active.  

