### PR TITLE
docs: links for tutorials

### DIFF
--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -11,6 +11,11 @@ Extensions are add-ons that provide a way to extend the functionality of Goose b
 Extensions are based on the [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol), so you can connect
 Goose to a wide ecosystem of capabilities.
 
+:::tip Tutorials
+Check out the [step-by-step tutorials](/docs/category/tutorials) for adding and using several Goose Extensions
+:::
+
+
 ## Built-in Extensions
 Out of the box, Goose is installed with a few extensions but with only the `Developer` extension enabled by default.
 
@@ -78,7 +83,7 @@ Here are the built-in extensions:
 </Tabs>
 
 
-:::tip
+:::info
 All of Goose's built-in extensions are MCP servers in their own right. If you'd like
 to use the MCP servers included with Goose with any other agent, you are free to do so.
 :::
@@ -95,16 +100,12 @@ You can also add any other [MCP Server](#mcp-servers) as a Goose extension, even
 
 Extensions can be installed directly via the [extensions directory][extensions-directory], CLI, or UI.
 
-:::tip
-For advanced users, you can also edit the `~/.config/goose/config.yaml` file directly to add an extension. 
-:::
-
 ### MCP Servers
 
 You can install any MCP server as a Goose extension. 
 
 :::tip MCP Server Directory
-See available servers in the **[MCP Server Directory](https://github.com/modelcontextprotocol/servers?tab=readme-ov-file#model-context-protocol-servers)**.
+See available servers in the **[MCP Server Directory](https://www.pulsemcp.com/servers)**.
 :::
 
 <Tabs groupId="interface">
@@ -125,28 +126,28 @@ See available servers in the **[MCP Server Directory](https://github.com/modelco
 
   4. Follow the prompts based on the type of extension you selected.
 
-  #### Example of adding the [Fetch MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch):
+  #### Example of adding the [Knowledge Graph Memory MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory):
 
   ```
-  ┌   goose-configure 
-  │
-  ◇  What would you like to configure?
-  │  Add Extension 
-  │
-  ◇  What type of extension would you like to add?
-  │  Command-line Extension 
-  │
-  ◇  What would you like to call this extension?
-  │  fetch
-  │
-  ◇  What command should be run?
-  │  uvx mcp-server-fetch
-  │
-  ◇  Would you like to add environment variables?
-  │  No 
-  │
-  └  Added fetch extension
-  ```
+ ┌   goose-configure 
+ │
+ ◇  What would you like to configure?
+ │  Add Extension 
+ │
+ ◇  What type of extension would you like to add?
+ │  Command-line Extension 
+ │
+ ◇  What would you like to call this extension?
+ │  Knowledge Graph Memory
+ │
+ ◇  What command should be run?
+ │  npx -y @modelcontextprotocol/server-memory
+ │
+ ◆  Would you like to add environment variables?
+ │  No 
+ │
+ └  Added Knowledge Graph Memory extension
+ ```
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
@@ -157,18 +158,14 @@ See available servers in the **[MCP Server Directory](https://github.com/modelco
   4. On the `Add Extension Manually` modal, enter the necessary details and click `Add` button
   5. Click `Add Extension` button
   
-  #### Example of adding the [Fetch MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch):
+  #### Example of adding the [Knowledge Graph Memory MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory):
     * **Type**: `Standard IO`
-    * **ID**: `fetch` (_set this to whatever you want_)
-    * **Name**: `fetch` (_set this to whatever you want_)
-    * **Description**: `Fetch MCP Server` (_set this to whatever you want_)
-    * **Command**: `uvx mcp-server-fetch`
+    * **ID**: `kgm-mcp` (_set this to whatever you want_)
+    * **Name**: `Knowledge Graph Memory` (_set this to whatever you want_)
+    * **Description**: `maps and stores complex relationships between concepts` (_set this to whatever you want_)
+    * **Command**: `npx -y @modelcontextprotocol/server-memory`
   </TabItem>
 </Tabs>
-
-  :::tip Tutorials
-  Check out our [tutorials](/docs/category/tutorials) with step-by-step instructions on adding MCP Servers.
-  :::
 
 ### Config Entry
 For advanced users, you can also directly edit the config file (`~/.config/goose/config.yaml`) to add, remove, or update an extension:

--- a/documentation/docs/tutorials/jetbrains-mcp.md
+++ b/documentation/docs/tutorials/jetbrains-mcp.md
@@ -1,6 +1,6 @@
 ---
 title: JetBrains Extension
-description: Add JetBrains MCP Server as a Goose Extension
+description: Use JetBrains MCP Server as a Goose Extension
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
- added link to tutorials to Using Extensions guide
- add link to PulseMCP server directory
- changed example to Knowledge Graph Memory extension
