### PR TITLE
feat: extract `StdioProcessError(msg)` to try to display

### DIFF
--- a/ui/desktop/src/extensions.tsx
+++ b/ui/desktop/src/extensions.tsx
@@ -105,8 +105,17 @@ export async function addExtension(
       return response;
     }
 
-    const errorMessage = `Error adding extension`;
-    console.error(errorMessage);
+    var errorMessage = `Error adding extension`;
+    // Attempt to extract the message from inside StdioProcessError()
+    const regex = /StdioProcessError\("(.*?)"\)/;
+    const match = data.message.match(regex);
+
+    if (match) {
+      const extracted = match[1];
+      // only display the message if it is less than 100 chars
+      errorMessage = extracted.length > 100 ? errorMessage : extracted;
+    }
+
     if (toastId) toast.dismiss(toastId);
     ToastError({
       title: extension.name,

--- a/ui/desktop/src/extensions.tsx
+++ b/ui/desktop/src/extensions.tsx
@@ -120,7 +120,7 @@ export async function addExtension(
     ToastError({
       title: extension.name,
       msg: errorMessage,
-      errorMessage: data.message,
+      traceback: data.message,
       toastOptions: { autoClose: false },
     });
 
@@ -131,7 +131,7 @@ export async function addExtension(
     ToastError({
       title: extension.name,
       msg: 'Failed to add extension',
-      errorMessage: error.message,
+      traceback: error.message,
       toastOptions: { autoClose: false },
     });
     throw error;
@@ -163,7 +163,7 @@ export async function removeExtension(name: string, silent: boolean = false): Pr
     ToastError({
       title: name,
       msg: 'Error removing extension',
-      errorMessage: data.message,
+      traceback: data.message,
       toastOptions: { autoClose: false },
     });
     return response;
@@ -173,7 +173,7 @@ export async function removeExtension(name: string, silent: boolean = false): Pr
     ToastError({
       title: name,
       msg: 'Error removing extension',
-      errorMessage: error.message,
+      traceback: error.message,
       toastOptions: { autoClose: false },
     });
     throw error;

--- a/ui/desktop/src/extensions.tsx
+++ b/ui/desktop/src/extensions.tsx
@@ -107,6 +107,7 @@ export async function addExtension(
 
     var errorMessage = `Error adding extension`;
     // Attempt to extract the message from inside StdioProcessError()
+    // NOTE: this may change if the error response from /extensions/add changes
     const regex = /StdioProcessError\("(.*?)"\)/;
     const match = data.message.match(regex);
 


### PR DESCRIPTION
* use a regex extraction to pull the contents of the msg field, and if the length is < 100 characters we display the error, otherwise we leave "Error adding extension"
* looks likes there was a change to `ToastError`, it expects `traceback` instead of `errorMessage` now, the copy button was not showing up until this was changed
https://github.com/block/goose/blob/main/ui/desktop/src/components/settings/models/toasts.tsx#L24-L30
