### PR TITLE
fix: fix empty result for view tool response

### DIFF
--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -422,7 +422,7 @@ mod tests {
         let tool_result: Vec<Content> = vec![
             Content::text("Hello"),
             Content::text("World"),
-            Content::text("This is a test."),
+            Content::embedded_text("test_uri", "This is a test."),
         ];
 
         let messages = vec![set_up_tool_response_message("response_id", tool_result)];

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -83,6 +83,7 @@ pub fn format_messages(messages: &[Message]) -> Vec<Value> {
                                     .iter()
                                     .filter_map(|c| match c {
                                         Content::Text(t) => Some(t.text.clone()),
+                                        Content::Resource(r) => Some(r.get_text()),
                                         _ => None,
                                     })
                                     .collect::<Vec<_>>()


### PR DESCRIPTION
Fix #2008

The issue is that we have the view response from goose, but it is in the [resource type](https://github.com/block/goose/blob/64d0cd186acf759b3492cc04c755740ab766c2f4/crates/goose-mcp/src/developer/mod.rs#L644) which is not processed in the gemini format_tool