### PR TITLE
[fix] fix model config logging to remove api key

### DIFF
--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -183,7 +183,7 @@ impl Provider for AnthropicProvider {
         let usage = get_usage(&response)?;
 
         let model = get_model(&response);
-        emit_debug_trace(self, &payload, &response, &usage);
+        emit_debug_trace(&self.model, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))
     }
 }

--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -142,7 +142,7 @@ impl Provider for AzureProvider {
             Err(e) => return Err(e),
         };
         let model = get_model(&response);
-        emit_debug_trace(self, &payload, &response, &usage);
+        emit_debug_trace(&self.model, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))
     }
 }

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -270,7 +270,7 @@ impl Provider for DatabricksProvider {
             Err(e) => return Err(e),
         };
         let model = get_model(&response);
-        super::utils::emit_debug_trace(self, &payload, &response, &usage);
+        super::utils::emit_debug_trace(&self.model, &payload, &response, &usage);
 
         Ok((message, ProviderUsage::new(model, usage)))
     }

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -501,7 +501,7 @@ impl Provider for GcpVertexAIProvider {
         let response = self.post(request.clone(), &context).await?;
         let usage = get_usage(&response, &context)?;
 
-        emit_debug_trace(self, &request, &response, &usage);
+        emit_debug_trace(&self.model, &request, &response, &usage);
 
         // Convert response to message
         let message = response_to_message(response, context)?;

--- a/crates/goose/src/providers/google.rs
+++ b/crates/goose/src/providers/google.rs
@@ -133,7 +133,7 @@ impl Provider for GoogleProvider {
             Some(model_version) => model_version.as_str().unwrap_or_default().to_string(),
             None => self.model.model_name.clone(),
         };
-        emit_debug_trace(self, &payload, &response, &usage);
+        emit_debug_trace(&self.model, &payload, &response, &usage);
         let provider_usage = ProviderUsage::new(model, usage);
         Ok((message, provider_usage))
     }

--- a/crates/goose/src/providers/groq.rs
+++ b/crates/goose/src/providers/groq.rs
@@ -148,7 +148,7 @@ impl Provider for GroqProvider {
             Err(e) => return Err(e),
         };
         let model = get_model(&response);
-        super::utils::emit_debug_trace(self, &payload, &response, &usage);
+        super::utils::emit_debug_trace(&self.model, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))
     }
 }

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -205,7 +205,7 @@ impl Provider for OllamaProvider {
             Err(e) => return Err(e),
         };
         let model = get_model(&response);
-        super::utils::emit_debug_trace(self, &payload, &response, &usage);
+        super::utils::emit_debug_trace(&self.model, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))
     }
 }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -150,7 +150,7 @@ impl Provider for OpenAiProvider {
             Err(e) => return Err(e),
         };
         let model = get_model(&response);
-        emit_debug_trace(self, &payload, &response, &usage);
+        emit_debug_trace(&self.model, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))
     }
 }

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -238,7 +238,7 @@ impl Provider for OpenRouterProvider {
             Err(e) => return Err(e),
         };
         let model = get_model(&response);
-        emit_debug_trace(self, &payload, &response, &usage);
+        emit_debug_trace(&self.model, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))
     }
 }

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{from_value, json, Map, Value};
 use std::io::Read;
 use std::path::Path;
+use crate::model::ModelConfig;
 
 use crate::providers::errors::{OpenAIError, ProviderError};
 use mcp_core::content::ImageContent;
@@ -316,21 +317,15 @@ pub fn unescape_json_values(value: &Value) -> Value {
     }
 }
 
-pub fn emit_debug_trace<T: serde::Serialize>(
-    model_config: &T,
-    payload: &impl serde::Serialize,
+pub fn emit_debug_trace(
+    model_config: &ModelConfig,
+    payload: &Value,
     response: &Value,
     usage: &Usage,
 ) {
-    // Handle both Map<String, Value> and Value payload types
-    let payload_str = match serde_json::to_value(payload) {
-        Ok(value) => serde_json::to_string_pretty(&value).unwrap_or_default(),
-        Err(_) => serde_json::to_string_pretty(&payload).unwrap_or_default(),
-    };
-
     tracing::debug!(
         model_config = %serde_json::to_string_pretty(model_config).unwrap_or_default(),
-        input = %payload_str,
+        input = %serde_json::to_string_pretty(payload).unwrap_or_default(),
         output = %serde_json::to_string_pretty(response).unwrap_or_default(),
         input_tokens = ?usage.input_tokens.unwrap_or_default(),
         output_tokens = ?usage.output_tokens.unwrap_or_default(),

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -1,5 +1,6 @@
 use super::base::Usage;
 use super::errors::GoogleErrorCode;
+use crate::model::ModelConfig;
 use anyhow::Result;
 use base64::Engine;
 use regex::Regex;
@@ -8,7 +9,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::{from_value, json, Map, Value};
 use std::io::Read;
 use std::path::Path;
-use crate::model::ModelConfig;
 
 use crate::providers::errors::{OpenAIError, ProviderError};
 use mcp_core::content::ImageContent;


### PR DESCRIPTION
Incorrect trace payload was being written to logs which included api keys on the provider.