### PR TITLE
docs: Update CLI Commands Guide

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -84,9 +84,10 @@ goose configure
 ---
 
 ### info [options]
-Shows Goose information, where goose will load `config.yaml`, store data and logs.
 
-- **`-v, --verbose`**: Show verbose information including config.yaml
+Shows Goose information, including the version, configuration file location, session storage, and logs.
+
+- **`-v, --verbose`**: (Optional) Show detailed configuration settings, including environment variables and enabled extensions.
 
 **Usage:**
 ```bash
@@ -169,3 +170,18 @@ Used to show the available implementations of the agent loop itself
 ```bash
 goose agents
 ```
+
+---
+## Keyboard Shortcuts
+
+Goose CLI supports several shortcuts and built-in commands for easier navigation.
+
+### **Slash Commands**
+- **`/exit` or `/quit`** - Exit the session
+- **`/t`** - Toggle between Light/Dark modes
+- **`/?` or `/help`** - Display the help menu
+
+### **Keyboard Navigation**
+- **`Ctrl+C`** - Interrupt the current request
+- **`Ctrl+J`** - Add a newline
+- **Up/Down arrows** - Navigate through command history


### PR DESCRIPTION
## Summary
This PR updates the Goose CLI commands guide to improve clarity and include additional information about the `goose info` command and keyboard shortcuts.

## Changes
- **Enhanced `goose info` section**:
  - Expanded details to include version, configuration file location, session storage, and logs.
  - Clarified the `-v, --verbose` option to show additional configuration settings, including environment variables and enabled extensions.

- **Added a new "Keyboard Shortcuts" section**:
  - **Slash Commands**:
    - `/exit` or `/quit` - Exit the session.
    - `/t` - Toggle between Light/Dark modes.
    - `/?` or `/help` - Display the help menu.
  - **Keyboard Navigation**:
    - `Ctrl+C` - Interrupt the current request.
    - `Ctrl+J` - Add a newline.
    - Up/Down arrows - Navigate through command history.

## File Changes
- **Modified:** `documentation/docs/guides/goose-cli-commands.md`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209548116780801