### PR TITLE
Fix word break and blockquote text color for markdown

### DIFF
--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -86,10 +86,11 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeinlineCodeProperty, rehypeRaw]}
-        className={`prose prose-xs dark:prose-invert w-full max-w-full break-words
+        className={`prose prose-xs dark:prose-invert w-full max-w-full word-break
           prose-pre:p-0 prose-pre:m-0 !p-0
           prose-code:break-all prose-code:whitespace-pre-wrap
           prose-table:table prose-table:w-full
+          prose-blockquote:text-inherit
           prose-td:border prose-td:border-borderSubtle prose-td:p-2
           prose-th:border prose-th:border-borderSubtle prose-th:p-2
           prose-thead:bg-bgSubtle

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -152,6 +152,12 @@
 }
 
 @layer components {
+  /* Tailwind doesn't offer all three with break-words */
+  .word-break {
+    overflow-wrap: break-word;
+    word-wrap: break-word;
+    word-break: break-word;
+  }
   .titlebar-drag-region {
     -webkit-app-region: drag;
     height: 32px;


### PR DESCRIPTION
Fixed 2 annoying issues with blockquote rendering:

1. Tailwinds `break-words` wasn't quite working for long lines like logs, added more css word breakery
2. Blockquote text in light mode wasn't visible, added inherit to pick up the white color from its parent.

Verified it looks good in light and dark mode.

Before with text not wrapping
<img width="1151" alt="Screenshot 2025-03-28 at 2 04 30 PM" src="https://github.com/user-attachments/assets/4ee42cc9-976f-4020-9926-a7e7aa35c71b" />

Before with blockquote color not showing in light mode
<img width="1161" alt="Screenshot 2025-03-28 at 2 03 51 PM" src="https://github.com/user-attachments/assets/f25c60c5-71f1-4bb5-b89d-2d24f40dacfb" />

After with text wrapping and color fixed
<img width="1173" alt="Screenshot 2025-03-28 at 2 04 07 PM" src="https://github.com/user-attachments/assets/9819c4c6-1e6c-4048-8779-898979cc8733" />

