### PR TITLE
feat: add gooseling/mini agent support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2367,6 +2367,7 @@ version = "1.0.16"
 dependencies = [
  "anyhow",
  "async-trait",
+ "base64 0.22.1",
  "bat",
  "chrono",
  "clap",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -50,6 +50,7 @@ tracing-appender = "0.2"
 once_cell = "1.20.2"
 shlex = "1.3.0"
 async-trait = "0.1.86"
+base64 = "0.22.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -86,6 +86,7 @@ async fn run_eval(
         false,
         requirements.external,
         requirements.builtin,
+        None,
         false,
     )
     .await;

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -87,6 +87,7 @@ async fn run_eval(
         requirements.external,
         requirements.builtin,
         None,
+        None,
         false,
     )
     .await;

--- a/crates/goose-cli/src/commands/gooseling.rs
+++ b/crates/goose-cli/src/commands/gooseling.rs
@@ -1,0 +1,60 @@
+use anyhow::Result;
+use base64::Engine;
+use console::style;
+use std::path::Path;
+
+use crate::gooseling::load_gooseling;
+
+/// Validates a gooseling file
+///
+/// # Arguments
+///
+/// * `file_path` - Path to the gooseling file to validate
+///
+/// # Returns
+///
+/// Result indicating success or failure
+pub fn handle_validate<P: AsRef<Path>>(file_path: P) -> Result<()> {
+    // Load and validate the gooseling file
+    match load_gooseling(&file_path, false) {
+        Ok(_) => {
+            println!("{} Gooseling file is valid", style("✓").green().bold());
+            Ok(())
+        }
+        Err(err) => {
+            println!("{} {}", style("✗").red().bold(), err);
+            Err(err)
+        }
+    }
+}
+
+/// Generates a deeplink for a gooseling file
+///
+/// # Arguments
+///
+/// * `file_path` - Path to the gooseling file
+///
+/// # Returns
+///
+/// Result indicating success or failure
+pub fn handle_deeplink<P: AsRef<Path>>(file_path: P) -> Result<()> {
+    // Load the gooseling file first to validate it
+    match load_gooseling(&file_path, false) {
+        Ok(gooseling) => {
+            if let Ok(gooseling_json) = serde_json::to_string(&gooseling) {
+                let deeplink = base64::engine::general_purpose::STANDARD.encode(gooseling_json);
+                println!(
+                    "{} Generated deeplink for: {}",
+                    style("✓").green().bold(),
+                    gooseling.title
+                );
+                println!("goose://gooseling?config={}", deeplink);
+            }
+            Ok(())
+        }
+        Err(err) => {
+            println!("{} {}", style("✗").red().bold(), err);
+            Err(err)
+        }
+    }
+}

--- a/crates/goose-cli/src/commands/mod.rs
+++ b/crates/goose-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 pub mod agent_version;
 pub mod bench;
 pub mod configure;
+pub mod gooseling;
 pub mod info;
 pub mod mcp;
 pub mod session;

--- a/crates/goose-cli/src/gooseling.rs
+++ b/crates/goose-cli/src/gooseling.rs
@@ -41,19 +41,19 @@ pub fn load_gooseling<P: AsRef<Path>>(path: P, log: bool) -> Result<Gooseling> {
             "json" => serde_json::from_str(&content).with_context(|| {
                 format!("Failed to parse JSON gooseling file: {}", path.display())
             })?,
-            "yaml" | "yml" => serde_yaml::from_str(&content).with_context(|| {
+            "yaml" => serde_yaml::from_str(&content).with_context(|| {
                 format!("Failed to parse YAML gooseling file: {}", path.display())
             })?,
             _ => {
                 return Err(anyhow::anyhow!(
-                "Unsupported file format for gooseling file: {}. Expected .yaml, .yml, or .json",
-                path.display()
-            ))
+                    "Unsupported file format for gooseling file: {}. Expected .yaml or .json",
+                    path.display()
+                ))
             }
         }
     } else {
         return Err(anyhow::anyhow!(
-            "File has no extension: {}. Expected .yaml, .yml, or .json",
+            "File has no extension: {}. Expected .yaml or .json",
             path.display()
         ));
     };

--- a/crates/goose-cli/src/gooseling.rs
+++ b/crates/goose-cli/src/gooseling.rs
@@ -1,0 +1,61 @@
+use anyhow::{Context, Result};
+use console::style;
+use std::path::Path;
+
+use goose::gooselings::Gooseling;
+
+/// Loads and validates a gooseling from a YAML file
+///
+/// # Arguments
+///
+/// * `path` - Path to the gooseling YAML file
+///
+/// # Returns
+///
+/// The parsed Gooseling struct if successful
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The file doesn't exist
+/// - The file can't be read
+/// - The YAML is invalid
+/// - The required fields are missing
+pub fn load_gooseling<P: AsRef<Path>>(path: P) -> Result<Gooseling> {
+    let path = path.as_ref();
+
+    // Check if file exists
+    if !path.exists() {
+        return Err(anyhow::anyhow!(
+            "Gooseling file not found: {}",
+            path.display()
+        ));
+    }
+    // Read file content
+    let content = std::fs::read_to_string(path)
+        .with_context(|| format!("Failed to read gooseling file: {}", path.display()))?;
+
+    // Parse YAML into Gooseling struct
+    let gooseling: Gooseling = serde_yaml::from_str(&content)
+        .with_context(|| format!("Failed to parse gooseling file: {}", path.display()))?;
+
+    // Display information about the loaded gooseling
+    println!(
+        "{} {}",
+        style("Loading gooseling:").green().bold(),
+        style(&gooseling.title).green()
+    );
+    println!("{} {}", style("Description:").dim(), &gooseling.description);
+
+    // Display activities if available
+    if let Some(activities) = &gooseling.activities {
+        println!("\n{}:", style("Activities").dim());
+        for activity in activities {
+            println!("- {}", activity);
+        }
+    }
+
+    println!(); // Add a blank line for spacing
+
+    Ok(gooseling)
+}

--- a/crates/goose-cli/src/gooseling.rs
+++ b/crates/goose-cli/src/gooseling.rs
@@ -21,7 +21,7 @@ use goose::gooselings::Gooseling;
 /// - The file can't be read
 /// - The YAML/JSON is invalid
 /// - The required fields are missing
-pub fn load_gooseling<P: AsRef<Path>>(path: P) -> Result<Gooseling> {
+pub fn load_gooseling<P: AsRef<Path>>(path: P, log: bool) -> Result<Gooseling> {
     let path = path.as_ref();
 
     // Check if file exists
@@ -58,23 +58,25 @@ pub fn load_gooseling<P: AsRef<Path>>(path: P) -> Result<Gooseling> {
         ));
     };
 
-    // Display information about the loaded gooseling
-    println!(
-        "{} {}",
-        style("Loading gooseling:").green().bold(),
-        style(&gooseling.title).green()
-    );
-    println!("{} {}", style("Description:").dim(), &gooseling.description);
+    if log {
+        // Display information about the loaded gooseling
+        println!(
+            "{} {}",
+            style("Loading gooseling:").green().bold(),
+            style(&gooseling.title).green()
+        );
+        println!("{} {}", style("Description:").dim(), &gooseling.description);
 
-    // Display activities if available
-    if let Some(activities) = &gooseling.activities {
-        println!("\n{}:", style("Activities").dim());
-        for activity in activities {
-            println!("- {}", activity);
+        // Display activities if available
+        if let Some(activities) = &gooseling.activities {
+            println!("\n{}:", style("Activities").dim());
+            for activity in activities {
+                println!("- {}", activity);
+            }
         }
-    }
 
-    println!(); // Add a blank line for spacing
+        println!(); // Add a blank line for spacing
+    }
 
     Ok(gooseling)
 }

--- a/crates/goose-cli/src/lib.rs
+++ b/crates/goose-cli/src/lib.rs
@@ -2,6 +2,7 @@ use etcetera::AppStrategyArgs;
 use once_cell::sync::Lazy;
 pub mod cli;
 pub mod commands;
+pub mod gooseling;
 pub mod logging;
 pub mod session;
 

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -16,6 +16,7 @@ pub async fn build_session(
     extensions: Vec<String>,
     builtins: Vec<String>,
     extensions_override: Option<Vec<ExtensionConfig>>,
+    additional_system_prompt: Option<String>,
     debug: bool,
 ) -> Session {
     // Load config and get provider/model
@@ -136,11 +137,16 @@ pub async fn build_session(
             process::exit(1);
         }
     }
+
     // Add CLI-specific system prompt extension
     session
         .agent
         .extend_system_prompt(super::prompt::get_cli_prompt())
         .await;
+
+    if let Some(additional_prompt) = additional_system_prompt {
+        session.agent.extend_system_prompt(additional_prompt).await;
+    }
 
     // Only override system prompt if a system override exists
     let system_prompt_file: Option<String> = config.get_param("GOOSE_SYSTEM_PROMPT_FILE_PATH").ok();

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -17,7 +17,7 @@ pub enum InputResult {
     GooseMode(String),
     Plan(PlanCommandOptions),
     EndPlan,
-    Gooseling,
+    Gooseling(Option<String>),
 }
 
 #[derive(Debug)]
@@ -132,9 +132,34 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
         }
         s if s.starts_with(CMD_PLAN) => parse_plan_command(s[CMD_PLAN.len()..].trim().to_string()),
         s if s == CMD_ENDPLAN => Some(InputResult::EndPlan),
-        s if s == CMD_GOOSELING => Some(InputResult::Gooseling),
+        s if s.starts_with(CMD_GOOSELING) => parse_gooseling_command(s),
         _ => None,
     }
+}
+
+fn parse_gooseling_command(s: &str) -> Option<InputResult> {
+    const CMD_GOOSELING: &str = "/gooseling";
+
+    if s == CMD_GOOSELING {
+        // No filepath provided, use default
+        return Some(InputResult::Gooseling(None));
+    }
+
+    // Extract the filepath from the command
+    let filepath = s[CMD_GOOSELING.len()..].trim();
+
+    if filepath.is_empty() {
+        return Some(InputResult::Gooseling(None));
+    }
+
+    // Validate that the filepath ends with .yaml
+    if !filepath.to_lowercase().ends_with(".yaml") {
+        println!("{}", console::style("Filepath must end with .yaml").red());
+        return Some(InputResult::Retry);
+    }
+
+    // Return the filepath for validation in the handler
+    Some(InputResult::Gooseling(Some(filepath.to_string())))
 }
 
 fn parse_prompts_command(args: &str) -> Option<InputResult> {
@@ -214,6 +239,8 @@ fn print_help() {
                         The model is used based on $GOOSE_PLANNER_PROVIDER and $GOOSE_PLANNER_MODEL environment variables.
                         If no model is set, the default model is used.
 /endplan - Exit plan mode and return to 'normal' goose mode.
+/gooseling [filepath] - Generate a gooseling from the current conversation and save it to the specified filepath (must end with .yaml).
+                       If no filepath is provided, it will be saved to ./gooseling.yaml.
 /? or /help - Display this help message
 
 Navigation:
@@ -423,5 +450,28 @@ mod tests {
             }
             _ => panic!("Expected Plan"),
         }
+    }
+
+    #[test]
+    fn test_gooseling_command() {
+        // Test gooseling with no filepath
+        if let Some(InputResult::Gooseling(filepath)) = handle_slash_command("/gooseling") {
+            assert!(filepath.is_none());
+        } else {
+            panic!("Expected Gooseling");
+        }
+
+        // Test gooseling with filepath
+        if let Some(InputResult::Gooseling(filepath)) =
+            handle_slash_command("/gooseling /path/to/file.yaml")
+        {
+            assert_eq!(filepath, Some("/path/to/file.yaml".to_string()));
+        } else {
+            panic!("Expected Gooseling with filepath");
+        }
+
+        // Test gooseling with invalid extension
+        let result = handle_slash_command("/gooseling /path/to/file.txt");
+        assert!(matches!(result, Some(InputResult::Retry)));
     }
 }

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -17,6 +17,7 @@ pub enum InputResult {
     GooseMode(String),
     Plan(PlanCommandOptions),
     EndPlan,
+    Gooseling,
 }
 
 #[derive(Debug)]
@@ -89,6 +90,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
     const CMD_MODE: &str = "/mode ";
     const CMD_PLAN: &str = "/plan";
     const CMD_ENDPLAN: &str = "/endplan";
+    const CMD_GOOSELING: &str = "/gooseling";
 
     match input {
         "/exit" | "/quit" => Some(InputResult::Exit),
@@ -130,6 +132,7 @@ fn handle_slash_command(input: &str) -> Option<InputResult> {
         }
         s if s.starts_with(CMD_PLAN) => parse_plan_command(s[CMD_PLAN.len()..].trim().to_string()),
         s if s == CMD_ENDPLAN => Some(InputResult::EndPlan),
+        s if s == CMD_GOOSELING => Some(InputResult::Gooseling),
         _ => None,
     }
 }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -490,8 +490,13 @@ impl Session {
                     }
                 }
                 InputResult::Gooseling => {
-                    let gooseling = self.agent.create_gooseling(&self.messages).await;
-                    println!("{:?}", gooseling);
+                    let gooseling = self.agent.create_gooseling(self.messages.clone()).await;
+                    if gooseling.is_ok() {
+                        println!(
+                            "{}",
+                            serde_json::to_string_pretty(&gooseling.unwrap()).unwrap_or_default()
+                        );
+                    }
                     continue;
                 }
             }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -18,6 +18,7 @@ use goose::agents::{Agent, SessionConfig};
 use goose::config::Config;
 use goose::message::{Message, MessageContent};
 use goose::session;
+use input::InputResult;
 use mcp_core::handler::ToolError;
 use mcp_core::prompt::PromptMessage;
 
@@ -487,6 +488,11 @@ impl Session {
                             Err(e) => output::render_error(&e.to_string()),
                         }
                     }
+                }
+                InputResult::Gooseling => {
+                    let gooseling = self.agent.create_gooseling(&self.messages).await;
+                    println!("{:?}", gooseling);
+                    continue;
                 }
             }
         }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -25,6 +25,7 @@ use mcp_core::prompt::PromptMessage;
 use rand::{distributions::Alphanumeric, Rng};
 use serde_json::Value;
 use std::collections::HashMap;
+use std::fs::File;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Instant;
@@ -490,13 +491,35 @@ impl Session {
                     }
                 }
                 InputResult::Gooseling => {
+                    println!("{}", console::style("Generating gooseling").green());
+
+                    output::show_thinking();
                     let gooseling = self.agent.create_gooseling(self.messages.clone()).await;
+                    output::hide_thinking();
+
                     if gooseling.is_ok() {
+                        let gooseling = gooseling.unwrap();
+                        if let Ok(file) = File::create("./gooseling.yaml") {
+                            match serde_yaml::to_writer(file, &gooseling) {
+                                Ok(_) => println!(
+                                    "{}",
+                                    console::style("Saved gooseling to ./gooseling.yaml").green()
+                                ),
+                                Err(e) => println!(
+                                    "{}: {:?}",
+                                    console::style("Failed to save gooseling").red(),
+                                    e
+                                ),
+                            }
+                        }
+                    } else {
                         println!(
-                            "{}",
-                            serde_json::to_string_pretty(&gooseling.unwrap()).unwrap_or_default()
+                            "{}: {:?}",
+                            console::style("Failed to generate gooseling").red(),
+                            gooseling
                         );
                     }
+
                     continue;
                 }
             }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -9,6 +9,7 @@ use serde_json::Value;
 use std::sync::Arc;
 
 use super::extension::{ExtensionConfig, ExtensionResult};
+use crate::gooselings::Gooseling;
 use crate::message::Message;
 use crate::providers::base::Provider;
 use crate::session;
@@ -68,4 +69,7 @@ pub trait Agent: Send + Sync {
 
     /// Get a reference to the provider used by this agent
     async fn provider(&self) -> Arc<Box<dyn Provider>>;
+
+    /// Create a gooseling file
+    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling>;
 }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -71,5 +71,5 @@ pub trait Agent: Send + Sync {
     async fn provider(&self) -> Arc<Box<dyn Provider>>;
 
     /// Create a gooseling file
-    async fn create_gooseling(&self, messages: &[Message]) -> Result<Gooseling>;
+    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling>;
 }

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -71,5 +71,5 @@ pub trait Agent: Send + Sync {
     async fn provider(&self) -> Arc<Box<dyn Provider>>;
 
     /// Create a gooseling file
-    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling>;
+    async fn create_gooseling(&self, messages: &[Message]) -> Result<Gooseling>;
 }

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -12,6 +12,7 @@ use tracing::{debug, instrument};
 
 use super::extension::{ExtensionConfig, ExtensionError, ExtensionInfo, ExtensionResult, ToolInfo};
 use crate::config::Config;
+use crate::gooselings::Gooseling;
 use crate::prompt_template;
 use crate::providers::base::Provider;
 use mcp_client::client::{ClientCapabilities, ClientInfo, McpClient, McpClientTrait};
@@ -652,6 +653,13 @@ impl Capabilities {
             .get_prompt(name, arguments)
             .await
             .map_err(|e| anyhow::anyhow!("Failed to get prompt: {}", e))
+    }
+
+    pub async fn get_gooseling_prompt(&self) -> String {
+        let context: HashMap<&str, Value> = HashMap::new();
+
+        prompt_template::render_inline_once("gooseling.md", &context)
+            .expect("should render gooseling prompt")
     }
 }
 

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -12,7 +12,6 @@ use tracing::{debug, instrument};
 
 use super::extension::{ExtensionConfig, ExtensionError, ExtensionInfo, ExtensionResult, ToolInfo};
 use crate::config::Config;
-use crate::gooselings::Gooseling;
 use crate::prompt_template;
 use crate::providers::base::Provider;
 use mcp_client::client::{ClientCapabilities, ClientInfo, McpClient, McpClientTrait};

--- a/crates/goose/src/agents/capabilities.rs
+++ b/crates/goose/src/agents/capabilities.rs
@@ -658,7 +658,7 @@ impl Capabilities {
     pub async fn get_gooseling_prompt(&self) -> String {
         let context: HashMap<&str, Value> = HashMap::new();
 
-        prompt_template::render_inline_once("gooseling.md", &context)
+        prompt_template::render_global_file("gooseling.md", &context)
             .expect("should render gooseling prompt")
     }
 }

--- a/crates/goose/src/agents/reference.rs
+++ b/crates/goose/src/agents/reference.rs
@@ -278,7 +278,7 @@ impl Agent for ReferenceAgent {
         capabilities.provider()
     }
 
-    async fn create_gooseling(&self, messages: &[Message]) -> Result<Gooseling> {
+    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 }

--- a/crates/goose/src/agents/reference.rs
+++ b/crates/goose/src/agents/reference.rs
@@ -13,6 +13,7 @@ use super::extension::ToolInfo;
 use super::Agent;
 use crate::agents::capabilities::Capabilities;
 use crate::agents::extension::{ExtensionConfig, ExtensionResult};
+use crate::gooselings::Gooseling;
 use crate::message::{Message, ToolRequest};
 use crate::providers::base::Provider;
 use crate::token_counter::TokenCounter;
@@ -275,6 +276,10 @@ impl Agent for ReferenceAgent {
     async fn provider(&self) -> Arc<Box<dyn Provider>> {
         let capabilities = self.capabilities.lock().await;
         capabilities.provider()
+    }
+
+    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
+        Err(anyhow::Error::msg("Not implemented"))
     }
 }
 

--- a/crates/goose/src/agents/reference.rs
+++ b/crates/goose/src/agents/reference.rs
@@ -278,7 +278,7 @@ impl Agent for ReferenceAgent {
         capabilities.provider()
     }
 
-    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
+    async fn create_gooseling(&self, messages: &[Message]) -> Result<Gooseling> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 }

--- a/crates/goose/src/agents/reference.rs
+++ b/crates/goose/src/agents/reference.rs
@@ -278,7 +278,7 @@ impl Agent for ReferenceAgent {
         capabilities.provider()
     }
 
-    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
+    async fn create_gooseling(&self, _messages: Vec<Message>) -> Result<Gooseling> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 }

--- a/crates/goose/src/agents/summarize.rs
+++ b/crates/goose/src/agents/summarize.rs
@@ -493,7 +493,7 @@ impl Agent for SummarizeAgent {
         capabilities.provider()
     }
 
-    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
+    async fn create_gooseling(&self, _messages: Vec<Message>) -> Result<Gooseling> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 }

--- a/crates/goose/src/agents/summarize.rs
+++ b/crates/goose/src/agents/summarize.rs
@@ -493,7 +493,7 @@ impl Agent for SummarizeAgent {
         capabilities.provider()
     }
 
-    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
+    async fn create_gooseling(&self, messages: &[Message]) -> Result<Gooseling> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 }

--- a/crates/goose/src/agents/summarize.rs
+++ b/crates/goose/src/agents/summarize.rs
@@ -18,6 +18,7 @@ use super::Agent;
 use crate::agents::capabilities::Capabilities;
 use crate::agents::extension::{ExtensionConfig, ExtensionResult};
 use crate::config::Config;
+use crate::gooselings::Gooseling;
 use crate::memory_condense::condense_messages;
 use crate::message::{Message, ToolRequest};
 use crate::providers::base::Provider;
@@ -490,6 +491,10 @@ impl Agent for SummarizeAgent {
     async fn provider(&self) -> Arc<Box<dyn Provider>> {
         let capabilities = self.capabilities.lock().await;
         capabilities.provider()
+    }
+
+    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
+        Err(anyhow::Error::msg("Not implemented"))
     }
 }
 

--- a/crates/goose/src/agents/summarize.rs
+++ b/crates/goose/src/agents/summarize.rs
@@ -493,7 +493,7 @@ impl Agent for SummarizeAgent {
         capabilities.provider()
     }
 
-    async fn create_gooseling(&self, messages: &[Message]) -> Result<Gooseling> {
+    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
         Err(anyhow::Error::msg("Not implemented"))
     }
 }

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -548,7 +548,7 @@ impl Agent for TruncateAgent {
         capabilities.provider()
     }
 
-    async fn create_gooseling(&self, messages: &[Message]) -> Result<Gooseling> {
+    async fn create_gooseling(&self, mut messages: Vec<Message>) -> Result<Gooseling> {
         // get the gooseling prompt
         let mut capabilities = self.capabilities.lock().await;
         let system_prompt = capabilities.get_system_prompt().await;
@@ -556,12 +556,9 @@ impl Agent for TruncateAgent {
         let provider = capabilities.provider();
         let tools = capabilities.get_prefixed_tools().await?;
 
-        let mut messages_vec = messages.to_vec();
-        messages_vec.push(Message::user().with_text(gooseling_prompt));
+        messages.push(Message::user().with_text(gooseling_prompt));
 
-        let (result, _usage) = provider
-            .complete(&system_prompt, &messages_vec, &tools)
-            .await?;
+        let (result, _usage) = provider.complete(&system_prompt, &messages, &tools).await?;
 
         let content = result.as_concat_text();
 

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -18,6 +18,7 @@ use crate::agents::capabilities::{get_parameter_names, Capabilities};
 use crate::agents::extension::{ExtensionConfig, ExtensionResult};
 use crate::agents::ToolPermissionStore;
 use crate::config::Config;
+use crate::config::ExtensionManager;
 use crate::gooselings::Gooseling;
 use crate::message::{Message, ToolRequest};
 use crate::providers::base::Provider;
@@ -582,11 +583,19 @@ impl Agent for TruncateAgent {
             .filter(|line| !line.is_empty())
             .collect();
 
+        let extensions = ExtensionManager::get_all().unwrap_or_default();
+        let extension_configs: Vec<_> = extensions
+            .iter()
+            .filter(|e| e.enabled)
+            .map(|e| e.config.clone())
+            .collect();
+
         let gooseling = Gooseling::builder()
             .title("Custom gooseling from chat")
             .description("a custom gooseling instance from this chat session")
             .instructions(instructions)
             .activities(activities)
+            .extensions(extension_configs)
             .build()
             .expect("valid gooseling");
 

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -19,6 +19,7 @@ use crate::agents::extension::{ExtensionConfig, ExtensionResult};
 use crate::agents::ToolPermissionStore;
 use crate::config::Config;
 use crate::config::ExtensionManager;
+use crate::gooselings::Author;
 use crate::gooselings::Gooseling;
 use crate::message::{Message, ToolRequest};
 use crate::providers::base::Provider;
@@ -597,12 +598,20 @@ impl Agent for TruncateAgent {
             .map(|e| e.config.clone())
             .collect();
 
+        let author = Author {
+            contact: std::env::var("USER")
+                .or_else(|_| std::env::var("USERNAME"))
+                .ok(),
+            metadata: None,
+        };
+
         let gooseling = Gooseling::builder()
             .title("Custom gooseling from chat")
             .description("a custom gooseling instance from this chat session")
             .instructions(instructions)
             .activities(activities)
             .extensions(extension_configs)
+            .author(author)
             .build()
             .expect("valid gooseling");
 

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -570,7 +570,7 @@ impl Agent for TruncateAgent {
 
         // Split once more to separate instructions from activities.
         let (instructions_part, activities_text) = after_instructions
-            .split_once("Activities:")
+            .split_once("#Activities:")
             .unwrap_or((after_instructions, ""));
 
         let instructions = instructions_part.trim().to_string();

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -570,10 +570,13 @@ impl Agent for TruncateAgent {
 
         // Split once more to separate instructions from activities.
         let (instructions_part, activities_text) = after_instructions
-            .split_once("#Activities:")
+            .split_once("Activities:")
             .unwrap_or((after_instructions, ""));
 
-        let instructions = instructions_part.trim().to_string();
+        let instructions = instructions_part
+            .trim_end_matches(|c: char| c.is_whitespace() || c == '#')
+            .trim()
+            .to_string();
         let activities_text = activities_text.trim();
 
         // Regex to remove bullet markers or numbers with an optional dot.

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -548,14 +548,21 @@ impl Agent for TruncateAgent {
         capabilities.provider()
     }
 
-    async fn create_gooseling(&self, messages: Vec<Message>) -> Result<Gooseling> {
+    async fn create_gooseling(&self, messages: &[Message]) -> Result<Gooseling> {
         // get the gooseling prompt
-        let capabilities = self.capabilities.lock().await;
+        let mut capabilities = self.capabilities.lock().await;
+        let system_prompt = capabilities.get_system_prompt().await;
         let gooseling_prompt = capabilities.get_gooseling_prompt().await;
-
         let provider = capabilities.provider();
+        let tools = capabilities.get_prefixed_tools().await?;
 
-        let (result, _usage) = provider.complete(&gooseling_prompt, &messages, &[]).await?;
+        let mut messages_vec = messages.to_vec();
+        messages_vec.push(Message::user().with_text(gooseling_prompt));
+
+        let (result, _usage) = provider
+            .complete(&system_prompt, &messages_vec, &tools)
+            .await?;
+
         let content = result.as_concat_text();
 
         // Use split_once to get the content after "Instructions:".

--- a/crates/goose/src/gooselings/gooseling.rs
+++ b/crates/goose/src/gooselings/gooseling.rs
@@ -17,6 +17,7 @@ fn default_version() -> String {
 /// * `Instructions` - Instructions that defines the Gooseling's behavior
 ///
 /// ## Optional Fields
+/// * `prompt` - the initial prompt to the session to start with
 /// * `extensions` - List of extension configurations required by the Gooseling
 /// * `goosehints` - Additional goosehints to be merged with existing .goosehints configuration
 /// * `context` - Supplementary context information for the Gooseling
@@ -26,7 +27,7 @@ fn default_version() -> String {
 /// # Example
 ///
 /// ```
-/// use your_crate::Gooseling;
+/// use goose::gooseling::Gooseling;
 ///
 /// // Using the builder pattern
 /// let gooseling = Gooseling::builder()
@@ -42,6 +43,7 @@ fn default_version() -> String {
 ///     title: "Example Agent".to_string(),
 ///     description: "An example Gooseling configuration".to_string(),
 ///     instructions: "Act as a helpful assistant".to_string(),
+///     prompt: None,
 ///     extensions: None,
 ///     goosehints: None,
 ///     context: None,
@@ -62,6 +64,9 @@ pub struct Gooseling {
     pub instructions: String, // the instructions for the model
 
     // Optional fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>, // the prompt to start the session with
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub extensions: Option<Vec<ExtensionConfig>>, // a list of extensions to enable
 
@@ -96,6 +101,7 @@ pub struct GooselingBuilder {
     instructions: Option<String>,
 
     // Optional fields
+    prompt: Option<String>,
     extensions: Option<Vec<ExtensionConfig>>,
     goosehints: Option<String>,
     context: Option<Vec<String>>,
@@ -122,6 +128,7 @@ impl Gooseling {
             title: None,
             description: None,
             instructions: None,
+            prompt: None,
             extensions: None,
             goosehints: None,
             context: None,
@@ -153,6 +160,11 @@ impl GooselingBuilder {
     /// Sets the instructions for the Gooseling (required)
     pub fn instructions(mut self, instructions: impl Into<String>) -> Self {
         self.instructions = Some(instructions.into());
+        self
+    }
+
+    pub fn prompt(mut self, prompt: impl Into<String>) -> Self {
+        self.prompt = Some(prompt.into());
         self
     }
 
@@ -199,6 +211,7 @@ impl GooselingBuilder {
             title,
             description,
             instructions,
+            prompt: self.prompt,
             extensions: self.extensions,
             goosehints: self.goosehints,
             context: self.context,

--- a/crates/goose/src/gooselings/gooseling.rs
+++ b/crates/goose/src/gooselings/gooseling.rs
@@ -27,7 +27,7 @@ fn default_version() -> String {
 /// # Example
 ///
 /// ```
-/// use goose::gooseling::Gooseling;
+/// use goose::gooselings::Gooseling;
 ///
 /// // Using the builder pattern
 /// let gooseling = Gooseling::builder()
@@ -115,6 +115,8 @@ impl Gooseling {
     /// # Example
     ///
     /// ```
+    /// use goose::gooselings::Gooseling;
+    ///
     /// let gooseling = Gooseling::builder()
     ///     .title("My Gooseling")
     ///     .description("A helpful assistant")

--- a/crates/goose/src/gooselings/gooseling.rs
+++ b/crates/goose/src/gooselings/gooseling.rs
@@ -1,0 +1,90 @@
+use crate::agents::extension::ExtensionConfig;
+use serde::{Deserialize, Serialize};
+
+fn default_version() -> String {
+    "1.0.0".to_string()
+}
+
+/// A Gooseling represents a personalized, user-generated agent configuration that defines
+/// specific behaviors and capabilities within the Goose system.
+///
+/// # Fields
+///
+/// ## Required Fields
+/// * `version` - Semantic version of the Gooseling file format (defaults to "1.0.0")
+/// * `title` - Short, descriptive name of the Gooseling
+/// * `description` - Detailed description explaining the Gooseling's purpose and functionality
+/// * `Instructions` - Instructions that defines the Gooseling's behavior
+///
+/// ## Optional Fields
+/// * `extensions` - List of extension configurations required by the Gooseling
+/// * `goosehints` - Additional goosehints to be merged with existing .goosehints configuration
+/// * `context` - Supplementary context information for the Gooseling
+/// * `activities` - Activity labels that appear when loading the Gooseling
+/// * `settings` - Configuration settings including model preferences
+/// * `author` - Information about the Gooseling's creator and metadata
+///
+/// # Example
+///
+/// ```
+/// use your_crate::Gooseling;
+///
+/// let gooseling = Gooseling {
+///     version: "1.0.0".to_string(),
+///     title: "Example Agent".to_string(),
+///     description: "An example Gooseling configuration".to_string(),
+///     instructions: "Act as a helpful assistant".to_string(),
+///     extensions: None,
+///     goosehints: None,
+///     context: None,
+///     activities: None,
+///     settings: None,
+///     author: None,
+/// };
+/// ```
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Gooseling {
+    // Required fields
+    #[serde(default = "default_version")]
+    pub version: String, // version of the file format, sem ver
+
+    pub title: String, // short title of the gooseling
+
+    pub description: String, // a longer description of the gooseling
+
+    pub instructions: String, // the instructions for the model
+
+    // Optional fields
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extensions: Option<Vec<ExtensionConfig>>, // a list of extensions to enable
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub goosehints: Option<String>, // any additional goosehints to merge with existing .goosehints
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context: Option<Vec<String>>, // any additional context
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub activities: Option<Vec<String>>, // the activity pills that show up when loading the
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings: Option<Settings>, // any additional settings information
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<Author>, // any additional author information
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Settings {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>, // settings/model; optionally provided
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Author {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact: Option<String>, // creator/contact information of the gooseling
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<String>, // any additional metadata for the author
+}

--- a/crates/goose/src/gooselings/gooseling.rs
+++ b/crates/goose/src/gooselings/gooseling.rs
@@ -21,7 +21,6 @@ fn default_version() -> String {
 /// * `goosehints` - Additional goosehints to be merged with existing .goosehints configuration
 /// * `context` - Supplementary context information for the Gooseling
 /// * `activities` - Activity labels that appear when loading the Gooseling
-/// * `settings` - Configuration settings including model preferences
 /// * `author` - Information about the Gooseling's creator and metadata
 ///
 /// # Example
@@ -29,6 +28,15 @@ fn default_version() -> String {
 /// ```
 /// use your_crate::Gooseling;
 ///
+/// // Using the builder pattern
+/// let gooseling = Gooseling::builder()
+///     .title("Example Agent")
+///     .description("An example Gooseling configuration")
+///     .instructions("Act as a helpful assistant")
+///     .build()
+///     .expect("Missing required fields");
+///
+/// // Or using struct initialization
 /// let gooseling = Gooseling {
 ///     version: "1.0.0".to_string(),
 ///     title: "Example Agent".to_string(),
@@ -38,7 +46,6 @@ fn default_version() -> String {
 ///     goosehints: None,
 ///     context: None,
 ///     activities: None,
-///     settings: None,
 ///     author: None,
 /// };
 /// ```
@@ -68,16 +75,7 @@ pub struct Gooseling {
     pub activities: Option<Vec<String>>, // the activity pills that show up when loading the
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub settings: Option<Settings>, // any additional settings information
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub author: Option<Author>, // any additional author information
-}
-
-#[derive(Serialize, Deserialize, Debug)]
-pub struct Settings {
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub model: Option<String>, // settings/model; optionally provided
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -87,4 +85,125 @@ pub struct Author {
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub metadata: Option<String>, // any additional metadata for the author
+}
+
+/// Builder for creating Gooseling instances
+pub struct GooselingBuilder {
+    // Required fields with default values
+    version: String,
+    title: Option<String>,
+    description: Option<String>,
+    instructions: Option<String>,
+
+    // Optional fields
+    extensions: Option<Vec<ExtensionConfig>>,
+    goosehints: Option<String>,
+    context: Option<Vec<String>>,
+    activities: Option<Vec<String>>,
+    author: Option<Author>,
+}
+
+impl Gooseling {
+    /// Creates a new GooselingBuilder to construct a Gooseling instance
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// let gooseling = Gooseling::builder()
+    ///     .title("My Gooseling")
+    ///     .description("A helpful assistant")
+    ///     .instructions("Act as a helpful assistant")
+    ///     .build()
+    ///     .expect("Failed to build Gooseling: missing required fields");
+    /// ```
+    pub fn builder() -> GooselingBuilder {
+        GooselingBuilder {
+            version: default_version(),
+            title: None,
+            description: None,
+            instructions: None,
+            extensions: None,
+            goosehints: None,
+            context: None,
+            activities: None,
+            author: None,
+        }
+    }
+}
+
+impl GooselingBuilder {
+    /// Sets the version of the Gooseling
+    pub fn version(mut self, version: impl Into<String>) -> Self {
+        self.version = version.into();
+        self
+    }
+
+    /// Sets the title of the Gooseling (required)
+    pub fn title(mut self, title: impl Into<String>) -> Self {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Sets the description of the Gooseling (required)
+    pub fn description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    /// Sets the instructions for the Gooseling (required)
+    pub fn instructions(mut self, instructions: impl Into<String>) -> Self {
+        self.instructions = Some(instructions.into());
+        self
+    }
+
+    /// Sets the extensions for the Gooseling
+    pub fn extensions(mut self, extensions: Vec<ExtensionConfig>) -> Self {
+        self.extensions = Some(extensions);
+        self
+    }
+
+    /// Sets the goosehints for the Gooseling
+    pub fn goosehints(mut self, goosehints: impl Into<String>) -> Self {
+        self.goosehints = Some(goosehints.into());
+        self
+    }
+
+    /// Sets the context for the Gooseling
+    pub fn context(mut self, context: Vec<String>) -> Self {
+        self.context = Some(context);
+        self
+    }
+
+    /// Sets the activities for the Gooseling
+    pub fn activities(mut self, activities: Vec<String>) -> Self {
+        self.activities = Some(activities);
+        self
+    }
+
+    /// Sets the author information for the Gooseling
+    pub fn author(mut self, author: Author) -> Self {
+        self.author = Some(author);
+        self
+    }
+
+    /// Builds the Gooseling instance
+    ///
+    /// Returns an error if any required fields are missing
+    pub fn build(self) -> Result<Gooseling, &'static str> {
+        let title = self.title.ok_or("Title is required")?;
+        let description = self.description.ok_or("Description is required")?;
+        let instructions = self.instructions.ok_or("Instructions are required")?;
+
+        Ok(Gooseling {
+            version: self.version,
+            title,
+            description,
+            instructions,
+            extensions: self.extensions,
+            goosehints: self.goosehints,
+            context: self.context,
+            activities: self.activities,
+            author: self.author,
+        })
+    }
 }

--- a/crates/goose/src/gooselings/gooseling.rs
+++ b/crates/goose/src/gooselings/gooseling.rs
@@ -19,7 +19,6 @@ fn default_version() -> String {
 /// ## Optional Fields
 /// * `prompt` - the initial prompt to the session to start with
 /// * `extensions` - List of extension configurations required by the Gooseling
-/// * `goosehints` - Additional goosehints to be merged with existing .goosehints configuration
 /// * `context` - Supplementary context information for the Gooseling
 /// * `activities` - Activity labels that appear when loading the Gooseling
 /// * `author` - Information about the Gooseling's creator and metadata
@@ -71,9 +70,6 @@ pub struct Gooseling {
     pub extensions: Option<Vec<ExtensionConfig>>, // a list of extensions to enable
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub goosehints: Option<String>, // any additional goosehints to merge with existing .goosehints
-
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<Vec<String>>, // any additional context
 
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -103,7 +99,6 @@ pub struct GooselingBuilder {
     // Optional fields
     prompt: Option<String>,
     extensions: Option<Vec<ExtensionConfig>>,
-    goosehints: Option<String>,
     context: Option<Vec<String>>,
     activities: Option<Vec<String>>,
     author: Option<Author>,
@@ -132,7 +127,6 @@ impl Gooseling {
             instructions: None,
             prompt: None,
             extensions: None,
-            goosehints: None,
             context: None,
             activities: None,
             author: None,
@@ -176,12 +170,6 @@ impl GooselingBuilder {
         self
     }
 
-    /// Sets the goosehints for the Gooseling
-    pub fn goosehints(mut self, goosehints: impl Into<String>) -> Self {
-        self.goosehints = Some(goosehints.into());
-        self
-    }
-
     /// Sets the context for the Gooseling
     pub fn context(mut self, context: Vec<String>) -> Self {
         self.context = Some(context);
@@ -215,7 +203,6 @@ impl GooselingBuilder {
             instructions,
             prompt: self.prompt,
             extensions: self.extensions,
-            goosehints: self.goosehints,
             context: self.context,
             activities: self.activities,
             author: self.author,

--- a/crates/goose/src/gooselings/mod.rs
+++ b/crates/goose/src/gooselings/mod.rs
@@ -1,0 +1,3 @@
+// Export the Gooseling struct and related types
+pub mod gooseling;
+pub use gooseling::*;

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod agents;
 pub mod config;
+pub mod gooselings;
 pub mod memory_condense;
 pub mod message;
 pub mod model;

--- a/crates/goose/src/prompts/gooseling.md
+++ b/crates/goose/src/prompts/gooseling.md
@@ -1,0 +1,14 @@
+Based on our conversation so far, could you create:
+
+1. A concise set of instructions (1-2 paragraphs) that describe what you've been helping with. Pay special attention if any output styles or formats are requested (and make it clear), and note any non standard tools used or required.
+
+2. A list of 3-5 example activities (as a few words each at most) that would be relevant to this topic
+
+Format your response with clear headings for 'Instructions:' and 'Activities:' sections
+For example, perhaps we have been discussing fruit and you might write:
+
+Instructions:
+Using web searches we find pictures of fruit, and always check what language to reply in.
+
+Activities:
+Show pics of apples, say a random fruit, share a fruit fact


### PR DESCRIPTION
## Gooselings (Name TDB)

This PR introduces Gooselings - a new capability that allows users to create, validate, and share custom agent configurations. 

Key changes:
- Added `Gooseling` struct with builder pattern for defining custom agent behaviors
- Implemented CLI commands for validating and creating deeplinks for gooseling files
- Added `/gooseling` command to generate gooselings from chat sessions
- CLI tosupport loading gooselings via the `--gooseling` flag
- Created prompt template for generating gooselings from conversations, move gooseling generation to backend