### PR TITLE
fix: append the attachment path to the existing text in the input prompt

### DIFF
--- a/ui/desktop/src/components/Input.tsx
+++ b/ui/desktop/src/components/Input.tsx
@@ -131,7 +131,11 @@ export default function Input({
   const handleFileSelect = async () => {
     const path = await window.electron.selectFileOrDirectory();
     if (path) {
-      setValue(path);
+      // Append the path to existing text, with a space if there's existing text
+      setValue((prev) => {
+        const currentText = prev.trim();
+        return currentText ? `${currentText} ${path}` : path;
+      });
       textAreaRef.current?.focus();
     }
   };


### PR DESCRIPTION
Fixes issue 1179 to append attachment paths to the existing text in the input prompt. 


