### PR TITLE
feat: allow user to turn off smart approve

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -622,24 +622,19 @@ pub fn remove_extension_dialog() -> Result<(), Box<dyn Error>> {
 }
 
 pub fn configure_settings_dialog() -> Result<(), Box<dyn Error>> {
-    let mut setting_select_builder = cliclack::select("What setting would you like to configure?")
+    let setting_type = cliclack::select("What setting would you like to configure?")
         .item("goose_mode", "Goose Mode", "Configure Goose mode")
         .item(
             "tool_output",
             "Tool Output",
             "Show more or less tool output",
-        );
-
-    // Conditionally add the "Toggle Experiment" option
-    if ExperimentManager::is_enabled("EXPERIMENT_CONFIG")? {
-        setting_select_builder = setting_select_builder.item(
+        )
+        .item(
             "experiment",
             "Toggle Experiment",
             "Enable or disable an experiment feature",
-        );
-    }
-
-    let setting_type = setting_select_builder.interact()?;
+        )
+        .interact()?;
 
     match setting_type {
         "goose_mode" => {

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -11,6 +11,7 @@ use super::Agent;
 use crate::agents::capabilities::Capabilities;
 use crate::agents::extension::{ExtensionConfig, ExtensionResult};
 use crate::config::Config;
+use crate::config::ExperimentManager;
 use crate::message::{Message, ToolRequest};
 use crate::providers::base::Provider;
 use crate::providers::base::ProviderUsage;
@@ -244,8 +245,11 @@ impl Agent for TruncateAgent {
                         let mode = goose_mode.clone();
                         match mode.as_str() {
                             "approve" => {
+                                let mut read_only_tools = Vec::new();
                                 // Process each tool request sequentially with confirmation
-                                let read_only_tools = detect_read_only_tools(&capabilities, tool_requests.clone()).await;
+                                if ExperimentManager::is_enabled("GOOSE_SMART_APPROVE")? {
+                                    read_only_tools = detect_read_only_tools(&capabilities, tool_requests.clone()).await;
+                                }
                                 for request in &tool_requests {
                                     if let Ok(tool_call) = request.tool_call.clone() {
                                         // Skip confirmation if the tool_call.name is in the read_only_tools list

--- a/crates/goose/src/config/experiments.rs
+++ b/crates/goose/src/config/experiments.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 /// It is the ground truth for init experiments. The experiment names in users' experiment list but not
 /// in the list will be remove from user list; The experiment names in the ground-truth list but not
 /// in users' experiment list will be added to user list with default value false;
-const ALL_EXPERIMENTS: &[(&str, bool)] = &[("EXPERIMENT_CONFIG", false)];
+const ALL_EXPERIMENTS: &[(&str, bool)] = &[("GOOSE_SMART_APPROVE", true)];
 
 /// Experiment configuration management
 pub struct ExperimentManager;
@@ -34,28 +34,19 @@ impl ExperimentManager {
     /// Enable or disable an experiment
     pub fn set_enabled(name: &str, enabled: bool) -> Result<()> {
         let config = Config::global();
-
-        // Load existing experiments or initialize a new map
         let mut experiments: HashMap<String, bool> =
             config.get("experiments").unwrap_or_else(|_| HashMap::new());
 
-        // Update the status of the experiment
         experiments.insert(name.to_string(), enabled);
 
-        // Save the updated experiments map
         config.set("experiments", serde_json::to_value(experiments)?)?;
         Ok(())
     }
 
     /// Check if an experiment is enabled
     pub fn is_enabled(name: &str) -> Result<bool> {
-        let config = Config::global();
-
-        // Load existing experiments or initialize a new map
-        let experiments: HashMap<String, bool> =
-            config.get("experiments").unwrap_or_else(|_| HashMap::new());
-
-        // Return whether the experiment is enabled, defaulting to false
-        Ok(*experiments.get(name).unwrap_or(&false))
+        let experiments = Self::get_all()?;
+        let experiments_map: HashMap<String, bool> = experiments.into_iter().collect();
+        Ok(*experiments_map.get(name).unwrap_or(&false))
     }
 }


### PR DESCRIPTION
Users can use goose configure to enable/disable the smart approve, or directly edit the config.yaml.

ExperimentManager will lazily refresh the experiment list.

Test:

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Goose Settings 
│
◇  What setting would you like to configure?
│  Toggle Experiment 
│
◇  enable experiments: (use "space" to toggle and "enter" to submit)
│  GOOSE_SMART_APPROVE 
│
└  Experiments settings updated successfully
```

```
─── text_editor | developer ──────────────────────────
path: ~/Documents/block/goose/test.txt
command: write
file_text: This is a test file.


◇  Goose would like to call the above tool, do you approve?
│  Yes 
│
### /Users/yingjiehe/Documents/block/goose/test.txt

This is a test file.


I've created a file named "test.txt" with some simple content. Let me verify that the file was created by checking its contents:

─── text_editor | developer ──────────────────────────
path: ~/Documents/block/goose/test.txt
command: view
```