### PR TITLE
feat(cli): Improve default behavior when no command is provided

### DIFF
--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
 
-
 use goose::config::Config;
 use goose_cli::commands::configure::handle_configure;
 use goose_cli::commands::info::handle_info;

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 
-use console::style;
+
 use goose::config::Config;
 use goose_cli::commands::configure::handle_configure;
 use goose_cli::commands::info::handle_info;

--- a/crates/goose-cli/src/main.rs
+++ b/crates/goose-cli/src/main.rs
@@ -292,14 +292,15 @@ async fn main() -> Result<()> {
             return Ok(());
         }
         None => {
-            Cli::command().print_help()?;
-            println!();
             if !Config::global().exists() {
-                println!(
-                    "\n  {}: Run '{}' to setup goose for the first time",
-                    style("Tip").green().italic(),
-                    style("goose configure").cyan()
-                );
+                let _ = handle_configure().await;
+                return Ok(());
+            } else {
+                // Run session command by default
+                let mut session = build_session(None, false, vec![], vec![]).await;
+                setup_logging(session.session_file().file_stem().and_then(|s| s.to_str()))?;
+                let _ = session.interactive(None).await;
+                return Ok(());
             }
         }
     }


### PR DESCRIPTION
Instead of showing help message:

- Run configure if Goose is not yet configured
- Start interactive session by default if already configured

This makes the CLI more user-friendly by reducing the number of commands needed for common operations.