### PR TITLE
docs: updating small typos I found

### DIFF
--- a/documentation/blog/2025-03-31-goose-benchmark/index.md
+++ b/documentation/blog/2025-03-31-goose-benchmark/index.md
@@ -1,6 +1,6 @@
 ---
 title: "Community-Inspired Benchmarking: The Goose Vibe Check"
-description: "Explore the new Speech MCP server that enables voice-controlled coding and natural conversation with your AI agent"
+description: "See how open source AI models measure up in our first Goose agent benchmark tests"
 authors: 
     - alice
 ---

--- a/documentation/docs/tutorials/tavily-mcp.md
+++ b/documentation/docs/tutorials/tavily-mcp.md
@@ -9,13 +9,13 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
 <YouTubeShortEmbed videoUrl="https://youtube.com/embed/mxS2G9afGxE" />
 
-This tutorial covers how to add the [Tavily Web Search MCP Server](https://github.com/RamXX/mcp-tavily) as a Goose extension to enable AI-powered web search functionality.
+This tutorial covers how to add the [Tavily Web Search MCP Server](https://github.com/tavily-ai/tavily-mcp) as a Goose extension to enable AI-powered web search functionality.
 
 :::tip TLDR
 
 **Command**
 ```sh
-uvx mcp-tavily
+npx -y tavily-mcp 
 ```
 
 **Environment Variable**
@@ -131,7 +131,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     │  tavily
     │
     ◇  What command should be run?
-    │  uvx mcp-tavily
+    │  npx -y tavily-mcp
     │
     ◇  Please set the timeout for this tool (in secs):
     │  300
@@ -154,7 +154,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=uvx&arg=mcp-tavily&id=tavily&name=Tavily%20Web%20Search&description=Web%20search%20capabilities%20powered%20by%20Tavily&env=TAVILY_API_KEY%3DAPI%20key%20for%20Tavily%20web%20search%20service)
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=tavily-mcp&id=tavily&name=Tavily%20Web%20Search&description=Search%20the%20web%20with%20Tavily%20MCP&env=TAVILY_API_KEY%3DTavily%20API%20Key)
   2. Press `Yes` to confirm the installation
   3. Obtain a [TAVILY_API_KEY](hhttps://tavily.com/) and paste it in
   4. Click `Save Configuration`
@@ -213,5 +213,5 @@ Would you like me to search for more specific information about any of these dev
 ```
 
 :::tip
-You can adjust the [search parameters](https://github.com/RamXX/mcp-tavily?tab=readme-ov-file#prompts) for different types of queries and depths of information. The extension supports both quick searches and comprehensive research.
+You can adjust the [search parameters](https://github.com/tavily-ai/tavily-mcp#tavily-search-examples) for different types of queries and depths of information. The extension supports both quick searches and comprehensive research.
 :::

--- a/documentation/src/pages/prompt-library/index.tsx
+++ b/documentation/src/pages/prompt-library/index.tsx
@@ -112,7 +112,7 @@ export default function HomePage() {
         <div className="search-container mb-6 md:mb-8">
           <input
             className="bg-bgApp font-light text-textProminent placeholder-textPlaceholder w-full px-3 py-2 md:py-3 text-2xl md:text-[40px] leading-tight md:leading-[52px] border-b border-borderSubtle focus:outline-none focus:ring-purple-500 focus:border-borderProminent caret-[#FF4F00] pl-0"
-            placeholder="Search prompts..."
+            placeholder="Search for prompts by keywords"
             value={searchQuery}
             onChange={(e) => {
               setSearchQuery(e.target.value);

--- a/documentation/yarn.lock
+++ b/documentation/yarn.lock
@@ -4518,6 +4518,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
 
+fsevents@~2.3.2:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
 function-bind@^1.1.2:
   version "1.1.2"
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
@@ -8660,7 +8665,6 @@ svgo@^3.0.2, svgo@^3.2.0:
     css-what "^6.1.0"
     csso "^5.0.5"
     picocolors "^1.0.0"
-
 
 swiper@^11.2.6:
   version "11.2.6"


### PR DESCRIPTION
- Updating Tavily MCP tutorial to use official company MCP server and not community built server
- Updating goose bench blog description as it was showing the old one
- Updated yarn lock because we were missing a dependency upon install
- Updating prompt library to say "search for prompts by keyword"