### PR TITLE
Updating Alice's Author Linkedin

### DIFF
--- a/documentation/blog/authors.yml
+++ b/documentation/blog/authors.yml
@@ -62,5 +62,5 @@ alice:
   image_url: https://avatars.githubusercontent.com/u/110418948?v=4
   page: true
   socials:
-    linkedin: alicehau
+    linkedin: alice-hau
     github: alicehau


### PR DESCRIPTION
This pull request includes a small change to the `documentation/blog/authors.yml` file. The change corrects the LinkedIn username for the author "alice" from `alicehau` to `alice-hau`.