### PR TITLE
fix: add text-textStandard to non-string args for light/dark mode

### DIFF
--- a/ui/desktop/src/components/ToolCallArguments.tsx
+++ b/ui/desktop/src/components/ToolCallArguments.tsx
@@ -71,8 +71,8 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
     return (
       <div className="mb-2">
         <div className="flex flex-row">
-          <span className="font-medium mr- min-w-[140px]2">{key}:</span>
-          <pre className="whitespace-pre-wrap">{content}</pre>
+          <span className="font-medium mr- text-textStandard min-w-[140px]2">{key}:</span>
+          <pre className="whitespace-pre-wrap text-textStandard">{content}</pre>
         </div>
       </div>
     );


### PR DESCRIPTION
fixes https://github.com/block/goose/issues/1742

The styling for non-string args (before stringifying) did not apply the `text-textStandard` which flips the styling depending on light vs dark mode. The arguments were there, just not visible:

### in v1.0.15
![image](https://github.com/user-attachments/assets/5f3a49d6-0964-430b-85fc-5965a77fe48d)
![image](https://github.com/user-attachments/assets/28c8543a-31fb-4230-bf8b-61a31b7af1f5)

![image](https://github.com/user-attachments/assets/dfabcb2c-909b-4b3e-bbd6-b9cb11c52fc2)

### this change
<img width="206" alt="image" src="https://github.com/user-attachments/assets/550a052c-eb42-47dd-8005-591cd8ba7a58" />

light mode doesn't change