### PR TITLE
Fix deep link opening when window is closed

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -74,6 +74,8 @@ export default function App() {
     return `${cmd} ${args.join(' ')}`.trim();
   }
 
+  useEffect(() => window.electron.reactReady(), []);
+
   useEffect(() => {
     const handleAddExtension = (_: any, link: string) => {
       const command = extractCommand(link);

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -4,6 +4,7 @@ const config = JSON.parse(process.argv.find((arg) => arg.startsWith('{')) || '{}
 
 // Define the API types in a single place
 type ElectronAPI = {
+  reactReady: () => void;
   getConfig: () => Record<string, any>;
   hideWindow: () => void;
   directoryChooser: (replace: string) => void;
@@ -44,6 +45,7 @@ type AppConfigAPI = {
 };
 
 const electronAPI: ElectronAPI = {
+  reactReady: () => ipcRenderer.send('react-ready'),
   getConfig: () => config,
   hideWindow: () => ipcRenderer.send('hide-window'),
   directoryChooser: (replace: string) => ipcRenderer.send('directory-chooser', replace),


### PR DESCRIPTION
Fixes https://github.com/block/goose/issues/1534

When clicking a deep link, sometimes the window is closed. We open up a new window, and then wait until that window has loaded to send a message to the renderer to open an extension link.

The issue is that even though the window has loaded, React has not loaded, so it misses this message.

Instead, we need React to tell the main process that it is ready. So, create a `reactReady` call that does this. This might be useful later on for other needs as well (deep link or otherwise).

Then, when the main process gets a `react-ready` message, if there is a `pendingDeepLink`, it sends the message to the renderer to open the extension link.