### PR TITLE
feat: add NWC MCP server to documentation servers list

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -142,5 +142,23 @@
     "endorsed": false,
     "githubStars": 27,
     "environmentVariables": []
+  },
+  {
+    "id": "nwc",
+    "name": "NWC",
+    "description": "Seamlessly interact with your bitcoin lightning wallet",
+    "command": "npx -y @getalby/nwc-mcp-server",
+    "link": "https://github.com/getalby/nwc-mcp-server",
+    "installation_notes": "Install using npx package manager. Requires a connection secret from an NWC-compatible wallet",
+    "is_builtin": false,
+    "endorsed": false,
+    "githubStars": 5,
+    "environmentVariables": [
+      {
+        "name": "NWC_CONNECTION_STRING",
+        "description": "NWC connection secret to access to your wallet",
+        "required": true
+      }
+    ]
   }
 ]


### PR DESCRIPTION
This enables goose to seamlessly interact with bitcoin lightning wallets using the Nostr Wallet Connect protocol

You can seamlessly connect to a variety of lightning wallets, including Alby Hub which is powered by [Lightning Dev Kit](https://github.com/lightningdevkit)

Example prompts:
"Make me a 10 sat invoice"
"Was it paid?" (check if the invoice was paid)
"Pay lnbc...." (pay an invoice)
"What's my balance?"
"What's the alias of my lightning node?"