### PR TITLE
docs: Add running tasks guide

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -144,7 +144,7 @@ goose mcp <name>
 
 ### run [options]
 
-Execute commands from an instruction file or stdin
+Execute commands from an instruction file or stdin. Check out the [full guide](/docs/guides/running-tasks) for more info.
 
 **Options:**
 

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -150,8 +150,12 @@ Execute commands from an instruction file or stdin
 
 - **`-i, --instructions <FILE>`**: Path to instruction file containing commands
 - **`-t, --text <TEXT>`**: Input text to provide to Goose directly
-- **`-n, --name <NAME>`**: Name for this run session (e.g., 'daily-tasks')
+- **`-s, --interactive`**: Continue in interactive mode after processing initial input
+- **`-n, --name <NAME>`**: Name for this run session (e.g. 'daily-tasks')
 - **`-r, --resume`**: Resume from a previous run
+- **`-p, --path <PATH>`**: Path for this run session (e.g. './playground.jsonl')
+- **`--with-extension <COMMAND>`**: Add stdio extensions (can be used multiple times in the same command)
+- **`--with-builtin <NAME>`**: Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')
 
 **Usage:**
 

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -18,7 +18,7 @@ goose run -t "your instructions here"
 
 Using the `-t` flag, one is able to pass a text instruction directly to the command. This is great for quick, one-off commands where you do not need an interactive session with Goose. The instructions will be executed, and the session will end. An example usage could be using in a CI/CD pipeline or running alongside other scripts.
 
-### Using an instruction file:
+### Using an instruction file
 If you have a complex set of instructions or a workflow that you want to automate, you can store them in a file and pass it to the `goose run` command:
 
 ```bash

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -109,7 +109,7 @@ goose run -t "Generate a test plan for the login feature"
 
 ### Development Workflows
 
-Start a development session with specific extensions:
+Start a session with specific extensions:
 ```bash
 goose run --with-builtin developer,git -n dev-session -s
 ```

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -52,7 +52,7 @@ Save findings in 'security_audit.md' with severity levels highlighted.
 
 ### Interactive Mode
 
-If you don't want Goose to exit at the end of the task, you can pass the `s` flag to start an interactive session after processing your initial commands:
+If you don't want Goose to exit at the end of the task, you can pass the `-s` or `--interactive` flag to start an interactive session after processing your initial commands:
 
 ```bash
 goose run -i instructions.txt -s
@@ -76,11 +76,15 @@ goose run -n my-project -r
 
 If you want to ensure specific extensions are available when running your task, you can indicate this with arguments. This can be done using the `--with-extension` or `--with-builtin` flags:
 
-```bash
-# Use built-in extensions e.g developer and computercontroller extensions
-goose run --with-builtin "developer,computercontroller" -t "your instructions"
+- Using built-in extensions e.g developer and computercontroller extensions
 
-# Use custom extensions
+```bash
+goose run --with-builtin "developer,computercontroller" -t "your instructions"
+```
+
+- Using custom extensions
+
+```bash
 goose run --with-extension "ENV1=value1 custom-extension-args" -t "your instructions"
 ```
 
@@ -104,14 +108,14 @@ goose run -i build-script.txt
 
 For one-off commands, use the text option:
 ```bash
-goose run -t "Generate a test plan for the login feature"
+goose run -t "Create a CHANGELOG.md entry comparing current git branch with main"
 ```
 
 ### Development Workflows
 
 Start a session with specific extensions:
 ```bash
-goose run --with-builtin developer,git -n dev-session -s
+goose run --with-builtin "developer,git" -n dev-session -s
 ```
 
 ### Combining Options
@@ -121,7 +125,7 @@ You can combine multiple options to create powerful workflows:
 ```bash
 # Complex example combining multiple options
 goose run \
-  --with-builtin developer,git \
+  --with-builtin "developer,git" \
   --with-extension "API_KEY=xyz123 custom-tool" \
   -n project-setup \
   -t "Initialize project" 

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -74,7 +74,7 @@ goose run -n my-project -r
 
 ### Working with Extensions
 
-If you want to ensure specific extensions are available when running your task, you can pas this as arguments as well to the `goose run` command. This can be done using the `--with-extension` or `--with-builtin` flags:
+If you want to ensure specific extensions are available when running your task, you can indicate this with arguments. This can be done using the `--with-extension` or `--with-builtin` flags:
 
 ```bash
 # Use built-in extensions e.g developer and computercontroller extensions

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -22,7 +22,7 @@ Using the `-t` flag, one is able to pass a text instruction directly to the comm
 If you have a complex set of instructions or a workflow that you want to automate, you can store them in a file and pass it to the `goose run` command:
 
 ```bash
-goose run -i instructions.txt
+goose run -i instructions.md
 ```
 
 Here's an example of an instruction file that runs a security audit on project dependencies:

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -1,0 +1,135 @@
+---
+sidebar_position: 7
+---
+# Running Tasks
+
+When working with the Goose CLI, you can pass files and instructions to the `goose run` command to execute tasks and workflows. This could be a simple one-liner command or a complex set of instructions stored in a file.
+
+## Basic Usage
+
+The `goose run` command starts a new session, begins executing using any arguments provided and exits the session automatically once the task is complete. 
+
+There are multiple ways to run tasks with Goose - see a list of `goose run` options [here](/docs/guides/goose-cli-commands.md#run-options):
+
+### Text in the command
+```bash
+goose run -t "your instructions here"
+```
+
+Using the `-t` flag, one is able to pass a text instruction directly to the command. This is great for quick, one-off commands. An example usage could be using in a CI/CD pipeline or running alongside other scripts.
+
+### Using an instruction file:
+If you have a complex set of instructions or a workflow that you want to automate, you can store them in a file and pass it to the `goose run` command:
+
+```bash
+goose run -i instructions.txt
+```
+
+Here's an example of an instruction file that runs a security audit on project dependencies:
+
+```text
+# Dependency Security Audit
+
+1. Analyze project dependencies:
+   - Check package.json and requirements.txt files
+   - List all dependencies with versions
+   - Identify outdated packages
+
+2. Security check:
+   - Run npm audit (for JavaScript packages)
+   - Check for known vulnerabilities in Python packages
+   - Identify dependencies with critical security issues
+
+3. Create an upgrade plan:
+   - List packages requiring immediate updates
+   - Note breaking changes in latest versions
+   - Estimate impact of required updates
+
+Save findings in 'security_audit.md' with severity levels highlighted.
+```
+
+## Key Features
+
+### Interactive Mode
+
+If you don't want Goose to exit at the end of the task, you can pass the `s` flag to start an interactive session after processing your initial commands:
+
+```bash
+goose run -i instructions.txt -s
+```
+
+This is useful when you want to continue working with Goose after your initial commands are processed.
+
+### Session Management
+
+You can name and manage your sessions:
+
+```bash
+# Start a new named session
+goose run -n my-project -t "initial instructions"
+
+# Resume a previous session
+goose run -n my-project -r
+```
+
+### Working with Extensions
+
+If you want to ensure specific extensions are available when running your task, you can pas this as arguments as well to the `goose run` command. This can be done using the `--with-extension` or `--with-builtin` flags:
+
+```bash
+# Use built-in extensions e.g developer and computercontroller extensions
+goose run --with-builtin "developer,computercontroller" -t "your instructions"
+
+# Use custom extensions
+goose run --with-extension "ENV1=value1 custom-extension-args" -t "your instructions"
+```
+
+## Common Use Cases
+
+### Running Script Files
+
+Create an instruction file (e.g., `build-script.txt`):
+```text
+Check the current branch
+Run the test suite
+Build the documentation
+```
+
+Then run it:
+```bash
+goose run -i build-script.txt
+```
+
+### Quick Commands
+
+For one-off commands, use the text option:
+```bash
+goose run -t "Generate a test plan for the login feature"
+```
+
+### Development Workflows
+
+Start a development session with specific extensions:
+```bash
+goose run --with-builtin developer,git -n dev-session -s
+```
+
+### Combining Options
+
+You can combine multiple options to create powerful workflows:
+
+```bash
+# Complex example combining multiple options
+goose run \
+  --with-builtin developer,git \
+  --with-extension "API_KEY=xyz123 custom-tool" \
+  -n project-setup \
+  -t "Initialize project" 
+```
+
+This command:
+1. Loads the developer and git built-in extensions
+2. Adds a custom extension with an API key
+3. Names the session "project-setup"
+4. Starts with "Initialize project" instruction
+5. Exits automatically after processing the command.

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -9,7 +9,7 @@ When working with the Goose CLI, you can pass files and instructions to the `goo
 
 The `goose run` command starts a new session, begins executing using any arguments provided and exits the session automatically once the task is complete. 
 
-There are multiple ways to run tasks with Goose - see a list of `goose run` options [here](/docs/guides/goose-cli-commands.md#run-options):
+There are multiple ways to run tasks with Goose; check out the [list of options](/docs/guides/goose-cli-commands.md#run-options).
 
 ### Text in the command
 ```bash

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -16,7 +16,7 @@ There are multiple ways to run tasks with Goose - see a list of `goose run` opti
 goose run -t "your instructions here"
 ```
 
-Using the `-t` flag, one is able to pass a text instruction directly to the command. This is great for quick, one-off commands. An example usage could be using in a CI/CD pipeline or running alongside other scripts.
+Using the `-t` flag, one is able to pass a text instruction directly to the command. This is great for quick, one-off commands where you do not need an interactive session with Goose. The instructions will be executed, and the session will end. An example usage could be using in a CI/CD pipeline or running alongside other scripts.
 
 ### Using an instruction file:
 If you have a complex set of instructions or a workflow that you want to automate, you can store them in a file and pass it to the `goose run` command:

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -27,7 +27,7 @@ goose run -i instructions.txt
 
 Here's an example of an instruction file that runs a security audit on project dependencies:
 
-```text
+```md
 # Dependency Security Audit
 
 1. Analyze project dependencies:


### PR DESCRIPTION
This pull request includes updates to the Goose CLI documentation to add new command options and provide detailed usage instructions.

### Documentation updates:

* [`documentation/docs/guides/goose-cli-commands.md`](diffhunk://#diff-3dcfd1ace334a91a35076b1c7e66337d2466d0aa1a5a13ee7e20db186fe401e4L153-R158): Added new command options `--interactive`, `--path`, `--with-extension`, and `--with-builtin` to the Goose CLI command reference.
* [`documentation/docs/guides/running-tasks.md`](diffhunk://#diff-72df0b00101b152475100b818a23517fe703a7598aa6f2ddc8d2407bad7b5cc5R1-R135): Created a new guide for running tasks with Goose CLI, including examples of basic usage, interactive mode, session management, working with extensions, and common use cases.