### PR TITLE
fix: handle the case sensitive in mac screenshot name

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -838,7 +838,7 @@ impl DeveloperRouter {
         if let Some(filename) = path.file_name().and_then(|f| f.to_str()) {
             // Check if this matches Mac screenshot pattern:
             // "Screenshot YYYY-MM-DD at H.MM.SS AM/PM.png"
-            if let Some(captures) = regex::Regex::new(r"^Screenshot \d{4}-\d{2}-\d{2} at \d{1,2}\.\d{2}\.\d{2} (AM|PM)(?: \(\d+\))?\.png$")
+            if let Some(captures) = regex::Regex::new(r"^Screenshot \d{4}-\d{2}-\d{2} at \d{1,2}\.\d{2}\.\d{2} (AM|PM|am|pm)(?: \(\d+\))?\.png$")
                 .ok()
                 .and_then(|re| re.captures(filename))
             {


### PR DESCRIPTION
Fix #2020

Before:
<img width="673" alt="Screenshot 2025-04-02 at 6 54 38 PM" src="https://github.com/user-attachments/assets/4ce03339-0149-4ed7-9233-f21bc12ea793" />

After:
![image](https://github.com/user-attachments/assets/ab3aca51-3b3c-490a-944e-228c2edd3996)
