### PR TITLE
docs: Add Session List To CLI Commands Guide

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -82,6 +82,21 @@ goose configure
     ```
 
 ---
+### session list
+
+List all saved sessions.
+
+- **`-v, --verbose`**: (Optional) Includes session file paths in the output.
+
+**Usage:**
+
+```bash
+goose session list
+```
+```bash
+goose session list --verbose
+```
+---
 
 ### info [options]
 

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -82,19 +82,27 @@ goose configure
     ```
 
 ---
-### session list
+### session list [options]
 
 List all saved sessions.
 
 - **`-v, --verbose`**: (Optional) Includes session file paths in the output.
+- **`-f, --format <format>`**: Specify output format (`text` or `json`). Default is `text`.
 
 **Usage:**
 
 ```bash
+# List all sessions in text format (default)
 goose session list
 ```
 ```bash
+# List sessions with file paths
 goose session list --verbose
+```
+
+```bash
+# List sessions in JSON format
+goose session list --format json
 ```
 ---
 


### PR DESCRIPTION
This pull request adds documentation for the `session list` command, detailing its usage and available options in the Goose CLI guide.


### New Section: `session list`
The `session list` command allows users to view all saved sessions.

#### **Options:**
- **`-v, --verbose`**: Includes session file paths in the output.
- **`-f, --format <format>`**: Specify output format (`text` or `json`). Default is `text`.


#### **Usage:**
```bash
goose session list
goose session list --verbose
goose session list --format json
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209683515285499