### PR TITLE
feat: Allow setting OpenAI timeout from config

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -54,8 +54,11 @@ impl OpenAiProvider {
             .unwrap_or_else(|_| "v1/chat/completions".to_string());
         let organization: Option<String> = config.get_param("OPENAI_ORGANIZATION").ok();
         let project: Option<String> = config.get_param("OPENAI_PROJECT").ok();
+        let timeout_secs: u64 = config
+            .get_param("OPENAI_TIMEOUT")
+            .unwrap_or(600); // Default to 600 seconds if not found
         let client = Client::builder()
-            .timeout(Duration::from_secs(600))
+            .timeout(Duration::from_secs(timeout_secs))
             .build()?;
 
         Ok(Self {
@@ -116,6 +119,7 @@ impl Provider for OpenAiProvider {
                 ConfigKey::new("OPENAI_BASE_PATH", true, false, Some("v1/chat/completions")),
                 ConfigKey::new("OPENAI_ORGANIZATION", false, false, None),
                 ConfigKey::new("OPENAI_PROJECT", false, false, None),
+                ConfigKey::new("OPENAI_TIMEOUT", false, false, Some("600")),
             ],
         )
     }

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -54,9 +54,7 @@ impl OpenAiProvider {
             .unwrap_or_else(|_| "v1/chat/completions".to_string());
         let organization: Option<String> = config.get_param("OPENAI_ORGANIZATION").ok();
         let project: Option<String> = config.get_param("OPENAI_PROJECT").ok();
-        let timeout_secs: u64 = config
-            .get_param("OPENAI_TIMEOUT")
-            .unwrap_or(600); // Default to 600 seconds if not found
+        let timeout_secs: u64 = config.get_param("OPENAI_TIMEOUT").unwrap_or(600);
         let client = Client::builder()
             .timeout(Duration::from_secs(timeout_secs))
             .build()?;


### PR DESCRIPTION
## OpenAI Timeout Configuration

This update introduces a configurable timeout for the OpenAI client in `crates/goose/src/providers/openai.rs`.

### Changes Made

1.  **Added `OPENAI_TIMEOUT` Config Key:**

    *   A new `ConfigKey` named `OPENAI_TIMEOUT` was added to the `metadata()` function of the `OpenAiProvider`.
    *   This key allows users to specify the timeout value in seconds via configuration.
    *   It is set as not secret (`false`), not required (`false`), and defaults to 600 seconds (`Some("600")`).

2.  **Read Timeout from Config:**

    *   In the `from_env()` function, the `OPENAI_TIMEOUT` value is read from the global configuration using `config.get_param("OPENAI_TIMEOUT")`.
    *   If the value is not found in the config, it defaults to 600 seconds.
    *   The retrieved value is parsed as a `u64` and used to set the timeout when building the `reqwest::Client`.

### How to Configure

The `OPENAI_TIMEOUT` can be configured in two ways:

1.  **Environment Variable:**

    Set the `OPENAI_TIMEOUT` environment variable to the desired timeout value in seconds. For example:

    ```bash
    export OPENAI_TIMEOUT=1200
    ```

3.  **`goose configure` command:**

    Use the `goose configure` command to set the `OPENAI_TIMEOUT` value.

Environment variables take precedence over the configuration file settings.

After setting the configuration, restart your Goose agent or server for the changes to take effect.
