### PR TITLE
Add deeplink redirect to install link generator

### DIFF
--- a/documentation/static/install-link-generator/index.html
+++ b/documentation/static/install-link-generator/index.html
@@ -5,6 +5,22 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Goose Install Link Generator</title>
     <link rel="stylesheet" href="./styles.css">
+    <style>
+        .error {
+            color: #dc3545;
+            padding: 10px;
+            border: 1px solid #dc3545;
+            border-radius: 4px;
+            margin: 10px 0;
+            background-color: #f8d7da;
+        }
+        .container {
+            display: none; /* Hidden by default, shown if no params or error */
+        }
+        .result {
+            display: none; /* Hidden by default, shown when needed */
+        }
+    </style>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
This pull request includes significant updates to the `install-link-generator` feature in the documentation. The changes enhance error handling, improve user feedback, and streamline the process for generating install links based on URL parameters.

### Enhancements to Error Handling and User Feedback:
* [`documentation/static/install-link-generator/index.html`](diffhunk://#diff-70c929fdb5492ca4917ab3778d84e2f9559789d8bfe8a31716f8c3898b98f2b3R8-R23): Added a new CSS class `.error` to style error messages and modified the `.container` and `.result` classes to control their visibility.
* [`documentation/static/install-link-generator/script.js`](diffhunk://#diff-86e778e8b0e0b641fa7e98bdee5164078ff73cab656d5c73914578345a18b14aR2-R89): Introduced a `showError` function to display error messages within the result container.
* [`documentation/static/install-link-generator/script.js`](diffhunk://#diff-86e778e8b0e0b641fa7e98bdee5164078ff73cab656d5c73914578345a18b14aL94-R184): Modified the JSON parsing error handling to use the `showError` function instead of `alert`.

### Improvements to Link Generation Process:
* [`documentation/static/install-link-generator/script.js`](diffhunk://#diff-86e778e8b0e0b641fa7e98bdee5164078ff73cab656d5c73914578345a18b14aR2-R89): Added a `handleGeneratedLink` function to manage the display or redirection of generated links, and updated existing link generation calls to use this function. [[1]](diffhunk://#diff-86e778e8b0e0b641fa7e98bdee5164078ff73cab656d5c73914578345a18b14aR2-R89) [[2]](diffhunk://#diff-86e778e8b0e0b641fa7e98bdee5164078ff73cab656d5c73914578345a18b14aL85-R173)
* [`documentation/static/install-link-generator/script.js`](diffhunk://#diff-86e778e8b0e0b641fa7e98bdee5164078ff73cab656d5c73914578345a18b14aR2-R89): Implemented logic to process URL parameters and generate install links for both built-in and custom extensions, including handling environment variables.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209885734079440