### PR TITLE
fix: Update link color in chat view for user messages (#1717)

### DIFF
--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -24,7 +24,7 @@ export default function UserMessage({ message }: UserMessageProps) {
         <div className="flex flex-col group">
           <div className="flex bg-slate text-white rounded-xl rounded-br-none py-2 px-3">
             <div ref={contentRef}>
-              <MarkdownContent content={textContent} className="text-white" />
+              <MarkdownContent content={textContent} className="text-white prose-a:text-white" />
             </div>
           </div>
           <div className="flex justify-end">


### PR DESCRIPTION
This is a small fix that updates the styling of links in the chat view for user messages. I've attached two photos in light and dark mode. Addressed in issue #1717 
<img width="282" alt="Screenshot 2025-03-18 at 5 36 10 PM" src="https://github.com/user-attachments/assets/e1a9f860-6d41-492e-ab8b-12a59b91c27d" />
<img width="272" alt="Screenshot 2025-03-18 at 5 36 28 PM" src="https://github.com/user-attachments/assets/c70326aa-b504-4ff5-b64c-4105b48855a7" />
