### PR TITLE
feat: use temp dir for extracting goose binary

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -78,12 +78,21 @@ if ! curl -sLf "$DOWNLOAD_URL" --output "$FILE"; then
   exit 1
 fi
 
-echo "Extracting $FILE..."
-tar -xjf "$FILE"
+# Create a temporary directory for extraction
+TMP_DIR="/tmp/goose_install_$RANDOM"
+if ! mkdir -p "$TMP_DIR"; then
+  echo "Error: Could not create temporary extraction directory"
+  exit 1
+fi
+# Clean up temporary directory
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Extracting $FILE to temporary directory..."
+tar -xjf "$FILE" -C "$TMP_DIR"
 rm "$FILE" # clean up the downloaded tarball
 
-# Make binaries executable
-chmod +x goose
+# Make binary executable
+chmod +x "$TMP_DIR/goose"
 
 # --- 5) Install to $GOOSE_BIN_DIR ---
 if [ ! -d "$GOOSE_BIN_DIR" ]; then
@@ -92,7 +101,7 @@ if [ ! -d "$GOOSE_BIN_DIR" ]; then
 fi
 
 echo "Moving goose to $GOOSE_BIN_DIR/$OUT_FILE"
-mv goose "$GOOSE_BIN_DIR/$OUT_FILE"
+mv "$TMP_DIR/goose" "$GOOSE_BIN_DIR/$OUT_FILE"
 
 # skip configuration for non-interactive installs e.g. automation, docker
 if [ "$CONFIGURE" = true ]; then


### PR DESCRIPTION
fixes https://github.com/block/goose/issues/1745

The following error happens when the user runs the download script and their working directory has a `goose` directory:
```bash
❯ goose update -c
Downloading canary release: goose-aarch64-apple-darwin.tar.bz2...
Extracting goose-aarch64-apple-darwin.tar.bz2...
goose: Can't replace existing directory with non-directory
tar: Error exit delayed from previous errors.
```

Use a temporary directory in `/tmp` to extract the binary, then move it to the final location
* use $RANDOM (https://tldp.org/LDP/abs/html/randomvar.html) to get a random number suffix
* `trap 'rm -rf "$TMP_DIR"' EXIT` to cleanup on script exit, even if an error occurs
 