### PR TITLE
fix: update openrouter referer website to point to github page site

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -71,7 +71,7 @@ impl OpenRouterProvider {
             .post(url)
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {}", self.api_key))
-            .header("HTTP-Referer", "https://github.com/block/goose")
+            .header("HTTP-Referer", "https://block.github.io/goose")
             .header("X-Title", "Goose")
             .json(&payload)
             .send()


### PR DESCRIPTION
The logo for Goose on the OpenRouter leaderboard for top public apps is the Github logo instead of the Goose logo. This is probably because the referer site we point to in our requests is the Goose Github repo which uses the Github logo as the favicon. This PR changes it to point to the [Goose Github pages site](https://block.github.io/goose/) which uses the Goose favicon.

<img width="770" alt="image" src="https://github.com/user-attachments/assets/5d378341-a7ff-4db1-98b0-60aa4610d45a" />
