### PR TITLE
ci: use cargo update --workspace to ensure Cargo.lock is updated

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -193,6 +193,9 @@ release version: ensure-main
 
     @cd ui/desktop && npm version {{ version }} --no-git-tag-version --allow-same-version
 
+    # see --workspace flag https://doc.rust-lang.org/cargo/commands/cargo-update.html
+    # used to update Cargo.lock after we've bumped versions in Cargo.toml
+    @cargo update --workspace
     @git add Cargo.toml Cargo.lock ui/desktop/package.json ui/desktop/package-lock.json
     @git commit --message "chore(release): release version {{ version }}"
 


### PR DESCRIPTION
Follow up to #1487, we actually need to run a `cargo update --workspace` to ensure the `Cargo.lock` file is also updated:

https://doc.rust-lang.org/cargo/commands/cargo-update.html
> --workspace
> Attempt to update only packages defined in the workspace. Other packages are updated only if they don’t already exist in the lockfile. This option is useful for updating Cargo.lock after you’ve changed version numbers in Cargo.toml.