### PR TITLE
fix: disappearing user text when stopped

### DIFF
--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -254,6 +254,12 @@ export default function ChatView({
     // isUserMessage also checks if the message is a toolConfirmationRequest
     // check if the last message is a real user's message
     if (lastMessage && isUserMessage(lastMessage) && !isToolResponse) {
+      // Get the text content from the last message before removing it
+      const textContent = lastMessage.content.find((c) => c.type === 'text')?.text || '';
+
+      // Set the text back to the input field
+      _setInput(textContent);
+
       // Remove the last user message if it's the most recent one
       if (messages.length > 1) {
         setMessages(messages.slice(0, -1));
@@ -432,6 +438,8 @@ export default function ChatView({
             isLoading={isLoading}
             onStop={onStopGoose}
             commandHistory={commandHistory}
+            value={_input}
+            onValueChange={_setInput}
           />
           <BottomMenu hasMessages={hasMessages} setView={setView} />
         </div>

--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -8,6 +8,8 @@ interface InputProps {
   isLoading?: boolean;
   onStop?: () => void;
   commandHistory?: string[];
+  value?: string;
+  onValueChange?: (value: string) => void;
 }
 
 export default function Input({
@@ -15,8 +17,19 @@ export default function Input({
   isLoading = false,
   onStop,
   commandHistory = [],
+  value: controlledValue,
+  onValueChange,
 }: InputProps) {
-  const [value, setValue] = useState('');
+  const [internalValue, setInternalValue] = useState('');
+  // Use controlled value if provided, otherwise use internal state
+  const value = controlledValue !== undefined ? controlledValue : internalValue;
+  const setValue = (newValue: string) => {
+    if (controlledValue !== undefined && onValueChange) {
+      onValueChange(newValue);
+    } else {
+      setInternalValue(newValue);
+    }
+  };
   // State to track if the IME is composing (i.e., in the middle of Japanese IME input)
   const [isComposing, setIsComposing] = useState(false);
   const [historyIndex, setHistoryIndex] = useState(-1);


### PR DESCRIPTION
fixes #1750 

before:
- when you hit the stop button, the original input text will disappear

after:
- when you hit the stop button, the original input text will remain