### PR TITLE
Add /clear command to clear goose context

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -17,6 +17,7 @@ pub enum InputResult {
     GooseMode(String),
     Plan(PlanCommandOptions),
     EndPlan,
+    Clear,
 }
 
 #[derive(Debug)]
@@ -81,6 +82,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
     const CMD_MODE: &str = "/mode ";
     const CMD_PLAN: &str = "/plan";
     const CMD_ENDPLAN: &str = "/endplan";
+    const CMD_CLEAR: &str = "/clear";
 
     match input {
         "/exit" | "/quit" => Some(InputResult::Exit),
@@ -122,6 +124,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
         }
         s if s.starts_with(CMD_PLAN) => parse_plan_command(s[CMD_PLAN.len()..].trim().to_string()),
         s if s == CMD_ENDPLAN => Some(InputResult::EndPlan),
+        s if s == CMD_CLEAR => Some(InputResult::Clear),
         _ => None,
     }
 }
@@ -204,6 +207,7 @@ fn print_help() {
                         If no model is set, the default model is used.
 /endplan - Exit plan mode and return to 'normal' goose mode.
 /? or /help - Display this help message
+/clear - Clears the current chat history
 
 Navigation:
 Ctrl+C - Interrupt goose (resets the interaction to before the interrupted user request)

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -431,6 +431,7 @@ impl Session {
                     save_history(&mut editor);
 
                     self.messages.clear();
+                    tracing::info!("Chat context cleared by user.");
                     output::render_message(
                         &Message::assistant().with_text("Chat context cleared."),
                         self.debug,

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -427,6 +427,16 @@ impl Session {
                     output::render_exit_plan_mode();
                     continue;
                 }
+                input::InputResult::Clear => {
+                    save_history(&mut editor);
+
+                    self.messages.clear();
+                    output::render_message(
+                        &Message::assistant().with_text("Chat context cleared."),
+                        self.debug,
+                    );
+                    continue;
+                }
                 input::InputResult::PromptCommand(opts) => {
                     save_history(&mut editor);
 


### PR DESCRIPTION
Hello!  I was interested in adding a `/clear` command to clear the bot's context during a session.

It would also probably make sense to instead have some kind of `/new` command to simply make a new session, which would then maintain the session file integrity.

It seems better than having to `quit` or `exit` then restart goose.

Thanks!  I've had fun goosing around.  