### PR TITLE
docs: Use Installer Link

### DIFF
--- a/documentation/docs/tutorials/fetch-mcp.md
+++ b/documentation/docs/tutorials/fetch-mcp.md
@@ -118,10 +118,8 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. Go to the [Extensions Directory](https://block.github.io/goose/v1/extensions/)
-  2. Find the `Fetch` extension
-  3. Click `Install`
-  4. Press `Yes` to confirm the installation
+  1. [Launch the installer](goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Web%20content%20fetching%20and%20processing%20capabilities)
+  2. Press `Yes` to confirm the installation
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/figma-mcp.md
+++ b/documentation/docs/tutorials/figma-mcp.md
@@ -129,20 +129,11 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Settings`
-  3. Under `Extensions`, click the `Add` link
-  4. On the `Add Extension Manually` modal, enter the following:
-        * **Type**: `Standard IO`
-        * **ID**: `figma-mcp` (_set this to whatever you want_)
-        * **Name**: `Figma` (_set this to whatever you want_)
-        * **Description**: `Figma MCP Server` (_set this to whatever you want_)
-        * **Command**: `npx @hapins/figma-mcp`
-        * **Environment Variables**
-            * **Name**: `FIGMA_ACCESS_TOKEN`
-            * **Value**: (_Obtain a [Figma Access Token](https://www.figma.com/developers/api#access-tokens) and paste it in._)
-            * Click `Add` button
-  5. Click `Add Extension` button
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40hapins%2Ffigma-mcp&id=figma&name=Figma&description=Figma%20design%20tool%20integration&env=FIGMA_ACCESS_TOKEN%3DAccess%20token%20from%20Figma%20user%20settings)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [Figma Access Token](https://www.figma.com/developers/api#access-tokens) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/github-mcp.md
+++ b/documentation/docs/tutorials/github-mcp.md
@@ -128,23 +128,11 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Settings`
-  3. Under `Extensions`, click the `Add` link
-  4. On the `Add Extension Manually` modal, enter the following:
-        * **Type**: `Standard IO`
-        * **ID**: `gh-mcp` (_set this to whatever you want_)
-        * **Name**: `github` (_set this to whatever you want_)
-        * **Description**: `GitHub MCP Server` (_set this to whatever you want_)
-        * **Command**: `npx -y @modelcontextprotocol/server-github`
-        * **Environment Variables**
-            * **Name**: `GITHUB_PERSONAL_ACCESS_TOKEN`
-            * **Value**: (_Obtain a [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens) and paste it in._)
-              :::info
-              When creating your access token, you can specify the repositories and granular permissions you'd like Goose to have access to.
-              :::
-            * Click `Add` button
-  5. Click `Add Extension` button
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-github&id=github&name=GitHub&description=GitHub%20API&env=GITHUB_PERSONAL_ACCESS_TOKEN%3DGitHub%20Personal%20Access%20Token)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/google-drive-mcp.md
+++ b/documentation/docs/tutorials/google-drive-mcp.md
@@ -15,7 +15,7 @@ This tutorial covers how to add the [Google Drive MCP Server](https://github.com
 
 **Authentication Command**
 
-In your terminal run the following:
+In your terminal, run the following:
 
 ```sh
 GDRIVE_OAUTH_PATH=/Users/<username>/.config/gcp-oauth.keys.json \ 
@@ -186,25 +186,18 @@ You'll need to re-authenticate once a day when using the Google Drive extension.
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Settings`
-  3. Under `Extensions`, click the `Add` link
-  4. On the `Add Extension Manually` modal, enter the following:
-        * **Type**: `Standard IO`
-        * **ID**: `g-drive-mcp` (_set this to whatever you want_)
-        * **Name**: `google drive` (_set this to whatever you want_)
-        * **Description**: `Google Drive MCP Server` (_set this to whatever you want_)
-        * **Command**: `npx -y @modelcontextprotocol/server-gdrive`
-        * **Environment Variables**
-            * **Name**: `GDRIVE_CREDENTIALS_PATH`
-            * **Value**: `~/.config/.gdrive-server-credentials.json`
-            * Click `Add` button
-        * **Environment Variables**
-            * **Name**: `GDRIVE_OAUTH_PATH`
-            * **Value**: `~/.config/gcp-oauth.keys.json`
-            * Click `Add` button
-        
-  5. Click `Add Extension` button
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-gdrive&id=google-drive&name=Google%20Drive&description=Google%20Drive%20integration&env=GDRIVE_CREDENTIALS_PATH%3DPath%20to%20Google%20Drive%20credentials&env=GDRIVE_OAUTH_PATH%3DPath%20to%20OAuth%20token)
+  2. Press `Yes` to confirm the installation
+  3. For `GDRIVE_CREDENTIALS_PATH`, enter the following:
+  ```
+  ~/.config/.gdrive-server-credentials.json
+  ```
+  4. For `GDRIVE_OAUTH_PATH`, enter the following:
+  ```
+  ~/.config/gcp-oauth.keys.json
+  ```
+  5. Click `Save Configuration`
+  6. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/google-maps-mcp.md
+++ b/documentation/docs/tutorials/google-maps-mcp.md
@@ -124,20 +124,11 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Settings`
-  3. Under `Extensions`, click the `Add` link
-  4. On the `Add Extension Manually` modal, enter the following:
-        * **Type**: `Standard IO`
-        * **ID**: `google-maps-mcp` (_set this to whatever you want_)
-        * **Name**: `Google Maps` (_set this to whatever you want_)
-        * **Description**: `Google Maps API` (_set this to whatever you want_)
-        * **Command**: `npx -y @modelcontextprotocol/server-google-maps`
-        * **Environment Variables**
-            * **Name**: `GOOGLE_MAPS_API_KEY`
-            * **Value**: (_Obtain a [GOOGLE_MAPS_API_KEY](https://developers.google.com/maps/documentation/javascript/get-api-key) and paste it in._)
-            * Click `Add` button
-  5. Click `Add Extension` button
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-google-maps&id=google-maps&name=Google%20Maps&description=Google%20Maps%20API%20integration&env=GOOGLE_MAPS_API_KEY%3DGoogle%20Maps%20API%20key)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [GOOGLE_MAPS_API_KEY](https://developers.google.com/maps/documentation/javascript/get-api-key) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/knowledge-graph-mcp.md
+++ b/documentation/docs/tutorials/knowledge-graph-mcp.md
@@ -112,16 +112,9 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Settings`
-  3. Under `Extensions`, click the `Add` link
-  4. On the `Add Extension Manually` modal, enter the following:
-        * **Type**: `Standard IO`
-        * **ID**: `knowledge-graph-mcp` (_set this to whatever you want_)
-        * **Name**: `knowledge graph memory` (_set this to whatever you want_)
-        * **Description**: `knowledge graph memory MCP Server` (_set this to whatever you want_)
-        * **Command**: `npx -y @modelcontextprotocol/server-memory`
-  5. Click `Add Extension` button
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-memory&id=knowledge_graph_memory&name=Knowledge%20Graph%20Memory&description=Graph-based%20memory%20system%20for%20persistent%20knowledge%20storage)
+  2. Press `Yes` to confirm the installation
+  3. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/memory-mcp.md
+++ b/documentation/docs/tutorials/memory-mcp.md
@@ -65,6 +65,7 @@ This tutorial covers enabling and using the Memory MCP Server, which is a built-
   1. Click `...` in the upper right corner
   2. Click `Settings`
   3. Under `Extensions`, toggle `Memory` to on.
+  4. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/puppeteer-mcp.md
+++ b/documentation/docs/tutorials/puppeteer-mcp.md
@@ -111,16 +111,9 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Settings`
-  3. Under `Extensions`, click the `Add` link
-  4. On the `Add Extension Manually` modal, enter the following:
-        * **Type**: `Standard IO`
-        * **ID**: `puppeteer-mcp` (_set this to whatever you want_)
-        * **Name**: `Puppeteer` (_set this to whatever you want_)
-        * **Description**: `Puppeteer MCP Server` (_set this to whatever you want_)
-        * **Command**: `npx -y @modelcontextprotocol/server-puppeteer`
-  5. Click `Add Extension` button
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-puppeteer&id=puppeteer&name=Puppeteer&description=Headless%20browser%20automation)
+  2. Press `Yes` to confirm the installation
+  3. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/tavily-mcp.md
+++ b/documentation/docs/tutorials/tavily-mcp.md
@@ -128,20 +128,11 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Settings`
-  3. Under `Extensions`, click the `Add` link
-  4. On the `Add Extension Manually` modal, enter the following:
-        * **Type**: `Standard IO`
-        * **ID**: `tavily-mcp` (_set this to whatever you want_)
-        * **Name**: `Tavily` (_set this to whatever you want_)
-        * **Description**: `Tavily Web Search` (_set this to whatever you want_)
-        * **Command**: `uvx mcp-tavily`
-        * **Environment Variables**
-            * **Name**: `TAVILY_API_KEY`
-            * **Value**: (_Obtain a [Tavily API Key](https://tavily.com/) and paste it in._)
-            * Click `Add` button
-  5. Click `Add Extension` button
+  1. [Launch the installer](goose://extension?cmd=uvx&arg=mcp-tavily&id=tavily&name=Tavily%20Web%20Search&description=Web%20search%20capabilities%20powered%20by%20Tavily&env=TAVILY_API_KEY%3DAPI%20key%20for%20Tavily%20web%20search%20service)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [TAVILY_API_KEY](hhttps://tavily.com/) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
This pull request includes updates to the installation instructions for extensions in goose desktop. The changes simplify the installation process by replacing multiple manual steps with a single installer link.

