### PR TITLE
refactor: extract common shim executable setup code

### DIFF
--- a/ui/desktop/src/bin/jbang
+++ b/ui/desktop/src/bin/jbang
@@ -1,54 +1,12 @@
 #!/bin/bash
 
-# Enable strict mode to exit on errors and unset variables
-set -euo pipefail
-
-# Set log file
-LOG_FILE="/tmp/mcp.log"
-
-# Clear the log file at the start
-> "$LOG_FILE"
-
-# Function for logging
-log() {
-    local MESSAGE="$1"
-    echo "$(date +'%Y-%m-%d %H:%M:%S') - $MESSAGE" | tee -a "$LOG_FILE"
-}
-
-# Trap errors and log them before exiting
-trap 'log "An error occurred. Exiting with status $?."' ERR
+# Source common functions
+source "$(dirname "$0")/lib/shim.sh"
 
 log "Starting jbang setup script."
 
-# Ensure ~/.config/goose/mcp-hermit/bin exists
-log "Creating directory ~/.config/goose/mcp-hermit/bin if it does not exist."
-mkdir -p ~/.config/goose/mcp-hermit/bin
-
-# Change to the ~/.config/goose/mcp-hermit directory
-log "Changing to directory ~/.config/goose/mcp-hermit."
-cd ~/.config/goose/mcp-hermit
-
-# Check if hermit binary exists and download if not
-if [ ! -f ~/.config/goose/mcp-hermit/bin/hermit ]; then
-    log "Hermit binary not found. Downloading hermit binary."
-    curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/').gz" \
-        | gzip -dc > ~/.config/goose/mcp-hermit/bin/hermit && chmod +x ~/.config/goose/mcp-hermit/bin/hermit
-    log "Hermit binary downloaded and made executable."
-else
-    log "Hermit binary already exists. Skipping download."
-fi
-
-log "setting hermit cache to be local for MCP servers"
-mkdir -p ~/.config/goose/mcp-hermit/cache
-export HERMIT_STATE_DIR=~/.config/goose/mcp-hermit/cache
-
-# Update PATH
-export PATH=~/.config/goose/mcp-hermit/bin:$PATH
-log "Updated PATH to include ~/.config/goose/mcp-hermit/bin."
-
-# Initialize hermit
-log "Initializing hermit."
-hermit init >> "$LOG_FILE"
+setup_directories
+setup_hermit
 
 # Install OpenJDK using hermit
 log "Installing OpenJDK with hermit."
@@ -62,27 +20,22 @@ if [ ! -f ~/.config/goose/mcp-hermit/bin/jbang ]; then
 fi
 
 # Verify installations
-log "Verifying installation locations:"
-log "hermit: $(which hermit)"
-log "java: $(which java)"
-log "jbang: $(which jbang)"
+verify_binary "hermit"
+verify_binary "java"
+verify_binary "jbang"
 
 # Check for custom registry settings
-log "Checking for GOOSE_JBANG_REGISTRY environment variable for custom jbang registry setup..."
-if [ -n "${GOOSE_JBANG_REGISTRY:-}" ] && curl -s --head --fail "$GOOSE_JBANG_REGISTRY" > /dev/null; then
-    log "Checking custom goose registry availability: $GOOSE_JBANG_REGISTRY"
-    log "$GOOSE_JBANG_REGISTRY is accessible. Setting it as JBANG_REPO."
+if [ -n "${GOOSE_JBANG_REGISTRY:-}" ] && check_url_accessible "$GOOSE_JBANG_REGISTRY"; then
+    log "Setting custom registry: $GOOSE_JBANG_REGISTRY"
     export JBANG_REPO="$GOOSE_JBANG_REGISTRY"
 else
-    log "GOOSE_JBANG_REGISTRY is not set or not accessible. Using default jbang repository."
+    log "Using default jbang repository."
 fi
 
-# Trust all jbang scripts that a user might install. Without this, Jbang will attempt to
-# prompt the user to trust each script. However, Goose does not surfact this modal and without
-# user input, the addExtension method will timeout and fail.
+# Trust all jbang scripts
 jbang --quiet trust add *
 
-# Final step: Execute jbang with passed arguments, always including --fresh and --quiet
+# Execute jbang
 log "Executing 'jbang' command with arguments: $*"
 jbang --fresh --quiet "$@" || log "Failed to execute 'jbang' with arguments: $*"
 

--- a/ui/desktop/src/bin/lib/shim.sh
+++ b/ui/desktop/src/bin/lib/shim.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+# Enable strict mode to exit on errors and unset variables
+set -euo pipefail
+
+# Set log file
+LOG_FILE="/tmp/mcp.log"
+
+# Clear the log file at the start
+> "$LOG_FILE"
+
+# Function for logging
+log() {
+    local MESSAGE="$1"
+    echo "$(date +'%Y-%m-%d %H:%M:%S') - $MESSAGE" | tee -a "$LOG_FILE"
+}
+
+# Trap errors and log them before exiting
+trap 'log "An error occurred. Exiting with status $?."' ERR
+
+# Common directory setup function
+setup_directories() {
+    # Ensure ~/.config/goose/mcp-hermit/bin exists
+    log "Creating directory ~/.config/goose/mcp-hermit/bin if it does not exist."
+    mkdir -p ~/.config/goose/mcp-hermit/bin
+
+    # Change to the ~/.config/goose/mcp-hermit directory
+    log "Changing to directory ~/.config/goose/mcp-hermit."
+    cd ~/.config/goose/mcp-hermit
+
+    # Setup hermit cache
+    log "setting hermit cache to be local for MCP servers"
+    mkdir -p ~/.config/goose/mcp-hermit/cache
+    export HERMIT_STATE_DIR=~/.config/goose/mcp-hermit/cache
+}
+
+# Common hermit setup function
+setup_hermit() {
+    # Check if hermit binary exists and download if not
+    if [ ! -f ~/.config/goose/mcp-hermit/bin/hermit ]; then
+        log "Hermit binary not found. Downloading hermit binary."
+        curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/').gz" \
+            | gzip -dc > ~/.config/goose/mcp-hermit/bin/hermit && chmod +x ~/.config/goose/mcp-hermit/bin/hermit
+        log "Hermit binary downloaded and made executable."
+    else
+        log "Hermit binary already exists. Skipping download."
+    fi
+
+    # Update PATH
+    export PATH=~/.config/goose/mcp-hermit/bin:$PATH
+    log "Updated PATH to include ~/.config/goose/mcp-hermit/bin."
+
+    # Initialize hermit
+    log "Initializing hermit."
+    hermit init >> "$LOG_FILE"
+}
+
+# Function to verify a URL is accessible
+check_url_accessible() {
+    local URL="$1"
+    curl -s --head --fail "$URL" > /dev/null
+}
+
+# Function to verify binary locations
+verify_binary() {
+    local BINARY_NAME="$1"
+    log "$BINARY_NAME: $(which $BINARY_NAME)"
+}

--- a/ui/desktop/src/bin/npx
+++ b/ui/desktop/src/bin/npx
@@ -1,104 +1,37 @@
 #!/bin/bash
 
-# Enable strict mode to exit on errors and unset variables
-set -euo pipefail
-
-# Set log file
-LOG_FILE="/tmp/mcp.log"
-
-# Clear the log file at the start
-> "$LOG_FILE"
-
-# Function for logging
-log() {
-    local MESSAGE="$1"
-    echo "$(date +'%Y-%m-%d %H:%M:%S') - $MESSAGE" | tee -a "$LOG_FILE"
-}
-
-# Trap errors and log them before exiting
-trap 'log "An error occurred. Exiting with status $?."' ERR
+# Source common functions
+source "$(dirname "$0")/lib/shim.sh"
 
 log "Starting npx setup script."
 
-# Ensure ~/.config/goose/mcp-hermit/bin exists
-log "Creating directory ~/.config/goose/mcp-hermit/bin if it does not exist."
-mkdir -p ~/.config/goose/mcp-hermit/bin
-
-# Change to the ~/.config/goose/mcp-hermit directory
-log "Changing to directory ~/.config/goose/mcp-hermit."
-cd ~/.config/goose/mcp-hermit
-
-
-# Check if hermit binary exists and download if not
-if [ ! -f ~/.config/goose/mcp-hermit/bin/hermit ]; then
-    log "Hermit binary not found. Downloading hermit binary."
-    curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/').gz" \
-        | gzip -dc > ~/.config/goose/mcp-hermit/bin/hermit && chmod +x ~/.config/goose/mcp-hermit/bin/hermit
-    log "Hermit binary downloaded and made executable."
-else
-    log "Hermit binary already exists. Skipping download."
-fi
-
-
-log "setting hermit cache to be local for MCP servers"
-mkdir -p ~/.config/goose/mcp-hermit/cache
-export HERMIT_STATE_DIR=~/.config/goose/mcp-hermit/cache
-
-
-# Update PATH
-export PATH=~/.config/goose/mcp-hermit/bin:$PATH
-log "Updated PATH to include ~/.config/goose/mcp-hermit/bin."
-
-
-# Verify hermit installation
-log "Checking for hermit in PATH."
-which hermit >> "$LOG_FILE"
-
-# Initialize hermit
-log "Initializing hermit."
-hermit init >> "$LOG_FILE"
+setup_directories
+setup_hermit
 
 # Install Node.js using hermit
 log "Installing Node.js with hermit."
 hermit install node >> "$LOG_FILE"
 
 # Verify installations
-log "Verifying installation locations:"
-log "hermit: $(which hermit)"
-log "node: $(which node)"
-log "npx: $(which npx)"
+verify_binary "hermit"
+verify_binary "node"
+verify_binary "npx"
 
-
-log "Checking for GOOSE_NPM_REGISTRY and GOOSE_NPM_CERT environment variables for custom npm registry setup..."
-# Check if GOOSE_NPM_REGISTRY is set and accessible
-if [ -n "${GOOSE_NPM_REGISTRY:-}" ] && curl -s --head --fail "$GOOSE_NPM_REGISTRY" > /dev/null; then
-    log "Checking custom goose registry availability: $GOOSE_NPM_REGISTRY"
-    log "$GOOSE_NPM_REGISTRY is accessible. Using it for npm registry."
+# Setup custom registry if available
+if [ -n "${GOOSE_NPM_REGISTRY:-}" ] && check_url_accessible "$GOOSE_NPM_REGISTRY"; then
+    log "Setting custom registry: $GOOSE_NPM_REGISTRY"
     export NPM_CONFIG_REGISTRY="$GOOSE_NPM_REGISTRY"
 
-    # Check if GOOSE_NPM_CERT is set and accessible
-    if [ -n "${GOOSE_NPM_CERT:-}" ] && curl -s --head --fail "$GOOSE_NPM_CERT" > /dev/null; then
+    if [ -n "${GOOSE_NPM_CERT:-}" ] && check_url_accessible "$GOOSE_NPM_CERT"; then
         log "Downloading certificate from: $GOOSE_NPM_CERT"
         curl -sSL -o ~/.config/goose/mcp-hermit/cert.pem "$GOOSE_NPM_CERT"
-        if [ $? -eq 0 ]; then
-            log "Certificate downloaded successfully."
-            export NODE_EXTRA_CA_CERTS=~/.config/goose/mcp-hermit/cert.pem
-        else
-            log "Unable to download the certificate. Skipping certificate setup."
-        fi
-    else
-        log "GOOSE_NPM_CERT is either not set or not accessible. Skipping certificate setup."
+        export NODE_EXTRA_CA_CERTS=~/.config/goose/mcp-hermit/cert.pem
     fi
-
 else
-    log "GOOSE_NPM_REGISTRY is either not set or not accessible. Falling back to default npm registry."
     export NPM_CONFIG_REGISTRY="https://registry.npmjs.org/"
 fi
 
-
-
-
-# Final step: Execute npx with passed arguments
+# Execute npx
 log "Executing 'npx' command with arguments: $*"
 npx "$@" || log "Failed to execute 'npx' with arguments: $*"
 

--- a/ui/desktop/src/bin/uvx
+++ b/ui/desktop/src/bin/uvx
@@ -1,88 +1,34 @@
 #!/bin/bash
 
-# Enable strict mode to exit on errors and unset variables
-set -euo pipefail
-
-# Set log file
-LOG_FILE="/tmp/mcp.log"
-
-# Clear the log file at the start
-> "$LOG_FILE"
-
-# Function for logging
-log() {
-    local MESSAGE="$1"
-    echo "$(date +'%Y-%m-%d %H:%M:%S') - $MESSAGE" | tee -a "$LOG_FILE"
-}
-
-# Trap errors and log them before exiting
-trap 'log "An error occurred. Exiting with status $?."' ERR
+# Source common functions
+source "$(dirname "$0")/lib/shim.sh"
 
 log "Starting uvx setup script."
 
-# Ensure ~/.config/goose/mcp-hermit/bin exists
-log "Creating directory ~/.config/goose/mcp-hermit/bin if it does not exist."
-mkdir -p ~/.config/goose/mcp-hermit/bin
+setup_directories
+setup_hermit
 
-# Change to the ~/.config/goose/mcp-hermit directory
-log "Changing to directory ~/.config/goose/mcp-hermit."
-cd ~/.config/goose/mcp-hermit
-
-# Check if hermit binary exists and download if not
-if [ ! -f ~/.config/goose/mcp-hermit/bin/hermit ]; then
-    log "Hermit binary not found. Downloading hermit binary."
-    curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/').gz" \
-        | gzip -dc > ~/.config/goose/mcp-hermit/bin/hermit && chmod +x ~/.config/goose/mcp-hermit/bin/hermit
-    log "Hermit binary downloaded and made executable."
-else
-    log "Hermit binary already exists. Skipping download."
-fi
-
-
-log "setting hermit cache to be local for MCP servers"
-mkdir -p ~/.config/goose/mcp-hermit/cache
-export HERMIT_STATE_DIR=~/.config/goose/mcp-hermit/cache
-
-# Update PATH
-export PATH=~/.config/goose/mcp-hermit/bin:$PATH
-log "Updated PATH to include ~/.config/goose/mcp-hermit/bin."
-
-
-# Verify hermit installation
-log "Checking for hermit in PATH."
-which hermit >> "$LOG_FILE"
-
-# Initialize hermit
-log "Initializing hermit."
-hermit init >> "$LOG_FILE"
-
-# Initialize python >= 3.10
-log "hermit install python 3.10"
+# Initialize python
+log "Installing Python 3.10 with hermit"
 hermit install python3@3.10 >> "$LOG_FILE"
 
-# Install UV for python using hermit
+# Install UV using hermit
 log "Installing UV with hermit."
 hermit install uv >> "$LOG_FILE"
 
 # Verify installations
-log "Verifying installation locations:"
-log "hermit: $(which hermit)"
-log "uv: $(which uv)"
-log "uvx: $(which uvx)"
+verify_binary "hermit"
+verify_binary "uv"
+verify_binary "uvx"
 
-
-log "Checking for GOOSE_UV_REGISTRY environment variable for custom python/pip/UV registry setup..."
-# Check if GOOSE_UV_REGISTRY is set and accessible
-if [ -n "${GOOSE_UV_REGISTRY:-}" ] && curl -s --head --fail "$GOOSE_UV_REGISTRY" > /dev/null; then
-    log "Checking custom goose registry availability: $GOOSE_UV_REGISTRY"
-    log "$GOOSE_UV_REGISTRY is accessible, setting it as UV_INDEX_URL. Setting UV_NATIVE_TLS to true."
+# Setup custom registry if available
+if [ -n "${GOOSE_UV_REGISTRY:-}" ] && check_url_accessible "$GOOSE_UV_REGISTRY"; then
+    log "Setting custom registry: $GOOSE_UV_REGISTRY"
     export UV_INDEX_URL="$GOOSE_UV_REGISTRY"
     export UV_NATIVE_TLS=true
-else
-    log "Neither GOOSE_UV_REGISTRY nor UV_INDEX_URL is set. Falling back to default configuration."
 fi
 
-# Final step: Execute uvx with passed arguments
+# Execute uvx
 log "Executing 'uvx' command with arguments: $*"
 uvx "$@" || log "Failed to execute 'uvx' with arguments: $*"
 


### PR DESCRIPTION
The three shim scripts have a lot of common functionality (e.g. setting up hermit) whish has been copy/pasted to each script file. This PR extracts the common code to a shared file (`src/bin/lib/shim.sh`) and leverages that in each of the shims.

This will have the benefit of streamlining adding support for new shims to support other MCP server language implementations.