### PR TITLE
feat(desktop-ui): Command/ctrl + comma goes to Settings view

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -150,6 +150,12 @@ export default function App() {
     };
   }, []);
 
+  useEffect(() => {
+    const handleSetView = (_, view) => setView(view);
+    window.electron.on('set-view', handleSetView);
+    return () => window.electron.off('set-view', handleSetView);
+  }, []);
+
   const handleConfirm = async () => {
     if (pendingLink && !isInstalling) {
       setIsInstalling(true);

--- a/ui/desktop/src/components/MoreMenu.tsx
+++ b/ui/desktop/src/components/MoreMenu.tsx
@@ -228,7 +228,7 @@ export default function MoreMenu({ setView }: { setView: (view: View) => void })
               }}
               className="w-full text-left p-2 text-sm hover:bg-bgSubtle transition-colors"
             >
-              Settings
+              Settings (cmd+,)
             </button>
 
             <button

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -473,6 +473,22 @@ app.whenReady().then(async () => {
   // Get the existing menu
   const menu = Menu.getApplicationMenu();
 
+  // App menu
+  const appMenu = menu.items.find((item) => item.label === 'Goose');
+  // add Settings to app menu after About
+  appMenu.submenu.insert(1, new MenuItem({ type: 'separator' }));
+  appMenu.submenu.insert(1,
+    new MenuItem({
+      label: 'Settings',
+      accelerator: 'CmdOrCtrl+,',
+      click() {
+        const focusedWindow = BrowserWindow.getFocusedWindow();
+        if (focusedWindow) focusedWindow.webContents.send('set-view', 'settings');
+      },
+    })
+  );
+  appMenu.submenu.insert(1, new MenuItem({ type: 'separator' }));
+
   // Add Environment menu items to View menu
   const viewMenu = menu.items.find((item) => item.label === 'View');
   if (viewMenu) {


### PR DESCRIPTION
A very standard shortcut is Command + comma (or Ctrl + comma) to go to an App's settings or preferences (try it out on Slack, Notion, Discord, or your favorite app).

Also adding Settings to the app menu, after the About item, which is also where Chrome/Notion/Slack has it.
<img width="170" alt="image" src="https://github.com/user-attachments/assets/b40dfc53-c003-44fb-92c1-3e86d1ba6141" />

Also, adding the general ability to change views with the `'set-view'` message.