### PR TITLE
Vendor keyring crate to fix non-hermetic builds

### DIFF
--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -46,7 +46,7 @@ lopdf = "0.35.0"
 docx-rs = "0.4.7"
 image = "0.24.9"
 umya-spreadsheet = "2.2.3"
-keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service"] }
+keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service", "vendored"] }
 oauth2 = { version = "5.0.0", features = ["reqwest"] }
 
 [dev-dependencies]

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -53,7 +53,7 @@ lazy_static = "1.5"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 wiremock = "0.6.0"
-keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service"] }
+keyring = { version = "3.6.1", features = ["apple-native", "windows-native", "sync-secret-service", "vendored"] }
 ctor = "0.2.7"
 paste = "1.0"
 serde_yaml = "0.9.34"


### PR DESCRIPTION
Adding the "vendored" feature to the keyring crate lets you avoid having to install `libdbus-1-dev` and `pkg-config` ([src](https://github.com/open-source-cooperative/keyring-rs#:~:text=The%20default%20build%20of%20this%20crate%20expects%20that%20libdbus%20will%20be%20installed%20on%20users%27%20machines.%20If%20you%20have%20users%20whose%20machines%20might%20not%20have%20libdbus%20installed%2C%20you%20can%20specify%20the%20vendored%20feature%20when%20building%20this%20crate%20to%20statically%20link%20the%20dbus%20library%20with%20your%20app.))