### PR TITLE
docs: Add Speech MCP Server Tutorial

### DIFF
--- a/documentation/docs/tutorials/speech-mcp.md
+++ b/documentation/docs/tutorials/speech-mcp.md
@@ -1,0 +1,243 @@
+---
+title: Speech Extension
+description: Add Speech MCP Server as a Goose Extension
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
+
+This tutorial covers how to add the [Speech MCP Server](https://github.com/Kvadratni/speech-mcp) as a Goose extension to enable real-time voice interaction, audio/video transcription, text-to-speech conversion, and multi-speaker audio generation.
+
+:::tip TLDR
+
+**Command**
+```sh
+uvx -p 3.10.14 speech-mcp@latest
+```
+
+**Requirement**
+
+[PortAudio](/docs/tutorials/speech-mcp#install-portaudio) is required for PyAudio to capture audio from your microphone
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on your system to run this command, as it uses `uvx`.
+:::
+
+## Install PortAudio
+
+Before adding this extension, make sure PortAudio is installed on your system. PortAudio is required for PyAudio to capture audio from your microphone.
+
+<Tabs groupId="interface">
+  <TabItem value="macOS" label="Mac Instructions" default>
+
+  ```bash
+    brew install portaudio
+    export LDFLAGS="-L/usr/local/lib"
+    export CPPFLAGS="-I/usr/local/include"
+  ```
+
+  </TabItem>
+  <TabItem value="Linux" label="Linux Instructions">
+   
+    ### Debian/Ubuntu
+
+    ```bash
+    sudo apt-get update
+    sudo apt-get install portaudio19-dev python3-dev
+    ```
+    ### Fedora/RHEL/CentOS
+
+    ```bash
+    sudo dnf install portaudio-devel
+    ```
+  </TabItem>
+  <TabItem value="Windows" label="Windows Instructions">
+
+    ```bash
+    pip install pyaudio
+    ```
+    :::important
+    PortAudio is included in the PyAudio wheel for Windows, so no separate installation is needed.
+    :::
+  </TabItem>
+</Tabs>
+
+## Add Speech Extension 
+
+<Tabs groupId="interface">
+  <TabItem value="cli" label="Goose CLI" default>
+  1. Run the `configure` command:
+  ```sh
+  goose configure
+  ```
+
+  2. Choose to add a `Command-line Extension`
+  ```sh
+    ┌   goose-configure 
+    │
+    ◇  What would you like to configure?
+    │  Add Extension 
+    │
+    ◆  What type of extension would you like to add?
+    │  ○ Built-in Extension 
+    // highlight-start    
+    │  ● Command-line Extension (Run a local command or script)
+    // highlight-end    
+    │  ○ Remote Extension 
+    └ 
+  ```
+
+  3. Give your extension a name
+  ```sh
+    ┌   goose-configure 
+    │
+    ◇  What would you like to configure?
+    │  Add Extension 
+    │
+    ◇  What type of extension would you like to add?
+    │  Command-line Extension 
+    │
+    // highlight-start
+    ◆  What would you like to call this extension?
+    │  speech
+    // highlight-end
+    └ 
+  ```
+
+  4. Enter the command
+  ```sh
+    ┌   goose-configure 
+    │
+    ◇  What would you like to configure?
+    │  Add Extension 
+    │
+    ◇  What type of extension would you like to add?
+    │  Command-line Extension 
+    │
+    ◇  What would you like to call this extension?
+    │  speech
+    │
+    // highlight-start
+    ◆  What command should be run?
+    │  uvx -p 3.10.14 speech-mcp@latest
+    // highlight-end
+    └ 
+  ```  
+
+  5. Enter the number of seconds Goose should wait for actions to complete before timing out. Default is 300s
+   ```sh
+    ┌   goose-configure 
+    │
+    ◇  What would you like to configure?
+    │  Add Extension 
+    │
+    ◇  What type of extension would you like to add?
+    │  Command-line Extension 
+    │
+    ◇  What would you like to call this extension?
+    │  speech
+    │
+    ◇  What command should be run?
+    │  uvx -p 3.10.14 speech-mcp@latest
+    │
+    // highlight-start
+    ◆  Please set the timeout for this tool (in secs):
+    │  300
+    // highlight-end
+    └ 
+  ```  
+ 6. Choose No when asked to add environment variables
+   ```sh
+    ┌   goose-configure 
+    │
+    ◇  What would you like to configure?
+    │  Add Extension 
+    │
+    ◇  What type of extension would you like to add?
+    │  Command-line Extension 
+    │
+    ◇  What would you like to call this extension?
+    │  speech
+    │
+    ◇  What command should be run?
+    │  uvx -p 3.10.14 speech-mcp@latest
+    │
+    ◇  Please set the timeout for this tool (in secs):
+    │  300
+    │
+    // highlight-start
+    ◆  Would you like to add environment variables?
+    │  No
+    │
+    // highlight-end
+    └  Added speech extension
+  ```  
+
+  </TabItem>
+  <TabItem value="ui" label="Goose Desktop">
+  1. [Launch the installer](goose://extension?cmd=uvx&&arg=-p&arg=3.10.14&arg=speech-mcp@latest&id=speech_mcp&name=Speech%20Interface&description=Voice%20interaction%20with%20audio%20visualization%20for%20Goose)
+  2. Press `Yes` to confirm the installation
+  3. Click `Save Configuration`
+  4. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+</Tabs>
+
+
+## Example Usage
+In this example, you'll see how to use Goose with the Speech MCP Server Extension to turn voice commands into code. By speaking directly to Goose, you can launch the speech interface, give a spoken prompt, and have Goose generate and open a webpage based on your request.
+
+This allows you to build with Goose hands-free, making development more accessible and interactive.
+
+<Tabs groupId="interface">
+  <TabItem value="cli" label="Goose CLI" default>
+
+  1. Open a terminal and start a new Goose session:
+
+  ```sh
+  goose session
+  ```
+
+  </TabItem>
+  <TabItem value="ui" label="Goose Desktop">
+   1. Open a new session in Goose Desktop
+  </TabItem>
+</Tabs>
+
+### Goose Prompt
+
+```
+Goose I don't feel like talking today
+```
+
+```
+I understand! In that case, I can help you use voice commands instead. I'll launch the speech interface so you can speak your requests rather than type them
+
+---- Launch Speech UI ----
+```
+
+### Goose Speech 🎙️
+
+**Goose:** 
+>_I've launched the speech interface. You can now speak your requests instead of typing. Just speak after you hear my voice and see the microphone activate. What would you like help with?_
+
+
+**Max:** 
+
+>_Goose, lets create a simple page with the word 'vibes' on it and maybe change colors and make it move around the page and then open this page in the browser once you're done_
+
+
+<div style={{ width: "100%", height: 0, position: "relative", paddingBottom: "56.25%" }}>
+  <iframe
+    src="https://streamyard.com/e/95b6b5zmry5vkusx"
+    width="100%"
+    height="100%"
+    frameBorder="0"
+    title="Embed recording"
+    allowFullScreen
+    style={{ width: "100%", height: "100%", position: "absolute", left: 0, top: 0, overflow: "hidden" }}
+  ></iframe>
+</div>


### PR DESCRIPTION
This PR adds a new tutorial covering how to integrate the [Speech MCP Server](https://github.com/Kvadratni/speech-mcp) as a Goose extension.

### 📚 What's Included

- Step-by-step instructions for configuring the Speech MCP Server with Goose
- OS-specific installation instructions for PortAudio (required for microphone access)
- CLI and Desktop setup guides for adding the speech extension
- Example usage demonstrating how Goose uses voice commands 

### 🎥 Demo

The tutorial includes an embedded video showing Goose launching the speech interface and responding to a spoken prompt to create and open a web page
