### PR TITLE
feat: interactive after run

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -106,6 +106,14 @@ enum Command {
         )]
         input_text: Option<String>,
 
+        /// Continue in interactive mode after processing input
+        #[arg(
+            short = 's',
+            long = "interactive",
+            help = "Continue in interactive mode after processing initial input"
+        )]
+        interactive: bool,
+
         /// Name for this run session
         #[arg(
             short,
@@ -182,12 +190,13 @@ async fn main() -> Result<()> {
         }) => {
             let mut session = build_session(name, resume, extension, builtin).await;
             setup_logging(session.session_file().file_stem().and_then(|s| s.to_str()))?;
-            let _ = session.start().await;
+            let _ = session.interactive(None).await;
             return Ok(());
         }
         Some(Command::Run {
             instructions,
             input_text,
+            interactive,
             name,
             resume,
             extension,
@@ -213,7 +222,12 @@ async fn main() -> Result<()> {
             };
             let mut session = build_session(name, resume, extension, builtin).await;
             setup_logging(session.session_file().file_stem().and_then(|s| s.to_str()))?;
-            let _ = session.headless_start(contents.clone()).await;
+
+            if interactive {
+                let _ = session.interactive(Some(contents)).await?;
+            } else {
+                let _ = session.headless(contents).await?;
+            }
             return Ok(());
         }
         Some(Command::Agents(cmd)) => {

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -224,9 +224,9 @@ async fn main() -> Result<()> {
             setup_logging(session.session_file().file_stem().and_then(|s| s.to_str()))?;
 
             if interactive {
-                let _ = session.interactive(Some(contents)).await?;
+                session.interactive(Some(contents)).await?;
             } else {
-                let _ = session.headless(contents).await?;
+                session.headless(contents).await?;
             }
             return Ok(());
         }

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1,7 +1,7 @@
 use bat::WrappingMode;
 use console::style;
 use goose::config::Config;
-use goose::message::{Message, MessageContent, ToolConfirmationRequest, ToolRequest, ToolResponse};
+use goose::message::{Message, MessageContent, ToolRequest, ToolResponse};
 use mcp_core::tool::ToolCall;
 use serde_json::Value;
 use std::cell::RefCell;
@@ -94,11 +94,11 @@ pub fn render_message(message: &Message) {
             MessageContent::Text(text) => print_markdown(&text.text, theme),
             MessageContent::ToolRequest(req) => render_tool_request(req, theme),
             MessageContent::ToolResponse(resp) => render_tool_response(resp, theme),
-            MessageContent::ToolConfirmationRequest(req) => {
-                render_tool_confirmation_request(req, theme)
-            }
             MessageContent::Image(image) => {
                 println!("Image: [data: {}, type: {}]", image.data, image.mime_type);
+            }
+            _ => {
+                println!("Message type could not be rendered");
             }
         }
     }
@@ -147,17 +147,6 @@ fn render_tool_response(resp: &ToolResponse, theme: Theme) {
             }
         }
         Err(e) => print_markdown(&e.to_string(), theme),
-    }
-}
-
-fn render_tool_confirmation_request(req: &ToolConfirmationRequest, theme: Theme) {
-    match &req.prompt {
-        Some(prompt) => {
-            let colored_prompt =
-                prompt.replace("Allow? (y/n)", &format!("{}", style("Allow? (y/n)").cyan()));
-            println!("{}", colored_prompt);
-        }
-        None => print_markdown("No prompt provided", theme),
     }
 }
 


### PR DESCRIPTION
This adds a flag -s/--interactive that drops into an interactive session after starting from a CLI/file message