### PR TITLE
feat: Copy error message button in toast

### DIFF
--- a/ui/desktop/src/extensions.tsx
+++ b/ui/desktop/src/extensions.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { getApiUrl, getSecretKey } from './config';
 import { type View } from './App';
 import { type SettingsViewOptions } from './components/settings/SettingsView';
@@ -103,9 +104,26 @@ export async function addExtension(
     }
 
     const errorMessage = `Error adding ${extension.name} extension ${data.message ? `. ${data.message}` : ''}`;
+    const ErrorMsg = ({ closeToast }: { closeToast?: () => void }) => (
+      <div className="flex flex-col gap-1">
+        <div>Error adding {extension.name} extension</div>
+        <div>
+          <button
+            className="text-sm rounded px-2 py-1 bg-gray-400 hover:bg-gray-300 text-white cursor-pointer"
+            onClick={() => {
+              navigator.clipboard.writeText(data.message);
+              closeToast();
+            }}
+          >
+            Copy error message
+          </button>
+        </div>
+      </div>
+    );
+
     console.error(errorMessage);
     if (toastId) toast.dismiss(toastId);
-    toast.error(errorMessage);
+    toast(ErrorMsg, { type: 'error', autoClose: false });
 
     return response;
   } catch (error) {


### PR DESCRIPTION
This fixes: https://github.com/block/goose/issues/1507

Right now, error messages from loading extensions are displayed in a toast with full stack trace.
This stack trace can be very large, and quickly goes off-screen inside the toast and you can only read a small portion of it.
You also cannot copy the error message in the toast, as clicking on the toast dismisses the toast.

This PR removes the stack trace from the toast, and adds a button in the toast that allows people to copy the error message to the clipboard.

We can update the styling for this button or behavior in any way we'd like.

## Old
<img width="350" alt="image" src="https://github.com/user-attachments/assets/8ad52881-d27b-4281-94f7-4dc1ac288547" />

## New
<img width="348" alt="image" src="https://github.com/user-attachments/assets/c88e9e54-83dd-4382-b8b3-c9be28a69e06" />
