### PR TITLE
Issue 1667 - update the client protocol string to match the spec

### DIFF
--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -245,7 +245,7 @@ where
         capabilities: ClientCapabilities,
     ) -> Result<InitializeResult, Error> {
         let params = InitializeParams {
-            protocol_version: "1.0.0".into(),
+            protocol_version: "2024-11-05".to_string(),
             client_info: info,
             capabilities,
         };


### PR DESCRIPTION
I followed the same pattern as for the proxy/server code - just put the string directly into the response.

There's an argument for extracting the protocol version out of the schema when it generates all the code - but that's a much much bigger change - and not something a drive-by contributor can do!