### PR TITLE
docs: Adding YT short for Computer Controller Tutorial

### DIFF
--- a/documentation/docs/tutorials/computer-controller-mcp.md
+++ b/documentation/docs/tutorials/computer-controller-mcp.md
@@ -7,6 +7,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/EuMzToNOQtw" />
+
 The Computer Controller extension helps automate everyday computer tasks and web interactions such as searching the web, controlling system settings, processing data files, and controlling applications without needing to know how to code.
 
 This tutorial covers enabling and using the Computer Controller MCP Server, which is a built-in Goose extension.


### PR DESCRIPTION
This pull request includes a small change to the `documentation/docs/tutorials/computer-controller-mcp.md` file. The change adds a YouTube video embed to the tutorial documentation.

* [`documentation/docs/tutorials/computer-controller-mcp.md`](diffhunk://#diff-8e9ab4ed524c97ce51c637da42c05b9ba6c0b913ae49abfeb27430a2a41adba7R10-R11): Added a YouTube video embed with the URL `https://www.youtube.com/embed/EuMzToNOQtw`.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209354827268319