### PR TITLE
docs: add deployment for install link generator

### DIFF
--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -65,6 +65,7 @@ jobs:
           cp -r documentation/build/* combined-build/
           mkdir -p combined-build/v1/extensions
           cp -r extensions-site/build/client/* combined-build/v1/extensions/
+          cp -r extensions-site/install-link-generator/* combined-build/v1/extensions/install-link-generator/
 
       - name: Deploy to /gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
This pull request includes a small but important change to the deployment process in the `.github/workflows/deploy-docs-and-extensions.yml` file. The change ensures that the install link generator files are copied to the correct directory during the deployment process.

* [`.github/workflows/deploy-docs-and-extensions.yml`](diffhunk://#diff-f4f5e7e1f608be6cd836684bc3c5094e63edbedfb2baee8512005bf9fb7450d3R68): Added a step to copy the `install-link-generator` files to the `combined-build/v1/extensions/install-link-generator/` directory.