### PR TITLE
fix: Goose UI fix typos

### DIFF
--- a/ui/desktop/src/components/settings/basic/ConfigureApproveMode.tsx
+++ b/ui/desktop/src/components/settings/basic/ConfigureApproveMode.tsx
@@ -23,7 +23,7 @@ export function ConfigureApproveMode({
     {
       key: 'smart_approve',
       label: 'Smart Approval',
-      description: 'Intelligently determime which actions need approval based on risk level ',
+      description: 'Intelligently determine which actions need approval based on risk level ',
     },
   ];
 

--- a/ui/desktop/src/components/settings/basic/ModeSelectionItem.tsx
+++ b/ui/desktop/src/components/settings/basic/ModeSelectionItem.tsx
@@ -23,7 +23,7 @@ export const all_goose_modes: GooseMode[] = [
   {
     key: 'smart_approve',
     label: 'Smart Approval',
-    description: 'Intelligently determime which actions need approval based on risk level ',
+    description: 'Intelligently determine which actions need approval based on risk level ',
   },
   {
     key: 'chat',


### PR DESCRIPTION
While using the Goose UI I stumbled across these 2 typos that are inside Settings -> Mode Selection
Main change is changing `determime` to `determine`