### PR TITLE
fix(goose-cli): theme persistence & selection

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -11,6 +11,7 @@ pub enum InputResult {
     AddExtension(String),
     AddBuiltin(String),
     ToggleTheme,
+    SelectTheme(String),
     Retry,
     ListPrompts(Option<String>),
     PromptCommand(PromptCommandOptions),
@@ -80,6 +81,22 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
             Some(InputResult::Retry)
         }
         "/t" => Some(InputResult::ToggleTheme),
+        s if s.starts_with("/t ") => {
+            let t = s
+                .strip_prefix("/t ")
+                .unwrap_or_default()
+                .trim()
+                .to_lowercase();
+            if ["light", "dark", "ansi"].contains(&t.as_str()) {
+                Some(InputResult::SelectTheme(t))
+            } else {
+                println!(
+                    "Theme Unavailable: {} Available themes are: light, dark, ansi",
+                    t
+                );
+                Some(InputResult::Retry)
+            }
+        }
         "/prompts" => Some(InputResult::ListPrompts(None)),
         s if s.starts_with(CMD_PROMPTS) => {
             // Parse arguments for /prompts command
@@ -173,6 +190,7 @@ fn print_help() {
         "Available commands:
 /exit or /quit - Exit the session
 /t - Toggle Light/Dark/Ansi theme
+/t <name> - Set theme directly (light, dark, ansi)
 /extension <command> - Add a stdio extension (format: ENV1=val1 command args...)
 /builtin <names> - Add builtin extensions by name (comma-separated)
 /prompts [--extension <name>] - List all available prompts, optionally filtered by extension

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -319,6 +319,28 @@ impl Session {
                     output::set_theme(new_theme);
                     continue;
                 }
+
+                input::InputResult::SelectTheme(theme_name) => {
+                    save_history(&mut editor);
+
+                    let new_theme = match theme_name.as_str() {
+                        "light" => {
+                            println!("Switching to Light theme");
+                            output::Theme::Light
+                        }
+                        "dark" => {
+                            println!("Switching to Dark theme");
+                            output::Theme::Dark
+                        }
+                        "ansi" => {
+                            println!("Switching to Ansi theme");
+                            output::Theme::Ansi
+                        }
+                        _ => output::Theme::Dark,
+                    };
+                    output::set_theme(new_theme);
+                    continue;
+                }
                 input::InputResult::Retry => continue,
                 input::InputResult::ListPrompts(extension) => {
                     save_history(&mut editor);

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -28,24 +28,46 @@ impl Theme {
 }
 
 thread_local! {
-    static CURRENT_THEME: RefCell<Theme> = RefCell::new(
-        std::env::var("GOOSE_CLI_THEME")
-            .ok()
-            .map(|val| {
-                if val.eq_ignore_ascii_case("light") {
-                    Theme::Light
-                } else if val.eq_ignore_ascii_case("ansi") {
-                    Theme::Ansi
-                } else {
-                    Theme::Dark
-                }
-            })
-            .unwrap_or(Theme::Dark)
-    );
+    static CURRENT_THEME: RefCell<Theme> = RefCell::new({
+        let config = Config::global();
+        if let Ok(theme_str) = config.get_param::<String>("GOOSE_CLI_THEME") {
+            if theme_str.eq_ignore_ascii_case("light") {
+                Theme::Light
+            } else if theme_str.eq_ignore_ascii_case("ansi") {
+                Theme::Ansi
+            } else {
+                Theme::Dark
+            }
+        } else {
+            std::env::var("GOOSE_CLI_THEME")
+                .ok()
+                .map(|val| {
+                    if val.eq_ignore_ascii_case("light") {
+                        Theme::Light
+                    } else if val.eq_ignore_ascii_case("ansi") {
+                        Theme::Ansi
+                    } else {
+                        Theme::Dark
+                    }
+                })
+                .unwrap_or(Theme::Dark)
+        }
+    });
 }
 
 pub fn set_theme(theme: Theme) {
     CURRENT_THEME.with(|t| *t.borrow_mut() = theme);
+
+    let config = Config::global();
+    let theme_str = match theme {
+        Theme::Light => "light",
+        Theme::Dark => "dark",
+        Theme::Ansi => "ansi",
+    };
+
+    if let Err(e) = config.set_param("GOOSE_CLI_THEME", Value::String(theme_str.to_string())) {
+        eprintln!("Failed to save theme setting to config: {}", e);
+    }
 }
 
 pub fn get_theme() -> Theme {

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -182,7 +182,8 @@ Goose CLI supports several shortcuts and built-in commands for easier navigation
 
 ### Slash Commands
 - **`/exit` or `/quit`** - Exit the session
-- **`/t`** - Toggle between Light/Dark modes
+- **`/t`** - Toggle between Light/Dark/Ansi themes
+- **`/t <theme>`** - Set theme directly (`/t light`, `/t dark`, or `/t ansi`)
 - **`/?` or `/help`** - Display the help menu
 
 ### Keyboard Navigation


### PR DESCRIPTION
- Persist selected theme `GOOSE_CLI_THEME`, to config
- Directly select theme `/t  light`
- Update Slash Commands in cli docs

#1521 