### PR TITLE
Extension error toast stays until dismissed, and error message cleanup

### DIFF
--- a/ui/desktop/src/extensions.ts
+++ b/ui/desktop/src/extensions.ts
@@ -100,12 +100,12 @@ export async function addExtension(
 
     const errorMessage = `Error adding ${extension.name} extension ${data.message ? `. ${data.message}` : ''}`;
     console.error(errorMessage);
-    toast.error(errorMessage);
+    toast.error(errorMessage, { autoClose: false });
     return response;
   } catch (error) {
     const errorMessage = `Failed to add ${extension.name} extension: ${error instanceof Error ? error.message : 'Unknown error'}`;
     console.error(errorMessage);
-    toast.error(errorMessage);
+    toast.error(errorMessage, { autoClose: false });
     throw error;
   }
 }
@@ -132,12 +132,12 @@ export async function removeExtension(name: string, silent: boolean = false): Pr
 
     const errorMessage = `Error removing ${name} extension${data.message ? `. ${data.message}` : ''}`;
     console.error(errorMessage);
-    toast.error(errorMessage);
+    toast.error(errorMessage, { autoClose: false });
     return response;
   } catch (error) {
     const errorMessage = `Failed to remove ${name} extension: ${error instanceof Error ? error.message : 'Unknown error'}`;
     console.error(errorMessage);
-    toast.error(errorMessage);
+    toast.error(errorMessage, { autoClose: false });
     throw error;
   }
 }
@@ -217,7 +217,7 @@ function envVarsRequired(config: ExtensionConfig) {
 }
 
 function handleError(message: string, shouldThrow = false): void {
-  toast.error(message);
+  toast.error(message, { autoClose: false });
   console.error(message);
   if (shouldThrow) {
     throw new Error(message);


### PR DESCRIPTION
When Goose fails to load an extension the error message now stays on the screen until you dismiss it.

<img width="927" alt="Screenshot 2025-03-12 at 2 24 49 PM" src="https://github.com/user-attachments/assets/7c9882fd-1c4f-472e-b8d4-3d3a48ab1512" />
