### PR TITLE
quickfix: Update install-link-generator path

### DIFF
--- a/documentation/static/install-link-generator/index.html
+++ b/documentation/static/install-link-generator/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Goose Install Link Generator</title>
-    <link rel="stylesheet" href="./install-link-generator/styles.css">
+    <link rel="stylesheet" href="./styles.css">
 </head>
 <body>
     <div class="container">
@@ -67,6 +67,6 @@
             <div id="generatedLink"></div>
         </div>
     </div>
-    <script src="./install-link-generator/script.js"></script>
+    <script src="./script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This pull request includes changes to the `documentation/static/install-link-generator/index.html` file to update the paths for the CSS and JavaScript files.

* Updated the stylesheet link to point to `./styles.css` instead of `./install-link-generator/styles.css`.
* Updated the script link to point to `./script.js` instead of `./install-link-generator/script.js`.