### PR TITLE
bug: change `reqwest` certificate store to platform's native

### DIFF
--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -30,7 +30,7 @@ serde = { version = "1.0", features = ["derive"] }  # For serialization
 serde_yaml = "0.9"
 etcetera = "0.8.0"
 reqwest = { version = "0.12.9", features = [
-        "rustls-tls",
+        "rustls-tls-native-roots",
         "json",
         "cookies",
         "gzip",

--- a/crates/goose-cli/src/logging.rs
+++ b/crates/goose-cli/src/logging.rs
@@ -183,7 +183,6 @@ mod tests {
     use std::env;
     use tempfile::TempDir;
     use test_case::test_case;
-    use tokio::runtime::Runtime;
 
     fn setup_temp_home() -> TempDir {
         let temp_dir = TempDir::new().unwrap();
@@ -209,12 +208,11 @@ mod tests {
         assert!(path_components.iter().any(|c| c.as_os_str() == "cli"));
     }
 
+    #[tokio::test]
     #[test_case(Some("test_session"), true ; "with session name and error capture")]
     #[test_case(Some("test_session"), false ; "with session name without error capture")]
     #[test_case(None, false ; "without session name")]
-    fn test_log_file_name(session_name: Option<&str>, _with_error_capture: bool) {
-        let _rt = Runtime::new().unwrap();
-
+    async fn test_log_file_name(session_name: Option<&str>, _with_error_capture: bool) {
         // Create a unique test directory for each test
         let test_name = session_name.unwrap_or("no_session");
         let random_suffix = std::time::SystemTime::now()

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -28,7 +28,7 @@ indoc = "2.0.5"
 xcap = "0.0.14"
 reqwest = { version = "0.11", features = [
     "json",
-    "rustls-tls",
+    "rustls-tls-native-roots",
 ], default-features = false }
 async-trait = "0.1"
 chrono = { version = "0.4.38", features = ["serde"] }

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -9,7 +9,7 @@ description.workspace = true
 
 [build-dependencies]
 tokio = { version = "1.36", features = ["full"] }
-reqwest = { version = "0.12.9", features = ["json", "rustls-tls"], default-features = false }
+reqwest = { version = "0.12.9", features = ["json", "rustls-tls-native-roots"], default-features = false }
 
 [dependencies]
 mcp-client = { path = "../mcp-client" }
@@ -18,7 +18,7 @@ anyhow = "1.0"
 thiserror = "1.0"
 futures = "0.3"
 reqwest = { version = "0.12.9", features = [
-        "rustls-tls",
+        "rustls-tls-native-roots",
         "json",
         "cookies",
         "gzip",

--- a/crates/mcp-client/Cargo.toml
+++ b/crates/mcp-client/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 mcp-core = { path = "../mcp-core" }
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.11", default-features = false, features = ["json", "stream", "rustls-tls-native-roots"] }
 eventsource-client = "0.12.0"
 futures = "0.3"
 serde = { version = "1.0", features = ["derive"] }


### PR DESCRIPTION
This PR addresses #1922.

I believe that `rustls-tls-native-roots` is the most suitable choice for the following reasons:

- It is officially supported by `reqwest`: 
https://docs.rs/reqwest/latest/reqwest/#optional-features  
- It requires minimal changes compared to the original `rustls-tls`.  
- It supports macOS, Linux, and Windows, and also allows customization via environment variables: https://github.com/rustls/rustls-native-certs?tab=readme-ov-file#platform-support