### PR TITLE
docs: Add `/plan` Command to CLI Documentation

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -227,12 +227,16 @@ The CLI provides a set of slash commands that can be accessed during a session. 
 - `/prompts [--extension <name>]` - List all available prompts, optionally filtered by extension
 - `/prompt <n> [--info] [key=value...]` - Get prompt info or execute a prompt
 - `/mode <name>` - Set the goose mode to use ('auto', 'approve', 'chat')
+- `/plan <message>` - Create a structured plan based on the given message
 - `/?` or `/help` - Display this help message
 
 All commands support tab completion. Press `<Tab>` after a slash (/) to cycle through available commands or to complete partial commands. 
 
 #### Examples
 ```bash
+# Create a plan for triaging test failures
+/plan let's create a plan for triaging test failures
+
 # List all prompts from the developer extension
 /prompts --extension developer
 


### PR DESCRIPTION
This PR adds the `/plan` command to the list of available CLI commands in the Goose documentation. The `/plan` command allows users to create structured plans based on a given message. This update helps to improve the usability of the CLI for organizing tasks and workflows.

#### Changes:
- Added `/plan <message>` command description under the Prompt Completion section of `goose-cli-commands.md`.
- Provided usage examples for the `/plan` command, including creating a plan for triaging test failures.

#### Example Usage:
```bash
# Create a plan for triaging test failures
/plan let's create a plan for triaging test failures
```
