### PR TITLE
Feat: support auto-including dirs in binary/bench-work-dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2228,6 +2228,7 @@ dependencies = [
  "chrono",
  "ctor",
  "goose",
+ "include_dir",
  "mcp-core",
  "paste",
  "serde",

--- a/crates/goose-bench/Cargo.toml
+++ b/crates/goose-bench/Cargo.toml
@@ -21,6 +21,7 @@ serde = { version = "1.0", features = ["derive"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["registry"] }
 tokio = { version = "1.0", features = ["full"] }
+include_dir = "0.7.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -115,7 +115,7 @@ async fn run_eval(
 
 async fn run_suite(suite: &str, work_dir: &mut BenchmarkWorkDir) -> anyhow::Result<SuiteResult> {
     let mut suite_result = SuiteResult::new(suite.to_string());
-    let eval_lock = Mutex::new(0);
+    let eval_lock = Mutex::new(());
 
     if let Some(evals) = EvaluationSuiteFactory::create(suite) {
         for eval in evals {
@@ -152,7 +152,7 @@ pub async fn run_benchmark(
         format!("{}-{}", provider_name, goose_model),
         include_dirs.clone(),
     );
-    let suite_lock = Mutex::new(0);
+    let suite_lock = Mutex::new(());
     for suite in suites {
         let _unused = suite_lock.lock().await;
         work_dir.set_suite(suite);


### PR DESCRIPTION
this should obviate the need to -i the assets dir. not needing it in the run bench shell-script either.