### PR TITLE
styles: update markdown styles

### DIFF
--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -101,18 +101,7 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
           ${className}`}
         components={{
           a: ({ node, ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" />,
-          code({
-            node,
-            children,
-            inlinecode,
-            ...props
-          }: {
-            node: any;
-            className?: string;
-            children: React.ReactNode;
-            inlinecode?: string;
-            [key: string]: any;
-          }) {
+          code({ node, className, children, inlinecode, ...props }) {
             const match = /language-(\w+)/.exec(className || 'language-text');
             return inlinecode == 'false' && match ? (
               <CodeBlock language={match[1]}>{String(children).replace(/\n$/, '')}</CodeBlock>

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -8,10 +8,6 @@ import { oneLight } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import { Check, Copy } from './icons';
 import { visit } from 'unist-util-visit';
 
-const UrlTransform = {
-  a: ({ node, ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" />,
-};
-
 function rehypeinlineCodeProperty() {
   return function (tree) {
     if (!tree) return;
@@ -86,7 +82,7 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
         rehypePlugins={[rehypeinlineCodeProperty, rehypeRaw]}
-        className={`prose prose-xs dark:prose-invert w-full max-w-full word-break
+        className={`prose prose-sm text-textStandard dark:prose-invert w-full max-w-full word-break
           prose-pre:p-0 prose-pre:m-0 !p-0
           prose-code:break-all prose-code:whitespace-pre-wrap
           prose-table:table prose-table:w-full
@@ -94,26 +90,40 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
           prose-td:border prose-td:border-borderSubtle prose-td:p-2
           prose-th:border prose-th:border-borderSubtle prose-th:p-2
           prose-thead:bg-bgSubtle
+          prose-h1:text-2xl prose-h1:font-medium prose-h1:mb-5 prose-h1:mt-5
+          prose-h2:text-xl prose-h2:font-medium prose-h2:mb-4 prose-h2:mt-4
+          prose-h3:text-lg prose-h3:font-medium prose-h3:mb-3 prose-h3:mt-3
+          prose-p:mt-0 prose-p:mb-2
+          prose-ol:my-2
+          prose-ul:mt-0 prose-ul:mb-3
+          prose-li:m-0
+
           ${className}`}
         components={{
-          ...UrlTransform,
-          code({ node, className, children, inlinecode, ...props }) {
+          a: ({ node, ...props }) => <a {...props} target="_blank" rel="noopener noreferrer" />,
+          code({
+            node,
+            children,
+            inlinecode,
+            ...props
+          }: {
+            node: any;
+            className?: string;
+            children: React.ReactNode;
+            inlinecode?: string;
+            [key: string]: any;
+          }) {
             const match = /language-(\w+)/.exec(className || 'language-text');
             return inlinecode == 'false' && match ? (
               <CodeBlock language={match[1]}>{String(children).replace(/\n$/, '')}</CodeBlock>
             ) : (
               <code
                 {...props}
-                className={`${className} break-all bg-inline-code dark:bg-inline-code-dark whitespace-pre-wrap`}
+                className={`break-all bg-inline-code dark:bg-inline-code-dark whitespace-pre-wrap`}
               >
                 {children}
               </code>
             );
-          },
-          // h3: 'div',
-          h3(props) {
-            const { node, ...rest } = props;
-            return <div className="text-textStandard text-sm" {...rest} />;
           },
         }}
       >

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -24,7 +24,10 @@ export default function UserMessage({ message }: UserMessageProps) {
         <div className="flex flex-col group">
           <div className="flex bg-slate text-white rounded-xl rounded-br-none py-2 px-3">
             <div ref={contentRef}>
-              <MarkdownContent content={textContent} className="text-white prose-a:text-white" />
+              <MarkdownContent
+                content={textContent}
+                className="text-white prose-a:text-white user-message"
+              />
             </div>
           </div>
           <div className="flex justify-end">

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -5,34 +5,34 @@
 /* Cash Sans */
 
 @font-face {
-  font-family: Cash Sans;
-  src: url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSans-Regular.woff2)
-    format('woff2');
+  font-family: 'Cash Sans';
+  src:
+    url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSans-Regular.woff2)
+      format('woff2'),
+    url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff/CashSans-Regular.woff)
+      format('woff');
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
-  font-family: Cash Sans;
-  src: url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSans-Medium.woff2)
-    format('woff2');
+  font-family: 'Cash Sans';
+  src:
+    url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSans-Medium.woff2)
+      format('woff2'),
+    url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff/CashSans-Medium.woff) format('woff');
   font-weight: 500;
   font-style: normal;
 }
 
 @font-face {
-  font-family: Cash Sans;
-  src: url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSans-Semibold.woff2)
-    format('woff2');
-  font-weight: 600;
-  font-style: normal;
-}
-
-@font-face {
-  font-family: Cash Sans;
-  src: url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSans-Bold.woff2)
-    format('woff2');
-  font-weight: 700;
+  font-family: 'Cash Sans Mono';
+  src:
+    url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSansMono-Regular.woff2)
+      format('woff2'),
+    url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff/CashSansMono-Regular.woff)
+      format('woff');
+  font-weight: 400;
   font-style: normal;
 }
 
@@ -245,6 +245,7 @@
     word-wrap: break-word;
     word-break: break-word;
   }
+
   .titlebar-drag-region {
     -webkit-app-region: drag;
     height: 32px;
@@ -261,8 +262,9 @@
 
   .bg-inline-code {
     border-radius: 4px;
-    color: rgba(255, 130, 130, 0.85);
-    font-family: 'Square Sans Mono';
+    color: rgb(255 67 67);
+    background-color: rgb(255 130 130 / 10%);
+    font-family: 'Cash Sans Mono', monospace;
     font-size: 12px;
     font-style: normal;
     font-weight: 400;
@@ -288,5 +290,9 @@
 
   .dark .bg-inline-code {
     color: rgba(248, 155, 89, 0.7);
+  }
+
+  .user-message p {
+    margin-bottom: 0 !important;
   }
 }

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -262,8 +262,9 @@
 
   .bg-inline-code {
     border-radius: 4px;
-    color: rgb(255 67 67);
-    background-color: rgb(255 130 130 / 10%);
+    color: rgb(255 119 43);
+    background-color: var(--background-app);
+    border: 1px solid var(--border-subtle);
     font-family: 'Cash Sans Mono', monospace;
     font-size: 12px;
     font-style: normal;
@@ -286,10 +287,6 @@
 
   .bg-inline-code:after {
     content: '';
-  }
-
-  .dark .bg-inline-code {
-    color: rgba(248, 155, 89, 0.7);
   }
 
   .user-message p {

--- a/ui/desktop/tailwind.config.ts
+++ b/ui/desktop/tailwind.config.ts
@@ -7,6 +7,7 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Cash Sans', 'sans-serif'],
+        mono: ['Cash Sans Mono', 'monospace'],
       },
       keyframes: {
         shimmer: {
@@ -72,6 +73,13 @@ export default {
         slate: 'var(--slate)',
         blockTeal: 'var(--block-teal)',
         blockOrange: 'var(--block-orange)',
+      },
+      typography: {
+        DEFAULT: {
+          css: {
+            color: 'var(--text-standard)',
+          },
+        },
       },
     },
   },


### PR DESCRIPTION
Key changes
- Updated header sizes
- Updated line heights
- Updated spacing
- Updated base font size (dropped down to 14px)
- Updated inline code block style

Before / Afters

<img width="1504" alt="Screenshot 2025-03-31 at 3 21 01 PM" src="https://github.com/user-attachments/assets/b5e4ec45-f807-483c-b98a-3eb01d0609e0" />
<img width="1503" alt="Screenshot 2025-03-31 at 3 26 05 PM" src="https://github.com/user-attachments/assets/fefc962a-68c3-47ae-8cf6-2f2e39f0dbd7" />
<img width="1504" alt="Screenshot 2025-03-31 at 3 54 13 PM" src="https://github.com/user-attachments/assets/be0f5a44-ec5a-4ca7-adf7-e673afd6ac8d" />
<img width="1505" alt="Screenshot 2025-03-31 at 4 18 13 PM" src="https://github.com/user-attachments/assets/1eed0974-84a7-4f2a-8e14-c62e78d7538d" />
