### PR TITLE
ci: have release depend on bundle-desktop-intel so zip is ready

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [build-cli, install-script, bundle-desktop]
+    needs: [build-cli, install-script, bundle-desktop, bundle-desktop-intel]
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
follow up to https://github.com/block/goose/pull/1488, the `.bundle-intel` command worked in https://github.com/block/goose/actions/runs/13646127790/job/38145289300