### PR TITLE
fix: update anthropic provider headers

### DIFF
--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -161,15 +161,14 @@ impl Provider for AnthropicProvider {
         headers.insert("x-api-key", self.api_key.parse().unwrap());
         headers.insert("anthropic-version", "2023-06-01".parse().unwrap());
 
-        let is_thinking_enabled = std::env::var("ANTHROPIC_THINKING_ENABLED").is_ok();
-        if self.model.model_name.starts_with("claude-3-7-sonnet-") && is_thinking_enabled {
+        if self.model.model_name.starts_with("claude-3-7-sonnet-") {
+            // https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-output-capabilities-beta
+            headers.insert("anthropic-beta", "output-128k-2025-02-19".parse().unwrap());
             // https://docs.anthropic.com/en/docs/build-with-claude/tool-use/token-efficient-tool-use
             headers.insert(
                 "anthropic-beta",
                 "token-efficient-tools-2025-02-19".parse().unwrap(),
-            );
-            // https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-output-capabilities-beta
-            headers.insert("anthropic-beta", "output-128k-2025-02-19".parse().unwrap());
+            );            
         }
         // Make request
         let response = self.post(headers, payload.clone()).await?;

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -164,7 +164,7 @@ impl Provider for AnthropicProvider {
         let is_thinking_enabled = std::env::var("ANTHROPIC_THINKING_ENABLED").is_ok();
         if self.model.model_name.starts_with("claude-3-7-sonnet-") && is_thinking_enabled {
             // https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-output-capabilities-beta
-            headers.insert("anthropic-beta", "output-128k-2025-02-19".parse().unwrap());          
+            headers.insert("anthropic-beta", "output-128k-2025-02-19".parse().unwrap());
         }
 
         if self.model.model_name.starts_with("claude-3-7-sonnet-") {
@@ -174,7 +174,6 @@ impl Provider for AnthropicProvider {
                 "token-efficient-tools-2025-02-19".parse().unwrap(),
             );
         }
-
 
         // Make request
         let response = self.post(headers, payload.clone()).await?;

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -161,15 +161,21 @@ impl Provider for AnthropicProvider {
         headers.insert("x-api-key", self.api_key.parse().unwrap());
         headers.insert("anthropic-version", "2023-06-01".parse().unwrap());
 
-        if self.model.model_name.starts_with("claude-3-7-sonnet-") {
+        let is_thinking_enabled = std::env::var("ANTHROPIC_THINKING_ENABLED").is_ok();
+        if self.model.model_name.starts_with("claude-3-7-sonnet-") && is_thinking_enabled {
             // https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#extended-output-capabilities-beta
-            headers.insert("anthropic-beta", "output-128k-2025-02-19".parse().unwrap());
+            headers.insert("anthropic-beta", "output-128k-2025-02-19".parse().unwrap());          
+        }
+
+        if self.model.model_name.starts_with("claude-3-7-sonnet-") {
             // https://docs.anthropic.com/en/docs/build-with-claude/tool-use/token-efficient-tool-use
             headers.insert(
                 "anthropic-beta",
                 "token-efficient-tools-2025-02-19".parse().unwrap(),
-            );            
+            );
         }
+
+
         // Make request
         let response = self.post(headers, payload.clone()).await?;
 


### PR DESCRIPTION
efficient tool use header only depends on the model being claude 3.7 sonnet (thinking doesn't need to be enabled)