### PR TITLE
fix: Only show one toast when extensions fail to add/activate/etc

### DIFF
--- a/ui/desktop/src/components/settings_v2/extensions/agent-api.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/agent-api.ts
@@ -58,11 +58,7 @@ export async function extensionApiCall(
     if (data.error) {
       const errorMessage = `Error ${action.type} extension: ${data.message || 'Unknown error'}`;
       toastService.dismiss(toastId);
-      toastService.error({
-        title: extensionName,
-        msg: errorMessage,
-        traceback: data.message || 'Unknown error',
-      });
+      // Rely on the global error catch to show the copyable error toast here
       throw new Error(errorMessage);
     }
 


### PR DESCRIPTION
Makes it so we only show one error toast when extensions fail to add / activate

**Before**

<img width="393" alt="Screenshot 2025-03-31 at 10 03 19 PM" src="https://github.com/user-attachments/assets/ea1c2879-2223-4470-be58-956fff0284e1" />

**After**

<img width="390" alt="Screenshot 2025-03-31 at 10 07 56 PM" src="https://github.com/user-attachments/assets/a9c20a46-2d9f-4875-93fa-ae88c709d0f7" />

