### PR TITLE
fix: check if working directory has changed before asking

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -76,13 +76,16 @@ pub async fn build_session(
             process::exit(1);
         });
 
-        // Ask user if they want to change the working directory
-        let change_workdir = cliclack::confirm(format!("{} The working directory of this session was set to {}. It does not match the current working directory. Would you like to change it?", style("WARNING:").yellow(), style(metadata.working_dir.display()).cyan()))
-                .initial_value(true)
-                .interact().expect("Failed to get user input");
+        let current_workdir = std::env::current_dir().expect("Failed to get current working directory");
+        if current_workdir != metadata.working_dir {
+            // Ask user if they want to change the working directory
+            let change_workdir = cliclack::confirm(format!("{} The working directory of this session was set to {}. It does not match the current working directory. Would you like to change it?", style("WARNING:").yellow(), style(metadata.working_dir.display()).cyan()))
+            .initial_value(true)
+            .interact().expect("Failed to get user input");
 
-        if change_workdir {
-            std::env::set_current_dir(metadata.working_dir).unwrap();
+            if change_workdir {
+                std::env::set_current_dir(metadata.working_dir).unwrap();
+            }
         }
     }
 

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -76,7 +76,8 @@ pub async fn build_session(
             process::exit(1);
         });
 
-        let current_workdir = std::env::current_dir().expect("Failed to get current working directory");
+        let current_workdir =
+            std::env::current_dir().expect("Failed to get current working directory");
         if current_workdir != metadata.working_dir {
             // Ask user if they want to change the working directory
             let change_workdir = cliclack::confirm(format!("{} The working directory of this session was set to {}. It does not match the current working directory. Would you like to change it?", style("WARNING:").yellow(), style(metadata.working_dir.display()).cyan()))


### PR DESCRIPTION
When running `goose run --resume --text 'hello goose'` I get this prompt:
```
WARNING: The working directory of this session was set to <path>. It does not match the current working directory. Would you like to change it?
```
When I run `pwd` I get the exact same path.

This is doubly an issue for my use case as I am trying to run goose in a non-interactive environment, in which case the error I get is:
```
thread 'main' panicked at /Users/runner/work/goose/goose/crates/goose-cli/src/session/builder.rs:82:29:
Failed to get user input: Kind(NotConnected)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
goose failed: exit status 101
```

I have added a check so that the user prompt only occurs if the current working directory does not match the path found in the existing session.