### PR TITLE
docs: Persistent Command History

### DIFF
--- a/documentation/docs/guides/logs.md
+++ b/documentation/docs/guides/logs.md
@@ -9,15 +9,22 @@ Goose uses a unified storage system for conversations and interactions. All conv
 
 | **Type**            | **Unix-like (macOS, Linux)**              | **Windows**                              |
 |---------------------|----------------------------------------|---------------------------------------------|
-| **Session Records** | `~/.local/share/goose/sessions/`      | `%APPDATA%\Block\goose\data\sessions\`     |
-| **System Logs**     | `~/.local/state/goose/logs/`          | `%APPDATA%\Block\goose\data\logs\`         |
-
+| **Command History** | `~/.config/goose/history.txt`          | `%APPDATA%\Block\goose\data\history.txt`    |
+| **Session Records** | `~/.local/share/goose/sessions/`       | `%APPDATA%\Block\goose\data\sessions\`      |
+| **System Logs**     | `~/.local/state/goose/logs/`           | `%APPDATA%\Block\goose\data\logs\`          |
 
 :::info Privacy
 Goose is a local application and all log files are stored locally. These logs are never sent to external servers or third parties, ensuring that all data remains private and under your control.
 :::
 
+## Command History
 
+Goose stores command history persistently across chat sessions, allowing Goose to recall previous commands.
+
+Command history logs are stored in:
+
+* Unix-like: ` ~/.config/goose/history.txt`
+* Windows: `%APPDATA%\Block\goose\data\history.txt`
 
 ## Session Records
 
@@ -26,7 +33,7 @@ Goose maintains session records in `~/.local/share/goose/sessions/` that track t
 Session files are named with the pattern `[session-id].jsonl` where the session ID matches the identifier used in the corresponding log files. For example, `ccK9OTmS.jsonl` corresponds to log files like `20250211_133920-ccK9OTmS.log`.
 
 Each session file contains a chronological record of:
-- User messages and commands
+- User messages and commands  (commands are also stored persistently in `history.txt`)
 - Assistant (Goose) responses
 - Tool requests and their results
 - Timestamps for all interactions


### PR DESCRIPTION
This PR updates the **Goose Logging System** documentation to include **persistent command history storage**. Instead of session-based history, Goose now retains command history across chat sessions in a dedicated history file.  

## ✨ Changes  
- **Added `Command History` section** to `logs.md`, detailing where command history is stored.  
- **Updated logging table** to include `~/.config/goose/history.txt` (Unix-like) and `%APPDATA%\Block\goose\data\history.txt` (Windows).  
- **Clarified session records** by noting that commands are now persistently stored in `history.txt`.  

## 📂 New Command History Storage Locations  
| **Type**            | **Unix-like (macOS, Linux)**             | **Windows**                              |
|---------------------|----------------------------------------|---------------------------------------------|
| **Command History** | `~/.config/goose/history.txt`          | `%APPDATA%\Block\goose\data\history.txt`    |



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209564071738931