### PR TITLE
feat: allow setting openai base path

### DIFF
--- a/crates/goose-server/src/routes/providers_and_keys.json
+++ b/crates/goose-server/src/routes/providers_and_keys.json
@@ -3,7 +3,7 @@
         "name": "OpenAI",
         "description": "Use GPT-4 and other OpenAI models",
         "models": ["gpt-4o", "gpt-4-turbo","o1"],
-        "required_keys": ["OPENAI_API_KEY", "OPENAI_HOST"]
+        "required_keys": ["OPENAI_API_KEY", "OPENAI_HOST", "OPENAI_BASE_PATH"]
     },
     "anthropic": {
         "name": "Anthropic",

--- a/ui/desktop/src/components/settings/api_keys/utils.tsx
+++ b/ui/desktop/src/components/settings/api_keys/utils.tsx
@@ -8,6 +8,7 @@ export function isSecretKey(keyName: string): boolean {
     'DATABRICKS_HOST',
     'OLLAMA_HOST',
     'OPENAI_HOST',
+    'OPENAI_BASE_PATH',
     'AZURE_OPENAI_ENDPOINT',
     'AZURE_OPENAI_DEPLOYMENT_NAME',
   ];
@@ -24,22 +25,22 @@ export async function getActiveProviders(): Promise<string[]> {
     const configSettings = await getConfigSettings();
 
     const activeProviders = Object.values(configSettings)
-        .filter((provider) => {
-          // 1. Get provider's config_status
-          const configStatus = provider.config_status ?? {};
+      .filter((provider) => {
+        // 1. Get provider's config_status
+        const configStatus = provider.config_status ?? {};
 
-          // 2. Collect only the keys *not* in default_key_value
-          const requiredKeyEntries = Object.entries(configStatus).filter(([k]) => isRequiredKey(k));
+        // 2. Collect only the keys *not* in default_key_value
+        const requiredKeyEntries = Object.entries(configStatus).filter(([k]) => isRequiredKey(k));
 
-          // 3. If there are *no* non-default keys, it is NOT active
-          if (requiredKeyEntries.length === 0) {
-            return false;
-          }
+        // 3. If there are *no* non-default keys, it is NOT active
+        if (requiredKeyEntries.length === 0) {
+          return false;
+        }
 
-          // 4. Otherwise, all non-default keys must be `is_set`
-          return requiredKeyEntries.every(([_, value]) => value?.is_set);
-        })
-        .map((provider) => provider.name || 'Unknown Provider');
+        // 4. Otherwise, all non-default keys must be `is_set`
+        return requiredKeyEntries.every(([_, value]) => value?.is_set);
+      })
+      .map((provider) => provider.name || 'Unknown Provider');
 
     console.log('[GET ACTIVE PROVIDERS]:', activeProviders);
     return activeProviders;

--- a/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
+++ b/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
@@ -65,7 +65,7 @@ export function getDefaultModel(key: string): string | undefined {
 export const short_list = ['gpt-4o', 'claude-3-5-sonnet-latest'];
 
 export const required_keys = {
-  OpenAI: ['OPENAI_API_KEY', 'OPENAI_HOST'],
+  OpenAI: ['OPENAI_API_KEY', 'OPENAI_HOST', 'OPENAI_BASE_PATH'],
   Anthropic: ['ANTHROPIC_API_KEY'],
   Databricks: ['DATABRICKS_HOST'],
   Groq: ['GROQ_API_KEY'],
@@ -77,6 +77,7 @@ export const required_keys = {
 
 export const default_key_value = {
   OPENAI_HOST: 'https://api.openai.com',
+  OPENAI_BASE_PATH: 'v1/chat/completions',
   OLLAMA_HOST: 'localhost',
 };
 


### PR DESCRIPTION
Test:
<img width="505" alt="Screenshot 2025-02-24 at 1 41 19 PM" src="https://github.com/user-attachments/assets/1c71295c-8278-4c21-8ca4-78c8ddf12a12" />


```
●  OPENAI_HOST is already configured
│  
◇  Would you like to update this value?
│  No 
│
◇  Provider OpenAI requires OPENAI_BASE_PATH, please enter a value
│  v1/chat/completions
│
◇  Enter a model from that provider:
│  gpt-4o
│
◐  Checking your configuration...                                                                                                   └  Configuration saved successfully
```