### PR TITLE
Update SSEActor error logging

### DIFF
--- a/crates/mcp-client/src/transport/mod.rs
+++ b/crates/mcp-client/src/transport/mod.rs
@@ -118,6 +118,14 @@ impl PendingRequests {
     pub async fn clear(&self) {
         self.requests.write().await.clear();
     }
+
+    pub async fn len(&self) -> usize {
+        self.requests.read().await.len()
+    }
+
+    pub async fn is_empty(&self) -> bool {
+        self.len().await == 0
+    }
 }
 
 pub mod stdio;

--- a/crates/mcp-client/src/transport/sse.rs
+++ b/crates/mcp-client/src/transport/sse.rs
@@ -210,8 +210,13 @@ impl SseActor {
         }
 
         // mpsc channel closed => no more outgoing messages
-        tracing::error!("SseActor: outgoing message loop ended. Clearing pending requests.");
-        pending_requests.clear().await;
+        let pending = pending_requests.len().await;
+        if pending > 0 {
+            tracing::error!("SSE stream ended or encountered an error with {pending} unfulfilled pending requests.");
+            pending_requests.clear().await;
+        } else {
+            tracing::info!("SseActor shutdown cleanly. No pending requests.");
+        }
     }
 }
 


### PR DESCRIPTION
Motivation:
* When using Goose via the fastmcp client, there is a log line that is emitted at error level even though it does not represent an actual error condition. See bug: https://github.com/block/goose/issues/2051

Approach:
* If there are no remaining pending requests in the queue and the server has been shut down, the logging should be info level. Otherwise if there are messages remaining and the server has been closed there should be an error message logged.
* Add two new methods to PendingRequests -- len and is_empty. Only len is used but is_empty is required by rust: https://rust-lang.github.io/rust-clippy/master/index.html#len_zero