### PR TITLE
fix: continue to use resumed session after confirmation is cancelled

### DIFF
--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -29,7 +29,9 @@ import {
 export interface ChatType {
   id: number;
   title: string;
-  historyMessageLength: number;
+  // messages up to this index are presumed to be "history" from a resumed session, this is used to track older tool confirmation requests
+  // anything before this index should not render any buttons, but anything after should
+  messageHistoryIndex: number;
   messages: Message[];
 }
 
@@ -77,7 +79,7 @@ export default function ChatView({
         return {
           id: Date.now(),
           title: resumedSession.metadata?.description || `ID: ${resumedSession.session_id}`,
-          historyMessageLength: convertedMessages.length,
+          messageHistoryIndex: convertedMessages.length,
           messages: convertedMessages,
         };
       } catch (e) {
@@ -100,7 +102,7 @@ export default function ChatView({
       id: Date.now(),
       title: 'Chat 1',
       messages: [],
-      historyMessageLength: 0,
+      messageHistoryIndex: 0,
     };
   });
   const [messageMetadata, setMessageMetadata] = useState<Record<string, string[]>>({});
@@ -322,7 +324,7 @@ export default function ChatView({
                   <UserMessage message={message} />
                 ) : (
                   <GooseMessage
-                    historyMessageLength={chat?.historyMessageLength}
+                    messageHistoryIndex={chat?.messageHistoryIndex}
                     message={message}
                     messages={messages}
                     metadata={messageMetadata[message.id || '']}

--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -29,6 +29,7 @@ import {
 export interface ChatType {
   id: number;
   title: string;
+  resumedMessageLength: number;
   messages: Message[];
 }
 
@@ -76,6 +77,7 @@ export default function ChatView({
         return {
           id: Date.now(),
           title: resumedSession.metadata?.description || `ID: ${resumedSession.session_id}`,
+          resumedMessageLength: convertedMessages.length,
           messages: convertedMessages,
         };
       } catch (e) {
@@ -98,6 +100,7 @@ export default function ChatView({
       id: Date.now(),
       title: 'Chat 1',
       messages: [],
+      resumedMessageLength: 0,
     };
   });
   const [messageMetadata, setMessageMetadata] = useState<Record<string, string[]>>({});
@@ -319,10 +322,15 @@ export default function ChatView({
                   <UserMessage message={message} />
                 ) : (
                   <GooseMessage
+                    resumedMessageLength={chat?.resumedMessageLength}
                     message={message}
                     messages={messages}
                     metadata={messageMetadata[message.id || '']}
                     append={(text) => append(createUserMessage(text))}
+                    appendMessage={(newMessage) => {
+                      const updatedMessages = [...messages, newMessage];
+                      setMessages(updatedMessages);
+                    }}
                   />
                 )}
               </div>

--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -29,7 +29,7 @@ import {
 export interface ChatType {
   id: number;
   title: string;
-  resumedMessageLength: number;
+  historyMessageLength: number;
   messages: Message[];
 }
 
@@ -77,7 +77,7 @@ export default function ChatView({
         return {
           id: Date.now(),
           title: resumedSession.metadata?.description || `ID: ${resumedSession.session_id}`,
-          resumedMessageLength: convertedMessages.length,
+          historyMessageLength: convertedMessages.length,
           messages: convertedMessages,
         };
       } catch (e) {
@@ -100,7 +100,7 @@ export default function ChatView({
       id: Date.now(),
       title: 'Chat 1',
       messages: [],
-      resumedMessageLength: 0,
+      historyMessageLength: 0,
     };
   });
   const [messageMetadata, setMessageMetadata] = useState<Record<string, string[]>>({});
@@ -322,7 +322,7 @@ export default function ChatView({
                   <UserMessage message={message} />
                 ) : (
                   <GooseMessage
-                    resumedMessageLength={chat?.resumedMessageLength}
+                    historyMessageLength={chat?.historyMessageLength}
                     message={message}
                     messages={messages}
                     metadata={messageMetadata[message.id || '']}

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -16,7 +16,7 @@ import ToolCallConfirmation from './ToolCallConfirmation';
 import MessageCopyLink from './MessageCopyLink';
 
 interface GooseMessageProps {
-  historyMessageLength: number;
+  messageHistoryIndex: number;
   message: Message;
   messages: Message[];
   metadata?: string[];
@@ -25,7 +25,7 @@ interface GooseMessageProps {
 }
 
 export default function GooseMessage({
-  historyMessageLength,
+  messageHistoryIndex,
   message,
   metadata,
   messages,
@@ -77,7 +77,7 @@ export default function GooseMessage({
   useEffect(() => {
     // If the message is the last message in the resumed session and has tool confirmation, it means the tool confirmation
     // is broken or cancelled, to contonue use the session, we need to append a tool response to avoid mismatch tool result error.
-    if (messageIndex == historyMessageLength - 1 && hasToolConfirmation) {
+    if (messageIndex == messageHistoryIndex - 1 && hasToolConfirmation) {
       appendMessage(
         createToolErrorResponseMessage(toolConfirmationContent.id, 'The tool call is cancelled.')
       );
@@ -112,7 +112,7 @@ export default function GooseMessage({
               <ToolCallWithResponse
                 // If the message is resumed and not matched tool response, it means the tool is broken or cancelled.
                 isCancelledMessage={
-                  messageIndex < historyMessageLength &&
+                  messageIndex < messageHistoryIndex &&
                   toolResponsesMap.get(toolRequest.id) == undefined
                 }
                 key={toolRequest.id}
@@ -125,8 +125,8 @@ export default function GooseMessage({
 
         {hasToolConfirmation && (
           <ToolCallConfirmation
-            isCancelledMessage={messageIndex == historyMessageLength - 1}
-            isClicked={messageIndex < historyMessageLength - 1}
+            isCancelledMessage={messageIndex == messageHistoryIndex - 1}
+            isClicked={messageIndex < messageHistoryIndex - 1}
             toolConfirmationId={toolConfirmationContent.id}
             toolName={toolConfirmationContent.toolName}
           />

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import LinkPreview from './LinkPreview';
 import GooseResponseForm from './GooseResponseForm';
 import { extractUrls } from '../utils/urlUtils';
@@ -10,18 +10,28 @@ import {
   getToolRequests,
   getToolResponses,
   getToolConfirmationContent,
+  createToolErrorResponseMessage,
 } from '../types/message';
 import ToolCallConfirmation from './ToolCallConfirmation';
 import MessageCopyLink from './MessageCopyLink';
 
 interface GooseMessageProps {
+  resumedMessageLength: number;
   message: Message;
   messages: Message[];
   metadata?: string[];
   append: (value: string) => void;
+  appendMessage: (message: Message) => void;
 }
 
-export default function GooseMessage({ message, metadata, messages, append }: GooseMessageProps) {
+export default function GooseMessage({
+  resumedMessageLength,
+  message,
+  metadata,
+  messages,
+  append,
+  appendMessage,
+}: GooseMessageProps) {
   const contentRef = useRef<HTMLDivElement>(null);
 
   // Extract text content from the message
@@ -64,6 +74,16 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
     return responseMap;
   }, [messages, messageIndex, toolRequests]);
 
+  useEffect(() => {
+    // If the message is the last message in the resumed session and has tool confirmation, it means the tool confirmation
+    // is broken or cancelled, to contonue use the session, we need to append a tool response to avoid mismatch tool result error.
+    if (messageIndex == resumedMessageLength - 1 && hasToolConfirmation) {
+      appendMessage(
+        createToolErrorResponseMessage(toolConfirmationContent.id, 'The tool call is cancelled.')
+      );
+    }
+  }, []);
+
   return (
     <div className="goose-message flex w-[90%] justify-start opacity-0 animate-[appear_150ms_ease-in_forwards]">
       <div className="flex flex-col w-full">
@@ -86,23 +106,30 @@ export default function GooseMessage({ message, metadata, messages, append }: Go
           </div>
         )}
 
-        {hasToolConfirmation && (
-          <ToolCallConfirmation
-            toolConfirmationId={toolConfirmationContent.id}
-            toolName={toolConfirmationContent.toolName}
-          />
-        )}
-
         {toolRequests.length > 0 && (
           <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 mt-1">
             {toolRequests.map((toolRequest) => (
               <ToolCallWithResponse
+                // If the message is resumed and not matched tool response, it means the tool is broken or cancelled.
+                isCancelledMessage={
+                  messageIndex < resumedMessageLength &&
+                  toolResponsesMap.get(toolRequest.id) == undefined
+                }
                 key={toolRequest.id}
                 toolRequest={toolRequest}
                 toolResponse={toolResponsesMap.get(toolRequest.id)}
               />
             ))}
           </div>
+        )}
+
+        {hasToolConfirmation && (
+          <ToolCallConfirmation
+            isCancelledMessage={messageIndex == resumedMessageLength - 1}
+            isClicked={messageIndex < resumedMessageLength - 1}
+            toolConfirmationId={toolConfirmationContent.id}
+            toolName={toolConfirmationContent.toolName}
+          />
         )}
       </div>
 

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -16,7 +16,7 @@ import ToolCallConfirmation from './ToolCallConfirmation';
 import MessageCopyLink from './MessageCopyLink';
 
 interface GooseMessageProps {
-  resumedMessageLength: number;
+  historyMessageLength: number;
   message: Message;
   messages: Message[];
   metadata?: string[];
@@ -25,7 +25,7 @@ interface GooseMessageProps {
 }
 
 export default function GooseMessage({
-  resumedMessageLength,
+  historyMessageLength,
   message,
   metadata,
   messages,
@@ -77,7 +77,7 @@ export default function GooseMessage({
   useEffect(() => {
     // If the message is the last message in the resumed session and has tool confirmation, it means the tool confirmation
     // is broken or cancelled, to contonue use the session, we need to append a tool response to avoid mismatch tool result error.
-    if (messageIndex == resumedMessageLength - 1 && hasToolConfirmation) {
+    if (messageIndex == historyMessageLength - 1 && hasToolConfirmation) {
       appendMessage(
         createToolErrorResponseMessage(toolConfirmationContent.id, 'The tool call is cancelled.')
       );
@@ -112,7 +112,7 @@ export default function GooseMessage({
               <ToolCallWithResponse
                 // If the message is resumed and not matched tool response, it means the tool is broken or cancelled.
                 isCancelledMessage={
-                  messageIndex < resumedMessageLength &&
+                  messageIndex < historyMessageLength &&
                   toolResponsesMap.get(toolRequest.id) == undefined
                 }
                 key={toolRequest.id}
@@ -125,8 +125,8 @@ export default function GooseMessage({
 
         {hasToolConfirmation && (
           <ToolCallConfirmation
-            isCancelledMessage={messageIndex == resumedMessageLength - 1}
-            isClicked={messageIndex < resumedMessageLength - 1}
+            isCancelledMessage={messageIndex == historyMessageLength - 1}
+            isClicked={messageIndex < historyMessageLength - 1}
             toolConfirmationId={toolConfirmationContent.id}
             toolName={toolConfirmationContent.toolName}
           />

--- a/ui/desktop/src/components/ToolCallConfirmation.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.tsx
@@ -2,9 +2,14 @@ import React, { useState } from 'react';
 import { ConfirmToolRequest } from '../utils/toolConfirm';
 import { snakeToTitleCase } from '../utils';
 
-export default function ToolConfirmation({ toolConfirmationId, toolName }) {
-  const [clicked, setClicked] = useState(false);
-  const [status, setStatus] = useState('');
+export default function ToolConfirmation({
+  isCancelledMessage,
+  isClicked,
+  toolConfirmationId,
+  toolName,
+}) {
+  const [clicked, setClicked] = useState(isClicked);
+  const [status, setStatus] = useState('unknown');
 
   const handleButtonClick = (confirmed) => {
     setClicked(true);
@@ -12,7 +17,11 @@ export default function ToolConfirmation({ toolConfirmationId, toolName }) {
     ConfirmToolRequest(toolConfirmationId, confirmed);
   };
 
-  return (
+  return isCancelledMessage ? (
+    <div className="goose-message-content bg-bgSubtle rounded-2xl px-4 py-2 text-textStandard">
+      Tool call confirmation is cancelled.
+    </div>
+  ) : (
     <>
       <div className="goose-message-content bg-bgSubtle rounded-2xl px-4 py-2 rounded-b-none text-textStandard">
         Goose would like to call the above tool. Allow?

--- a/ui/desktop/src/components/ToolCallConfirmation.tsx
+++ b/ui/desktop/src/components/ToolCallConfirmation.tsx
@@ -54,7 +54,9 @@ export default function ToolConfirmation({
               </svg>
             )}
             <span className="ml-2 text-textStandard">
-              {snakeToTitleCase(toolName.substring(toolName.lastIndexOf('__') + 2))} is {status}
+              {isClicked
+                ? 'Tool confirmation is not available'
+                : `${snakeToTitleCase(toolName.substring(toolName.lastIndexOf('__') + 2))} is ${status}`}
             </span>
           </div>
         </div>

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -9,11 +9,13 @@ import { Content, ToolRequestMessageContent, ToolResponseMessageContent } from '
 import { snakeToTitleCase } from '../utils';
 
 interface ToolCallWithResponseProps {
+  isCancelledMessage: boolean;
   toolRequest: ToolRequestMessageContent;
   toolResponse?: ToolResponseMessageContent;
 }
 
 export default function ToolCallWithResponse({
+  isCancelledMessage,
   toolRequest,
   toolResponse,
 }: ToolCallWithResponseProps) {
@@ -27,17 +29,19 @@ export default function ToolCallWithResponse({
     <div className="w-full">
       <Card className="">
         <ToolCallView toolCall={toolCall} />
-        {toolResponse ? (
-          <ToolResultView
-            result={
-              toolResponse.toolResult.status === 'success'
-                ? toolResponse.toolResult.value
-                : undefined
-            }
-          />
-        ) : (
-          <LoadingPlaceholder />
-        )}
+        {!isCancelledMessage ? (
+          toolResponse ? (
+            <ToolResultView
+              result={
+                toolResponse.toolResult.status === 'success'
+                  ? toolResponse.toolResult.value
+                  : undefined
+              }
+            />
+          ) : (
+            <LoadingPlaceholder />
+          )
+        ) : undefined}
       </Card>
     </div>
   );

--- a/ui/desktop/src/components/sessions/SessionHistoryView.tsx
+++ b/ui/desktop/src/components/sessions/SessionHistoryView.tsx
@@ -166,6 +166,11 @@ const SessionHistoryView: React.FC<SessionHistoryViewProps> = ({
                             <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 mt-1">
                               {toolRequests.map((toolRequest) => (
                                 <ToolCallWithResponse
+                                  // In the session history page, if no tool response found for given request, it means the tool call
+                                  // is broken or cancelled.
+                                  isCancelledMessage={
+                                    toolResponsesMap.get(toolRequest.id) == undefined
+                                  }
                                   key={toolRequest.id}
                                   toolRequest={toolRequest}
                                   toolResponse={toolResponsesMap.get(toolRequest.id)}


### PR DESCRIPTION
In the original implementaion, if users use approve mode and there is a pending confirmation and then users switch to a new session and try to resume the session, the confirmation will not be displayed corrected and cannot keep using due to mismatched tool request and response error.

In the PR, we tracked the resumed message length and use it for the base to check whether the confirmation is broken. And also append a tool response error message(mentioning the tool is cancelled) to fix the mismatch error.

Test:

https://github.com/user-attachments/assets/bb0f823b-8f64-4adc-ac18-da7a157de4e1



