### PR TITLE
fix: add scrollability to manual extension modal (#1605)

### DIFF
--- a/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/ManualExtensionModal.tsx
@@ -129,8 +129,8 @@ export function ManualExtensionModal({ isOpen, onClose, onSubmit }: ManualExtens
   if (!isOpen) return null;
 
   return (
-    <div className="fixed inset-0 bg-black/20 dark:bg-white/20 backdrop-blur-sm">
-      <Card className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[500px] bg-bgApp rounded-xl overflow-hidden shadow-none p-[16px] pt-[24px] pb-0">
+    <div className="fixed flex items-center justify-center inset-0 bg-black/20 dark:bg-white/20 backdrop-blur-sm">
+      <Card className="w-[500px] bg-bgApp rounded-xl overflow-hidden shadow-none p-[16px] pt-[24px] pb-0 max-h-[90vh] overflow-y-auto">
         <div className="px-4 pb-0 space-y-8">
           <div className="flex">
             <h2 className="text-2xl font-regular text-textStandard">Add custom extension</h2>
@@ -246,23 +246,24 @@ export function ManualExtensionModal({ isOpen, onClose, onSubmit }: ManualExtens
                 {envVars.length > 0 && (
                   <div className="space-y-2">
                     {envVars.map((envVar) => (
-                      <div
-                        key={envVar.key}
-                        className="flex items-center justify-between bg-gray-100 dark:bg-gray-700 p-2 rounded"
-                      >
-                        <div className="flex-1">
-                          <span className="text-sm font-medium">{envVar.key}</span>
-                          <span className="text-sm text-gray-500 dark:text-gray-400 ml-2">
-                            = {envVar.value}
-                          </span>
+                      <div key={envVar.key} className="flex items-center justify-between gap-1">
+                        <div className="flex-1 whitespace-nowrap overflow-x-auto bg-gray-100 dark:bg-gray-700 p-2 rounded">
+                          <div className="flex-1">
+                            <span className="text-sm font-medium">{envVar.key}</span>
+                            <span className="text-sm text-gray-500 dark:text-gray-400 ml-2">
+                              = {envVar.value}
+                            </span>
+                          </div>
                         </div>
-                        <button
-                          type="button"
-                          onClick={() => handleRemoveEnvVar(envVar.key)}
-                          className="text-red-500 hover:text-red-700 ml-2"
-                        >
-                          Remove
-                        </button>
+                        <div className="bg-gray-100 dark:bg-gray-700 p-2 rounded">
+                          <button
+                            type="button"
+                            onClick={() => handleRemoveEnvVar(envVar.key)}
+                            className="text-red-500 hover:text-red-700 ml-2"
+                          >
+                            Remove
+                          </button>
+                        </div>
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
This patch fixes issues with the ManualExtensionModal raised in #1605  that prevented the modal from scrolling as environment variables were added and the modal resized. There was also an issue with the content in the container of the added environment variables flowing outside of the container making the remove button inaccessible. It accomplishes this fix by:

- removing the fixed nature of the Card itself
- moving centering logic into the parent div of the Card component that holds the modal's contents
- adding overflow classes to the Card
- limiting the size of the modal so that it doesn't outgrow the viewport
- refactoring the layout of the environment variable by separating the button and the text content and adding x-axis overflow to the text content

Before:
<img width="699" alt="Screenshot 2025-03-19 at 4 39 11 AM" src="https://github.com/user-attachments/assets/851046c4-6bba-4cde-a1cf-25179fbe4e6a" />

After:
<img width="657" alt="Screenshot 2025-03-19 at 4 00 12 AM" src="https://github.com/user-attachments/assets/7556036d-ba81-4234-bea2-e8672ccea3c7" />

