### PR TITLE
fix: message summary incorrectly generated

### DIFF
--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -248,37 +248,7 @@ pub async fn persist_messages(
     // Check if we need to update the description (after 1st or 3rd user message)
     if let Some(provider) = provider {
         if user_message_count < 4 {
-            // Generate description
-            let mut description_prompt = "Based on the conversation so far, provide a concise header for this session in 4 words or less. This will be used for finding the session later in a UI with limited space - reply *ONLY* with the header. Avoid filler words such as help, summary, exchange, request etc that do not help distinguish different conversations.".to_string();
-
-            // get context from messages so far
-            let context: Vec<String> = messages.iter().map(|m| m.as_concat_text()).collect();
-
-            if !context.is_empty() {
-                description_prompt = format!(
-                    "Here are the first few user messages:\n{}\n\n{}",
-                    context.join("\n"),
-                    description_prompt
-                );
-            }
-
-            // Generate the description
-            let message = Message::user().with_text(&description_prompt);
-            match provider
-                .complete(
-                    "Reply with only a description in four words or less.",
-                    &[message],
-                    &[],
-                )
-                .await
-            {
-                Ok((response, _)) => {
-                    metadata.description = response.as_concat_text();
-                }
-                Err(e) => {
-                    tracing::error!("Failed to generate session description: {:?}", e);
-                }
-            }
+            generate_description(session_file, messages, provider.as_ref().as_ref()).await?;
         }
     }
 

--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -293,12 +293,19 @@ pub async fn generate_description(
     // Create a special message asking for a 3-word description
     let mut description_prompt = "Based on the conversation so far, provide a concise description of this session in 4 words or less. This will be used for finding the session later in a UI with limited space - reply *ONLY* with the description".to_string();
 
-    // get context from messages so far
+    // get context from messages so far, limiting each message to 300 chars
     let context: Vec<String> = messages
         .iter()
         .filter(|m| m.role == mcp_core::role::Role::User)
         .take(3) // Use up to first 3 user messages for context
-        .map(|m| m.as_concat_text())
+        .map(|m| {
+            let text = m.as_concat_text();
+            if text.len() > 300 {
+                format!("{}...", &text[..297]) // truncate to 300 chars with ellipsis
+            } else {
+                text
+            }
+        })
         .collect();
 
     if !context.is_empty() {

--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -335,7 +335,7 @@ pub async fn generate_description(
     metadata.description = description;
 
     // Update the file with the new metadata and existing messages
-    return save_messages_with_metadata(session_file, &metadata, messages);
+    save_messages_with_metadata(session_file, &metadata, messages)
 }
 
 /// Update only the metadata in a session file, preserving all messages

--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -298,14 +298,7 @@ pub async fn generate_description(
         .iter()
         .filter(|m| m.role == mcp_core::role::Role::User)
         .take(3) // Use up to first 3 user messages for context
-        .map(|m| {
-            let text = m.as_concat_text();
-            if text.len() > 300 {
-                format!("{}...", &text[..297]) // truncate to 300 chars with ellipsis
-            } else {
-                text
-            }
-        })
+        .map(|m| m.as_concat_text())
         .collect();
 
     if !context.is_empty() {


### PR DESCRIPTION
fixes #1524. generate_description wasn't being used. The (mostly duplicated) logic didn't filter for user messages. Sending the whole conversation for summary probably misses the point and burns tokens.