### PR TITLE
docs: rearrange menu

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -117,25 +117,31 @@ const config: Config = {
           position: "left",
         },
         {
-          to: "/docs/category/getting-started",
-          position: "left",
-          label: "Docs",
-        },
-        { to: "/blog", label: "Blog", position: "left" },
-        {
           to: "https://block.github.io/goose/v1/extensions/",
           label: "Extensions",
           position: "left",
         },
         {
+          to: "/docs/category/getting-started",
+          position: "left",
+          label: "Docs",
+        },
+        {
+          to: "/docs/category/tutorials",
+          position: "left",
+          label: "Tutorials",
+        },
+        { to: "/blog", label: "Blog", position: "left" },
+
+        {
           href: "https://discord.gg/block-opensource",
           label: "Discord",
-          position: "left",
+          position: "right",
         },
         {
           href: "https://github.com/block/goose",
           label: "GitHub",
-          position: "left",
+          position: "right",
         },
       ],
     },


### PR DESCRIPTION
* Reordered `Extensions` link in navigation bar from 4th to 2nd link
* Added `Tutorials` link to nav bar
* Moved `Discord` and `GitHub` links from the left to the right side of the navigation bar.

**Before**

<img width="1701" alt="image" src="https://github.com/user-attachments/assets/a83acb80-c34d-49be-91cb-a8dc5eed21c4" />


**After**

<img width="1708" alt="image" src="https://github.com/user-attachments/assets/04dc24a2-d1ba-4971-8765-dba11c86c7a5" />
