### PR TITLE
fix: return tool error for invalid param

### DIFF
--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -501,7 +501,12 @@ impl ComputerControllerRouter {
                     })?;
                     (bytes.to_vec(), "bin")
                 }
-                _ => unreachable!(), // Prevented by enum in tool definition
+                _ => {
+                    return Err(ToolError::InvalidParameters(format!(
+                    "Invalid 'save_as' parameter: {}. Valid options are: 'text', 'json', 'binary'",
+                    save_as
+                )));
+                }
             };
 
         // Save to cache
@@ -571,7 +576,11 @@ impl ComputerControllerRouter {
                     script_path.display()
                 )
             }
-            _ => unreachable!(), // Prevented by enum in tool definition
+            _ => {
+                return Err( ToolError::InvalidParameters(
+                    format!("Invalid 'language' parameter: {}. Valid options are: 'shell', 'batch', 'ruby', 'powershell", language)
+                ));
+            }
         };
 
         // Run the script

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -721,7 +721,12 @@ impl ComputerControllerRouter {
 
                 Ok(vec![Content::text("Cache cleared successfully.")])
             }
-            _ => unreachable!(), // Prevented by enum in tool definition
+            _ => {
+                return Err(ToolError::InvalidParameters(format!(
+                "Invalid 'command' parameter: {}. Valid options are: 'list', 'view', 'delete', 'clear'",
+                command
+            )));
+            }
         }
     }
 }

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -721,12 +721,10 @@ impl ComputerControllerRouter {
 
                 Ok(vec![Content::text("Cache cleared successfully.")])
             }
-            _ => {
-                return Err(ToolError::InvalidParameters(format!(
+            _ => Err(ToolError::InvalidParameters(format!(
                 "Invalid 'command' parameter: {}. Valid options are: 'list', 'view', 'delete', 'clear'",
                 command
-            )));
-            }
+            )))
         }
     }
 }


### PR DESCRIPTION
the LLM can hallucinate different params even when you provide it a list of choices