### PR TITLE
docs: remove limitation about mac intel

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -3,10 +3,10 @@ sidebar_position: 1
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import Link from "@docusaurus/Link";
-import { IconDownload } from "@site/src/components/icons/download";
 import SupportedEnvironments from '@site/src/components/SupportedEnvironments';
 import RateLimits from '@site/src/components/RateLimits';
+import DesktopInstallButtons from '@site/src/components/DesktopInstallButtons';
+
 
 
 # Install Goose
@@ -40,18 +40,10 @@ import RateLimits from '@site/src/components/RateLimits';
         :::
       </TabItem>
       <TabItem value="ui" label="Goose Desktop">
-        To install Goose, click the **button** below:
-        <div className="pill-button">
-          <Link
-            className="button button--primary button--lg"
-            to="https://github.com/block/goose/releases/download/stable/Goose.zip"
-          >
-            <IconDownload />
-            download goose desktop for macOS
-          </Link>
-        </div>
+        <DesktopInstallButtons/>
+
         <div style={{ marginTop: '1rem' }}>
-          1. Unzip the downloaded `Goose.zip` file.
+          1. Unzip the downloaded zip file.
           2. Run the executable file to launch the Goose desktop application.
 
           :::tip Updating Goose
@@ -59,11 +51,11 @@ import RateLimits from '@site/src/components/RateLimits';
           :::
 
           :::note Permissions
-            If you’re on an Apple Mac M3 and the Goose desktop app shows no window on launch, check and update the following:
+          If you’re on an Apple Mac M3 and the Goose desktop app shows no window on launch, check and update the following:
 
-            Ensure the `~/.config` directory has read and write access.
+          Ensure the `~/.config` directory has read and write access.
 
-            Goose needs this access to create the log directory and file. Once permissions are granted, the app should load correctly. For steps on how to do this, refer to the  [Troubleshooting Guide](/docs/troubleshooting.md#macos-permission-issues-m3-macs)
+          Goose needs this access to create the log directory and file. Once permissions are granted, the app should load correctly. For steps on how to do this, refer to the  [Troubleshooting Guide](/docs/troubleshooting.md#macos-permission-issues-m3-macs)
           :::
         </div>
       </TabItem>

--- a/documentation/docs/guides/updating-goose.md
+++ b/documentation/docs/guides/updating-goose.md
@@ -6,8 +6,7 @@ sidebar_position: 2
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import { IconDownload } from "@site/src/components/icons/download";
-import Link from "@docusaurus/Link";
+import DesktopInstallButtons from '@site/src/components/DesktopInstallButtons';
 
 <Tabs groupId="interface">
   <TabItem value="cli" label="Goose CLI" default>
@@ -45,17 +44,8 @@ import Link from "@docusaurus/Link";
         To update Goose to the latest stable version, reinstall using the instructions below
         :::
         <div style={{ marginTop: '1rem' }}>
-          1. To update Goose Desktop, click the button below:
-            <div className="pill-button">
-              <Link
-                className="button button--primary button--lg"
-                to="https://github.com/block/goose/releases/download/stable/Goose.zip"
-              >
-                <IconDownload />
-                download goose desktop for macOS
-              </Link>
-            </div>
-          2. Unzip the downloaded `Goose.zip` file.
+          1. <DesktopInstallButtons/>
+          2. Unzip the downloaded zip file.
           3. Run the executable file to launch the Goose Desktop application.
           4. Overwrite the existing Goose application with the new version.
           5. Run the executable file to launch the Goose desktop application.

--- a/documentation/src/components/DesktopInstallButtons.js
+++ b/documentation/src/components/DesktopInstallButtons.js
@@ -1,0 +1,26 @@
+import Link from "@docusaurus/Link";
+import { IconDownload } from "@site/src/components/icons/download";
+
+const DesktopInstallButtons = () => {
+  return (
+    <div>
+      <p>To download Goose Desktop for macOS, click one of the buttons below:</p>
+      <div className="pill-button">
+        <Link
+          className="button button--primary button--lg"
+          to="https://github.com/block/goose/releases/download/stable/Goose.zip"
+        >
+          <IconDownload /> macOS Silicon
+        </Link>
+        <Link
+          className="button button--primary button--lg"
+          to="https://github.com/block/goose/releases/download/stable/Goose_intel_mac.zip"
+        >
+          <IconDownload /> macOS Intel
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default DesktopInstallButtons;

--- a/documentation/src/components/SupportedEnvironments.js
+++ b/documentation/src/components/SupportedEnvironments.js
@@ -4,8 +4,8 @@ import Admonition from "@theme/Admonition";
 const SupportedEnvironments = () => {
   return (
     <Admonition type="info" title="Supported Environments">
-      The Goose CLI currently works on <strong>macOS</strong> and <strong>Linux</strong> systems and supports both <strong>ARM</strong> and <strong>x86</strong> architectures. However, the macOS desktop app is not currently supported for x86. 
-
+      The Goose CLI currently works on <strong>macOS</strong> and <strong>Linux</strong> systems and supports both <strong>ARM</strong> and <strong>x86</strong> architectures. 
+      
       On <strong>Windows</strong>, Goose CLI can run via WSL. If you'd like to request support for additional operating systems, please{" "}
       <a
         href="https://github.com/block/goose/discussions/867"


### PR DESCRIPTION
Updated the supported environments information by removing the note about the macOS desktop app not supporting x86.