### PR TITLE
docs: Remove Installer Link From Filesystem Tutorial

### DIFF
--- a/documentation/docs/tutorials/filesystem-mcp.md
+++ b/documentation/docs/tutorials/filesystem-mcp.md
@@ -141,13 +141,20 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
   <TabItem value="ui" label="Goose Desktop">
 
-    1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-filesystem&id=filesystem&name=Filesystem&description=Filesystem%20access%20server&env=FILESYSTEM_ALLOWED_DIRS)
-    2. Press `Yes` to confirm the installation
-    3. Scroll to the top and click `Exit` from the upper left corner
+    1. Click `...` in the upper right corner
+    2. Click `Settings`
+    3. Under `Extensions`, click the `Add` link
+    4. On the `Add Extension Manually` modal, enter the following:
+            * **Type**: `Standard IO`
+            * **ID**: `filesystem-mcp` (_set this to whatever you want_)
+            * **Name**: `filesystem` (_set this to whatever you want_)
+            * **Description**: `filesystem MCP Server` (_set this to whatever you want_)
+            * **Command**: `npx -y @modelcontextprotocol/server-filesystem /path/to/allowed/directory`
+    5. Click `Add Extension` button
 
-    :::tip Multiple Directories
-    You can specify multiple directories by separating them with a space.
-    ::: 
+        :::tip Multiple Directories
+        You can specify multiple directories by separating them with a space.
+        ::: 
 
   </TabItem>
 </Tabs>


### PR DESCRIPTION
This PR removes the installer link for the **Filesystem MCP extension** because the installation process incorrectly treats directories as environment variables, which causes the extension to fail. The installation command needs to be **dynamic**, and this approach is not feasible with the installer link.  

## Changes  
- ✅ Removed the **installer link** from the documentation.  
- ✅ Updated instructions to guide users through manually adding the extension with the correct **dynamic command format**.  
- ✅ Ensured the documentation provides a clear and functional installation process.  
