### PR TITLE
feat(google_drive): More comments, replies, folders, shortcuts, file moves

### DIFF
--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -611,7 +611,7 @@ impl GoogleDriveRouter {
             query.push(format!("'{}' in parents", p).to_string());
         }
         let query_string = query.join(" and ");
-        if query_string.len() == 0 {
+        if query_string.is_empty() {
             return Err(ToolError::InvalidParameters(
                 "No query provided. Please include one of ('name', 'mimeType', 'parent')."
                     .to_string(),

--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -46,7 +46,6 @@ enum FileOperation {
     Update { file_id: String },
 }
 #[derive(PartialEq)]
-
 enum PaginationState {
     Start,
     Next(String),

--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -1182,6 +1182,7 @@ impl GoogleDriveRouter {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn upload_to_drive(
         &self,
         operation: FileOperation,


### PR DESCRIPTION
This PR adds a number of new features and improves existing ones:

- Pagination for listing LOTS of comments as well as removing duplication between the oddly redundant LIST and GET comments endpoints.
- Limit file searches to a specific folder
- List shared drives
- Create replies
- Resolve comments
- Create folders
- Create shortcuts
- Move files
- Change file searching to allow you to query based on just mimetype, just name-contains, just parent folder, or any combination of the 3.
- Create comments (although the drive API only allows _unanchored comments_, and the show up saying "Original content deleted" in addition to the actual content.
