### PR TITLE
Check that we have wl-copy and paste

### DIFF
--- a/crates/goose-mcp/src/computercontroller/platform/linux.rs
+++ b/crates/goose-mcp/src/computercontroller/platform/linux.rs
@@ -86,7 +86,7 @@ impl LinuxAutomation {
     }
 
     fn check_wayland_dependencies(&self) -> Result<()> {
-        let wayland_deps = ["wtype", "wl-clipboard"];
+        let wayland_deps = ["wtype", "wl-copy", "wl-paste"];
         self.check_dependencies(&wayland_deps)
     }
 


### PR DESCRIPTION
this replaces checking if wl-clipboard is installed, since wl-clipboard is not an actually executable (as far as i know)