### PR TITLE
fix: properly return errors for malformed config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,7 +2789,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.8",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -4758,6 +4758,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
@@ -4773,7 +4774,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -4807,6 +4807,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls 0.23.23",
+ "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4823,7 +4824,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.8",
+ "webpki-roots",
  "windows-registry",
 ]
 
@@ -6550,12 +6551,6 @@ dependencies = [
  "url",
  "web-sys",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -185,7 +185,17 @@ pub async fn get_extensions(
 
     match ExtensionManager::get_all() {
         Ok(extensions) => Ok(Json(ExtensionResponse { extensions })),
-        Err(_) => Err(StatusCode::INTERNAL_SERVER_ERROR),
+        Err(err) => {
+            // Return UNPROCESSABLE_ENTITY only for DeserializeError, INTERNAL_SERVER_ERROR for everything else
+            if err
+                .downcast_ref::<goose::config::base::ConfigError>()
+                .is_some_and(|e| matches!(e, goose::config::base::ConfigError::DeserializeError(_)))
+            {
+                Err(StatusCode::UNPROCESSABLE_ENTITY)
+            } else {
+                Err(StatusCode::INTERNAL_SERVER_ERROR)
+            }
+        }
     }
 }
 
@@ -196,6 +206,7 @@ pub async fn get_extensions(
     responses(
         (status = 200, description = "Extension added or updated successfully", body = String),
         (status = 400, description = "Invalid request"),
+        (status = 422, description = "Could not serialize config.yaml"),
         (status = 500, description = "Internal server error")
     )
 )]

--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -109,8 +109,7 @@ impl ExtensionManager {
     /// Get all extensions and their configurations
     pub fn get_all() -> Result<Vec<ExtensionEntry>> {
         let config = Config::global();
-        let extensions: HashMap<String, ExtensionEntry> =
-            config.get_param("extensions").unwrap_or_default();
+        let extensions: HashMap<String, ExtensionEntry> = config.get_param("extensions")?;
         Ok(Vec::from_iter(extensions.values().cloned()))
     }
 

--- a/crates/goose/src/config/mod.rs
+++ b/crates/goose/src/config/mod.rs
@@ -1,4 +1,4 @@
-mod base;
+pub mod base;
 mod experiments;
 pub mod extensions;
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -84,6 +84,9 @@
           "400": {
             "description": "Invalid request"
           },
+          "422": {
+            "description": "Could not serialize config.yaml"
+          },
           "500": {
             "description": "Internal server error"
           }

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -179,6 +179,10 @@ export type AddExtensionErrors = {
      */
     400: unknown;
     /**
+     * Could not serialize config.yaml
+     */
+    422: unknown;
+    /**
      * Internal server error
      */
     500: unknown;


### PR DESCRIPTION
Right now if `config.yaml` is malformed or cannot deserialize to the right schema, it just responds that there is an empty list of extensions. This makes it respond specifically with an `UNPROCESSABLE_ENTITY` status code. In a next change, we can update the frontend to handle this by showing options to the user (edit the file, or reset config file)