### PR TITLE
ui: make modals auto-close

### DIFF
--- a/ui/desktop/src/components/settings_v2/extensions/modal/ExtensionModal.tsx
+++ b/ui/desktop/src/components/settings_v2/extensions/modal/ExtensionModal.tsx
@@ -108,7 +108,12 @@ export default function ExtensionModal({
         </p>
       </div>
       <Button
-        onClick={() => onDelete && onDelete(formData.name)}
+        onClick={() => {
+          if (onDelete) {
+            onDelete(formData.name);
+            onClose(); // Add this line to close the modal after deletion
+          }
+        }}
         className="w-full h-[60px] rounded-none border-b border-borderSubtle bg-transparent hover:bg-red-900/20 text-red-500 font-medium text-md"
       >
         <Trash2 className="h-4 w-4 mr-2" /> Confirm Delete

--- a/ui/desktop/src/components/settings_v2/models/subcomponents/AddModelModal.tsx
+++ b/ui/desktop/src/components/settings_v2/models/subcomponents/AddModelModal.tsx
@@ -45,6 +45,7 @@ export const AddModelModal = ({ onClose, setView }: AddModelModalProps) => {
 
   const changeModel = async () => {
     await switchModel({ model: model, provider: provider, writeToConfig: upsert });
+    onClose(); // Add this line to close the modal after changing the model
   };
 
   useEffect(() => {


### PR DESCRIPTION
Fixes:
* Add Model Modal -> when you click “Add” the modal doesn’t auto-close 
* In Settings v2 when i delete an extension, after i click “yes, delete” on the “are you sure you want to delete?” popup, the modal should close automatically but it is staying open 