### PR TITLE
Support custom headers for openai provider

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use reqwest::Client;
 use serde_json::Value;
+use std::collections::HashMap;
 use std::time::Duration;
 
 use super::base::{ConfigKey, Provider, ProviderMetadata, ProviderUsage, Usage};
@@ -33,6 +34,7 @@ pub struct OpenAiProvider {
     organization: Option<String>,
     project: Option<String>,
     model: ModelConfig,
+    custom_headers: Option<HashMap<String, String>>,
 }
 
 impl Default for OpenAiProvider {
@@ -54,6 +56,10 @@ impl OpenAiProvider {
             .unwrap_or_else(|_| "v1/chat/completions".to_string());
         let organization: Option<String> = config.get_param("OPENAI_ORGANIZATION").ok();
         let project: Option<String> = config.get_param("OPENAI_PROJECT").ok();
+        let custom_headers: Option<HashMap<String, String>> = config
+            .get_secret("OPENAI_CUSTOM_HEADERS")
+            .ok()
+            .map(parse_custom_headers);
         let client = Client::builder()
             .timeout(Duration::from_secs(600))
             .build()?;
@@ -66,6 +72,7 @@ impl OpenAiProvider {
             organization,
             project,
             model,
+            custom_headers,
         })
     }
 
@@ -89,6 +96,12 @@ impl OpenAiProvider {
         // Add project header if present
         if let Some(project) = &self.project {
             request = request.header("OpenAI-Project", project);
+        }
+
+        if let Some(custom_headers) = &self.custom_headers {
+            for (key, value) in custom_headers {
+                request = request.header(key, value);
+            }
         }
 
         let response = request.json(&payload).send().await?;
@@ -116,6 +129,7 @@ impl Provider for OpenAiProvider {
                 ConfigKey::new("OPENAI_BASE_PATH", true, false, Some("v1/chat/completions")),
                 ConfigKey::new("OPENAI_ORGANIZATION", false, false, None),
                 ConfigKey::new("OPENAI_PROJECT", false, false, None),
+                ConfigKey::new("OPENAI_CUSTOM_HEADERS", false, true, None),
             ],
         )
     }
@@ -153,4 +167,19 @@ impl Provider for OpenAiProvider {
         emit_debug_trace(&self.model, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))
     }
+}
+
+fn parse_custom_headers(s: String) -> HashMap<String, String> {
+    s.split(',')
+        .filter_map(|header| {
+            let mut parts = header.splitn(2, '=');
+            let Some(key) = parts.next() else {
+                return None;
+            };
+            let Some(value) = parts.next() else {
+                return None;
+            };
+            Some((key.trim().to_string(), value.trim().to_string()))
+        })
+        .collect()
 }


### PR DESCRIPTION
## Description

At $DAYJOB, we have an OpenAI-compatible internal API that we use for our LLM needs. However, it requires setting some additional headers for authentication. I figured this could be the case for others, so I'm opening this PR. It adds a new config key for the OpenAI provider named `OPENAI_CUSTOM_HEADERS`, marked as secret since it could contain sensitive auth information. This config key is expected to be in the format `"HEADER_A=VALUE_A,HEADER_B=VALUE_B"`, which will get parsed and added as headers to the request made to the OpenAI endpoint.

## Testing

I confirmed the changes work with the following commands:

```shell
$ cargo build -p goose-cli
$ export OPENAI_CUSTOM_HEADERS="HEADER_A=VALUE_A,HEADER_B=VALUE_B"
$ goose configure # set up openai provider as necessary
```