### PR TITLE
style: added launch text and styling

### DIFF
--- a/ui/desktop/src/components/settings/providers/BaseProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/BaseProviderGrid.tsx
@@ -204,9 +204,10 @@ function BaseProviderCard({
                       e.stopPropagation();
                       onTakeoff();
                     }}
-                    className="rounded-full h-7 w-7 p-0 bg-bgApp hover:bg-bgApp shadow-none text-textSubtle border border-borderSubtle hover:border-borderStandard hover:text-textStandard transition-colors"
+                    className="rounded-full h-7 px-3 bg-bgApp hover:bg-bgApp shadow-none text-textSubtle border border-borderSubtle hover:border-transparent hover:bg-[#FF9772] hover:text-textProminent transition-colors"
                   >
                     <Rocket className="!size-4" />
+                    Launch
                   </Button>
                 </TooltipTrigger>
                 <Portal>


### PR DESCRIPTION
Added `Launch` text to configured providers to make the call-to-action more prominent. This addresses #1270 

<img width="500" alt="Screenshot 2025-02-26 at 9 02 59 PM" src="https://github.com/user-attachments/assets/8aae0441-9aa4-47ed-8722-8f5947c17b61" />
