### PR TITLE
Fix padding in chat ScrollArea pushing out scrollbar

### DIFF
--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -387,7 +387,8 @@ export default function ChatView({
             activities={botConfig?.activities || null}
           />
         ) : (
-          <ScrollArea ref={scrollRef} className="flex-1 px-4" autoScroll>
+          /* padding needs to be passed into the container inside ScrollArea to avoid pushing the scrollbar out */
+          <ScrollArea ref={scrollRef} className="flex-1" paddingX={4} autoScroll>
             <SearchView className="mt-[16px]" scrollAreaRef={scrollRef}>
               {filteredMessages.map((message, index) => (
                 <div key={message.id || index} className="mt-[16px] message-content">

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -12,10 +12,13 @@ export interface ScrollAreaHandle {
 
 interface ScrollAreaProps extends React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root> {
   autoScroll?: boolean;
+  /* padding needs to be passed into the container inside ScrollArea to avoid pushing the scrollbar out */
+  paddingX?: number;
+  paddingY?: number;
 }
 
 const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
-  ({ className, children, autoScroll = false, ...props }, ref) => {
+  ({ className, children, autoScroll = false, paddingX, paddingY, ...props }, ref) => {
     const rootRef = React.useRef<React.ElementRef<typeof ScrollAreaPrimitive.Root>>(null);
     const viewportRef = React.useRef<HTMLDivElement>(null);
     const viewportEndRef = React.useRef<HTMLDivElement>(null);
@@ -104,8 +107,10 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
           ref={viewportRef}
           className="h-full w-full rounded-[inherit] [&>div]:!block"
         >
-          {children}
-          {autoScroll && <div ref={viewportEndRef} style={{ height: '1px' }} />}
+          <div className={cn(paddingX ? `px-${paddingX}` : '', paddingY ? `py-${paddingY}` : '')}>
+            {children}
+            {autoScroll && <div ref={viewportEndRef} style={{ height: '1px' }} />}
+          </div>
         </ScrollAreaPrimitive.Viewport>
         <ScrollBar />
         <ScrollAreaPrimitive.Corner />


### PR DESCRIPTION
Fix padding in chat `ScrollView` pushing out the scrollbar. Regression from https://github.com/block/goose/pull/1790 so I made it a bit more enforced by adding optional padding props to `ScrollView` which then adds it to an internal container.

Before (padding directly on `ScrollView`) note scrollbar is pushed out on right side:

<img width="1067" alt="Screenshot 2025-03-31 at 5 48 36 PM" src="https://github.com/user-attachments/assets/6ba2586d-c266-4504-a5c9-b4617c9c990e" />

After (padding on inner container):

<img width="1067" alt="Screenshot 2025-03-31 at 5 51 42 PM" src="https://github.com/user-attachments/assets/8c77bf56-b6c5-44ee-b22b-57d1ccdfcf3d" />
