### PR TITLE
More responsive provider grid

### DIFF
--- a/ui/desktop/src/components/settings/providers/BaseProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/BaseProviderGrid.tsx
@@ -252,7 +252,7 @@ export function BaseProviderGrid({
   onTakeoff,
 }: BaseProviderGridProps) {
   return (
-    <div className="grid grid-cols-3 sm:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7 gap-3 auto-rows-fr max-w-full [&_*]:z-20">
+    <div className="grid grid-cols-[repeat(auto-fill,_minmax(140px,_1fr))] gap-3 [&_*]:z-20">
       {providers.map((provider) => {
         const hasRequiredKeys = required_keys[provider.name]?.length > 0;
         return (


### PR DESCRIPTION
The current Provider grid gets a little squished if the window is wide:
<img width="1893" alt="image" src="https://github.com/user-attachments/assets/986cae33-ab52-481c-9bf3-3d4cdd625d1a" />

Making this a little more responsive for the home screen
![Screen Recording 2025-02-28 at 3 46 16 PM](https://github.com/user-attachments/assets/8e054ea3-2505-432e-b165-da5078c08be4)

This CSS can be used in other places, and/or for the new Provider grid design.