### PR TITLE
feat: support goose mode in UI

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -86,7 +86,7 @@ async fn extend_prompt(
         return Err(StatusCode::UNAUTHORIZED);
     }
 
-    let mut agent = state.agent.lock().await;
+    let mut agent = state.agent.write().await;
     if let Some(ref mut agent) = *agent {
         agent.extend_system_prompt(payload.extension).await;
         Ok(Json(ExtendPromptResponse { success: true }))
@@ -134,7 +134,7 @@ async fn create_agent(
 
     let new_agent = AgentFactory::create(&version, provider).expect("Failed to create agent");
 
-    let mut agent = state.agent.lock().await;
+    let mut agent = state.agent.write().await;
     *agent = Some(new_agent);
 
     Ok(Json(CreateAgentResponse { version }))

--- a/crates/goose-server/src/routes/extension.rs
+++ b/crates/goose-server/src/routes/extension.rs
@@ -152,7 +152,7 @@ async fn add_extension(
     };
 
     // Acquire a lock on the agent and attempt to add the extension.
-    let mut agent = state.agent.lock().await;
+    let mut agent = state.agent.write().await;
     let agent = agent.as_mut().ok_or(StatusCode::PRECONDITION_REQUIRED)?;
     let response = agent.add_extension(extension_config).await;
 
@@ -192,7 +192,7 @@ async fn remove_extension(
     }
 
     // Acquire a lock on the agent and attempt to remove the extension
-    let mut agent = state.agent.lock().await;
+    let mut agent = state.agent.write().await;
     let agent = agent.as_mut().ok_or(StatusCode::PRECONDITION_REQUIRED)?;
     agent.remove_extension(&name).await;
 

--- a/crates/goose-server/src/state.rs
+++ b/crates/goose-server/src/state.rs
@@ -3,13 +3,13 @@ use goose::agents::Agent;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, RwLock};
 
 /// Shared application state
 #[allow(dead_code)]
 #[derive(Clone)]
 pub struct AppState {
-    pub agent: Arc<Mutex<Option<Box<dyn Agent>>>>,
+    pub agent: Arc<RwLock<Option<Box<dyn Agent>>>>,
     pub secret_key: String,
     pub config: Arc<Mutex<HashMap<String, Value>>>,
 }
@@ -17,7 +17,7 @@ pub struct AppState {
 impl AppState {
     pub async fn new(secret_key: String) -> Result<Self> {
         Ok(Self {
-            agent: Arc::new(Mutex::new(None)),
+            agent: Arc::new(RwLock::new(None)),
             secret_key,
             config: Arc::new(Mutex::new(HashMap::new())),
         })

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -274,7 +274,8 @@ impl Agent for TruncateAgent {
 
                                             // Wait for confirmation response through the channel
                                             let mut rx = self.confirmation_rx.lock().await;
-                                            if let Some((req_id, confirmed)) = rx.recv().await {
+                                            // Loop the recv until we have a matched req_id due to potential duplicate messages.
+                                            while let Some((req_id, confirmed)) = rx.recv().await {
                                                 if req_id == request.id {
                                                     if confirmed {
                                                         // User approved - dispatch the tool call
@@ -290,6 +291,7 @@ impl Agent for TruncateAgent {
                                                             Ok(vec![Content::text("User declined to run this tool.")]),
                                                         );
                                                     }
+                                                    break; // Exit the loop once the matching `req_id` is found
                                                 }
                                             }
                                         }

--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-avatar": "^1.1.1",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-icons": "^1.3.1",
+        "@radix-ui/react-radio-group": "^1.2.3",
         "@radix-ui/react-scroll-area": "^1.2.0",
         "@radix-ui/react-select": "^2.1.5",
         "@radix-ui/react-slot": "^1.1.1",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -72,6 +72,7 @@
     "@radix-ui/react-avatar": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-icons": "^1.3.1",
+    "@radix-ui/react-radio-group": "^1.2.3",
     "@radix-ui/react-scroll-area": "^1.2.0",
     "@radix-ui/react-select": "^2.1.5",
     "@radix-ui/react-slot": "^1.1.1",

--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -167,13 +167,27 @@ export default function ChatView({ setView }: { setView: (view: View) => void })
     if (message.role === 'user') {
       const hasOnlyToolResponses = message.content.every((c) => c.type === 'toolResponse');
       const hasTextContent = message.content.some((c) => c.type === 'text');
+      const hasToolConfirmation = message.content.every(
+        (c) => c.type === 'toolConfirmationRequest'
+      );
 
-      // Keep the message if it has text content or is not just tool responses
-      return hasTextContent || !hasOnlyToolResponses;
+      // Keep the message if it has text content or tool confirmation or is not just tool responses
+      return hasTextContent || !hasOnlyToolResponses || hasToolConfirmation;
     }
 
     return true;
   });
+
+  const isUserMessage = (message: Message) => {
+    if (message.role === 'assistant') {
+      return false;
+    }
+
+    if (message.content.every((c) => c.type === 'toolConfirmationRequest')) {
+      return false;
+    }
+    return true;
+  };
 
   return (
     <div className="flex flex-col w-full h-screen items-center justify-center">
@@ -187,7 +201,7 @@ export default function ChatView({ setView }: { setView: (view: View) => void })
           <ScrollArea ref={scrollRef} className="flex-1 px-4" autoScroll>
             {filteredMessages.map((message, index) => (
               <div key={message.id || index} className="mt-[16px]">
-                {message.role === 'user' ? (
+                {isUserMessage(message) ? (
                   <UserMessage message={message} />
                 ) : (
                   <GooseMessage

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -27,11 +27,6 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
   // Get tool requests from the message
   const toolRequests = getToolRequests(message);
 
-  const [toolConfirmationId, hasToolConfirmation] = getToolConfirmationRequestId(message);
-  if (hasToolConfirmation) {
-    textContent = 'Goose would like to call the above tool. Allow?';
-  }
-
   // Extract URLs under a few conditions
   // 1. The message is purely text
   // 2. The link wasn't also present in the previous message
@@ -40,6 +35,12 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
   const previousMessage = messageIndex > 0 ? messages[messageIndex - 1] : null;
   const previousUrls = previousMessage ? extractUrls(getTextContent(previousMessage)) : [];
   const urls = toolRequests.length === 0 ? extractUrls(textContent, previousUrls) : [];
+
+  const isToolConfirmationActive = messageIndex === messages.length - 1;
+  const [toolConfirmationId, hasToolConfirmation] = getToolConfirmationRequestId(message);
+  if (hasToolConfirmation) {
+    textContent = 'Goose would like to call the above tool. Allow?';
+  }
 
   // Find tool responses that correspond to the tool requests in this message
   const toolResponsesMap = useMemo(() => {
@@ -76,18 +77,18 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
         )}
 
         {hasToolConfirmation && (
-          <div className="flex gap-4 mt-2">
+          <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 flex gap-4 mt-2">
             <button
-              className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-500"
+              className="px-4 py-2 bg-green-400 text-white rounded-lg hover:bg-green-500"
               onClick={() => ConfirmToolRequest(toolConfirmationId, true)}
             >
-              Yes
+              Allow tool
             </button>
             <button
-              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-500"
+              className="px-4 py-2 bg-red-400 text-white rounded-lg hover:bg-red-500"
               onClick={() => ConfirmToolRequest(toolConfirmationId, false)}
             >
-              No
+              Deny
             </button>
           </div>
         )}

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -11,7 +11,7 @@ import {
   getToolResponses,
   getToolConfirmationRequestId,
 } from '../types/message';
-import { ConfirmToolRequest } from '../utils/toolConfirm';
+import ToolCallConfirmation from './ToolCallConfirmation';
 
 interface GooseMessageProps {
   message: Message;
@@ -72,27 +72,7 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
           </div>
         )}
 
-        {hasToolConfirmation && (
-          <>
-            <div className="goose-message-content bg-bgSubtle rounded-2xl px-4 py-2 rounded-b-none">
-              Goose would like to call the above tool. Allow?
-            </div>
-            <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 flex gap-4 mt-1">
-              <button
-                className="hover:bg-slate hover:text-white rounded-full px-6 py-2 transition"
-                onClick={() => ConfirmToolRequest(toolConfirmationId, true)}
-              >
-                Allow tool
-              </button>
-              <button
-                className="hover:bg-slate hover:text-white rounded-full px-6 py-2 transition"
-                onClick={() => ConfirmToolRequest(toolConfirmationId, false)}
-              >
-                Deny
-              </button>
-            </div>
-          </>
-        )}
+        {hasToolConfirmation && <ToolCallConfirmation toolConfirmationId />}
 
         {toolRequests.length > 0 && (
           <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 mt-1">

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -79,13 +79,13 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
             </div>
             <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 flex gap-4 mt-1">
               <button
-                className="px-4 py-2 bg-green-400 text-white rounded-lg hover:bg-green-500"
+                className="hover:bg-slate hover:text-white rounded-full px-6 py-2 transition"
                 onClick={() => ConfirmToolRequest(toolConfirmationId, true)}
               >
                 Allow tool
               </button>
               <button
-                className="px-4 py-2 bg-red-400 text-white rounded-lg hover:bg-red-500"
+                className="hover:bg-slate hover:text-white rounded-full px-6 py-2 transition"
                 onClick={() => ConfirmToolRequest(toolConfirmationId, false)}
               >
                 Deny

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -4,7 +4,14 @@ import GooseResponseForm from './GooseResponseForm';
 import { extractUrls } from '../utils/urlUtils';
 import MarkdownContent from './MarkdownContent';
 import ToolCallWithResponse from './ToolCallWithResponse';
-import { Message, getTextContent, getToolRequests, getToolResponses } from '../types/message';
+import {
+  Message,
+  getTextContent,
+  getToolRequests,
+  getToolResponses,
+  getToolConfirmationRequestId,
+} from '../types/message';
+import { ConfirmToolRequest } from '../utils/toolConfirm';
 
 interface GooseMessageProps {
   message: Message;
@@ -15,10 +22,15 @@ interface GooseMessageProps {
 
 export default function GooseMessage({ message, metadata, messages, append }: GooseMessageProps) {
   // Extract text content from the message
-  const textContent = getTextContent(message);
+  let textContent = getTextContent(message);
 
   // Get tool requests from the message
   const toolRequests = getToolRequests(message);
+
+  const [toolConfirmationId, hasToolConfirmation] = getToolConfirmationRequestId(message);
+  if (hasToolConfirmation) {
+    textContent = 'Goose would like to call the above tool. Allow?';
+  }
 
   // Extract URLs under a few conditions
   // 1. The message is purely text
@@ -60,6 +72,23 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
             className={`goose-message-content bg-bgSubtle rounded-2xl px-4 py-2 ${toolRequests.length > 0 ? 'rounded-b-none' : ''}`}
           >
             {textContent ? <MarkdownContent content={textContent} /> : null}
+          </div>
+        )}
+
+        {hasToolConfirmation && (
+          <div className="flex gap-4 mt-2">
+            <button
+              className="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-500"
+              onClick={() => ConfirmToolRequest(toolConfirmationId, true)}
+            >
+              Yes
+            </button>
+            <button
+              className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-500"
+              onClick={() => ConfirmToolRequest(toolConfirmationId, false)}
+            >
+              No
+            </button>
           </div>
         )}
 

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -36,11 +36,7 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
   const previousUrls = previousMessage ? extractUrls(getTextContent(previousMessage)) : [];
   const urls = toolRequests.length === 0 ? extractUrls(textContent, previousUrls) : [];
 
-  const isToolConfirmationActive = messageIndex === messages.length - 1;
   const [toolConfirmationId, hasToolConfirmation] = getToolConfirmationRequestId(message);
-  if (hasToolConfirmation) {
-    textContent = 'Goose would like to call the above tool. Allow?';
-  }
 
   // Find tool responses that correspond to the tool requests in this message
   const toolResponsesMap = useMemo(() => {
@@ -77,20 +73,25 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
         )}
 
         {hasToolConfirmation && (
-          <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 flex gap-4 mt-2">
-            <button
-              className="px-4 py-2 bg-green-400 text-white rounded-lg hover:bg-green-500"
-              onClick={() => ConfirmToolRequest(toolConfirmationId, true)}
-            >
-              Allow tool
-            </button>
-            <button
-              className="px-4 py-2 bg-red-400 text-white rounded-lg hover:bg-red-500"
-              onClick={() => ConfirmToolRequest(toolConfirmationId, false)}
-            >
-              Deny
-            </button>
-          </div>
+          <>
+            <div className="goose-message-content bg-bgSubtle rounded-2xl px-4 py-2 rounded-b-none">
+              Goose would like to call the above tool. Allow?
+            </div>
+            <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 flex gap-4 mt-1">
+              <button
+                className="px-4 py-2 bg-green-400 text-white rounded-lg hover:bg-green-500"
+                onClick={() => ConfirmToolRequest(toolConfirmationId, true)}
+              >
+                Allow tool
+              </button>
+              <button
+                className="px-4 py-2 bg-red-400 text-white rounded-lg hover:bg-red-500"
+                onClick={() => ConfirmToolRequest(toolConfirmationId, false)}
+              >
+                Deny
+              </button>
+            </div>
+          </>
         )}
 
         {toolRequests.length > 0 && (

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -72,7 +72,7 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
           </div>
         )}
 
-        {hasToolConfirmation && <ToolCallConfirmation toolConfirmationId />}
+        {hasToolConfirmation && <ToolCallConfirmation toolConfirmationId={toolConfirmationId} />}
 
         {toolRequests.length > 0 && (
           <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 mt-1">

--- a/ui/desktop/src/components/ToolCallConfirmation.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.tsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { ConfirmToolRequest } from '../utils/toolConfirm';
 
 export default function ToolConfirmation({ toolConfirmationId }) {
-  const [hovered, setHovered] = useState(false);
   const [disabled, setDisabled] = useState(false);
 
   const handleButtonClick = (confirmed) => {
@@ -20,7 +19,6 @@ export default function ToolConfirmation({ toolConfirmationId }) {
           className={
             'bg-black text-white dark:bg-white dark:text-black rounded-full px-6 py-2 transition'
           }
-          onMouseEnter={() => setHovered(true)}
           onClick={() => handleButtonClick(true)}
           disabled={disabled}
         >

--- a/ui/desktop/src/components/ToolCallConfirmation.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.tsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { ConfirmToolRequest } from '../utils/toolConfirm';
+
+export default function ToolConfirmation({ toolConfirmationId }) {
+  const [hovered, setHovered] = useState(false);
+  const [disabled, setDisabled] = useState(false);
+
+  const handleButtonClick = (confirmed) => {
+    setDisabled(true);
+    ConfirmToolRequest(toolConfirmationId, confirmed);
+  };
+
+  return (
+    <>
+      <div className="goose-message-content bg-bgSubtle rounded-2xl px-4 py-2 rounded-b-none">
+        Goose would like to call the above tool. Allow?
+      </div>
+      <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 flex gap-4 mt-1">
+        <button
+          className={`${
+            hovered
+              ? 'bg-white text-black dark:bg-black dark:text-white dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 border'
+              : 'bg-gray-100 dark:bg-gray-800'
+          } border-gray-300 rounded-full px-6 py-2 transition ${
+            disabled ? 'opacity-50 cursor-not-allowed' : ''
+          }`}
+          onMouseEnter={() => setHovered(true)}
+          onClick={() => handleButtonClick(true)}
+          disabled={disabled}
+        >
+          Allow tool
+        </button>
+        <button
+          className={`bg-white text-black dark:bg-black dark:text-white border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full px-6 py-2 transition ${
+            disabled ? 'opacity-50 cursor-not-allowed' : ''
+          }`}
+          onClick={() => handleButtonClick(false)}
+          disabled={disabled}
+        >
+          Deny
+        </button>
+      </div>
+    </>
+  );
+}

--- a/ui/desktop/src/components/ToolCallConfirmation.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.tsx
@@ -17,13 +17,9 @@ export default function ToolConfirmation({ toolConfirmationId }) {
       </div>
       <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 flex gap-4 mt-1">
         <button
-          className={`${
-            hovered
-              ? 'bg-white text-black dark:bg-black dark:text-white dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 border'
-              : 'bg-gray-100 dark:bg-gray-800'
-          } border-gray-300 rounded-full px-6 py-2 transition ${
-            disabled ? 'opacity-50 cursor-not-allowed' : ''
-          }`}
+          className={
+            'bg-black text-white dark:bg-white dark:text-black rounded-full px-6 py-2 transition'
+          }
           onMouseEnter={() => setHovered(true)}
           onClick={() => handleButtonClick(true)}
           disabled={disabled}
@@ -31,9 +27,9 @@ export default function ToolConfirmation({ toolConfirmationId }) {
           Allow tool
         </button>
         <button
-          className={`bg-white text-black dark:bg-black dark:text-white border border-gray-300 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 rounded-full px-6 py-2 transition ${
-            disabled ? 'opacity-50 cursor-not-allowed' : ''
-          }`}
+          className={
+            'bg-white text-black dark:bg-black dark:text-white border border-gray-300 dark:border-gray-700 rounded-full px-6 py-2 transition'
+          }
           onClick={() => handleButtonClick(false)}
           disabled={disabled}
         >

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -80,6 +80,9 @@ function ToolResultView({ result }: ToolResultViewProps) {
 
   // Find results where either audience is not set, or it's set to a list that includes user
   const filteredResults = result.filter((item) => {
+    if (!item.annotations) {
+      return false;
+    }
     // Check audience (which may not be in the type)
     const audience = item.annotations?.audience;
 

--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -15,6 +15,8 @@ import BackButton from '../ui/BackButton';
 import { RecentModelsRadio } from './models/RecentModels';
 import { ExtensionItem } from './extensions/ExtensionItem';
 import type { View } from '../../App';
+import ModeSelection from './basic/ModeSelection';
+import { getApiUrl, getSecretKey } from '../../config';
 
 const EXTENSIONS_DESCRIPTION =
   'The Model Context Protocol (MCP) is a system that allows AI models to securely connect with local or remote resources using standard server setups. It works like a client-server setup and expands AI capabilities using three main components: Prompts, Resources, and Tools.';
@@ -60,6 +62,53 @@ export default function SettingsView({
   setView: (view: View) => void;
   viewOptions: SettingsViewOptions;
 }) {
+  const [mode, setMode] = useState('approve');
+
+  const handleModeChange = async (newMode: string) => {
+    const storeResponse = await fetch(getApiUrl('/configs/store'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Secret-Key': getSecretKey(),
+      },
+      body: JSON.stringify({
+        key: 'GOOSE_MODE',
+        value: newMode,
+        isSecret: false,
+      }),
+    });
+
+    if (!storeResponse.ok) {
+      const errorText = await storeResponse.text();
+      console.error('Store response error:', errorText);
+      throw new Error(`Failed to store new goose mode: ${newMode}`);
+    }
+    setMode(newMode);
+  };
+
+  useEffect(() => {
+    const fetchCurrentMode = async () => {
+      try {
+        const response = await fetch(getApiUrl('/configs/get?key=GOOSE_MODE'), {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Secret-Key': getSecretKey(),
+          },
+        });
+
+        if (response.ok) {
+          const { value } = await response.json();
+          setMode(value);
+        }
+      } catch (error) {
+        console.error('Error fetching current mode:', error);
+      }
+    };
+
+    fetchCurrentMode();
+  }, []);
+
   const [settings, setSettings] = React.useState<SettingsType>(() => {
     const saved = localStorage.getItem('user_settings');
     window.electron.logInfo('Settings: ' + saved);
@@ -84,7 +133,7 @@ export default function SettingsView({
   const [isManualModalOpen, setIsManualModalOpen] = useState(false);
 
   // Persist settings changes
-  React.useEffect(() => {
+  useEffect(() => {
     localStorage.setItem('user_settings', JSON.stringify(settings));
   }, [settings]);
 
@@ -253,6 +302,20 @@ export default function SettingsView({
                       </button>
                     </div>
                   )}
+                </div>
+              </section>
+
+              <section id="others">
+                <div className="flex justify-between items-center mb-6 border-b border-borderSubtle px-8">
+                  <h2 className="text-xl font-semibold text-textStandard">Others</h2>
+                </div>
+
+                <div className="px-8">
+                  <p className="text-sm text-textStandard mb-4">
+                    Others setting like Goose Mode, Tool Output, Experiment and more
+                  </p>
+
+                  <ModeSelection value={mode} onChange={handleModeChange} />
                 </div>
               </section>
             </div>

--- a/ui/desktop/src/components/settings/basic/ModeSelection.tsx
+++ b/ui/desktop/src/components/settings/basic/ModeSelection.tsx
@@ -1,0 +1,50 @@
+import * as RadioGroup from '@radix-ui/react-radio-group';
+import React from 'react';
+
+const ModeSelection = ({ value, onChange }) => {
+  const modes = [
+    {
+      value: 'auto',
+      label: 'Completely autonomous',
+      description: 'Full file modification capabilities, edit, create, and delete files freely.',
+    },
+    {
+      value: 'approve',
+      label: 'Approval needed',
+      description: 'Editing, creating, and deleting files will require human approval.',
+    },
+    {
+      value: 'chat',
+      label: 'Chat only',
+      description: 'Engage with the selected provider without using tools or extensions.',
+    },
+  ];
+
+  return (
+    <div>
+      <h4 className="font-medium mb-4">Mode Selection</h4>
+
+      <RadioGroup.Root className="flex flex-col space-y-2" value={value} onValueChange={onChange}>
+        {modes.map((mode) => (
+          <RadioGroup.Item
+            key={mode.value}
+            value={mode.value}
+            className="flex items-center justify-between p-2 hover:bg-gray-100 rounded transition-all cursor-pointer"
+          >
+            <div className="flex flex-col text-left">
+              <h3 className="text-sm font-semibold text-textStandard">{mode.label}</h3>
+              <p className="text-xs text-textSubtle mt-[2px]">{mode.description}</p>
+            </div>
+            <div className="flex-shrink-0">
+              <div className="w-4 h-4 flex items-center justify-center rounded-full border border-gray-500">
+                {value === mode.value && <div className="w-2 h-2 bg-black rounded-full" />}
+              </div>
+            </div>
+          </RadioGroup.Item>
+        ))}
+      </RadioGroup.Root>
+    </div>
+  );
+};
+
+export default ModeSelection;

--- a/ui/desktop/src/hooks/useMessageStream.ts
+++ b/ui/desktop/src/hooks/useMessageStream.ts
@@ -217,6 +217,7 @@ export function useMessageStream({
                 switch (parsedEvent.type) {
                   case 'Message':
                     // Update messages with the new message
+                    console.log(parsedEvent);
                     currentMessages = [...currentMessages, parsedEvent.message];
                     mutate(currentMessages, false);
                     break;

--- a/ui/desktop/src/hooks/useMessageStream.ts
+++ b/ui/desktop/src/hooks/useMessageStream.ts
@@ -217,7 +217,6 @@ export function useMessageStream({
                 switch (parsedEvent.type) {
                   case 'Message':
                     // Update messages with the new message
-                    console.log(parsedEvent);
                     currentMessages = [...currentMessages, parsedEvent.message];
                     mutate(currentMessages, false);
                     break;

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -187,6 +187,22 @@ export function getToolResponses(message: Message): ToolResponseMessageContent[]
   );
 }
 
+export function getToolConfirmationRequestId(message: Message): [string, boolean] {
+  const hasToolConfirmationRequest = message.content.some(
+    (content): content is ToolConfirmationRequestMessageContent =>
+      content.type === 'toolConfirmationRequest'
+  );
+
+  const contentId = hasToolConfirmationRequest
+    ? message.content.find(
+        (content): content is ToolConfirmationRequestMessageContent =>
+          content.type === 'toolConfirmationRequest'
+      )?.id || ''
+    : '';
+
+  return [contentId, hasToolConfirmationRequest];
+}
+
 export function hasCompletedToolCalls(message: Message): boolean {
   const toolRequests = getToolRequests(message);
   if (toolRequests.length === 0) return false;

--- a/ui/desktop/src/utils/toolConfirm.ts
+++ b/ui/desktop/src/utils/toolConfirm.ts
@@ -1,0 +1,25 @@
+import { getApiUrl, getSecretKey } from '../config';
+
+export async function ConfirmToolRequest(requesyId: string, confirmed: boolean) {
+  try {
+    const response = await fetch(getApiUrl('/confirm'), {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Secret-Key': getSecretKey(),
+      },
+      body: JSON.stringify({
+        id: requesyId,
+        confirmed,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error('Delete response error: ', errorText);
+      throw new Error('Failed to confirm tool');
+    }
+  } catch (error) {
+    console.error('Error confirm tool: ', error);
+  }
+}


### PR DESCRIPTION
Right now, the approval workflow is like in the agent reply, when we have some tool calls, we will hold here before execution and have a recv queue waiting for confirmation, in CLI, it doesn't have any issue. In UI, I had two options to implement the approval flow:

1. have a separate API for confirmation only
2. send a confirmation message via reply endpoint,

However, I found that we have the [lock](https://github.com/block/goose/blob/main/crates/goose-server/src/routes/reply.rs#L116) on reply API until the streaming is done, so both of options don't work in this case, because previous session is not done, waiting for confirmation to finish the stream, but the confirmation message is waiting for the existing stream to release the lock, then you see, deadlock....
The tweak I did is to use read write lock in [AppState](https://github.com/block/goose/blob/main/crates/goose-server/src/state.rs#L12), I did a quick check in the repo, looks like in reply api, we don't have to use the write lock

Test: 
![image](https://github.com/user-attachments/assets/30dd3da8-02df-4d37-9537-2706af0fd5be)

Config
![image](https://github.com/user-attachments/assets/4ab60e5a-8762-4935-b80b-78b29ffdcad0)
