### PR TITLE
Build Goose in a Docker Container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,123 @@
+# Build stage
+FROM rust:1.75-bullseye AS builder
+
+# Install Node.js and any missing dependencies
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get update && apt-get install -y \
+    nodejs \
+    libdbus-1-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create a new directory for the app
+WORKDIR /usr/src/goose
+
+# Copy the entire project
+COPY . .
+
+# Build the project
+RUN cargo build --release
+
+# Runtime stage
+FROM ubuntu:22.04
+
+# Configure non-interactive installation
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install runtime libraries with DBus and keyring support
+RUN apt-get update && apt-get install -y \
+    # Runtime dependencies
+    ca-certificates \
+    curl \
+    gnupg \
+    # DBus and keyring
+    dbus \
+    dbus-x11 \
+    gnome-keyring \
+    libsecret-1-0 \
+    libsecret-tools \
+    # Other dependencies
+    libssl3 \
+    libxcb1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Node.js
+RUN curl -fsSL https://deb.nodesource.com/setup_lts.x | bash - && \
+    apt-get update && apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install common development tools
+RUN apt-get update && apt-get install -y \
+    # Version control
+    git \
+    # Text processing and search
+    ripgrep \
+    fd-find \
+    fzf \
+    # File manipulation
+    jq \
+    # Network tools
+    wget \
+    # Process management
+    htop \
+    # System utilities
+    sudo \
+    # Text editors
+    nano \
+    vim \
+    # Archive tools
+    zip \
+    unzip \
+    # Build essentials
+    build-essential \
+    # Python
+    python3 \
+    python3-pip \
+    # Additional tools
+    tree \
+    tmux \
+    && rm -rf /var/lib/apt/lists/*
+
+# Create goose user with sudo privileges
+ARG USER_ID=1000
+RUN useradd -u ${USER_ID} -m goose && \
+    echo "goose ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/goose
+
+# Create workspace directory with correct permissions
+RUN mkdir -p /home/goose/workspace && \
+    chown -R goose:goose /home/goose
+
+WORKDIR /home/goose/workspace
+
+# Copy the built binaries
+COPY --from=builder /usr/src/goose/target/release/goose /usr/local/bin/
+
+# Create a wrapper script to initialize DBus and keyring
+RUN echo '#!/bin/bash\n\
+# Start DBus session daemon if not running\n\
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]; then\n\
+  eval $(dbus-launch --sh-syntax)\n\
+  export DBUS_SESSION_BUS_ADDRESS\n\
+fi\n\
+\n\
+# Initialize keyring if needed\n\
+if [ -z "$GNOME_KEYRING_CONTROL" ]; then\n\
+  eval $(gnome-keyring-daemon --start)\n\
+  export GNOME_KEYRING_CONTROL SSH_AUTH_SOCK\n\
+fi\n\
+\n\
+# Run the original command\n\
+exec goose "$@"\n\
+' > /usr/local/bin/goose-wrapper && \
+    chmod +x /usr/local/bin/goose-wrapper
+
+USER goose
+
+# Set up some basic git config
+RUN git config --global init.defaultBranch main && \
+    git config --global core.editor "vim"
+
+# Add some helpful aliases
+RUN echo 'alias ll="ls -la"' >> ~/.bashrc && \
+    echo 'alias fd=fdfind' >> ~/.bashrc
+
+ENTRYPOINT ["/usr/local/bin/goose-wrapper"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+services:
+  goose-cli:
+    build:
+      context: .
+      args:
+        USER_ID: ${UID:-1000}
+    volumes:
+      # Mount user's directory with read-write access
+      - .:/home/goose/workspace
+      # Mount git config (optional)
+      - ~/.gitconfig:/home/goose/.gitconfig:ro
+      # Mount SSH keys (optional)
+      - ~/.ssh:/home/goose/.ssh:ro
+    working_dir: /home/goose/workspace
+    environment:
+      - GOOSE_HOME=/home/goose/.goose
+      # Set default editor
+      - EDITOR=vim
+      # Preserve git author info
+      - GIT_AUTHOR_NAME=${GIT_AUTHOR_NAME:-Goose User}
+      - GIT_AUTHOR_EMAIL=${GIT_AUTHOR_EMAIL:-goose@example.com}
+      # Set GOOGLE_API_KEY to your own API key
+      - GOOGLE_API_KEY="XXX"
+      - GOOSE_PROVIDER=google
+      - GOOSE_MODEL=gemini-2.0-flash-exp
+      - DBUS_SESSION_BUS_ADDRESS
+      - GNOME_KEYRING_CONTROL
+      - SSH_AUTH_SOCK
+    stdin_open: true
+    tty: true
+    entrypoint: ["/bin/bash"]

--- a/documentation/docs/guides/goose-in-docker.md
+++ b/documentation/docs/guides/goose-in-docker.md
@@ -1,0 +1,49 @@
+---
+title: Goose in Docker
+sidebar_position: 3
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+:::info Tell Us What You Need
+There are various scenarios where you might want to build Goose in Docker. If the instructions below do not meet your needs, please contact us by replying to our [discussion topic](https://github.com/block/goose/discussions/1496).
+:::
+# Use Case 1: Building Goose from the source in Docker
+
+As a Goose user and developer, you can build Goose from the source file within a Docker container. This approach not only provides security benefits by creating an isolated environment but also enhances consistency and portability. For example, if you need to troubleshoot an error on a platform you don't usually work with (such as Ubuntu), you can easily debug it using Docker.
+
+To begin, you will need to modify the `Dockerfile` and `docker-compose.yml` files to suit your requirements. Some changes you might consider include:
+- Setting your API key, provider, and model in the `docker-compose.yml` file. Our example uses the Google API key and its corresponding settings, but you can find your own list of API keys [here](https://github.com/block/goose/blob/main/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx#L86-L94) and the corresponding settings [here](https://github.com/block/goose/blob/main/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx#L67-L77).
+- Changing the base image to a different Linux distribution in the `Dockerfile`. Our example uses Ubuntu, but you can switch to another distribution such as CentOS, Fedora, or Alpine.
+- Mounting your personal Goose settings and hints files in the `docker-compose.yml` file. This allows you to use your personal settings and hints files within the Docker container.
+
+Among these, only the first change is mandatory. We need to set the API key, provider, and model as environment variables because the keyring settings do not work on Ubuntu in Docker.
+
+After setting the credentials, you can build the Docker image using the following command:
+
+```bash
+docker-compose build
+```
+
+Next, run the container and connect to it using the following command:
+
+```bash
+docker-compose run --rm goose-cli
+```
+Inside the container, first try to run the following command to configure Goose:
+
+```bash
+goose configure
+```
+When prompted to save the API key to the keyring, select No, as we are already passing the API key as an environment variable.
+
+Then, you can configure Goose a second time, and this time, you can add extensions:
+```bash
+goose configure
+```
+For example, you can add the `Developer` extension. After that, you can start a session:
+```bash
+goose session
+```
+You should now be able to connect to Goose with the developer extension enabled. Follow the other tutorials if you want to enable more extensions.


### PR DESCRIPTION
## Description
This update partially addresses [issue #1072](https://github.com/block/goose/issues/1072), where users requested the ability to build and run Goose in a Docker container. Since users may have different use cases for using Docker, I've added a [discussion thread](https://github.com/block/goose/discussions/1496) to explore additional use cases and allow users to contribute their own. This update also includes a brief guide on how to build Goose within a Docker container.

## Testing
I tested this on my local laptop. 

1. When running the Goose CLI in the docker container, you can observe the following:
![goose1](https://github.com/user-attachments/assets/12c4b1fe-922f-490a-8ebe-e057378f4b9b)

2. On the first run of goose config, you select the API key settings:
![goose2](https://github.com/user-attachments/assets/032f0f48-6c9b-47c7-b470-c9d728a34a26)

3. On the second run of goose config, you choose the extension settings (I selected the developer tool).
![goose3](https://github.com/user-attachments/assets/0c618950-2acf-4088-b909-141880ec32ff)

4. Running goose session will then initiate a Goose session with developer tool capabilities.
![goose4](https://github.com/user-attachments/assets/9951bfe3-7f1f-422b-b912-bc246e4d9767)
