### PR TITLE
feat: disallow env vars for extensions with spaces in the name

### DIFF
--- a/ui/desktop/src/components/settings_v2/extensions/modal/EnvVarsSection.tsx
+++ b/ui/desktop/src/components/settings_v2/extensions/modal/EnvVarsSection.tsx
@@ -30,6 +30,7 @@ export default function EnvVarsSection({
   const handleAdd = () => {
     const keyEmpty = !newKey.trim();
     const valueEmpty = !newValue.trim();
+    const keyHasSpaces = newKey.includes(' ');
 
     if (keyEmpty || valueEmpty) {
       setInvalidFields({
@@ -37,6 +38,15 @@ export default function EnvVarsSection({
         value: valueEmpty,
       });
       setValidationError('Both variable name and value must be entered');
+      return;
+    }
+
+    if (keyHasSpaces) {
+      setInvalidFields({
+        key: true,
+        value: false,
+      });
+      setValidationError('Variable name cannot contain spaces');
       return;
     }
 


### PR DESCRIPTION
Fixes a small issue in Settings V2 where env vars could have spaces in the title. Adds validation

![Screenshot 2025-04-07 at 3 36 29 PM](https://github.com/user-attachments/assets/7b889da9-1dd4-4649-aa8b-cb5a9e9fd5ce)
