### PR TITLE
Fix chat width issues

### DIFF
--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -23,7 +23,7 @@ export default function UserMessage({ message }: UserMessageProps) {
       <div className="flex-col max-w-[85%]">
         <div className="flex flex-col group">
           <div className="flex bg-slate text-white rounded-xl rounded-br-none py-2 px-3">
-            <div ref={contentRef}>
+            <div className="break-all" ref={contentRef}>
               <MarkdownContent content={textContent} className="text-white" />
             </div>
           </div>

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -73,7 +73,10 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
         className={cn('relative overflow-hidden', className)}
         {...props}
       >
-        <ScrollAreaPrimitive.Viewport ref={viewportRef} className="h-full w-full rounded-[inherit]">
+        <ScrollAreaPrimitive.Viewport
+          ref={viewportRef}
+          className="h-full w-full rounded-[inherit] [&>div]:!block"
+        >
           {children}
           {autoScroll && <div ref={viewportEndRef} style={{ height: '1px' }} />}
         </ScrollAreaPrimitive.Viewport>


### PR DESCRIPTION
This solves https://github.com/block/goose/issues/1152

This is an open issue with RadixUI. [Here is the issue, and a proposed somewhat hacky fix that works](https://github.com/radix-ui/primitives/issues/2722#issuecomment-2404594842). This fixes the issue with the width growing very wide.

Also adding `"break-all"` to the UserMessage to allow for the text wrapping to work properly, regardless of chat width, for very long strings.

## Before
<img width="2557" alt="image" src="https://github.com/user-attachments/assets/d77a7895-88bc-43e9-a722-e2e655f75f5f" />

## After
<img width="1108" alt="image" src="https://github.com/user-attachments/assets/bd2bec47-7779-415a-bede-1ce8ad745596" />
