### PR TITLE
fix(cli): disable line wrap

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -323,7 +323,7 @@ fn print_markdown(content: &str, theme: Theme) {
         .input(bat::Input::from_bytes(content.as_bytes()))
         .theme(theme.as_str())
         .language("Markdown")
-        .wrapping_mode(WrappingMode::Character)
+        .wrapping_mode(WrappingMode::NoWrapping(true))
         .print()
         .unwrap();
 }


### PR DESCRIPTION
This PR closes #1305. As the author of that issue said, the problem really matters when the user wants to yank text from output. If we wrap lines manually, there would be redundant line breaks (according to the size of the current terminal), making it difficult to use the output directly.

![image](https://github.com/user-attachments/assets/f5cd5939-f322-4a00-b68c-fbe7455d9b8c)
