### PR TITLE
use provider display names

### DIFF
--- a/ui/desktop/src/components/settings_v2/models/index.ts
+++ b/ui/desktop/src/components/settings_v2/models/index.ts
@@ -1,28 +1,26 @@
 import { initializeSystem } from '../../../utils/providerUtils';
 import { toastError, toastSuccess } from '../../../toasts';
 import { ProviderDetails } from '@/src/api';
-import { getProviderMetadata } from './modelInterface';
+import Model, { getProviderMetadata } from './modelInterface';
 import { ProviderMetadata } from '../../../api';
 import type { ExtensionConfig, FixedExtensionEntry } from '../../ConfigContext';
 
 // titles
-const CHANGE_MODEL_TOAST_TITLE = 'Model selected';
-const START_AGENT_TITLE = 'Initialize agent';
 export const UNKNOWN_PROVIDER_TITLE = 'Provider name lookup';
 
 // errors
-const SWITCH_MODEL_AGENT_ERROR_MSG = 'Failed to start agent with selected model';
-const CONFIG_UPDATE_ERROR_MSG = 'Failed to update configuration settings';
-const CONFIG_READ_MODEL_ERROR_MSG = 'Failed to read GOOSE_MODEL or GOOSE_PROVIDER from config';
+const CHANGE_MODEL_ERROR_TITLE = 'Change failed';
+const SWITCH_MODEL_AGENT_ERROR_MSG =
+  'Failed to start agent with selected model -- please try again';
+const CONFIG_UPDATE_ERROR_MSG = 'Failed to update configuration settings -- please try again';
 export const UNKNOWN_PROVIDER_MSG = 'Unknown provider in config -- please inspect your config.yaml';
 
 // success
+const CHANGE_MODEL_TOAST_TITLE = 'Model changed';
 const SWITCH_MODEL_SUCCESS_MSG = 'Successfully switched models';
-const INITIALIZE_SYSTEM_WITH_MODEL_SUCCESS_MSG = 'Successfully started Goose';
 
 interface changeModelProps {
-  model: string;
-  provider: string;
+  model: Model;
   writeToConfig: (key: string, value: unknown, is_secret: boolean) => Promise<void>;
   getExtensions?: (b: boolean) => Promise<FixedExtensionEntry[]>;
   addExtension?: (name: string, config: ExtensionConfig, enabled: boolean) => Promise<void>;
@@ -31,20 +29,21 @@ interface changeModelProps {
 // TODO: error handling
 export async function changeModel({
   model,
-  provider,
   writeToConfig,
   getExtensions,
   addExtension,
 }: changeModelProps) {
+  const modelName = model.name;
+  const providerName = model.provider;
   try {
-    await initializeSystem(provider, model, {
+    await initializeSystem(providerName, modelName, {
       getExtensions,
       addExtension,
     });
   } catch (error) {
-    console.error(`Failed to change model at agent step -- ${model} ${provider}`);
+    console.error(`Failed to change model at agent step -- ${modelName} ${providerName}`);
     toastError({
-      title: CHANGE_MODEL_TOAST_TITLE,
+      title: CHANGE_MODEL_ERROR_TITLE,
       msg: SWITCH_MODEL_AGENT_ERROR_MSG,
       traceback: error,
     });
@@ -53,12 +52,12 @@ export async function changeModel({
   }
 
   try {
-    await writeToConfig('GOOSE_PROVIDER', provider, false);
-    await writeToConfig('GOOSE_MODEL', model, false);
+    await writeToConfig('GOOSE_PROVIDER', providerName, false);
+    await writeToConfig('GOOSE_MODEL', modelName, false);
   } catch (error) {
-    console.error(`Failed to change model at config step -- ${model} ${provider}`);
+    console.error(`Failed to change model at config step -- ${modelName} ${providerName}}`);
     toastError({
-      title: CHANGE_MODEL_TOAST_TITLE,
+      title: CHANGE_MODEL_ERROR_TITLE,
       msg: CONFIG_UPDATE_ERROR_MSG,
       traceback: error,
     });
@@ -68,7 +67,7 @@ export async function changeModel({
     // show toast
     toastSuccess({
       title: CHANGE_MODEL_TOAST_TITLE,
-      msg: `${SWITCH_MODEL_SUCCESS_MSG} -- using ${model} from ${provider}`,
+      msg: `${SWITCH_MODEL_SUCCESS_MSG} -- using ${model.alias ?? modelName} from ${model.subtext ?? providerName}`,
     });
   }
 }

--- a/ui/desktop/src/components/settings_v2/models/subcomponents/AddModelModal.tsx
+++ b/ui/desktop/src/components/settings_v2/models/subcomponents/AddModelModal.tsx
@@ -9,6 +9,7 @@ import { Select } from '../../../ui/Select';
 import { useConfig } from '../../../ConfigContext';
 import { changeModel } from '../index';
 import type { View } from '../../../../App';
+import Model, { getProviderMetadata } from '../modelInterface';
 
 const ModalButtons = ({ onSubmit, onCancel, isValid, validationErrors }) => (
   <div>
@@ -77,9 +78,11 @@ export const AddModelModal = ({ onClose, setView }: AddModelModalProps) => {
     const isFormValid = validateForm();
 
     if (isFormValid) {
+      const providerMetaData = await getProviderMetadata(provider, getProviders);
+      const providerDisplayName = providerMetaData.display_name;
+
       await changeModel({
-        model: model,
-        provider: provider,
+        model: { name: model, provider: provider, subtext: providerDisplayName } as Model, // pass in a Model object
         writeToConfig: upsert,
         getExtensions,
         addExtension,


### PR DESCRIPTION
Uses `Model` objects now when switching models -- this lets us pass around objects in the UI that have the model name, provider, alias (model nickname), and subtext (can be the 'pretty' version of the provider name or something more bespoke like 'Databricks (recommended)'. 

Toasts were showing 'Switched to `<model-name>` by `<lower cased provider name>`'

Now they show 'Switched to `<model-name>` by `<provider display name>`'