### PR TITLE
feat: show added extensions in settings v2 regardless of whether they activate

### DIFF
--- a/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
+++ b/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
@@ -73,9 +73,15 @@ export default function ExtensionsSection() {
 
   const handleAddExtension = async (formData: ExtensionFormData) => {
     const extensionConfig = createExtensionConfig(formData);
-    await activateExtension({ addToConfig: addExtension, extensionConfig: extensionConfig });
-    handleModalClose();
-    await fetchExtensions();
+    try {
+      await activateExtension({ addToConfig: addExtension, extensionConfig: extensionConfig });
+    } catch (error) {
+      // Even if activation fails, the extension is added as disabled, so we want to show it
+      console.error('Failed to activate extension:', error);
+    } finally {
+      handleModalClose();
+      await fetchExtensions();
+    }
   };
 
   const handleUpdateExtension = async (formData: ExtensionFormData) => {


### PR DESCRIPTION
Fixes an issue where extensions didn't show up if they fail to activate/are added to config as disabled. This allows for easy editing of the config right away.