### PR TITLE
docs: Add prompt completion

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -35,12 +35,12 @@ goose configure
 
     **Options:**
 
-    **`-n, --name <name>`**
+    **`-n, --name <n>`**
 
     **Usage:**
 
     ```bash
-    goose session --name <name>
+    goose session --name <n>
     ```
 
 - Resume a previous session
@@ -52,7 +52,7 @@ goose configure
     **Usage:**
 
     ```bash
-    goose session --resume --name <name>
+    goose session --resume --name <n>
     ```
 
 - Start a session with the specified extension
@@ -156,11 +156,11 @@ goose update --reconfigure
 
 ### mcp
 
-Run an enabled MCP server specified by `<name>` (e.g. 'Google Drive')
+Run an enabled MCP server specified by `<n>` (e.g. 'Google Drive')
 
 **Usage:**
 ```bash
-goose mcp <name>
+goose mcp <n>
 ```
 
 ---
@@ -174,11 +174,11 @@ Execute commands from an instruction file or stdin. Check out the [full guide](/
 - **`-i, --instructions <FILE>`**: Path to instruction file containing commands. Use - for stdin.
 - **`-t, --text <TEXT>`**: Input text to provide to Goose directly
 - **`-s, --interactive`**: Continue in interactive mode after processing initial input
-- **`-n, --name <NAME>`**: Name for this run session (e.g. 'daily-tasks')
+- **`-n, --name <n>`**: Name for this run session (e.g. 'daily-tasks')
 - **`-r, --resume`**: Resume from a previous run
 - **`-p, --path <PATH>`**: Path for this run session (e.g. './playground.jsonl')
 - **`--with-extension <COMMAND>`**: Add stdio extensions (can be used multiple times in the same command)
-- **`--with-builtin <NAME>`**: Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')
+- **`--with-builtin <n>`**: Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')
 
 **Usage:**
 
@@ -197,6 +197,33 @@ Used to show the available implementations of the agent loop itself
 ```bash
 goose agents
 ```
+
+---
+## Prompt Completion
+
+The CLI provides a set of slash commands that can be accessed during a session. These commands support tab completion for easier use.
+
+#### Available Commands
+- `/exit` or `/quit` - Exit the current session
+- `/t` - Toggle between Light/Dark/Ansi themes
+- `/extension <command>` - Add a stdio extension (format: ENV1=val1 command args...)
+- `/builtin <names>` - Add builtin extensions by name (comma-separated)
+- `/prompts [--extension <name>]` - List all available prompts, optionally filtered by extension
+- `/prompt <n> [--info] [key=value...]` - Get prompt info or execute a prompt
+- `/mode <name>` - Set the goose mode to use ('auto', 'approve', 'chat')
+- `/?` or `/help` - Display this help message
+
+All commands support tab completion. Press `<Tab>` after a slash (/) to cycle through available commands or to complete partial commands. 
+
+#### Examples
+```bash
+# List all prompts from the developer extension
+/prompts --extension developer
+
+# Switch to chat mode
+/mode chat
+```
+
 
 ---
 ## Keyboard Shortcuts

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -35,12 +35,12 @@ goose configure
 
     **Options:**
 
-    **`-n, --name <n>`**
+    **`-n, --name <name>`**
 
     **Usage:**
 
     ```bash
-    goose session --name <n>
+    goose session --name <name>
     ```
 
 - Resume a previous session
@@ -52,7 +52,7 @@ goose configure
     **Usage:**
 
     ```bash
-    goose session --resume --name <n>
+    goose session --resume --name <name>
     ```
 
 - Start a session with the specified extension
@@ -156,11 +156,11 @@ goose update --reconfigure
 
 ### mcp
 
-Run an enabled MCP server specified by `<n>` (e.g. 'Google Drive')
+Run an enabled MCP server specified by `<name>` (e.g. 'Google Drive')
 
 **Usage:**
 ```bash
-goose mcp <n>
+goose mcp <name>
 ```
 
 ---
@@ -174,11 +174,11 @@ Execute commands from an instruction file or stdin. Check out the [full guide](/
 - **`-i, --instructions <FILE>`**: Path to instruction file containing commands. Use - for stdin.
 - **`-t, --text <TEXT>`**: Input text to provide to Goose directly
 - **`-s, --interactive`**: Continue in interactive mode after processing initial input
-- **`-n, --name <n>`**: Name for this run session (e.g. 'daily-tasks')
+- **`-n, --name <NAME>`**: Name for this run session (e.g. 'daily-tasks')
 - **`-r, --resume`**: Resume from a previous run
 - **`-p, --path <PATH>`**: Path for this run session (e.g. './playground.jsonl')
 - **`--with-extension <COMMAND>`**: Add stdio extensions (can be used multiple times in the same command)
-- **`--with-builtin <n>`**: Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')
+- **`--with-builtin <NAME>`**: Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')
 
 **Usage:**
 


### PR DESCRIPTION

This pull request includes an update to the `documentation/docs/guides/goose-cli-commands.md` file to add a new section about prompt completion and available CLI commands.

Documentation updates:

* [`documentation/docs/guides/goose-cli-commands.md`](diffhunk://#diff-3dcfd1ace334a91a35076b1c7e66337d2466d0aa1a5a13ee7e20db186fe401e4R201-R227): Added a new section titled "Prompt Completion" that details the available slash commands, their descriptions, and examples of their usage. This section also highlights the tab completion feature for easier command use.