### PR TITLE
feat: Add tutorial built-in extension for app

### DIFF
--- a/ui/desktop/src/extensions.ts
+++ b/ui/desktop/src/extensions.ts
@@ -74,6 +74,14 @@ export const BUILT_IN_EXTENSIONS = [
     type: 'builtin',
     env_keys: [],
   },
+  {
+    id: 'tutorial',
+    name: 'Tutorial',
+    description: 'Access interactive tutorials and guides',
+    enabled: false,
+    type: 'builtin',
+    env_keys: [],
+  },
   /* TODO re-enable when we have a smoother auth flow {
     id: 'google_drive',
     name: 'Google Drive',


### PR DESCRIPTION
@acekyd Mentioned we don't yet include/show the tutorial extension in the app - this enables it.

I remember a conversation last week about tutorials and how we'd want it to reflect in the app, but don't recall the result. I can close this out if we have something different in mind. This does facilitate a basic UX for proceeding through a tutorial.

<img width="990" alt="Screenshot 2025-02-25 at 14 32 00" src="https://github.com/user-attachments/assets/707ec7a4-de9a-4a0f-97f9-1750c030f418" />
<img width="987" alt="Screenshot 2025-02-25 at 14 33 36" src="https://github.com/user-attachments/assets/100d8cfb-e7dd-4da9-933b-3127ae508016" />