### PR TITLE
fix: gemini empty content

### DIFF
--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -425,7 +425,6 @@ mod tests {
 
         let messages = vec![set_up_tool_response_message("response_id", tool_result)];
         let payload = format_messages(&messages);
-        tracing::debug!("debug {:?}", payload);
 
         let expected_payload = vec![json!({
             "role": "model",

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -94,7 +94,7 @@ pub fn format_messages(messages: &[Message]) -> Vec<Value> {
                                     parts.push(json!({
                                         "functionResponse": {
                                             "name": response.id,
-                                            "response": {"content": text},
+                                            "response": {"content": {"text": text}},
                                         }}
                                     ));
                                 }
@@ -413,6 +413,37 @@ mod tests {
             payload[0]["parts"][0]["functionResponse"]["response"]["content"]["text"],
             "Hello"
         );
+    }
+
+    #[test]
+    fn test_message_to_google_spec_tool_result_multiple_texts() {
+        let tool_result: Vec<Content> = vec![
+            Content::text("Hello"),
+            Content::text("World"),
+            Content::text("This is a test."),
+        ];
+
+        let messages = vec![set_up_tool_response_message("response_id", tool_result)];
+        let payload = format_messages(&messages);
+        tracing::debug!("debug {:?}", payload);
+
+        let expected_payload = vec![json!({
+            "role": "model",
+            "parts": [
+                {
+                    "functionResponse": {
+                        "name": "response_id",
+                        "response": {
+                            "content": {
+                                "text": "Hello\nWorld\nThis is a test."
+                            }
+                        }
+                    }
+                }
+            ]
+        })];
+
+        assert_eq!(payload, expected_payload);
     }
 
     #[test]


### PR DESCRIPTION
fix #1359 
In our tool call, the response may be empty, like running command `touch xxx`, in such case, gemini will return the error about empty content part. Fix it by setting default content.
Also gemini requires the number of function response parts should be equal to number of function call parts of the function call turn, sometime the tool response can have multiple content part, we need to combine them into one content

Before:
```
( O)> create a test.txt file under the dir

─── shell | developer ──────────────────────────
command: touch test.txt


◇  Goose would like to call the above tool, do you approve?
│  Yes 
│

◐  Enchanting electrons...                                                                                                            2025-02-27T18:24:55.244805Z ERROR goose::agents::truncate: Error: Request failed: Request failed with status: 400 Bad Request. Message: * GenerateContentRequest.contents[6].parts: contents.parts must not be empty.

    at crates/goose/src/agents/truncate.rs:375

Ran into this error: Request failed: Request failed with status: 400 Bad Request. Message: * GenerateContentRequest.contents[6].part
s: contents.parts must not be empty.
.

Please retry if you think this is a transient or recoverable error.
```

After:

```
( O)> create a test.txt file under the dir

─── shell | developer ──────────────────────────
command: touch test.txt


◇  Goose would like to call the above tool, do you approve?
│  Yes 
│

I have created an empty file named `test.txt` in the current directory.
```