### PR TITLE
fix(provider): update url path handling for azure provider

### DIFF
--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -67,11 +67,17 @@ impl AzureProvider {
         // Get the existing path without trailing slashes
         let existing_path = base_url.path().trim_end_matches('/');
         let new_path = if existing_path.is_empty() {
-            format!("/openai/deployments/{}/chat/completions", self.deployment_name)
+            format!(
+                "/openai/deployments/{}/chat/completions",
+                self.deployment_name
+            )
         } else {
-            format!("{}/openai/deployments/{}/chat/completions", existing_path, self.deployment_name)
+            format!(
+                "{}/openai/deployments/{}/chat/completions",
+                existing_path, self.deployment_name
+            )
         };
-                
+
         base_url.set_path(&new_path);
         base_url.set_query(Some(&format!("api-version={}", self.api_version)));
 

--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -64,10 +64,15 @@ impl AzureProvider {
         let mut base_url = url::Url::parse(&self.endpoint)
             .map_err(|e| ProviderError::RequestFailed(format!("Invalid base URL: {e}")))?;
 
-        base_url.set_path(&format!(
-            "openai/deployments/{}/chat/completions",
-            self.deployment_name
-        ));
+        // Get the existing path without trailing slashes
+        let existing_path = base_url.path().trim_end_matches('/');
+        let new_path = if existing_path.is_empty() {
+            format!("/openai/deployments/{}/chat/completions", self.deployment_name)
+        } else {
+            format!("{}/openai/deployments/{}/chat/completions", existing_path, self.deployment_name)
+        };
+                
+        base_url.set_path(&new_path);
         base_url.set_query(Some(&format!("api-version={}", self.api_version)));
 
         let response: reqwest::Response = self


### PR DESCRIPTION
## Summary
This PR fixes an issue where the Azure provider would overwrite existing paths in endpoint URLs. The fix ensures that any existing path in the Azure endpoint URL is preserved when appending the required deployment path.

> Related Issue: https://github.com/block/goose/issues/1352#issuecomment-2690807448

## Technical Details
Previous behavior: 
- Base URL paths were completely overwritten when setting the Azure deployment path
- Custom deployments with path prefixes would fail to connect properly

New behavior:
- Existing paths in base URLs are preserved and joined with Azure-specific paths
- Trailing slashes are properly handled to ensure clean path construction

## Implementation
```rust
// Before
base_url.set_path(&format!(
    "openai/deployments/{}/chat/completions",
    self.deployment_name
));

// After
let existing_path = base_url.path().trim_end_matches('/');
let new_path = if existing_path.is_empty() {
    format!("/openai/deployments/{}/chat/completions", self.deployment_name)
} else {
    format!("{}/openai/deployments/{}/chat/completions", existing_path, self.deployment_name)
};
base_url.set_path(&new_path);
```

## Areas for Review
- Path concatenation logic for different URL formats
- Compatibility with existing Azure OpenAI configurations

> ⚠️  Author is new to rust, please review carefully

