### PR TITLE
fix: extension site not rendering servers

### DIFF
--- a/extensions-site/public/servers.json
+++ b/extensions-site/public/servers.json
@@ -130,5 +130,5 @@
     "endorsed": true,
     "githubStars": 1,
     "environmentVariables": []
-  },  
+  }
 ]


### PR DESCRIPTION
The latest PR had a trailing comma in servers.json, so then the extension site rendered this :

<img width="1588" alt="Screenshot 2025-03-24 at 2 20 00 AM" src="https://github.com/user-attachments/assets/bfd7afa1-82ce-4b21-b43e-7528f46b36a8" />

I only realized because I'm copying parts of the extensions site for the prompt library