### PR TITLE
docs: adding update command to cli command guide

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -31,6 +31,13 @@ import RateLimits from '@site/src/components/RateLimits';
         ```sh
         curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
         ```
+
+        :::tip Updating Goose CLI
+        It's best to keep Goose updated. To update Goose, run:
+        ```sh
+        goose update
+        ```
+        :::
       </TabItem>
       <TabItem value="ui" label="Goose Desktop">
         To install Goose, click the **button** below:
@@ -47,6 +54,10 @@ import RateLimits from '@site/src/components/RateLimits';
           1. Unzip the downloaded `Goose.zip` file.
           2. Run the executable file to launch the Goose desktop application.
 
+          :::tip Updating Goose Desktop
+          It's best to keep Goose updated. To update, reperform installation steps.
+          :::
+
           :::note Permissions
             If you’re on an Apple Mac M3 and the Goose desktop app shows no window on launch, check and update the following:
 
@@ -55,7 +66,6 @@ import RateLimits from '@site/src/components/RateLimits';
             Goose needs this access to create the log directory and file. Once permissions are granted, the app should load correctly. For steps on how to do this, refer to the  [Troubleshooting Guide](/docs/troubleshooting.md#macos-permission-issues-m3-macs)
           :::
         </div>
-
       </TabItem>
     </Tabs>
   </TabItem>
@@ -104,13 +114,7 @@ import RateLimits from '@site/src/components/RateLimits';
     curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
     ```  
   </TabItem>
-
 </Tabs>
-
-  :::tip Updating Goose
-  It’s best to keep Goose updated. To update, reperform installation steps.
-  :::
-
 
 ## Set LLM Provider
 Goose works with a set of [supported LLM providers][providers], and you’ll need an API key to get started. When you use Goose for the first time, you’ll be prompted to select a provider and enter your API key.

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -32,7 +32,7 @@ import RateLimits from '@site/src/components/RateLimits';
         curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
         ```
 
-        :::tip Updating Goose CLI
+        :::tip Updating Goose
         It's best to keep Goose updated. To update Goose, run:
         ```sh
         goose update
@@ -54,7 +54,7 @@ import RateLimits from '@site/src/components/RateLimits';
           1. Unzip the downloaded `Goose.zip` file.
           2. Run the executable file to launch the Goose desktop application.
 
-          :::tip Updating Goose Desktop
+          :::tip Updating Goose
           It's best to keep Goose updated. To update, reperform installation steps.
           :::
 

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -106,6 +106,30 @@ goose --version
 
 ---
 
+### update [options]
+
+Update the Goose CLI to a newer version.
+
+**Options:**
+
+- **`--canary, -c`**: Update to the canary (development) version instead of the stable version
+- **`--reconfigure, -r`**: Forces Goose to reset configuration settings during the update process
+
+**Usage:**
+
+```bash
+# Update to latest stable version
+goose update
+
+# Update to latest canary version
+goose update --canary
+
+# Update and reconfigure settings
+goose update --reconfigure
+```
+
+---
+
 ### mcp
 
 Run an enabled MCP server specified by `<name>` (e.g. 'Google Drive')

--- a/documentation/docs/guides/updating-goose.md
+++ b/documentation/docs/guides/updating-goose.md
@@ -9,16 +9,22 @@ import TabItem from '@theme/TabItem';
 import { IconDownload } from "@site/src/components/icons/download";
 import Link from "@docusaurus/Link";
 
-:::info
-To update Goose to the latest stable version, reinstall using the instructions below
-:::
-
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
-    You can update Goose by simply running:
+    You can update Goose by running:
 
     ```sh
     goose update
+    ```
+
+    Additional [options](/docs/guides/goose-cli-commands#update-options):
+    
+    ```sh
+    # Update to latest canary (development) version
+    goose update --canary
+
+    # Update and reconfigure settings
+    goose update --reconfigure
     ```
 
     Or you can run the [installation](/docs/getting-started/installation) script again:
@@ -35,6 +41,9 @@ To update Goose to the latest stable version, reinstall using the instructions b
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
+        :::info
+        To update Goose to the latest stable version, reinstall using the instructions below
+        :::
         <div style={{ marginTop: '1rem' }}>
           1. To update Goose Desktop, click the button below:
             <div className="pill-button">
@@ -53,5 +62,3 @@ To update Goose to the latest stable version, reinstall using the instructions b
         </div>
   </TabItem>
 </Tabs>
-
-All configuration settings will remain the same, with Goose updated to the latest version.


### PR DESCRIPTION
This pull request adds a new section to the Goose CLI documentation, detailing the `update` command and its options.

Documentation updates:

* [`documentation/docs/guides/goose-cli-commands.md`](diffhunk://#diff-3dcfd1ace334a91a35076b1c7e66337d2466d0aa1a5a13ee7e20db186fe401e4R109-R132): Added a new section for the `update` command, including options for updating to the canary version and forcing reconfiguration during the update process.