### PR TITLE
docs: Add shorts to TY extension

### DIFF
--- a/documentation/docs/tutorials/youtube-transcript.md
+++ b/documentation/docs/tutorials/youtube-transcript.md
@@ -7,6 +7,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/N38u7hZqZJg" />
+
 This tutorial covers how to add the [YouTube Transcript MCP Server](https://github.com/jkawamoto/mcp-youtube-transcript) as a Goose extension to enable fetching and working with YouTube video transcripts.
 
 :::tip TLDR


### PR DESCRIPTION
This pull request includes a small change to the `documentation/docs/tutorials/youtube-transcript.md` file. The change adds an embedded YouTube video to the tutorial using the `YouTubeShortEmbed` component.

* [`documentation/docs/tutorials/youtube-transcript.md`](diffhunk://#diff-b00d715dcdd37842ddd1c954d37fbd3b34c2eff4df218c3a9e759d3580236f61R10-R11): Added a `YouTubeShortEmbed` component to embed a YouTube video.