### PR TITLE
docs: add stdin

### DIFF
--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -64,6 +64,7 @@ jobs:
           mkdir combined-build
           cp -r documentation/build/* combined-build/
           mkdir -p combined-build/v1/extensions
+          mkdir -p combined-build/v1/extensions/install-link-generator
           cp -r extensions-site/build/client/* combined-build/v1/extensions/
           cp -r extensions-site/install-link-generator/* combined-build/v1/extensions/install-link-generator/
 

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -171,7 +171,7 @@ Execute commands from an instruction file or stdin. Check out the [full guide](/
 
 **Options:**
 
-- **`-i, --instructions <FILE>`**: Path to instruction file containing commands
+- **`-i, --instructions <FILE>`**: Path to instruction file containing commands. Use - for stdin.
 - **`-t, --text <TEXT>`**: Input text to provide to Goose directly
 - **`-s, --interactive`**: Continue in interactive mode after processing initial input
 - **`-n, --name <NAME>`**: Name for this run session (e.g. 'daily-tasks')

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -48,6 +48,24 @@ Here's an example of an instruction file that runs a security audit on project d
 Save findings in 'security_audit.md' with severity levels highlighted.
 ```
 
+### With stdin
+You can also pass instructions to Goose using standard input via `-i -`. This is useful when you want to pipe commands from another tool or script into Goose.
+
+#### Simple echo pipe
+
+```bash
+echo "What is 2+2?" | goose run -i -
+```
+
+#### Multi-line instructions
+```bash
+cat << EOF | goose run -i -
+Please help me with these tasks:
+1. Calculate 15% of 85
+2. Convert 32°C to Fahrenheit
+EOF
+```
+
 ## Key Features
 
 ### Interactive Mode


### PR DESCRIPTION
This pull request includes updates to the Goose CLI documentation to clarify the usage of the `--instructions` option and provide examples of using standard input for instructions.

Documentation updates:

* [`documentation/docs/guides/goose-cli-commands.md`](diffhunk://#diff-3dcfd1ace334a91a35076b1c7e66337d2466d0aa1a5a13ee7e20db186fe401e4L174-R174): Updated the description of the `-i, --instructions <FILE>` option to indicate that it can also accept instructions from standard input using `-`.
* [`documentation/docs/guides/running-tasks.md`](diffhunk://#diff-72df0b00101b152475100b818a23517fe703a7598aa6f2ddc8d2407bad7b5cc5R51-R68): Added examples demonstrating how to pass instructions to Goose using standard input, including simple echo pipe and multi-line instructions.