### PR TITLE
feat(vscode): add the vscode server to the list

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -130,5 +130,17 @@
     "endorsed": true,
     "githubStars": 1,
     "environmentVariables": []
+  },
+  {
+    "id": "vscode",
+    "name": "VSCode",
+    "description": "Provides a VSCode IDE integration for development workflows",
+    "command": "npx vscode-mcp-server",
+    "link": "https://github.com/block/vscode-mcp",
+    "installation_notes": "Install using npx package manager.",
+    "is_builtin": false,
+    "endorsed": false,
+    "githubStars": 27,
+    "environmentVariables": []
   }
 ]


### PR DESCRIPTION
This PR adds the VSCode extension to the goose website: https://block.github.io/goose/extensions