### PR TITLE
feat: enhance Debian desktop build process

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -34,12 +34,6 @@ let cfg = {
     appleIdPassword: process.env['APPLE_ID_PASSWORD'],
     teamId: process.env['APPLE_TEAM_ID']
   },
-  protocols: [
-    {
-      name: "GooseProtocol",     // The macOS CFBundleURLName
-      schemes: ["goose"]         // The macOS CFBundleURLSchemes array
-    }
-  ]
 }
 
 if (process.env['APPLE_ID'] === undefined) {

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -5,6 +5,7 @@ const { resolve } = require('path');
 let cfg = {
   asar: true,
   extraResource: ['src/bin', 'src/images'],
+  executableName: 'goose-app',
   icon: 'src/images/icon',
   // Windows specific configuration
   win32: {

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -11,7 +11,7 @@
     "start:test-error": "GOOSE_TEST_ERROR=true electron-forge start",
     "package": "electron-forge package",
     "make": "electron-forge make",
-    "bundle:default": "npm run make && cd out/Goose-darwin-arm64 && ditto -c -k --sequesterRsrc --keepParent Goose.app Goose.zip",
+    "bundle:default": "npm run make && (cd out/Goose-darwin-arm64 && ditto -c -k --sequesterRsrc --keepParent Goose.app Goose.zip) || echo 'out/Goose-darwin-arm64 not found; either the binary is not built or you are not on macOS'",    
     "bundle:windows": "node scripts/build-main.js && npm run make -- --platform=win32 --arch=x64 && node scripts/copy-windows-dlls.js",
     "bundle:intel": "npm run make -- --arch=x64 && cd out/Goose-darwin-x64 && ditto -c -k --sequesterRsrc --keepParent Goose.app Goose_intel_mac.zip",
     "debug": "echo 'run --remote-debugging-port=8315' && lldb out/Goose-darwin-arm64/Goose.app",


### PR DESCRIPTION
This PR improves developer experience when building the Goose UI for Debian systems.

To start, you will need a Debian-based system such as Ubuntu with `just`, `rpm`, and `dpkg` installed. Navigate to the `ui/desktop` directory, run `npm install`, and navigate back to the project root. There, run `just release-binaries` which compiles the binaries. If you encounter errors here, they **are not addressed by this PR** and are likely missing dependency or system-specific. Next, run `just make-ui`, which will build the UI and create the `.deb` and `.rpm` builds for Linux in the `ui/desktop/out/make/` directory.

What this **PR does address**:
- An `executableName` is now set, since the make script expects a binary named `goose-app` and not `Goose`
- Duplicate `protocols` field is removed
- `bundle:default` script won't exit with an error status if the macOS output is not found

**:warning: Additional things to check**:
I do not have a macOS device. I see some of the package.json scripts might be trying to copy `Goose.app` which may not exist (it might be `goose-app.app` or similar instead). So if somebody on macOS could please test running `just make-ui` and give the results, that would be very helpful!