### PR TITLE
docs: add youtube vscode short

### DIFF
--- a/documentation/docs/tutorials/vscode-mcp.md
+++ b/documentation/docs/tutorials/vscode-mcp.md
@@ -5,6 +5,10 @@ description: Use VS Code MCP Server as a Goose Extension for file operations and
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
+
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/gddEgvCLrgU" />
+
 
 This tutorial covers how to add the [VS Code MCP Server](https://github.com/block/vscode-mcp) as a Goose extension to enable VS Code integration, file operations, and development workflow management.
 


### PR DESCRIPTION
This pull request includes an update to the `documentation/docs/tutorials/vscode-mcp.md` file to enhance the tutorial with an embedded YouTube video.

Documentation update:

* [`documentation/docs/tutorials/vscode-mcp.md`](diffhunk://#diff-b9caa09ea51de4fb225fd9722d4135cd2a628756830fcf1866ed79f2cea6e86cR8-R11): Added an embedded YouTube video to the tutorial for better visual guidance on using the VS Code MCP Server as a Goose extension.