### PR TITLE
docs: fix docusaurus sidebar limit

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -55,6 +55,7 @@ const config: Config = {
           onInlineTags: "warn",
           onInlineAuthors: "warn",
           onUntruncatedBlogPosts: "warn",
+          blogSidebarCount: 'ALL'
         },
         theme: {
           customCss: "./src/css/custom.css",


### PR DESCRIPTION
This pull request includes a small change to the `documentation/docusaurus.config.ts` file. The change adds a new configuration option to display all blog posts in the sidebar.

Configuration update:

* [`documentation/docusaurus.config.ts`](diffhunk://#diff-18363c0e89010c49d5f105f49fdc20200f1de368a3ec607c830d47b4a6b7d06cR58): Added the `blogSidebarCount` option with the value `'ALL'` to show all blog posts in the sidebar.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209681798597464