### PR TITLE
Remove Screenshot from Using Extension Guide

### DIFF
--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -212,10 +212,8 @@ You can enable or disable installed extensions based on your workflow needs.
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
   1. Click the three dots in the top-right corner of the application.
-  2. Select `Settings` from the menu, then click on the `Extensions` section.
+  2. Select `Settings` from the menu, scroll down to the `Extensions` section.
   2. Use the toggle switch next to each extension to enable or disable it.
-
-  ![Install Extension](../assets/guides/manage-extensions-ui.png)
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
This update removes an outdated screenshot from the **Using Extensions** documentation to improve clarity.

- **Removed:** `manage-extensions-ui.png` screenshot.
- **Updated:** Adjusted wording for better readability.



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209476671933343