### PR TITLE
ui: create-chat-window opens most recent directory

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -530,6 +530,10 @@ app.whenReady().then(async () => {
   });
 
   ipcMain.on('create-chat-window', (_, query, dir, version) => {
+    if (!dir?.trim()) {
+      const recentDirs = loadRecentDirs();
+      dir = recentDirs.length > 0 ? recentDirs[0] : null;
+    }
     createChat(app, query, dir, version);
   });
 


### PR DESCRIPTION
**Summary**
Use most recent directory if no directory is specified when creating a new chat window.

**Testing**
![Screenshot 2025-02-25 at 3 02 39 PM](https://github.com/user-attachments/assets/1cac9bd1-563d-46da-94a6-055cbb712a90)

- Open window with ⌘+N 
- Confirm new window has the same directory path.

**Issue**
https://github.com/block/goose/issues/1150

