### PR TITLE
ci: pin github action to specific hash

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
 
       - name: Update version in Cargo.toml
         if: ${{ inputs.version != '' }}
@@ -49,7 +49,7 @@ jobs:
           rm -f Cargo.toml.bak
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b # pin@stable
         with:
           toolchain: stable
           target: ${{ matrix.architecture }}-${{ matrix.target-suffix }}
@@ -81,7 +81,7 @@ jobs:
           echo "ARTIFACT=target/${TARGET}/release/goose-${TARGET}.tar.bz2" >> $GITHUB_ENV
 
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
         with:
           name: goose-${{ matrix.architecture }}-${{ matrix.target-suffix }}
           path: ${{ env.ARTIFACT }}

--- a/.github/workflows/bundle-desktop-intel.yml
+++ b/.github/workflows/bundle-desktop-intel.yml
@@ -76,7 +76,7 @@ jobs:
           echo "All required signing secrets are present."
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       # Update versions before build
       - name: Update versions
@@ -91,7 +91,7 @@ jobs:
           npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b # pin@stable
         with:
           toolchain: stable
           targets: x86_64-apple-darwin
@@ -112,7 +112,7 @@ jobs:
           df -h
 
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-intel-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -120,7 +120,7 @@ jobs:
             ${{ runner.os }}-intel-cargo-registry-
 
       - name: Cache Cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: ~/.cargo/index
           key: ${{ runner.os }}-intel-cargo-index
@@ -128,7 +128,7 @@ jobs:
             ${{ runner.os }}-intel-cargo-index
 
       - name: Cache Cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: target
           key: ${{ runner.os }}-intel-cargo-build-${{ hashFiles('**/Cargo.lock') }}
@@ -165,7 +165,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # pin@v2
         with:
           node-version: 'lts/*'
 
@@ -231,7 +231,7 @@ jobs:
           df -h
 
       - name: Upload Desktop artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
         with:
           name: Goose-darwin-x64
           path: ui/desktop/out/Goose-darwin-x64/Goose_intel_mac.zip

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -26,11 +26,11 @@ jobs:
     steps:
       # 1) Check out source
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       # 2) Set up Rust
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b
         # If you need a specific version, you could do:
         # or uses: actions/setup-rust@v1
         # with:
@@ -38,13 +38,13 @@ jobs:
 
       # 3) Set up Node.js
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # pin@v3
         with:
           node-version: 16
 
       # 4) Cache dependencies (optional, can add more paths if needed)
       - name: Cache node_modules
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: |
             node_modules
@@ -151,7 +151,7 @@ jobs:
 
       # 11) Upload the final Windows build
       - name: Upload Windows build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
         with:
           name: desktop-windows-dist
           path: ui/desktop/out/Goose-win32-x64/

--- a/.github/workflows/bundle-desktop.yml
+++ b/.github/workflows/bundle-desktop.yml
@@ -76,7 +76,7 @@ jobs:
           echo "All required signing secrets are present."
 
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
       # Update versions before build
       - name: Update versions
@@ -106,12 +106,12 @@ jobs:
           df -h
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b # pin@stable
         with:
           toolchain: stable
 
       - name: Cache Cargo registry
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -119,7 +119,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache Cargo index
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: ~/.cargo/index
           key: ${{ runner.os }}-cargo-index
@@ -127,7 +127,7 @@ jobs:
             ${{ runner.os }}-cargo-index
 
       - name: Cache Cargo build
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
@@ -163,7 +163,7 @@ jobs:
           CERTIFICATE_PASSWORD: ${{ secrets.CERTIFICATE_PASSWORD }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # pin@v2
         with:
           node-version: 'lts/*'
 
@@ -222,7 +222,7 @@ jobs:
           df -h
 
       - name: Upload Desktop artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
         with:
           name: Goose-darwin-arm64
           path: ui/desktop/out/Goose-darwin-arm64/Goose.zip

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -26,7 +26,7 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
     steps:
       # checkout code so we can read the Cargo.toml
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - name: Generate a canary version
         id: set-version
         run: |
@@ -53,8 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-cli]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/upload-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
         with:
           name: download_cli.sh
           path: download_cli.sh
@@ -87,13 +87,13 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
         with:
           merge-multiple: true
 
       # Create/update the canary release
       - name: Release canary
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # pin@v1
         with:
           tag: canary
           name: Canary

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,10 +19,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b # pin@stable
         with:
           toolchain: stable
 
@@ -56,7 +56,7 @@ jobs:
           df -h
           
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
 
       - name: Install Dependencies
         run: |
@@ -64,12 +64,12 @@ jobs:
           sudo apt install -y libdbus-1-dev gnome-keyring libxcb1-dev
 
       - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@38b70195107dddab2c7bbd522bcf763bac00963b # pin@stable
         with:
           toolchain: stable
 
       - name: Cache Cargo Registry
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: ~/.cargo/registry
           key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
@@ -77,7 +77,7 @@ jobs:
             ${{ runner.os }}-cargo-registry-
 
       - name: Cache Cargo Index
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: ~/.cargo/index
           key: ${{ runner.os }}-cargo-index
@@ -85,7 +85,7 @@ jobs:
             ${{ runner.os }}-cargo-index
 
       - name: Cache Cargo Build
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: target
           key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
@@ -131,10 +131,10 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@7c12f8017d5436eb855f1ed4399f037a36fbd9e8 # pin@v2
         with:
           node-version: "lts/*"
 

--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -17,15 +17,15 @@ jobs:
 
     steps:
       - name: Checkout the branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # pin@v3
         with:
           node-version: 20 
 
       - name: Cache Node.js modules (documentation)
-        uses: actions/cache@v3
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
           path: ./documentation/node_modules
           key: ${{ runner.os }}-documentation-${{ hashFiles('./documentation/package-lock.json') }}
@@ -44,7 +44,7 @@ jobs:
 
       - name: Deploy to /gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@373f7f263a76c20808c831209c920827a82a2847 # pin@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: documentation/build

--- a/.github/workflows/pr-comment-bundle-intel.yml
+++ b/.github/workflows/pr-comment-bundle-intel.yml
@@ -32,7 +32,7 @@ jobs:
       pr_number: ${{ steps.command.outputs.issue_number || github.event.inputs.pr_number }}
     steps:
       - if: ${{ github.event_name == 'issue_comment' }}
-        uses: github/command@v1.3.0
+        uses: github/command@319d5236cc34ed2cb72a47c058a363db0b628ebe # pin@v1.3.0
         id: command
         with:
           command: ".bundle-intel"
@@ -63,13 +63,13 @@ jobs:
 
     steps:
       - name: Download Intel artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
         with:
           name: Goose-darwin-x64
           path: intel-dist
 
       - name: Comment on PR with Intel download link
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # pin@v4
         with:
           issue-number: ${{ needs.trigger-on-command.outputs.pr_number }}
           body: |

--- a/.github/workflows/pr-comment-bundle-windows.yml
+++ b/.github/workflows/pr-comment-bundle-windows.yml
@@ -32,7 +32,7 @@ jobs:
       pr_number: ${{ steps.command.outputs.issue_number || github.event.inputs.pr_number }}
     steps:
       - if: ${{ github.event_name == 'issue_comment' }}
-        uses: github/command@v1.3.0
+        uses: github/command@319d5236cc34ed2cb72a47c058a363db0b628ebe # pin@v1.3.0
         id: command
         with:
           command: ".bundle-windows"
@@ -60,13 +60,13 @@ jobs:
 
     steps:
       - name: Download Windows artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
         with:
           name: desktop-windows-dist
           path: windows-dist
 
       - name: Comment on PR with Windows download link
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # pin@v4
         with:
           issue-number: ${{ needs.trigger-on-command.outputs.pr_number }}
           body: |

--- a/.github/workflows/pr-comment-bundle.yml
+++ b/.github/workflows/pr-comment-bundle.yml
@@ -32,7 +32,7 @@ jobs:
       pr_number: ${{ steps.command.outputs.issue_number || github.event.inputs.pr_number }}
     steps:
       - if: ${{ github.event_name == 'issue_comment' }}
-        uses: github/command@v1.3.0
+        uses: github/command@319d5236cc34ed2cb72a47c058a363db0b628ebe # pin@v1.3.0
         id: command
         with:
           command: ".bundle"
@@ -63,13 +63,13 @@ jobs:
 
     steps:
       - name: Download ARM64 artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
         with:
           name: Goose-darwin-arm64
           path: arm64-dist
 
       - name: Comment on PR with ARM64 download link
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # pin@v4
         with:
           issue-number: ${{ needs.trigger-on-command.outputs.pr_number }}
           body: |

--- a/.github/workflows/pr-website-preview.yml
+++ b/.github/workflows/pr-website-preview.yml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the branch
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
 
       - name: Setup Node.js
         if: github.event.action != 'closed'
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # pin@v3
         with:
           node-version: 20 
 
@@ -38,7 +38,7 @@ jobs:
           npm run build
 
       - name: Deploy preview
-        uses: rossjrw/pr-preview-action@v1
+        uses: rossjrw/pr-preview-action@df22037db54ab6ee34d3c1e2b8810ac040a530c6 # pin@v1
         if: ${{ github.event.pull_request.head.repo.full_name == 'block/goose' }}
         with:
           source-dir: documentation/build

--- a/.github/workflows/quarantine.yml
+++ b/.github/workflows/quarantine.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       - name: Check PR Author
         run: |
           # Get PR author

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,8 +26,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-cli]
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/upload-artifact@v4
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
         with:
           name: download_cli.sh
           path: download_cli.sh
@@ -84,13 +84,13 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
         with:
           merge-multiple: true
 
       # Create/update the versioned release
       - name: Release versioned
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # pin@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
@@ -103,7 +103,7 @@ jobs:
 
       # Create/update the stable release
       - name: Release stable
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # pin@v1
         with:
           tag: stable
           name: Stable


### PR DESCRIPTION
We do not want a compromised github action (or maintainer thereof) to take over the repo's secrets or integrity. This PR pins every action to a full length commit SHA.

This is the way recommended by github [0]. The following tool was used in this PR: https://github.com/mheap/pin-github-action

Example vulnerability that exploits this vector: https://github.com/advisories/GHSA-mrrh-fwg8-r2c3 (CVE-2025-30066).

[0] https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions