### PR TITLE
feat: handling larger more complex PDF docs (and fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,26 @@ jobs:
       - name: Check disk space before build
         run: df -h
 
+      - name: Aggressive pre-build cleanup
+        run: |
+          # Clean package manager caches
+          sudo apt-get clean
+          sudo apt-get autoremove -y
+          npm cache clean --force || true
+          
+          # Clean up unused swap and memory
+          sudo swapoff -a
+          sudo swapon -a
 
+          rm -rf /opt/hostedtoolcache          
+          
+          echo "Disk space after aggressive cleanup:"
+          df -h
+
+      - name: Clean previous build artifacts
+        run: cargo clean
+        working-directory: crates
+        
       - name: Build and Test
         run: |
           gnome-keyring-daemon --components=secrets --daemonize --unlock <<< 'foobar'
@@ -85,26 +104,34 @@ jobs:
       - name: Check disk space before cleanup
         run: df -h
 
-      - name: Clean up disk space
+      - name: Clean up disk space after build
         run: |
-          echo "Cleaning up disk space..."
+          echo "Cleaning up disk space after build..."
           # Remove debug artifacts that are no longer needed after tests
-          rm -rf target/debug/deps
-          rm -rf target/debug/build
-          rm -rf target/debug/incremental
-          # Clean npm cache if it exists
-          npm cache clean --force || true
-          # Clean apt cache
-          sudo apt-get clean
-          # Remove unnecessary large directories
+          rm -rf target/debug/deps || true
+          rm -rf target/debug/build || true
+          rm -rf target/debug/incremental || true
+          
+          # Clean Cargo cache
+          rm -rf ~/.cargo/registry/src || true
           rm -rf ~/.cargo/registry/index || true
-          # Remove docker images if any
+          rm -rf ~/.cargo/git/checkouts || true
+          rm -rf ~/.cargo/git/db || true
+          
+          # Clean package manager caches
+          npm cache clean --force || true
+          sudo apt-get clean
+          sudo apt-get autoremove -y
+          
+          # Remove Docker images if any
           docker system prune -af || true
-          # Remove unused packages
-          sudo apt-get autoremove -y || true
-
-      - name: Check disk space after cleanup
-        run: df -h
+          
+          # Remove temp files
+          sudo rm -rf /tmp/* || true
+          
+          # Check disk space after all cleanup
+          echo "Final disk space:"
+          df -h
 
       - name: Lint
         run: cargo clippy -- -D warnings

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,9 @@ jobs:
           sudo rm -rf /usr/local/lib/android/sdk/ndk
           sudo rm -rf /usr/share/dotnet
           sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost          
+          sudo rm -rf /usr/local/share/boost
+          rm -rf target/debug/deps
+          rm -rf target/debug/incremental                    
           
           # Clean up unused swap and memory
           sudo swapoff -a
@@ -95,9 +97,6 @@ jobs:
           echo "Disk space after aggressive cleanup:"
           df -h
 
-      - name: Clean previous build artifacts
-        run: cargo clean
-        working-directory: crates
         
       - name: Build and Test
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,13 +79,18 @@ jobs:
           # Clean package manager caches
           sudo apt-get clean
           sudo apt-get autoremove -y
-          npm cache clean --force || true
+
+          sudo rm -rf /opt/hostedtoolcache
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost          
           
           # Clean up unused swap and memory
           sudo swapoff -a
-          sudo swapon -a
-
-          rm -rf /opt/hostedtoolcache          
+          sudo swapon -a          
           
           echo "Disk space after aggressive cleanup:"
           df -h

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-build-
 
+      # Add disk space cleanup before linting
+      - name: Check disk space before build
+        run: df -h
+
+
       - name: Build and Test
         run: |
           gnome-keyring-daemon --components=secrets --daemonize --unlock <<< 'foobar'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,9 @@ jobs:
           cargo test
         working-directory: crates
 
+      - name: Lint
+        run: cargo clippy -- -D warnings
+
       # Add disk space cleanup before linting
       - name: Check disk space before cleanup
         run: df -h
@@ -137,8 +140,6 @@ jobs:
           echo "Final disk space:"
           df -h
 
-      - name: Lint
-        run: cargo clippy -- -D warnings
 
   desktop-lint:
     name: Lint Electron Desktop App

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1076,6 +1076,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d2c12f985c78475a6b8d629afd0c360260ef34cfef52efccdcfd31972f81c2e"
 
 [[package]]
+name = "bzip2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
+dependencies = [
+ "bzip2-sys",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1209,7 +1228,7 @@ checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
  "libc",
- "libloading",
+ "libloading 0.8.6",
 ]
 
 [[package]]
@@ -1450,7 +1469,7 @@ dependencies = [
  "bitflags 2.9.0",
  "core-foundation 0.10.0",
  "core-graphics-types",
- "foreign-types",
+ "foreign-types 0.5.0",
  "libc",
 ]
 
@@ -1473,6 +1492,21 @@ checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
 
 [[package]]
 name = "crc32fast"
@@ -1661,6 +1695,12 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "deflate64"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da692b8d1080ea3045efaab14434d40468c3d8657e42abddfffca87b428f4c1b"
 
 [[package]]
 name = "deranged"
@@ -1936,6 +1976,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "extractous"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "082fd3334d09f6722e230d3a824e4ebab34bcf88e8d40b40c0bdb806d436d3f4"
+dependencies = [
+ "bytemuck",
+ "flate2",
+ "fs_extra",
+ "jni",
+ "libc",
+ "reqwest 0.12.12",
+ "strum",
+ "strum_macros",
+ "tar",
+ "thiserror 1.0.69",
+ "walkdir",
+ "zip 2.2.3",
+]
+
+[[package]]
 name = "fancy-regex"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1959,7 +2019,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.52.0",
 ]
 
@@ -1970,6 +2030,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1990,12 +2062,21 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
 dependencies = [
  "foreign-types-macros",
- "foreign-types-shared",
+ "foreign-types-shared 0.3.1",
 ]
 
 [[package]]
@@ -2008,6 +2089,12 @@ dependencies = [
  "quote",
  "syn 2.0.99",
 ]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "foreign-types-shared"
@@ -2029,6 +2116,12 @@ name = "fragile"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -2407,6 +2500,7 @@ dependencies = [
  "chrono",
  "docx-rs",
  "etcetera",
+ "extractous",
  "google-drive3",
  "google-sheets4",
  "http-body-util",
@@ -2784,6 +2878,22 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
 ]
 
 [[package]]
@@ -3193,6 +3303,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
+name = "java-locator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c46c1fe465c59b1474e665e85e1256c3893dd00927b8d55f63b09044c1e64f"
+dependencies = [
+ "glob",
+]
+
+[[package]]
 name = "jni"
 version = "0.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3201,7 +3320,9 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
+ "java-locator",
  "jni-sys",
+ "libloading 0.7.4",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -3351,6 +3472,16 @@ dependencies = [
 
 [[package]]
 name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
+
+[[package]]
+name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
@@ -3367,6 +3498,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3392,6 +3524,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db9c683daf087dc577b7506e9695b3d556a9f3849903fa28186283afd6809e9"
 
 [[package]]
 name = "litemap"
@@ -3458,6 +3596,16 @@ dependencies = [
  "thiserror 2.0.12",
  "time",
  "weezl",
+]
+
+[[package]]
+name = "lzma-rs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297e814c836ae64db86b36cf2a557ba54368d03f6afcd7d947c266692f71115e"
+dependencies = [
+ "byteorder",
+ "crc",
 ]
 
 [[package]]
@@ -3704,6 +3852,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -3973,10 +4138,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
+name = "openssl"
+version = "0.10.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if",
+ "foreign-types 0.3.2",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.106"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -4049,6 +4252,16 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pbkdf2"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
+dependencies = [
+ "digest",
+ "hmac",
+]
 
 [[package]]
 name = "pem"
@@ -4675,7 +4888,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
@@ -4701,6 +4914,7 @@ dependencies = [
  "cookie",
  "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.8",
@@ -4709,11 +4923,13 @@ dependencies = [
  "http-body-util",
  "hyper 1.6.0",
  "hyper-rustls 0.27.5",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -4725,7 +4941,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
+ "system-configuration 0.6.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
@@ -4820,7 +5038,20 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7178faa4b75a30e269c71e61c353ce2748cf3d76f0c44c393f4e60abf49b825"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.2",
  "windows-sys 0.59.0",
 ]
 
@@ -5375,6 +5606,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5485,7 +5735,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5493,6 +5754,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5509,6 +5780,17 @@ dependencies = [
  "pkg-config",
  "toml",
  "version-compare",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -5537,7 +5819,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -5556,7 +5838,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -5829,6 +6111,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.99",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -6492,7 +6784,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -6967,6 +7259,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
+name = "xattr"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+dependencies = [
+ "libc",
+ "rustix 1.0.2",
+]
+
+[[package]]
 name = "xcap"
 version = "0.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7180,15 +7482,27 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b280484c454e74e5fff658bbf7df8fdbe7a07c6b2de4a53def232c15ef138f3a"
 dependencies = [
+ "aes",
  "arbitrary",
+ "bzip2",
+ "constant_time_eq",
  "crc32fast",
  "crossbeam-utils",
+ "deflate64",
  "displaydoc",
  "flate2",
+ "hmac",
  "indexmap 2.7.1",
+ "lzma-rs",
  "memchr",
+ "pbkdf2",
+ "rand",
+ "sha1",
  "thiserror 2.0.12",
+ "time",
+ "zeroize",
  "zopfli",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -42,6 +42,7 @@ ignore = "0.4"
 lopdf = "0.35.0"
 docx-rs = "0.4.7"
 image = "0.24.9"
+extractous = "0.3.0"
 umya-spreadsheet = "2.2.3"
 keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service"] }
 

--- a/crates/goose-mcp/src/computercontroller/document_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/document_tool.rs
@@ -1,0 +1,196 @@
+use extractous::Extractor;
+use mcp_core::{Content, ToolError};
+use std::{
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+};
+
+// Threshold for large text files (2MB - about half of the 4,194,304 bytes limit)
+const LARGE_TEXT_THRESHOLD: usize = 2 * 1024 * 1024; // 2MB in bytes
+
+pub async fn document_tool(
+    path: &str,
+    operation: &str,
+    cache_dir: &Path,
+) -> Result<Vec<Content>, ToolError> {
+    match operation {
+        "get_text" => {
+            // Use extractous library for text extraction
+            let extractor = Extractor::new();
+
+            // Check if the path is a URL or a file
+            let (text, metadata) = if path.starts_with("http://") || path.starts_with("https://") {
+                // Handle URL extraction
+                let (mut stream_reader, metadata) = extractor.extract_url(path).map_err(|e| {
+                    ToolError::ExecutionError(format!("Failed to extract text from URL: {}", e))
+                })?;
+
+                // Convert StreamReader to String
+                let mut text = String::new();
+                stream_reader.read_to_string(&mut text).map_err(|e| {
+                    ToolError::ExecutionError(format!("Failed to read text from URL: {}", e))
+                })?;
+
+                (text, metadata)
+            } else {
+                // Extract text from the file (PDF, DOCX, XLSX, etc.)
+                extractor.extract_file_to_string(path).map_err(|e| {
+                    ToolError::ExecutionError(format!("Failed to extract text from file: {}", e))
+                })?
+            };
+
+            // Check if the extracted text is large
+            let text_size = text.len();
+            if text_size > LARGE_TEXT_THRESHOLD {
+                // Create a directory for large text files if it doesn't exist
+                let large_text_dir = cache_dir.join("large_document_texts");
+                fs::create_dir_all(&large_text_dir).map_err(|e| {
+                    ToolError::ExecutionError(format!(
+                        "Failed to create directory for large text: {}",
+                        e
+                    ))
+                })?;
+
+                // Create a filename based on the original document name
+                let doc_path = PathBuf::from(path);
+                let doc_filename = doc_path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("unnamed_document");
+
+                let text_file_path = large_text_dir.join(format!("{}.txt", doc_filename));
+
+                // Write the text to a file
+                fs::write(&text_file_path, &text).map_err(|e| {
+                    ToolError::ExecutionError(format!("Failed to write large text to file: {}", e))
+                })?;
+
+                // Format size in human-readable form
+                let size_str = if text_size < 1024 * 1024 {
+                    format!("{:.2} KB", text_size as f64 / 1024.0)
+                } else {
+                    format!("{:.2} MB", text_size as f64 / (1024.0 * 1024.0))
+                };
+
+                Ok(vec![Content::text(format!(
+                    "Large text extracted from document ({})\n\n\
+                    The extracted text is too large to display directly.\n\
+                    Text has been written to: {}\n\n\
+                    You can search through this file using ripgrep:\n\
+                    rg 'search term' {}\n\n\
+                    Or view portions of it:\n\
+                    head -n 50 {}\n\
+                    tail -n 50 {}\n\
+                    less {}",
+                    size_str,
+                    text_file_path.display(),
+                    text_file_path.display(),
+                    text_file_path.display(),
+                    text_file_path.display(),
+                    text_file_path.display()
+                ))])
+            } else {
+                // Include metadata information in the output
+                let metadata_info = format!(
+                    "Document Metadata:\n{}\n\n",
+                    serde_json::to_string_pretty(&metadata)
+                        .unwrap_or_else(|_| "Unable to format metadata".to_string())
+                );
+
+                Ok(vec![Content::text(format!(
+                    "{}Extracted text from document:\n\n{}",
+                    metadata_info, text
+                ))])
+            }
+        }
+        _ => Err(ToolError::InvalidParameters(format!(
+            "Invalid operation: {}. Valid operation is: 'get_text'",
+            operation
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[tokio::test]
+    async fn test_docx_text_extraction() {
+        let test_docx_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/computercontroller/tests/data/sample.docx");
+        let cache_dir = tempfile::tempdir().unwrap().into_path();
+
+        println!(
+            "Testing text extraction from DOCX: {}",
+            test_docx_path.display()
+        );
+
+        let result = document_tool(test_docx_path.to_str().unwrap(), "get_text", &cache_dir).await;
+
+        assert!(result.is_ok(), "DOCX text extraction should succeed");
+        let content = result.unwrap();
+        assert!(!content.is_empty(), "Extracted text should not be empty");
+        let text = content[0].as_text().unwrap();
+        println!("Extracted text:\n{}", text);
+        assert!(
+            text.contains("Document Metadata") || !text.is_empty(),
+            "Should contain metadata or at least some text content"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_url_text_extraction() {
+        // Skip this test if we're not online
+        // This is a simple test URL that should be stable
+        let test_url = "https://example.com";
+        let cache_dir = tempfile::tempdir().unwrap().into_path();
+
+        println!("Testing text extraction from URL: {}", test_url);
+
+        let result = document_tool(test_url, "get_text", &cache_dir).await;
+
+        // If the test fails due to network issues, just skip it
+        if let Err(err) = &result {
+            if err.to_string().contains("network") || err.to_string().contains("connection") {
+                println!("Skipping URL extraction test due to network issues");
+                return;
+            }
+        }
+
+        assert!(result.is_ok(), "URL text extraction should succeed");
+        let content = result.unwrap();
+        assert!(!content.is_empty(), "Extracted text should not be empty");
+        let text = content[0].as_text().unwrap();
+        println!("Extracted text from URL:\n{}", text);
+        assert!(
+            text.contains("Example Domain"),
+            "Should contain expected content from example.com"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_document_invalid_path() {
+        let cache_dir = tempfile::tempdir().unwrap().into_path();
+        let result = document_tool("nonexistent.pdf", "get_text", &cache_dir).await;
+
+        assert!(result.is_err(), "Should fail with invalid path");
+    }
+
+    #[tokio::test]
+    async fn test_document_invalid_operation() {
+        let test_pdf_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/computercontroller/tests/data/test.pdf");
+        let cache_dir = tempfile::tempdir().unwrap().into_path();
+
+        let result = document_tool(
+            test_pdf_path.to_str().unwrap(),
+            "invalid_operation",
+            &cache_dir,
+        )
+        .await;
+
+        assert!(result.is_err(), "Should fail with invalid operation");
+    }
+}

--- a/crates/goose-mcp/src/computercontroller/document_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/document_tool.rs
@@ -16,98 +16,144 @@ pub async fn document_tool(
 ) -> Result<Vec<Content>, ToolError> {
     match operation {
         "get_text" => {
-            // Use extractous library for text extraction
-            let extractor = Extractor::new();
-
-            // Check if the path is a URL or a file
-            let (text, metadata) = if path.starts_with("http://") || path.starts_with("https://") {
-                // Handle URL extraction
-                let (mut stream_reader, metadata) = extractor.extract_url(path).map_err(|e| {
-                    ToolError::ExecutionError(format!("Failed to extract text from URL: {}", e))
-                })?;
-
-                // Convert StreamReader to String
-                let mut text = String::new();
-                stream_reader.read_to_string(&mut text).map_err(|e| {
-                    ToolError::ExecutionError(format!("Failed to read text from URL: {}", e))
-                })?;
-
-                (text, metadata)
-            } else {
-                // Extract text from the file (PDF, DOCX, XLSX, etc.)
-                extractor.extract_file_to_string(path).map_err(|e| {
-                    ToolError::ExecutionError(format!("Failed to extract text from file: {}", e))
-                })?
-            };
-
-            // Check if the extracted text is large
-            let text_size = text.len();
-            if text_size > LARGE_TEXT_THRESHOLD {
-                // Create a directory for large text files if it doesn't exist
-                let large_text_dir = cache_dir.join("large_document_texts");
-                fs::create_dir_all(&large_text_dir).map_err(|e| {
-                    ToolError::ExecutionError(format!(
-                        "Failed to create directory for large text: {}",
-                        e
-                    ))
-                })?;
-
-                // Create a filename based on the original document name
-                let doc_path = PathBuf::from(path);
-                let doc_filename = doc_path
-                    .file_name()
-                    .and_then(|name| name.to_str())
-                    .unwrap_or("unnamed_document");
-
-                let text_file_path = large_text_dir.join(format!("{}.txt", doc_filename));
-
-                // Write the text to a file
-                fs::write(&text_file_path, &text).map_err(|e| {
-                    ToolError::ExecutionError(format!("Failed to write large text to file: {}", e))
-                })?;
-
-                // Format size in human-readable form
-                let size_str = if text_size < 1024 * 1024 {
-                    format!("{:.2} KB", text_size as f64 / 1024.0)
-                } else {
-                    format!("{:.2} MB", text_size as f64 / (1024.0 * 1024.0))
-                };
-
-                Ok(vec![Content::text(format!(
-                    "Large text extracted from document ({})\n\n\
-                    The extracted text is too large to display directly.\n\
-                    Text has been written to: {}\n\n\
-                    You can search through this file using ripgrep:\n\
-                    rg 'search term' {}\n\n\
-                    Or view portions of it:\n\
-                    head -n 50 {}\n\
-                    tail -n 50 {}\n\
-                    less {}",
-                    size_str,
-                    text_file_path.display(),
-                    text_file_path.display(),
-                    text_file_path.display(),
-                    text_file_path.display(),
-                    text_file_path.display()
-                ))])
-            } else {
-                // Include metadata information in the output
-                let metadata_info = format!(
-                    "Document Metadata:\n{}\n\n",
-                    serde_json::to_string_pretty(&metadata)
-                        .unwrap_or_else(|_| "Unable to format metadata".to_string())
-                );
-
-                Ok(vec![Content::text(format!(
-                    "{}Extracted text from document:\n\n{}",
-                    metadata_info, text
-                ))])
-            }
+            // Extract text from a local file (PDF, DOCX, XLSX, etc.)
+            extract_text_from_file(path, cache_dir)
+        }
+        "get_text_url" => {
+            // Extract text from a URL
+            extract_text_from_url(path, cache_dir)
         }
         _ => Err(ToolError::InvalidParameters(format!(
-            "Invalid operation: {}. Valid operation is: 'get_text'",
+            "Invalid operation: {}. Valid operations are: 'get_text', 'get_text_url'",
             operation
         ))),
+    }
+}
+
+fn extract_text_from_file(path: &str, cache_dir: &Path) -> Result<Vec<Content>, ToolError> {
+    // Use extractous library for text extraction
+    let extractor = Extractor::new();
+
+    // Extract text from the file
+    let (text, metadata) = extractor.extract_file_to_string(path).map_err(|e| {
+        ToolError::ExecutionError(format!("Failed to extract text from file: {}", e))
+    })?;
+
+    process_extracted_text(text, metadata, path, cache_dir)
+}
+
+fn extract_text_from_url(url: &str, cache_dir: &Path) -> Result<Vec<Content>, ToolError> {
+    // Validate that the input is actually a URL
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        return Err(ToolError::InvalidParameters(format!(
+            "Invalid URL: {}. URL must start with http:// or https://",
+            url
+        )));
+    }
+
+    // Use extractous library for text extraction
+    let extractor = Extractor::new();
+
+    // Handle URL extraction
+    let (mut stream_reader, metadata) = extractor.extract_url(url).map_err(|e| {
+        ToolError::ExecutionError(format!("Failed to extract text from URL: {}", e))
+    })?;
+
+    // Convert StreamReader to String
+    let mut text = String::new();
+    stream_reader
+        .read_to_string(&mut text)
+        .map_err(|e| ToolError::ExecutionError(format!("Failed to read text from URL: {}", e)))?;
+
+    process_extracted_text(text, metadata, url, cache_dir)
+}
+
+fn process_extracted_text(
+    text: String,
+    metadata: std::collections::HashMap<String, Vec<String>>,
+    source_path: &str,
+    cache_dir: &Path,
+) -> Result<Vec<Content>, ToolError> {
+    // Check if the extracted text is large
+    let text_size = text.len();
+    if text_size > LARGE_TEXT_THRESHOLD {
+        // Create a directory for large text files if it doesn't exist
+        let large_text_dir = cache_dir.join("large_document_texts");
+        fs::create_dir_all(&large_text_dir).map_err(|e| {
+            ToolError::ExecutionError(format!("Failed to create directory for large text: {}", e))
+        })?;
+
+        // Create a filename based on the original document name
+        let doc_path = PathBuf::from(source_path);
+        let doc_filename = doc_path
+            .file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("unnamed_document");
+
+        let text_file_path = large_text_dir.join(format!("{}.txt", doc_filename));
+
+        // Write the text to a file
+        fs::write(&text_file_path, &text).map_err(|e| {
+            ToolError::ExecutionError(format!("Failed to write large text to file: {}", e))
+        })?;
+
+        // Format size in human-readable form
+        let size_str = if text_size < 1024 * 1024 {
+            format!("{:.2} KB", text_size as f64 / 1024.0)
+        } else {
+            format!("{:.2} MB", text_size as f64 / (1024.0 * 1024.0))
+        };
+
+        Ok(vec![Content::text(format!(
+            "Large text extracted from document ({})\n\n\
+            The extracted text is too large to display directly.\n\
+            Text has been written to: {}\n\n\
+            You can search through this file using ripgrep:\n\
+            rg 'search term' {}\n\n\
+            Or view portions of it:\n\
+            head -n 50 {}\n\
+            tail -n 50 {}\n\
+            less {}",
+            size_str,
+            text_file_path.display(),
+            text_file_path.display(),
+            text_file_path.display(),
+            text_file_path.display(),
+            text_file_path.display()
+        ))])
+    } else {
+        // Include metadata information in the output
+        let metadata_info = if metadata.is_empty() {
+            "Document Metadata: None\n\n".to_string()
+        } else {
+            let mut formatted_metadata = String::from("Document Metadata:\n");
+
+            // Format each metadata entry
+            for (key, values) in &metadata {
+                formatted_metadata.push_str(&format!("  {}: ", key));
+
+                // Single value case
+                if values.len() == 1 {
+                    formatted_metadata.push_str(&format!("{}\n", values[0]));
+                    continue;
+                }
+
+                // Multiple values case
+                formatted_metadata.push_str("[\n");
+                for value in values {
+                    formatted_metadata.push_str(&format!("    {}\n", value));
+                }
+                formatted_metadata.push_str("  ]\n");
+            }
+
+            formatted_metadata.push_str("\n");
+            formatted_metadata
+        };
+
+        Ok(vec![Content::text(format!(
+            "{}Extracted text from document:\n\n{}",
+            metadata_info, text
+        ))])
     }
 }
 
@@ -149,7 +195,7 @@ mod tests {
 
         println!("Testing text extraction from URL: {}", test_url);
 
-        let result = document_tool(test_url, "get_text", &cache_dir).await;
+        let result = document_tool(test_url, "get_text_url", &cache_dir).await;
 
         // If the test fails due to network issues, just skip it
         if let Err(err) = &result {
@@ -192,5 +238,32 @@ mod tests {
         .await;
 
         assert!(result.is_err(), "Should fail with invalid operation");
+    }
+
+    #[tokio::test]
+    async fn test_url_with_get_text() {
+        let test_url = "https://example.com";
+        let cache_dir = tempfile::tempdir().unwrap().into_path();
+
+        let result = document_tool(test_url, "get_text", &cache_dir).await;
+
+        // This should fail since URLs should use get_text_url
+        assert!(result.is_err(), "Using get_text with URL should fail");
+    }
+
+    #[tokio::test]
+    async fn test_file_with_get_text_url() {
+        let test_docx_path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/computercontroller/tests/data/sample.docx");
+        let cache_dir = tempfile::tempdir().unwrap().into_path();
+
+        let result =
+            document_tool(test_docx_path.to_str().unwrap(), "get_text_url", &cache_dir).await;
+
+        // This should fail since local files should use get_text
+        assert!(
+            result.is_err(),
+            "Using get_text_url with local file should fail"
+        );
     }
 }

--- a/crates/goose-mcp/src/computercontroller/document_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/document_tool.rs
@@ -6,8 +6,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-// Threshold for large text files (2MB - about half of the 4,194,304 bytes limit)
-const LARGE_TEXT_THRESHOLD: usize = 2 * 1024 * 1024; // 2MB in bytes
+// Threshold for large text files (0.22MB - about 1/18 of the 4,194,304 bytes limit)
+const LARGE_TEXT_THRESHOLD: usize = (2 * 1024 * 1024) / 9; // ~0.22MB in bytes
 
 pub async fn document_tool(
     path: &str,
@@ -146,7 +146,7 @@ fn process_extracted_text(
                 formatted_metadata.push_str("  ]\n");
             }
 
-            formatted_metadata.push_str("\n");
+            formatted_metadata.push_str('\n');
             formatted_metadata
         };
 

--- a/crates/goose-mcp/src/computercontroller/document_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/document_tool.rs
@@ -146,7 +146,7 @@ fn process_extracted_text(
                 formatted_metadata.push_str("  ]\n");
             }
 
-            formatted_metadata.push_str('\n');
+            formatted_metadata.push('\n');
             formatted_metadata
         };
 

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -289,25 +289,19 @@ impl ComputerControllerRouter {
 
         // Conditionally include OCR information in the description
         let image_formats_desc = if has_tesseract {
-            "extract any embedded text via OCR: png, jpeg, tiff, bmp, gif, ico, psd, svg (extracts text with OCR)"
+            "This will also extract any embedded text via OCR for the following: png, jpeg, tiff, bmp, gif, ico, psd, svg and pdf (use this if there are embedded images in PDF)"
         } else {
             "metadata only: png, jpeg, tiff, bmp, gif, ico, psd, svg (metadata only, OCR not available as tesseract not installed)"
-        };
-
-        let pdf_desc = if has_tesseract {
-            "PDF: pdf (extracts embedded content, supports OCR)"
-        } else {
-            "PDF: pdf (extracts embedded content, no OCR as tesseract not installed)"
         };
 
         let document_tool = Tool::new(
             "document_tool",
             formatdoc! {r#"
-                Extract plain text from various file formats. Use this when you see a file extension or a url to a document.
+                Extract plain text from various file formats. Use this when you see a file extension of the following, 
+                OR a url to treat as a document to get text from.
                 Formats: 
                     doc, docx, ppt, pptx, xls, xlsx, rtf, odt, ods, odp
                         (consider using docx and xlsx tools for those first)
-                    {pdf_desc}
                     csv, tsv
                         (when not handled by other tools)
                     html, xml,epub, txt
@@ -321,7 +315,6 @@ impl ComputerControllerRouter {
 
                 Use this for general text extraction from misc document types.
             "#,
-                pdf_desc = pdf_desc,
                 image_formats_desc = image_formats_desc
             },
             json!({

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -123,6 +123,7 @@ impl ComputerControllerRouter {
                 - File Operations: Organize files/folders
                 - Integration: Calendar, reminders, messages
                 - Data: Interact with spreadsheets and documents
+                - Text: extract content from many file formats
 
                 Can be combined with screenshot tool for visual task assistance.
             "#},
@@ -268,11 +269,20 @@ impl ComputerControllerRouter {
         let document_tool = Tool::new(
             "document_tool",
             indoc! {r#"
-                Process documents to extract text from various file formats.
-                Supports separate operations for local files and URLs.
+                Extract plain text from various file formats. Use this when you see a file extension or a url to a document.
+                Formats: 
+                    doc, docx, ppt, pptx, xls, xlsx, rtf, odt, ods, odp
+                        (consider using docx and xlsx tools for those first)
+                    PDF: pdf (extracts embedded content, supports OCR)
+                    csv, tsv
+                        (when not handled by other tools)
+                    html, xml,epub, txt
+
+                    Images: png, jpeg, tiff, bmp, gif, ico, psd, svg (extracts text with OCR)
+                    E-Mail: eml, msg, mbox, pst (extracts content, headers, attachments)                
 
                 Supports operations:
-                - get_text: Extract all text content from local document files (DOC, xls, etc can be tried if not handled by other tools)
+                - get_text: Extract all text content from local document files
                 - get_text_url: Extract all text content from a document at a URL
 
                 Use this for general text extraction from misc document types.
@@ -594,14 +604,13 @@ impl ComputerControllerRouter {
 
             {os_instructions}
 
-            web_search
-              - Search the web using DuckDuckGo's API for general topics or keywords
-            web_fetch
-              - Fetch content from html websites and APIs
-              - Save as text, JSON, or binary files
-              - Content is cached locally for later use
-              - This is not optimised for complex websites, so don't use this as the first tool.
-            cache
+            This extension has many tools to automate, for example:
+            
+            web_search, web_fetch, quick_script, computer_control for automation, 
+            pdf_tool (pdfs text), 
+            document_tool (many doc types and URLs), docx_tool, xlsx_tool, make_presentation
+
+            cache of content:
               - Manage your cached files
               - List, view, delete files
               - Clear all cached data

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -269,10 +269,11 @@ impl ComputerControllerRouter {
             "document_tool",
             indoc! {r#"
                 Process documents to extract text from various file formats.
-                Can be from a file or a URL.
+                Supports separate operations for local files and URLs.
 
                 Supports operations:
-                - get_text: Extract all text content from documents (DOC, xls, etc can be tried if not handled by other tools)
+                - get_text: Extract all text content from local document files (DOC, xls, etc can be tried if not handled by other tools)
+                - get_text_url: Extract all text content from a document at a URL
 
                 Use this for general text extraction from misc document types.
             "#},
@@ -286,7 +287,7 @@ impl ComputerControllerRouter {
                     },
                     "operation": {
                         "type": "string",
-                        "enum": ["get_text"],
+                        "enum": ["get_text", "get_text_url"],
                         "description": "Operation to perform on the document"
                     }
                 }

--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -242,10 +242,10 @@ impl ComputerControllerRouter {
             indoc! {r#"
                 Process PDF files to extract text and images.
                 Supports operations:
-                - extract_text: Extract all text content from the PDF
+                - extract_text: Extract all text content from the PDF (file or url to file)
                 - extract_images: Extract and save embedded images to PNG files
 
-                Use this when there is a .pdf file or files that need to be processed.
+                Use this when there is a .pdf file or files that need to be processed.                
             "#},
             json!({
                 "type": "object",
@@ -253,7 +253,7 @@ impl ComputerControllerRouter {
                 "properties": {
                     "path": {
                         "type": "string",
-                        "description": "Path to the PDF file"
+                        "description": "Path to the PDF file or URL to pdf"
                     },
                     "operation": {
                         "type": "string",

--- a/crates/goose-mcp/src/computercontroller/pdf_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/pdf_tool.rs
@@ -7,8 +7,8 @@ use std::{
     path::{Path, PathBuf},
 };
 
-// Threshold for large text files (2MB - about half of the 4,194,304 bytes limit)
-const LARGE_TEXT_THRESHOLD: usize = 2 * 1024 * 1024; // 2MB in bytes
+// Threshold for large text files (0.22MB - about 1/18 of the 4,194,304 bytes limit)
+const LARGE_TEXT_THRESHOLD: usize = (2 * 1024 * 1024) / 9; // ~0.22MB in bytes
 
 pub async fn pdf_tool(
     path: &str,


### PR DESCRIPTION
Using a new library https://crates.io/crates/extractous which seems to perform vastly better (still using low level obejcts to extract images when needed).

Enhancements: 
* can load large PDFs
* can load PDFs from URLs/websites
* can load many other doc formats (office docs, email, ebooks, presentations)
* can load web content (as text)
* ADVANCED: if tesseract is installed, it can OCR text out of image files, PDFs

Fixes: https://github.com/block/goose/issues/1664