### PR TITLE
feat: implement global command history storage

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -40,7 +40,7 @@ pub fn get_input(
         },
     };
 
-    // Add valid input to history
+    // Add valid input to history (history saving to file is handled in the Session::interactive method)
     if !input.trim().is_empty() {
         editor.add_history_entry(input.as_str())?;
     }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -159,41 +159,42 @@ impl Session {
         }
 
         let mut editor = rustyline::Editor::<(), rustyline::history::DefaultHistory>::new()?;
-        
+
         // Create and use a global history file in ~/.config/goose directory
         // This allows command history to persist across different chat sessions
         // instead of being tied to each individual session's messages
         let history_file = choose_app_strategy(crate::APP_STRATEGY.clone())
             .expect("goose requires a home dir")
             .in_config_dir("history.txt");
-            
+
         // Ensure config directory exists
         if let Some(parent) = history_file.parent() {
             if !parent.exists() {
                 std::fs::create_dir_all(parent)?;
             }
         }
-        
+
         // Load history from the global file
         if history_file.exists() {
             if let Err(err) = editor.load_history(&history_file) {
                 eprintln!("Warning: Failed to load command history: {}", err);
             }
         }
-        
+
         // Helper function to save history after commands
-        let save_history = |editor: &mut rustyline::Editor<(), rustyline::history::DefaultHistory>| {
-            if let Err(err) = editor.save_history(&history_file) {
-                eprintln!("Warning: Failed to save command history: {}", err);
-            }
-        };
+        let save_history =
+            |editor: &mut rustyline::Editor<(), rustyline::history::DefaultHistory>| {
+                if let Err(err) = editor.save_history(&history_file) {
+                    eprintln!("Warning: Failed to save command history: {}", err);
+                }
+            };
 
         output::display_greeting();
         loop {
             match input::get_input(&mut editor)? {
                 input::InputResult::Message(content) => {
                     save_history(&mut editor);
-                    
+
                     self.messages.push(Message::user().with_text(&content));
                     storage::persist_messages(&self.session_file, &self.messages)?;
 
@@ -204,7 +205,7 @@ impl Session {
                 input::InputResult::Exit => break,
                 input::InputResult::AddExtension(cmd) => {
                     save_history(&mut editor);
-                    
+
                     match self.add_extension(cmd.clone()).await {
                         Ok(_) => output::render_extension_success(&cmd),
                         Err(e) => output::render_extension_error(&cmd, &e.to_string()),
@@ -212,7 +213,7 @@ impl Session {
                 }
                 input::InputResult::AddBuiltin(names) => {
                     save_history(&mut editor);
-                    
+
                     match self.add_builtin(names.clone()).await {
                         Ok(_) => output::render_builtin_success(&names),
                         Err(e) => output::render_builtin_error(&names, &e.to_string()),
@@ -220,7 +221,7 @@ impl Session {
                 }
                 input::InputResult::ToggleTheme => {
                     save_history(&mut editor);
-                    
+
                     let current = output::get_theme();
                     let new_theme = match current {
                         output::Theme::Light => {
@@ -242,12 +243,12 @@ impl Session {
                 input::InputResult::Retry => continue,
                 input::InputResult::ListPrompts => {
                     save_history(&mut editor);
-                    
+
                     output::render_prompts(&self.list_prompts().await)
                 }
                 input::InputResult::PromptCommand(opts) => {
                     save_history(&mut editor);
-                    
+
                     // name is required
                     if opts.name.is_empty() {
                         output::render_error("Prompt name argument is required");

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -243,7 +243,7 @@ impl Session {
 
         // Helper function to save history after commands
         let save_history =
-            |editor: &mut rustyline::Editor<(), rustyline::history::DefaultHistory>| {
+            |editor: &mut rustyline::Editor<GooseCompleter, rustyline::history::DefaultHistory>| {
                 if let Err(err) = editor.save_history(&history_file) {
                     eprintln!("Warning: Failed to save command history: {}", err);
                 }
@@ -303,7 +303,7 @@ impl Session {
                 input::InputResult::Retry => continue,
                 input::InputResult::ListPrompts(extension) => {
                     save_history(&mut editor);
-                  
+
                     match self.list_prompts(extension).await {
                         Ok(prompts) => output::render_prompts(&prompts),
                         Err(e) => output::render_error(&e.to_string()),

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -10,6 +10,7 @@ pub use storage::Identifier;
 
 use anyhow::Result;
 use etcetera::choose_app_strategy;
+use etcetera::AppStrategy;
 use goose::agents::extension::{Envs, ExtensionConfig};
 use goose::agents::Agent;
 use goose::message::{Message, MessageContent};
@@ -158,25 +159,41 @@ impl Session {
         }
 
         let mut editor = rustyline::Editor::<(), rustyline::history::DefaultHistory>::new()?;
-
-        // Load history from messages
-        for msg in self
-            .messages
-            .iter()
-            .filter(|m| m.role == mcp_core::role::Role::User)
-        {
-            for content in msg.content.iter() {
-                if let Some(text) = content.as_text() {
-                    if let Err(e) = editor.add_history_entry(text) {
-                        eprintln!("Warning: Failed to add history entry: {}", e);
-                    }
-                }
+        
+        // Create and use a global history file in ~/.config/goose directory
+        // This allows command history to persist across different chat sessions
+        // instead of being tied to each individual session's messages
+        let history_file = choose_app_strategy(crate::APP_STRATEGY.clone())
+            .expect("goose requires a home dir")
+            .in_config_dir("history.txt");
+            
+        // Ensure config directory exists
+        if let Some(parent) = history_file.parent() {
+            if !parent.exists() {
+                std::fs::create_dir_all(parent)?;
             }
         }
+        
+        // Load history from the global file
+        if history_file.exists() {
+            if let Err(err) = editor.load_history(&history_file) {
+                eprintln!("Warning: Failed to load command history: {}", err);
+            }
+        }
+        
+        // Helper function to save history after commands
+        let save_history = |editor: &mut rustyline::Editor<(), rustyline::history::DefaultHistory>| {
+            if let Err(err) = editor.save_history(&history_file) {
+                eprintln!("Warning: Failed to save command history: {}", err);
+            }
+        };
+
         output::display_greeting();
         loop {
             match input::get_input(&mut editor)? {
                 input::InputResult::Message(content) => {
+                    save_history(&mut editor);
+                    
                     self.messages.push(Message::user().with_text(&content));
                     storage::persist_messages(&self.session_file, &self.messages)?;
 
@@ -186,18 +203,24 @@ impl Session {
                 }
                 input::InputResult::Exit => break,
                 input::InputResult::AddExtension(cmd) => {
+                    save_history(&mut editor);
+                    
                     match self.add_extension(cmd.clone()).await {
                         Ok(_) => output::render_extension_success(&cmd),
                         Err(e) => output::render_extension_error(&cmd, &e.to_string()),
                     }
                 }
                 input::InputResult::AddBuiltin(names) => {
+                    save_history(&mut editor);
+                    
                     match self.add_builtin(names.clone()).await {
                         Ok(_) => output::render_builtin_success(&names),
                         Err(e) => output::render_builtin_error(&names, &e.to_string()),
                     }
                 }
                 input::InputResult::ToggleTheme => {
+                    save_history(&mut editor);
+                    
                     let current = output::get_theme();
                     let new_theme = match current {
                         output::Theme::Light => {
@@ -218,9 +241,13 @@ impl Session {
                 }
                 input::InputResult::Retry => continue,
                 input::InputResult::ListPrompts => {
+                    save_history(&mut editor);
+                    
                     output::render_prompts(&self.list_prompts().await)
                 }
                 input::InputResult::PromptCommand(opts) => {
+                    save_history(&mut editor);
+                    
                     // name is required
                     if opts.name.is_empty() {
                         output::render_error("Prompt name argument is required");


### PR DESCRIPTION
Store command history in ~/.config/goose/history.txt instead of per-session.

This allows command history to persist across different chat sessions.