### PR TITLE
feat: add migration logic from settingsV1 to settingsV2

### DIFF
--- a/ui/desktop/src/utils/providerUtils.ts
+++ b/ui/desktop/src/utils/providerUtils.ts
@@ -143,7 +143,7 @@ export const migrateExtensionsToSettingsV2 = async () => {
       .join('\n');
     toastService.error({
       title: 'Config Migration Error',
-      msg: 'Extension failed to start and will be disabled.',
+      msg: 'There was a problem updating your config file',
       traceback: errorSummaryStr,
     });
   }


### PR DESCRIPTION
Migration logic:
* on startup, check for `configVersion` in `localStorage` if it (doesn’t exist, or is < 2) proceed with migration
* grab extensions from `user_settings` in `localStorage`
  * convert and extract all extensions
  * iterate through and add them to `config.yaml`, skipping `builtins`
* set `configVersion: 2` in `localStorage` so this only happens once

we skip `builtin` and rely on `initializeBundledExtensions` or `syncBundledExtensions` to setup all bundled extensions in the new format

we then just drop into normal initialization logic afterwards, relying on normal agent/extension startup