### PR TITLE
Retain session through view changes

### DIFF
--- a/ui/desktop/src/hooks/useChat.ts
+++ b/ui/desktop/src/hooks/useChat.ts
@@ -1,0 +1,51 @@
+import { useEffect, useState } from 'react';
+import { ChatType } from '../components/ChatView';
+import { fetchSessionDetails, generateSessionId } from '../sessions';
+
+export const useChat = ({ setIsLoadingSession, setView }) => {
+  const [chat, setChat] = useState<ChatType>({
+    id: generateSessionId(),
+    title: 'New Chat',
+    messages: [],
+    messageHistoryIndex: 0,
+  });
+
+  // Check for resumeSessionId in URL parameters
+  useEffect(() => {
+    const checkForResumeSession = async () => {
+      const urlParams = new URLSearchParams(window.location.search);
+      const resumeSessionId = urlParams.get('resumeSessionId');
+
+      if (!resumeSessionId) {
+        return;
+      }
+
+      setIsLoadingSession(true);
+      try {
+        const sessionDetails = await fetchSessionDetails(resumeSessionId);
+
+        // Only set view if we have valid session details
+        if (sessionDetails && sessionDetails.session_id) {
+          setChat({
+            id: sessionDetails.session_id,
+            title: sessionDetails.metadata?.description || `ID: ${sessionDetails.session_id}`,
+            messages: sessionDetails.messages,
+            messageHistoryIndex: sessionDetails.messages.length,
+          });
+          setView('chat');
+        } else {
+          console.error('Invalid session details received');
+        }
+      } catch (error) {
+        console.error('Failed to fetch session details:', error);
+      } finally {
+        // Always clear the loading state
+        setIsLoadingSession(false);
+      }
+    };
+
+    checkForResumeSession();
+  }, [setIsLoadingSession, setView]);
+
+  return { chat, setChat };
+};

--- a/ui/desktop/src/hooks/useChat.ts
+++ b/ui/desktop/src/hooks/useChat.ts
@@ -2,7 +2,11 @@ import { useEffect, useState } from 'react';
 import { ChatType } from '../components/ChatView';
 import { fetchSessionDetails, generateSessionId } from '../sessions';
 
-export const useChat = ({ setIsLoadingSession, setView }) => {
+type UseChatArgs = {
+  setIsLoadingSession: (isLoading: boolean) => void;
+  setView: (view: string) => void;
+};
+export const useChat = ({ setIsLoadingSession, setView }: UseChatArgs) => {
   const [chat, setChat] = useState<ChatType>({
     id: generateSessionId(),
     title: 'New Chat',
@@ -45,7 +49,7 @@ export const useChat = ({ setIsLoadingSession, setView }) => {
     };
 
     checkForResumeSession();
-  }, [setIsLoadingSession, setView]);
+  }, []);
 
   return { chat, setChat };
 };

--- a/ui/desktop/src/sessions.ts
+++ b/ui/desktop/src/sessions.ts
@@ -1,4 +1,5 @@
 import { getApiUrl, getSecretKey } from './config';
+import { Message } from './types/message';
 
 export interface SessionMetadata {
   description: string;
@@ -40,7 +41,7 @@ export interface SessionMessage {
 export interface SessionDetails {
   session_id: string;
   metadata: SessionMetadata;
-  messages: SessionMessage[];
+  messages: Message[];
 }
 
 /**

--- a/ui/desktop/src/sessions.ts
+++ b/ui/desktop/src/sessions.ts
@@ -29,15 +29,6 @@ export interface SessionsResponse {
   sessions: Session[];
 }
 
-export interface SessionMessage {
-  role: 'user' | 'assistant';
-  created: number;
-  content: {
-    type: string;
-    text: string;
-  }[];
-}
-
 export interface SessionDetails {
   session_id: string;
   metadata: SessionMetadata;


### PR DESCRIPTION
Fixes: https://github.com/block/goose/issues/1532

Currently, chat messages are stored in the Chat View. So, if you navigate away from the Chat View (such as to Settings), the chat messages are lost.

This PR:
1. Moves chat message storage to the root level of the App. That way, navigating to any screen means that the chat is always retained,
2. Consolidates chat logic inside of a new hook `useChat()`. There was a few different files in which messages we being loaded/reloaded, and now it all happens here. This also allows for some refactoring and simplifying. `chat` is now where both the `messages` and `id` (aka session id) now live. It might be a good idea to combine this with the `useMessageStream()` hook, given that they share a bit of responsibility and are mildly stepping on each other's toes.