### PR TITLE
feat(goose): support customizing extension timeout

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -442,7 +442,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 enabled: true,
                 config: ExtensionConfig::Builtin {
                     name: extension.clone(),
-                    // TODO: should set timeout
+                    // NOTE: default timeout for builtin tools
                     timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
                 },
             })?;
@@ -472,6 +472,14 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     } else {
                         Ok(())
                     }
+                })
+                .interact()?;
+
+            let timeout: u64 = cliclack::input("Please set the timeout for this tool (in secs):")
+                .placeholder(&goose::config::DEFAULT_EXTENSION_TIMEOUT.to_string())
+                .validate(|input: &String| match input.parse::<u64>() {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err("Please enter a valide timeout"),
                 })
                 .interact()?;
 
@@ -509,8 +517,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     cmd,
                     args,
                     envs: Envs::new(envs),
-                    // TODO: should set timeout
-                    timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
+                    timeout,
                 },
             })?;
 
@@ -544,6 +551,14 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 })
                 .interact()?;
 
+            let timeout: u64 = cliclack::input("Please set the timeout for this tool (in secs):")
+                .placeholder(&goose::config::DEFAULT_EXTENSION_TIMEOUT.to_string())
+                .validate(|input: &String| match input.parse::<u64>() {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err("Please enter a valide timeout"),
+                })
+                .interact()?;
+
             let add_env =
                 cliclack::confirm("Would you like to add environment variables?").interact()?;
 
@@ -572,8 +587,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     name: name.clone(),
                     uri,
                     envs: Envs::new(envs),
-                    // TODO: should set timeout
-                    timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
+                    timeout,
                 },
             })?;
 

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -38,6 +38,7 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
                     enabled: true,
                     config: ExtensionConfig::Builtin {
                         name: "developer".to_string(),
+                        timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
                     },
                 })?;
             }
@@ -441,6 +442,8 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 enabled: true,
                 config: ExtensionConfig::Builtin {
                     name: extension.clone(),
+                    // TODO: should set timeout
+                    timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
                 },
             })?;
 
@@ -506,6 +509,8 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     cmd,
                     args,
                     envs: Envs::new(envs),
+                    // TODO: should set timeout
+                    timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
                 },
             })?;
 
@@ -567,6 +572,8 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     name: name.clone(),
                     uri,
                     envs: Envs::new(envs),
+                    // TODO: should set timeout
+                    timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
                 },
             })?;
 

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -438,12 +438,19 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 .interact()?
                 .to_string();
 
+            let timeout: u64 = cliclack::input("Please set the timeout for this tool (in secs):")
+                .placeholder(&goose::config::DEFAULT_EXTENSION_TIMEOUT.to_string())
+                .validate(|input: &String| match input.parse::<u64>() {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err("Please enter a valide timeout"),
+                })
+                .interact()?;
+
             ExtensionManager::set(ExtensionEntry {
                 enabled: true,
                 config: ExtensionConfig::Builtin {
                     name: extension.clone(),
-                    // NOTE: default timeout for builtin tools
-                    timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
+                    timeout: Some(timeout),
                 },
             })?;
 

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -38,7 +38,7 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
                     enabled: true,
                     config: ExtensionConfig::Builtin {
                         name: "developer".to_string(),
-                        timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
+                        timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
                     },
                 })?;
             }
@@ -443,7 +443,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 config: ExtensionConfig::Builtin {
                     name: extension.clone(),
                     // NOTE: default timeout for builtin tools
-                    timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
+                    timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
                 },
             })?;
 
@@ -517,7 +517,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     cmd,
                     args,
                     envs: Envs::new(envs),
-                    timeout,
+                    timeout: Some(timeout),
                 },
             })?;
 
@@ -587,7 +587,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     name: name.clone(),
                     uri,
                     envs: Envs::new(envs),
-                    timeout,
+                    timeout: Some(timeout),
                 },
             })?;
 

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -80,7 +80,7 @@ impl Session {
             args: parts.iter().map(|s| s.to_string()).collect(),
             envs: Envs::new(envs),
             // TODO: should set timeout
-            timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
+            timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
         };
 
         self.agent
@@ -98,7 +98,7 @@ impl Session {
             let config = ExtensionConfig::Builtin {
                 name: name.trim().to_string(),
                 // TODO: should set a timeout
-                timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
+                timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
             };
             self.agent
                 .add_extension(config)

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -79,6 +79,8 @@ impl Session {
             cmd,
             args: parts.iter().map(|s| s.to_string()).collect(),
             envs: Envs::new(envs),
+            // TODO: should set timeout
+            timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
         };
 
         self.agent
@@ -95,6 +97,8 @@ impl Session {
         for name in builtin_name.split(',') {
             let config = ExtensionConfig::Builtin {
                 name: name.trim().to_string(),
+                // TODO: should set a timeout
+                timeout: goose::config::DEFAULT_EXTENSION_TIMEOUT,
             };
             self.agent
                 .add_extension(config)

--- a/crates/goose-server/src/routes/extension.rs
+++ b/crates/goose-server/src/routes/extension.rs
@@ -23,6 +23,7 @@ enum ExtensionConfigRequest {
         /// List of environment variable keys. The server will fetch their values from the keyring.
         #[serde(default)]
         env_keys: Vec<String>,
+        timeout: u64,
     },
     /// Standard I/O (stdio) extension.
     #[serde(rename = "stdio")]
@@ -37,12 +38,14 @@ enum ExtensionConfigRequest {
         /// List of environment variable keys. The server will fetch their values from the keyring.
         #[serde(default)]
         env_keys: Vec<String>,
+        timeout: u64,
     },
     /// Built-in extension that is part of the goose binary.
     #[serde(rename = "builtin")]
     Builtin {
         /// The name of the built-in extension.
         name: String,
+        timeout: u64,
     },
 }
 
@@ -84,6 +87,7 @@ async fn add_extension(
             name,
             uri,
             env_keys,
+            timeout,
         } => {
             let mut env_map = HashMap::new();
             for key in env_keys {
@@ -111,6 +115,7 @@ async fn add_extension(
                 name,
                 uri,
                 envs: Envs::new(env_map),
+                timeout: Some(timeout),
             }
         }
         ExtensionConfigRequest::Stdio {
@@ -118,6 +123,7 @@ async fn add_extension(
             cmd,
             args,
             env_keys,
+            timeout,
         } => {
             let mut env_map = HashMap::new();
             for key in env_keys {
@@ -146,9 +152,13 @@ async fn add_extension(
                 cmd,
                 args,
                 envs: Envs::new(env_map),
+                timeout: Some(timeout),
             }
         }
-        ExtensionConfigRequest::Builtin { name } => ExtensionConfig::Builtin { name },
+        ExtensionConfigRequest::Builtin { name, timeout } => ExtensionConfig::Builtin {
+            name,
+            timeout: Some(timeout),
+        },
     };
 
     // Acquire a lock on the agent and attempt to add the extension.

--- a/crates/goose-server/src/routes/extension.rs
+++ b/crates/goose-server/src/routes/extension.rs
@@ -23,7 +23,7 @@ enum ExtensionConfigRequest {
         /// List of environment variable keys. The server will fetch their values from the keyring.
         #[serde(default)]
         env_keys: Vec<String>,
-        timeout: u64,
+        timeout: Option<u64>,
     },
     /// Standard I/O (stdio) extension.
     #[serde(rename = "stdio")]
@@ -38,14 +38,14 @@ enum ExtensionConfigRequest {
         /// List of environment variable keys. The server will fetch their values from the keyring.
         #[serde(default)]
         env_keys: Vec<String>,
-        timeout: u64,
+        timeout: Option<u64>,
     },
     /// Built-in extension that is part of the goose binary.
     #[serde(rename = "builtin")]
     Builtin {
         /// The name of the built-in extension.
         name: String,
-        timeout: u64,
+        timeout: Option<u64>,
     },
 }
 
@@ -115,7 +115,7 @@ async fn add_extension(
                 name,
                 uri,
                 envs: Envs::new(env_map),
-                timeout: Some(timeout),
+                timeout,
             }
         }
         ExtensionConfigRequest::Stdio {
@@ -152,13 +152,12 @@ async fn add_extension(
                 cmd,
                 args,
                 envs: Envs::new(env_map),
-                timeout: Some(timeout),
+                timeout,
             }
         }
-        ExtensionConfigRequest::Builtin { name, timeout } => ExtensionConfig::Builtin {
-            name,
-            timeout: Some(timeout),
-        },
+        ExtensionConfigRequest::Builtin { name, timeout } => {
+            ExtensionConfig::Builtin { name, timeout }
+        }
     };
 
     // Acquire a lock on the agent and attempt to add the extension.

--- a/crates/goose/examples/agent.rs
+++ b/crates/goose/examples/agent.rs
@@ -1,6 +1,7 @@
 use dotenv::dotenv;
 use futures::StreamExt;
 use goose::agents::{AgentFactory, ExtensionConfig};
+use goose::config::DEFAULT_EXTENSION_TIMEOUT;
 use goose::message::Message;
 use goose::providers::databricks::DatabricksProvider;
 
@@ -14,7 +15,11 @@ async fn main() {
     // Setup an agent with the developer extension
     let mut agent = AgentFactory::create("reference", provider).expect("default should exist");
 
-    let config = ExtensionConfig::stdio("developer", "./target/debug/developer");
+    let config = ExtensionConfig::stdio(
+        "developer",
+        "./target/debug/developer",
+        DEFAULT_EXTENSION_TIMEOUT,
+    );
     agent.add_extension(config).await.unwrap();
 
     println!("Extensions:");

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -108,7 +108,12 @@ impl Capabilities {
             } => {
                 let transport = SseTransport::new(uri, envs.get_env());
                 let handle = transport.start().await?;
-                let service = McpService::with_timeout(handle, Duration::from_secs(*timeout));
+                let service = McpService::with_timeout(
+                    handle,
+                    Duration::from_secs(
+                        timeout.unwrap_or(crate::config::DEFAULT_EXTENSION_TIMEOUT),
+                    ),
+                );
                 Box::new(McpClient::new(service))
             }
             ExtensionConfig::Stdio {
@@ -120,7 +125,12 @@ impl Capabilities {
             } => {
                 let transport = StdioTransport::new(cmd, args.to_vec(), envs.get_env());
                 let handle = transport.start().await?;
-                let service = McpService::with_timeout(handle, Duration::from_secs(*timeout));
+                let service = McpService::with_timeout(
+                    handle,
+                    Duration::from_secs(
+                        timeout.unwrap_or(crate::config::DEFAULT_EXTENSION_TIMEOUT),
+                    ),
+                );
                 Box::new(McpClient::new(service))
             }
             ExtensionConfig::Builtin { name, timeout } => {
@@ -136,7 +146,12 @@ impl Capabilities {
                     HashMap::new(),
                 );
                 let handle = transport.start().await?;
-                let service = McpService::with_timeout(handle, Duration::from_secs(*timeout));
+                let service = McpService::with_timeout(
+                    handle,
+                    Duration::from_secs(
+                        timeout.unwrap_or(crate::config::DEFAULT_EXTENSION_TIMEOUT),
+                    ),
+                );
                 Box::new(McpClient::new(service))
             }
         };

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -4,6 +4,8 @@ use mcp_client::client::Error as ClientError;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
+use crate::config;
+
 /// Errors from Extension operation
 #[derive(Error, Debug)]
 pub enum ExtensionError {
@@ -52,6 +54,7 @@ pub enum ExtensionConfig {
         uri: String,
         #[serde(default)]
         envs: Envs,
+        timeout: u64,
     },
     /// Standard I/O client with command and arguments
     #[serde(rename = "stdio")]
@@ -62,38 +65,43 @@ pub enum ExtensionConfig {
         args: Vec<String>,
         #[serde(default)]
         envs: Envs,
+        timeout: u64,
     },
     /// Built-in extension that is part of the goose binary
     #[serde(rename = "builtin")]
     Builtin {
         /// The name used to identify this extension
         name: String,
+        timeout: u64,
     },
 }
 
 impl Default for ExtensionConfig {
     fn default() -> Self {
         Self::Builtin {
-            name: String::from("default"),
+            name: config::DEFAULT_EXTENSION.to_string(),
+            timeout: config::DEFAULT_EXTENSION_TIMEOUT,
         }
     }
 }
 
 impl ExtensionConfig {
-    pub fn sse<S: Into<String>>(name: S, uri: S) -> Self {
+    pub fn sse<S: Into<String>, T: Into<u64>>(name: S, uri: S, timeout: T) -> Self {
         Self::Sse {
             name: name.into(),
             uri: uri.into(),
             envs: Envs::default(),
+            timeout: timeout.into(),
         }
     }
 
-    pub fn stdio<S: Into<String>>(name: S, cmd: S) -> Self {
+    pub fn stdio<S: Into<String>, T: Into<u64>>(name: S, cmd: S, timeout: T) -> Self {
         Self::Stdio {
             name: name.into(),
             cmd: cmd.into(),
             args: vec![],
             envs: Envs::default(),
+            timeout: timeout.into(),
         }
     }
 
@@ -104,12 +112,17 @@ impl ExtensionConfig {
     {
         match self {
             Self::Stdio {
-                name, cmd, envs, ..
+                name,
+                cmd,
+                envs,
+                timeout,
+                ..
             } => Self::Stdio {
                 name,
                 cmd,
                 envs,
                 args: args.into_iter().map(Into::into).collect(),
+                timeout,
             },
             other => other,
         }
@@ -120,7 +133,7 @@ impl ExtensionConfig {
         match self {
             Self::Sse { name, .. } => name,
             Self::Stdio { name, .. } => name,
-            Self::Builtin { name } => name,
+            Self::Builtin { name, .. } => name,
         }
     }
 }
@@ -134,7 +147,7 @@ impl std::fmt::Display for ExtensionConfig {
             } => {
                 write!(f, "Stdio({}: {} {})", name, cmd, args.join(" "))
             }
-            ExtensionConfig::Builtin { name } => write!(f, "Builtin({})", name),
+            ExtensionConfig::Builtin { name, .. } => write!(f, "Builtin({})", name),
         }
     }
 }

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -54,7 +54,9 @@ pub enum ExtensionConfig {
         uri: String,
         #[serde(default)]
         envs: Envs,
-        timeout: u64,
+        // NOTE: set timeout to be optional for compatibility.
+        // However, new configurations should include this field.
+        timeout: Option<u64>,
     },
     /// Standard I/O client with command and arguments
     #[serde(rename = "stdio")]
@@ -65,14 +67,14 @@ pub enum ExtensionConfig {
         args: Vec<String>,
         #[serde(default)]
         envs: Envs,
-        timeout: u64,
+        timeout: Option<u64>,
     },
     /// Built-in extension that is part of the goose binary
     #[serde(rename = "builtin")]
     Builtin {
         /// The name used to identify this extension
         name: String,
-        timeout: u64,
+        timeout: Option<u64>,
     },
 }
 
@@ -80,7 +82,7 @@ impl Default for ExtensionConfig {
     fn default() -> Self {
         Self::Builtin {
             name: config::DEFAULT_EXTENSION.to_string(),
-            timeout: config::DEFAULT_EXTENSION_TIMEOUT,
+            timeout: Some(config::DEFAULT_EXTENSION_TIMEOUT),
         }
     }
 }
@@ -91,7 +93,7 @@ impl ExtensionConfig {
             name: name.into(),
             uri: uri.into(),
             envs: Envs::default(),
-            timeout: timeout.into(),
+            timeout: Some(timeout.into()),
         }
     }
 
@@ -101,7 +103,7 @@ impl ExtensionConfig {
             cmd: cmd.into(),
             args: vec![],
             envs: Envs::default(),
-            timeout: timeout.into(),
+            timeout: Some(timeout.into()),
         }
     }
 

--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -4,7 +4,8 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-const DEFAULT_EXTENSION: &str = "developer";
+pub const DEFAULT_EXTENSION: &str = "developer";
+pub const DEFAULT_EXTENSION_TIMEOUT: u64 = 300;
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
 pub struct ExtensionEntry {
@@ -32,6 +33,7 @@ impl ExtensionManager {
                         enabled: true,
                         config: ExtensionConfig::Builtin {
                             name: DEFAULT_EXTENSION.to_string(),
+                            timeout: DEFAULT_EXTENSION_TIMEOUT,
                         },
                     },
                 )]);

--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -33,7 +33,7 @@ impl ExtensionManager {
                         enabled: true,
                         config: ExtensionConfig::Builtin {
                             name: DEFAULT_EXTENSION.to_string(),
-                            timeout: DEFAULT_EXTENSION_TIMEOUT,
+                            timeout: Some(DEFAULT_EXTENSION_TIMEOUT),
                         },
                     },
                 )]);

--- a/crates/goose/src/config/mod.rs
+++ b/crates/goose/src/config/mod.rs
@@ -6,3 +6,6 @@ pub use crate::agents::ExtensionConfig;
 pub use base::{Config, ConfigError, APP_STRATEGY};
 pub use experiments::ExperimentManager;
 pub use extensions::{ExtensionEntry, ExtensionManager};
+
+pub use extensions::DEFAULT_EXTENSION;
+pub use extensions::DEFAULT_EXTENSION_TIMEOUT;

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -11,7 +11,7 @@ interface UserMessageProps {
 export default function UserMessage({ message }: UserMessageProps) {
   // Extract text content from the message
   const textContent = getTextContent(message);
-  
+
   // Extract URLs which explicitly contain the http:// or https:// protocol
   const urls = extractUrls(textContent, []);
 

--- a/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Card } from '../../ui/card';
 import { Button } from '../../ui/button';
 import { Input } from '../../ui/input';
-import { FullExtensionConfig } from '../../../extensions';
+import { FullExtensionConfig, DEFAULT_EXTENSION_TIMEOUT } from '../../../extensions';
 import { toast } from 'react-toastify';
 import Select from 'react-select';
 import { createDarkSelectStyles, darkSelectTheme } from '../../ui/select-styles';
@@ -22,6 +22,7 @@ export function ManualExtensionModal({ isOpen, onClose, onSubmit }: ManualExtens
     enabled: true,
     args: [],
     commandInput: '',
+    timeout: DEFAULT_EXTENSION_TIMEOUT,
   });
   const [envKey, setEnvKey] = useState('');
   const [envValue, setEnvValue] = useState('');
@@ -267,8 +268,24 @@ export function ManualExtensionModal({ isOpen, onClose, onSubmit }: ManualExtens
                   </div>
                 )}
               </div>
-            </div>
 
+              {formData.type !== 'builtin' && (
+                <div>
+                  <label className="block text-sm font-medium text-textStandard mb-2">
+                    Timeout *
+                  </label>
+                  <Input
+                    type="number"
+                    value={formData.timeout || DEFAULT_EXTENSION_TIMEOUT}
+                    onChange={(e) =>
+                      setFormData({ ...formData, timeout: parseInt(e.target.value) })
+                    }
+                    className="w-full"
+                    required
+                  />
+                </div>
+              )}
+            </div>
             <div className="mt-[8px] -ml-8 -mr-8 pt-8">
               <Button
                 type="submit"

--- a/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
@@ -269,22 +269,18 @@ export function ManualExtensionModal({ isOpen, onClose, onSubmit }: ManualExtens
                 )}
               </div>
 
-              {formData.type !== 'builtin' && (
-                <div>
-                  <label className="block text-sm font-medium text-textStandard mb-2">
-                    Timeout (secs)*
-                  </label>
-                  <Input
-                    type="number"
-                    value={formData.timeout || DEFAULT_EXTENSION_TIMEOUT}
-                    onChange={(e) =>
-                      setFormData({ ...formData, timeout: parseInt(e.target.value) })
-                    }
-                    className="w-full"
-                    required
-                  />
-                </div>
-              )}
+              <div>
+                <label className="block text-sm font-medium text-textStandard mb-2">
+                  Timeout (secs)*
+                </label>
+                <Input
+                  type="number"
+                  value={formData.timeout || DEFAULT_EXTENSION_TIMEOUT}
+                  onChange={(e) => setFormData({ ...formData, timeout: parseInt(e.target.value) })}
+                  className="w-full"
+                  required
+                />
+              </div>
             </div>
             <div className="mt-[8px] -ml-8 -mr-8 pt-8">
               <Button

--- a/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
@@ -272,7 +272,7 @@ export function ManualExtensionModal({ isOpen, onClose, onSubmit }: ManualExtens
               {formData.type !== 'builtin' && (
                 <div>
                   <label className="block text-sm font-medium text-textStandard mb-2">
-                    Timeout *
+                    Timeout (secs)*
                   </label>
                   <Input
                     type="number"

--- a/ui/desktop/src/extensions.ts
+++ b/ui/desktop/src/extensions.ts
@@ -4,6 +4,7 @@ import { type SettingsViewOptions } from './components/settings/SettingsView';
 import { toast } from 'react-toastify';
 
 // ExtensionConfig type matching the Rust version
+// TODO: refactor this
 export type ExtensionConfig =
   | {
       type: 'sse';


### PR DESCRIPTION
This PR closes #1422, adding support for setting extension timeout in both CLI and app.

![image](https://github.com/user-attachments/assets/0bb13622-9917-43c5-a45f-6bfe5b4dfc7f)
