### PR TITLE
style: address clippy clippy::double_ended_iterator_last, and clippy::manual_ok_err

### DIFF
--- a/crates/goose-server/src/routes/configs.rs
+++ b/crates/goose-server/src/routes/configs.rs
@@ -173,10 +173,8 @@ pub async fn get_config(
     let config = Config::global();
     let value = if let Ok(config_value) = config.get_param::<String>(&query.key) {
         Some(config_value)
-    } else if let Ok(env_value) = std::env::var(&query.key) {
-        Some(env_value)
     } else {
-        None
+        std::env::var(&query.key).ok()
     };
 
     // Return the value

--- a/crates/goose/src/agents/permission_store.rs
+++ b/crates/goose/src/agents/permission_store.rs
@@ -89,7 +89,7 @@ impl ToolPermissionStore {
             records
                 .iter()
                 .filter(|record| record.expiry.is_none_or(|exp| exp > Utc::now().timestamp()))
-                .last()
+                .next_back()
                 .map(|record| record.allowed)
         })
     }

--- a/crates/mcp-core/src/resource.rs
+++ b/crates/mcp-core/src/resource.rs
@@ -63,7 +63,7 @@ impl Resource {
             Some(n) => n,
             None => url
                 .path_segments()
-                .and_then(|segments| segments.last())
+                .and_then(|mut segments| segments.next_back())
                 .unwrap_or("unnamed")
                 .to_string(),
         };


### PR DESCRIPTION
the ci is now using rust 1.86, address clippy warnings to fix pipelines