### PR TITLE
docs: Add Filesystem Short Video to Tutorial

### DIFF
--- a/documentation/docs/tutorials/filesystem-mcp.md
+++ b/documentation/docs/tutorials/filesystem-mcp.md
@@ -7,6 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
+<YouTubeShortEmbed videoUrl="https://youtube.com/embed/2IVPcjEr-yQ" /> 
 
 This tutorial covers how to add the [Filesystem MCP server](https://github.com/modelcontextprotocol/servers/tree/HEAD/src/filesystem) as a Goose extension, enabling powerful code analysis and file management. With this extension, Goose can analyze project structures, edit and organize files, detect unused dependencies, and generate documentation to improve software maintainability.
 


### PR DESCRIPTION
This pull request adds a YouTube Short video embed to the **Filesystem MCP** tutorial documentation. The video provides a visual guide on integrating the Filesystem MCP server as a Goose extension.

### Changes
- **Modified file:** `documentation/docs/tutorials/filesystem-mcp.md`
- **Added:** YouTube Short embed for a quick tutorial on Filesystem MCP.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209692018518352