### PR TITLE
fix developer mcp for windows

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -22,6 +22,7 @@ use mcp_core::{
     protocol::ServerCapabilities,
     resource::Resource,
     tool::Tool,
+    Content,
 };
 use mcp_core::{
     prompt::{Prompt, PromptArgument, PromptTemplate},
@@ -30,7 +31,6 @@ use mcp_core::{
 use mcp_server::router::CapabilitiesBuilder;
 use mcp_server::Router;
 
-use mcp_core::content::Content;
 use mcp_core::role::Role;
 
 use self::shell::{
@@ -507,7 +507,8 @@ impl DeveloperRouter {
             .await
             .map_err(|e| ToolError::ExecutionError(e.to_string()))?;
 
-        let output_str = String::from_utf8_lossy(&output.stdout);
+        let stdout_str = String::from_utf8_lossy(&output.stdout);
+        let output_str = stdout_str;
 
         // Check the character count of the output
         const MAX_CHAR_COUNT: usize = 400_000; // 409600 chars = 400KB

--- a/crates/goose-mcp/src/developer/shell.rs
+++ b/crates/goose-mcp/src/developer/shell.rs
@@ -10,11 +10,11 @@ pub struct ShellConfig {
 impl Default for ShellConfig {
     fn default() -> Self {
         if cfg!(windows) {
-            // Use cmd.exe for simpler command execution
+            // Execute PowerShell commands directly
             Self {
-                executable: "cmd.exe".to_string(),
-                arg: "/C".to_string(),
-                redirect_syntax: "2>&1".to_string(), // cmd.exe also supports this syntax
+                executable: "powershell.exe".to_string(),
+                arg: "-NoProfile -NonInteractive -Command".to_string(),
+                redirect_syntax: "2>&1".to_string(),
             }
         } else {
             Self {
@@ -32,8 +32,13 @@ pub fn get_shell_config() -> ShellConfig {
 
 pub fn format_command_for_platform(command: &str) -> String {
     let config = get_shell_config();
-    // For all shells, no braces needed
-    format!("{} {}", command, config.redirect_syntax)
+    if cfg!(windows) {
+        // For PowerShell, wrap the command in braces to handle special characters
+        format!("{{ {} }} {}", command, config.redirect_syntax)
+    } else {
+        // For other shells, no braces needed
+        format!("{} {}", command, config.redirect_syntax)
+    }
 }
 
 pub fn expand_path(path_str: &str) -> String {


### PR DESCRIPTION
this fix should allow goose to correctly use powershell in native windows 