### PR TITLE
fix: check all required keys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,7 +3419,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.96",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/ui/desktop/src/components/settings/api_keys/utils.tsx
+++ b/ui/desktop/src/components/settings/api_keys/utils.tsx
@@ -32,15 +32,15 @@ export async function getActiveProviders(): Promise<string[]> {
         // 1. Get provider's config_status
         const configStatus = provider.config_status ?? {};
 
-        // 2. Collect only the keys *not* in default_key_value
+        // 2. Collect only the keys in required_keys
         const requiredKeyEntries = Object.entries(configStatus).filter(([k]) => isRequiredKey(k));
 
-        // 3. If there are *no* non-default keys, it is NOT active
+        // 3. If there are *no* required keys, it is NOT active
         if (requiredKeyEntries.length === 0) {
           return false;
         }
 
-        // 4. Otherwise, all non-default keys must be `is_set`
+        // 4. Otherwise, all required keys must be `is_set`
         return requiredKeyEntries.every(([_, value]) => value?.is_set);
       })
       .map((provider) => provider.name || 'Unknown Provider');

--- a/ui/desktop/src/components/settings/api_keys/utils.tsx
+++ b/ui/desktop/src/components/settings/api_keys/utils.tsx
@@ -1,6 +1,6 @@
 import { Provider, ProviderResponse } from './types';
 import { getApiUrl, getSecretKey } from '../../../config';
-import { required_keys } from '../models/hardcoded_stuff'; // e.g. { OPENAI_HOST: '', OLLAMA_HOST: '' }
+import { default_key_value, required_keys } from '../models/hardcoded_stuff'; // e.g. { OPENAI_HOST: '', OLLAMA_HOST: '' }
 
 export function isSecretKey(keyName: string): boolean {
   // Endpoints and hosts should not be stored as secrets
@@ -17,33 +17,45 @@ export function isSecretKey(keyName: string): boolean {
   return !nonSecretKeys.includes(keyName);
 }
 
-// A small helper: returns true if key is *not* in default_key_value
-function isRequiredKey(key: string): boolean {
-  const allRequiredKeys = Object.values(required_keys).flat();
-  return allRequiredKeys.includes(key);
-}
-
 export async function getActiveProviders(): Promise<string[]> {
   try {
     const configSettings = await getConfigSettings();
-
     const activeProviders = Object.values(configSettings)
       .filter((provider) => {
-        // 1. Get provider's config_status
+        const providerName = provider.name;
         const configStatus = provider.config_status ?? {};
 
-        // 2. Collect only the keys in required_keys
-        const requiredKeyEntries = Object.entries(configStatus).filter(([k]) => isRequiredKey(k));
+        // Skip if provider isn't in required_keys
+        if (!required_keys[providerName]) return false;
 
-        // 3. If there are *no* required keys, it is NOT active
-        if (requiredKeyEntries.length === 0) {
-          return false;
+        // Get all required keys for this provider
+        const providerRequiredKeys = required_keys[providerName];
+
+        // Special case: If a provider has exactly one required key and that key
+        // has a default value, check if it's explicitly set
+        if (providerRequiredKeys.length === 1 && providerRequiredKeys[0] in default_key_value) {
+          const key = providerRequiredKeys[0];
+          // Only consider active if the key is explicitly set
+          return configStatus[key]?.is_set === true;
         }
 
-        // 4. Otherwise, all required keys must be `is_set`
-        return requiredKeyEntries.every(([_, value]) => value?.is_set);
+        // For providers with multiple keys or keys without defaults:
+        // Check if all required keys without defaults are set
+        const requiredNonDefaultKeys = providerRequiredKeys.filter(
+          (key) => !(key in default_key_value)
+        );
+
+        // If there are no non-default keys, this provider needs at least one key explicitly set
+        if (requiredNonDefaultKeys.length === 0) {
+          return providerRequiredKeys.some((key) => configStatus[key]?.is_set === true);
+        }
+
+        // Otherwise, all non-default keys must be set
+        return requiredNonDefaultKeys.every((key) => configStatus[key]?.is_set === true);
       })
       .map((provider) => provider.name || 'Unknown Provider');
+
+    console.log('[GET ACTIVE PROVIDERS]:', activeProviders);
     return activeProviders;
   } catch (error) {
     console.error('Failed to get active providers:', error);

--- a/ui/desktop/src/components/settings/api_keys/utils.tsx
+++ b/ui/desktop/src/components/settings/api_keys/utils.tsx
@@ -36,7 +36,7 @@ export async function getActiveProviders(): Promise<string[]> {
         if (providerRequiredKeys.length === 1 && providerRequiredKeys[0] in default_key_value) {
           const key = providerRequiredKeys[0];
           // Only consider active if the key is explicitly set
-          return configStatus[key]?.is_set;
+          return configStatus[key]?.is_set === true;
         }
 
         // For providers with multiple keys or keys without defaults:
@@ -47,11 +47,11 @@ export async function getActiveProviders(): Promise<string[]> {
 
         // If there are no non-default keys, this provider needs at least one key explicitly set
         if (requiredNonDefaultKeys.length === 0) {
-          return providerRequiredKeys.some((key) => configStatus[key]?.is_set);
+          return providerRequiredKeys.some((key) => configStatus[key]?.is_set === true);
         }
 
         // Otherwise, all non-default keys must be set
-        return requiredNonDefaultKeys.every((key) => configStatus[key]?.is_set);
+        return requiredNonDefaultKeys.every((key) => configStatus[key]?.is_set === true);
       })
       .map((provider) => provider.name || 'Unknown Provider');
 

--- a/ui/desktop/src/components/settings/api_keys/utils.tsx
+++ b/ui/desktop/src/components/settings/api_keys/utils.tsx
@@ -36,7 +36,7 @@ export async function getActiveProviders(): Promise<string[]> {
         if (providerRequiredKeys.length === 1 && providerRequiredKeys[0] in default_key_value) {
           const key = providerRequiredKeys[0];
           // Only consider active if the key is explicitly set
-          return configStatus[key]?.is_set === true;
+          return configStatus[key]?.is_set;
         }
 
         // For providers with multiple keys or keys without defaults:
@@ -47,11 +47,11 @@ export async function getActiveProviders(): Promise<string[]> {
 
         // If there are no non-default keys, this provider needs at least one key explicitly set
         if (requiredNonDefaultKeys.length === 0) {
-          return providerRequiredKeys.some((key) => configStatus[key]?.is_set === true);
+          return providerRequiredKeys.some((key) => configStatus[key]?.is_set);
         }
 
         // Otherwise, all non-default keys must be set
-        return requiredNonDefaultKeys.every((key) => configStatus[key]?.is_set === true);
+        return requiredNonDefaultKeys.every((key) => configStatus[key]?.is_set);
       })
       .map((provider) => provider.name || 'Unknown Provider');
 

--- a/ui/desktop/src/components/settings/api_keys/utils.tsx
+++ b/ui/desktop/src/components/settings/api_keys/utils.tsx
@@ -1,6 +1,6 @@
 import { Provider, ProviderResponse } from './types';
 import { getApiUrl, getSecretKey } from '../../../config';
-import { default_key_value } from '../models/hardcoded_stuff'; // e.g. { OPENAI_HOST: '', OLLAMA_HOST: '' }
+import { required_keys } from '../models/hardcoded_stuff'; // e.g. { OPENAI_HOST: '', OLLAMA_HOST: '' }
 
 export function isSecretKey(keyName: string): boolean {
   // Endpoints and hosts should not be stored as secrets
@@ -19,7 +19,8 @@ export function isSecretKey(keyName: string): boolean {
 
 // A small helper: returns true if key is *not* in default_key_value
 function isRequiredKey(key: string): boolean {
-  return !Object.prototype.hasOwnProperty.call(default_key_value, key);
+  const allRequiredKeys = Object.values(required_keys).flat();
+  return allRequiredKeys.includes(key);
 }
 
 export async function getActiveProviders(): Promise<string[]> {
@@ -43,8 +44,6 @@ export async function getActiveProviders(): Promise<string[]> {
         return requiredKeyEntries.every(([_, value]) => value?.is_set);
       })
       .map((provider) => provider.name || 'Unknown Provider');
-
-    console.log('[GET ACTIVE PROVIDERS]:', activeProviders);
     return activeProviders;
   } catch (error) {
     console.error('Failed to get active providers:', error);

--- a/ui/desktop/src/utils/providerUtils.ts
+++ b/ui/desktop/src/utils/providerUtils.ts
@@ -4,14 +4,11 @@ import { GOOSE_PROVIDER } from '../env_vars';
 import { Model } from '../components/settings/models/ModelContext';
 
 export function getStoredProvider(config: any): string | null {
-  console.log('config goose provider', config.GOOSE_PROVIDER);
-  console.log('local storage goose provider', localStorage.getItem(GOOSE_PROVIDER));
   return config.GOOSE_PROVIDER || localStorage.getItem(GOOSE_PROVIDER);
 }
 
 export function getStoredModel(): string | null {
   const storedModel = localStorage.getItem('GOOSE_MODEL'); // Adjust key name if necessary
-  console.log('local storage goose model', storedModel);
 
   if (storedModel) {
     try {


### PR DESCRIPTION
To check whether it is required key, we should check the required_keys map instead of default_keys as some keys are required and do have default value. Right now users cannot launch with ollama

Before:
<img width="877" alt="Screenshot 2025-03-03 at 5 03 55 PM" src="https://github.com/user-attachments/assets/005dbf13-b2f3-4142-bcd9-719528f3275f" />

After:
<img width="881" alt="Screenshot 2025-03-03 at 5 03 21 PM" src="https://github.com/user-attachments/assets/dd6eb5cf-23b7-4b9d-a16e-e072bb595365" />
