### PR TITLE
fix: update approve prompt

### DIFF
--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -261,7 +261,7 @@ impl Agent for TruncateAgent {
                                                 request.id.clone(),
                                                 tool_call.name.clone(),
                                                 tool_call.arguments.clone(),
-                                                Some("Goose would like to call the tool: {}\nAllow? (y/n): ".to_string()),
+                                                Some("Goose would like to call the above tool. Allow? (y/n):".to_string()),
                                             );
                                             yield confirmation;
 


### PR DESCRIPTION
Right now, we have two `Goose would like to call the above tool. Allow? (y/n):` in the terminal screen.

Before:

```
( O)> write a test.txt to my dir
I'll help you write a test.txt file to the current directory. I'll use the text editor tool to create this file.

─── text_editor | developer ──────────────────────────
path: ~/Documents/block/goose/test.txt
command: write
file_text: This is a test file.


Goose would like to call the above tool. Allow? (y/n):

( O)> y
Goose would like to call the above tool. Allow? (y/n):

### /Users/yingjiehe/Documents/block/goose/test.txt
```

After
```
( O)> write a test.txt to my dir
I'll help you write a test.txt file in the current directory. I'll use the text editor tool to create this file.

─── text_editor | developer ──────────────────────────
path: ~/Documents/block/goose/test.txt
command: write
file_text: This is a test file.


Goose would like to call the above tool. Allow? (y/n):

( O)> y
### /Users/yingjiehe/Documents/block/goose/test.txt
```