### PR TITLE
feat: parallelize extension startup and handle errors with toasts

### DIFF
--- a/ui/desktop/src/utils/providerUtils.ts
+++ b/ui/desktop/src/utils/providerUtils.ts
@@ -135,13 +135,15 @@ export const initializeSystem = async (
         await syncBundledExtensions(refreshedExtensions, options.addExtension);
       }
 
-      // Add enabled extensions to agent
-      for (const extensionEntry of refreshedExtensions) {
-        if (extensionEntry.enabled) {
-          const extensionConfig = extractExtensionConfig(extensionEntry);
-          await addToAgentOnStartup({ addToConfig: options.addExtension, extensionConfig });
-        }
-      }
+      // enable all extensions in parallel
+      await Promise.all(
+        refreshedExtensions
+          .filter((e) => e.enabled)
+          .map((extensionEntry) => {
+            const extensionConfig = extractExtensionConfig(extensionEntry);
+            return addToAgentOnStartup({ addToConfig: options.addExtension, extensionConfig });
+          })
+      );
     } else {
       loadAndAddStoredExtensions().catch((error) => {
         console.error('Failed to load and add stored extension configs:', error);


### PR DESCRIPTION
in settings v2, if an extension is configured with a bad command, or the command fails (warp error, the entire app crashes with the `Honk! Goose experienced a fatal error` message. it would also under the hood toggle off the extension, and on a retry things would seem to magically work

this change updates it so failed extensions are not fatal, instead we present a toast letting the user know it failed and that it will be disabled:
![image](https://github.com/user-attachments/assets/374309d7-b9fc-4a49-ae19-dbfc6d2ff187)

---

- added generic `retryWithBackoff` function for exponential backoff retry 
- update `addToAgentOnStartup` to use that
- attempt to add all extensions in parallel on startup

