### PR TITLE
chore: log errors to debug, not all extensions support prompts

### DIFF
--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -619,7 +619,7 @@ impl Capabilities {
 
         // Log any errors that occurred
         if !errors.is_empty() {
-            tracing::error!(
+            tracing::debug!(
                 errors = ?errors
                     .into_iter()
                     .map(|e| format!("{:?}", e))


### PR DESCRIPTION
this prevents seeing
```
  2025-03-03T17:29:05.776501Z ERROR goose::agents::capabilities: errors from listing prompts, errors: ["ExecutionError(\"Unable to list prompts for google_drive, RpcError { code: -32601, message: \\\"Server does not support 'prompts' capability\\\" }\")"]
    at crates/goose/src/agents/capabilities.rs:622
```
for every extension that doesn't support prompts on startup