### PR TITLE
remove env vars from bottom menu model setting

### DIFF
--- a/ui/desktop/src/components/BottomMenu.tsx
+++ b/ui/desktop/src/components/BottomMenu.tsx
@@ -179,7 +179,7 @@ export default function BottomMenu({
               <ModelRadioList
                 className="divide-y divide-borderSubtle"
                 renderItem={({ model, isSelected, onSelect }) => (
-                  <label key={model.name} className="block cursor-pointer">
+                  <label key={model.alias ?? model.name} className="block cursor-pointer">
                     <div
                       className="flex items-center justify-between p-2 text-textStandard hover:bg-bgSubtle transition-colors"
                       onClick={onSelect}

--- a/ui/desktop/src/components/BottomMenu.tsx
+++ b/ui/desktop/src/components/BottomMenu.tsx
@@ -118,10 +118,7 @@ export default function BottomMenu({
     };
   }, [isGooseModeMenuOpen]);
 
-  let envModelProvider = null;
-  if (window.electron.getConfig().GOOSE_MODEL && window.electron.getConfig().GOOSE_PROVIDER) {
-    envModelProvider = `${window.electron.getConfig().GOOSE_MODEL}  - ${window.electron.getConfig().GOOSE_PROVIDER}`;
-  }
+  // Removed the envModelProvider code that was checking for environment variables
 
   return (
     <div className="flex justify-between items-center text-textSubtle relative bg-bgSubtle border-t border-borderSubtle text-xs pl-4 h-[40px] pb-1 align-middle">
@@ -167,9 +164,7 @@ export default function BottomMenu({
           className="flex items-center cursor-pointer"
           onClick={() => setIsModelMenuOpen(!isModelMenuOpen)}
         >
-          <span>
-            {envModelProvider || (currentModel?.alias ?? currentModel?.name) || 'Select Model'}
-          </span>
+          <span>{currentModel?.name || 'Select Model'}</span>
           {isModelMenuOpen ? (
             <ChevronDown className="w-4 h-4 ml-1" />
           ) : (
@@ -184,14 +179,14 @@ export default function BottomMenu({
               <ModelRadioList
                 className="divide-y divide-borderSubtle"
                 renderItem={({ model, isSelected, onSelect }) => (
-                  <label key={model.alias ?? model.name} className="block cursor-pointer">
+                  <label key={model.name} className="block cursor-pointer">
                     <div
                       className="flex items-center justify-between p-2 text-textStandard hover:bg-bgSubtle transition-colors"
                       onClick={onSelect}
                     >
                       <div>
-                        <p className="text-sm ">{model.alias ?? model.name}</p>
-                        <p className="text-xs text-textSubtle">{model.subtext ?? model.provider}</p>
+                        <p className="text-sm ">{model.name}</p>
+                        <p className="text-xs text-textSubtle">{model.provider}</p>
                       </div>
                       <div className="relative">
                         <input

--- a/ui/desktop/src/components/BottomMenu.tsx
+++ b/ui/desktop/src/components/BottomMenu.tsx
@@ -164,7 +164,7 @@ export default function BottomMenu({
           className="flex items-center cursor-pointer"
           onClick={() => setIsModelMenuOpen(!isModelMenuOpen)}
         >
-          <span>{currentModel?.name || 'Select Model'}</span>
+          <span>{(currentModel?.alias ?? currentModel?.name) || 'Select Model'}</span>
           {isModelMenuOpen ? (
             <ChevronDown className="w-4 h-4 ml-1" />
           ) : (
@@ -185,8 +185,8 @@ export default function BottomMenu({
                       onClick={onSelect}
                     >
                       <div>
-                        <p className="text-sm ">{model.name}</p>
-                        <p className="text-xs text-textSubtle">{model.provider}</p>
+                        <p className="text-sm ">{model.alias ?? model.name}</p>
+                        <p className="text-xs text-textSubtle">{model.subtext ?? model.provider}</p>
                       </div>
                       <div className="relative">
                         <input


### PR DESCRIPTION
We should only lookup the current model from the UI settings and not use environment variables. 

If environment variables are provided, sync them at startup with the React context provider (the object that provides to all components the model and provider information)  so we don't keep looking up the environment variables every time we need to display the model name, we just use the context provider -- this allows the state to dynamically change and we don't keep showing the same model/provider for the bottom menu 