### PR TITLE
fix: handle interruptions during tool responses

### DIFF
--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -148,13 +148,9 @@ export default function ChatView({
       } else {
         setMessages([]);
       }
-    } else if (lastMessage && isUserMessage(lastMessage) && isToolResponse) {
       // Interruption occured after a tool has completed, but no assistant reply
-      let responseMessage = createAssistantMessage(
-        'The tool calling loop was interrupted. How would you like to proceed?'
-      );
-
-      setMessages([...messages, responseMessage]);
+      // handle his if we want to popup a message too the user
+      // } else if (lastMessage && isUserMessage(lastMessage) && isToolResponse) {
     } else if (!isUserMessage(lastMessage)) {
       // the last message was an assistant message
       // check if we have any tool requests or tool confirmation requests
@@ -207,12 +203,8 @@ export default function ChatView({
           responseMessage.content.push(toolResponse);
         }
 
-        let assistantResponseMessage = createAssistantMessage(
-          `The existing call to \`${lastToolName}\`was interrupted. How would you like to proceed?`
-        );
-
         // Use an immutable update to add the response message to the messages array
-        setMessages([...messages, responseMessage, assistantResponseMessage]);
+        setMessages([...messages, responseMessage]);
       }
     }
   };


### PR DESCRIPTION
goose can be interrupted during tool responses as well, previously it would fall into the first conditional and just remove the last user message and get the following:
```
Ran into this error: Request failed: Request failed with status: 400 Bad Request. Message: {"external_model_provider":"amazon-bedrock","external_model_error":{"message":"messages.140: Did not find 1 tool_result block(s) at the beginning of this message. Messages following tool_use blocks must begin with a matching number of tool_result blocks."}}.
```

at some point before the message apis changes we were checking that
https://github.com/block/goose/blob/81a0334aa109b4c636ce1448c7425225ba11b3b6/ui/desktop/src/components/ChatView.tsx#L101
there were no "toolInvocations" in the user message.

this PR adds that check back in for the updated api messages.
