### PR TITLE
docs: Add Puppeteer MCP Tutorial Video To Guide

### DIFF
--- a/documentation/docs/tutorials/puppeteer-mcp.md
+++ b/documentation/docs/tutorials/puppeteer-mcp.md
@@ -7,6 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
+<YouTubeShortEmbed videoUrl="https://youtube.com/embed/rms0wVGnlXA" />
 
 This tutorial covers how to add the [Puppeteer MCP Server](https://github.com/modelcontextprotocol/servers/tree/HEAD/src/puppeteer) as a Goose extension, enabling Goose to interact with websites - navigating pages, filling forms, clicking buttons, taking screenshots, and executing JavaScript in a real browser environment.
 


### PR DESCRIPTION
## Summary
This PR adds a YouTube Short video to the **Puppeteer MCP** tutorial, providing a visual walkthrough of how to integrate the **Puppeteer MCP Server** as a Goose extension.

## Changes
- **Added** a YouTubeShortEmbed component with the video link:
  ```html
  <YouTubeShortEmbed videoUrl="https://youtube.com/embed/rms0wVGnlXA" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209548116780809