### PR TITLE
Make claude-3.7-sonnet the default for OpenRouter

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -16,7 +16,7 @@ use crate::providers::formats::openai::{create_request, get_usage, response_to_m
 use mcp_core::tool::Tool;
 use url::Url;
 
-pub const OPENROUTER_DEFAULT_MODEL: &str = "anthropic/claude-3.5-sonnet";
+pub const OPENROUTER_DEFAULT_MODEL: &str = "anthropic/claude-3.7-sonnet";
 pub const OPENROUTER_MODEL_PREFIX_ANTHROPIC: &str = "anthropic";
 
 // OpenRouter can run many models, we suggest the default


### PR DESCRIPTION
To not have to keep manually pasting over this:

![Screenshot from 2025-04-05 16-42-02](https://github.com/user-attachments/assets/0496251d-5f0f-46aa-943f-756c4d1afe30)
