### PR TITLE
feat: add permission field to the list tools response

### DIFF
--- a/crates/goose-server/src/openapi.rs
+++ b/crates/goose-server/src/openapi.rs
@@ -1,11 +1,12 @@
-use utoipa::OpenApi;
-
 use goose::agents::extension::Envs;
+use goose::agents::extension::ToolInfo;
 use goose::agents::ExtensionConfig;
+use goose::config::permission::PermissionLevel;
 use goose::config::ExtensionEntry;
 use goose::providers::base::ConfigKey;
 use goose::providers::base::ProviderMetadata;
 use mcp_core::tool::{Tool, ToolAnnotations};
+use utoipa::OpenApi;
 
 #[allow(dead_code)] // Used by utoipa for OpenAPI generation
 #[derive(OpenApi)]
@@ -36,6 +37,8 @@ use mcp_core::tool::{Tool, ToolAnnotations};
         Envs,
         Tool,
         ToolAnnotations,
+        ToolInfo,
+        PermissionLevel,
     ))
 )]
 pub struct ApiDoc;

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -9,6 +9,7 @@ use utoipa::ToSchema;
 
 use crate::config;
 use crate::config::extensions::name_to_key;
+use crate::config::permission::PermissionLevel;
 
 /// Errors from Extension operation
 #[derive(Error, Debug)]
@@ -277,19 +278,26 @@ impl ExtensionInfo {
 }
 
 /// Information about the tool used for building prompts
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, ToSchema)]
 pub struct ToolInfo {
     name: String,
     description: String,
     parameters: Vec<String>,
+    permission: Option<PermissionLevel>,
 }
 
 impl ToolInfo {
-    pub fn new(name: &str, description: &str, parameters: Vec<String>) -> Self {
+    pub fn new(
+        name: &str,
+        description: &str,
+        parameters: Vec<String>,
+        permission: Option<PermissionLevel>,
+    ) -> Self {
         Self {
             name: name.to_string(),
             description: description.to_string(),
             parameters,
+            permission,
         }
     }
 }

--- a/crates/goose/src/agents/reference.rs
+++ b/crates/goose/src/agents/reference.rs
@@ -289,7 +289,14 @@ impl Agent for ReferenceAgent {
         let tools = capabilities.get_prefixed_tools().await?;
         let tools_info = tools
             .into_iter()
-            .map(|tool| ToolInfo::new(&tool.name, &tool.description, get_parameter_names(&tool)))
+            .map(|tool| {
+                ToolInfo::new(
+                    &tool.name,
+                    &tool.description,
+                    get_parameter_names(&tool),
+                    None,
+                )
+            })
             .collect();
 
         let plan_prompt = capabilities.get_planning_prompt(tools_info).await;

--- a/crates/goose/src/agents/summarize.rs
+++ b/crates/goose/src/agents/summarize.rs
@@ -489,7 +489,14 @@ impl Agent for SummarizeAgent {
         let tools = capabilities.get_prefixed_tools().await?;
         let tools_info = tools
             .into_iter()
-            .map(|tool| ToolInfo::new(&tool.name, &tool.description, get_parameter_names(&tool)))
+            .map(|tool| {
+                ToolInfo::new(
+                    &tool.name,
+                    &tool.description,
+                    get_parameter_names(&tool),
+                    None,
+                )
+            })
             .collect();
 
         let plan_prompt = capabilities.get_planning_prompt(tools_info).await;

--- a/crates/goose/src/agents/truncate.rs
+++ b/crates/goose/src/agents/truncate.rs
@@ -774,7 +774,14 @@ impl Agent for TruncateAgent {
         let tools = capabilities.get_prefixed_tools().await?;
         let tools_info = tools
             .into_iter()
-            .map(|tool| ToolInfo::new(&tool.name, &tool.description, get_parameter_names(&tool)))
+            .map(|tool| {
+                ToolInfo::new(
+                    &tool.name,
+                    &tool.description,
+                    get_parameter_names(&tool),
+                    None,
+                )
+            })
             .collect();
 
         let plan_prompt = capabilities.get_planning_prompt(tools_info).await;

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -5,9 +5,10 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
+use utoipa::ToSchema;
 
 /// Enum representing the possible permission levels for a tool.
-#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq)]
+#[derive(Debug, Deserialize, Serialize, Clone, PartialEq, Eq, ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum PermissionLevel {
     AlwaysAllow, // Tool can always be used without prompt

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -19,6 +19,18 @@
           "super::routes::agent"
         ],
         "operationId": "get_tools",
+        "parameters": [
+          {
+            "name": "extension_name",
+            "in": "query",
+            "description": "Optional extension name to filter tools",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Tools retrieved successfully",
@@ -547,6 +559,15 @@
           }
         }
       },
+      "PermissionLevel": {
+        "type": "string",
+        "description": "Enum representing the possible permission levels for a tool.",
+        "enum": [
+          "always_allow",
+          "ask_before",
+          "never_allow"
+        ]
+      },
       "ProviderDetails": {
         "type": "object",
         "required": [
@@ -684,6 +705,37 @@
           "title": {
             "type": "string",
             "description": "A human-readable title for the tool.",
+            "nullable": true
+          }
+        }
+      },
+      "ToolInfo": {
+        "type": "object",
+        "description": "Information about the tool used for building prompts",
+        "required": [
+          "name",
+          "description",
+          "parameters"
+        ],
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "parameters": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "permission": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PermissionLevel"
+              }
+            ],
             "nullable": true
           }
         }

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -84,6 +84,11 @@ export type ExtensionResponse = {
     extensions: Array<ExtensionEntry>;
 };
 
+/**
+ * Enum representing the possible permission levels for a tool.
+ */
+export type PermissionLevel = 'always_allow' | 'ask_before' | 'never_allow';
+
 export type ProviderDetails = {
     /**
      * Indicates whether the provider is fully configured
@@ -204,6 +209,16 @@ export type ToolAnnotations = {
     title?: string | null;
 };
 
+/**
+ * Information about the tool used for building prompts
+ */
+export type ToolInfo = {
+    description: string;
+    name: string;
+    parameters: Array<string>;
+    permission?: PermissionLevel | null;
+};
+
 export type UpsertConfigQuery = {
     is_secret: boolean;
     key: string;
@@ -213,7 +228,12 @@ export type UpsertConfigQuery = {
 export type GetToolsData = {
     body?: never;
     path?: never;
-    query?: never;
+    query?: {
+        /**
+         * Optional extension name to filter tools
+         */
+        extension_name?: string | null;
+    };
     url: '/agent/tools';
 };
 


### PR DESCRIPTION
Add list query filter to list tools for specified extensions. And use ToolInfo instead of Tool for the response because ToolInfo contains the enough info and adding permission field doesn't have any impact on existing code, while Tool is aligning with MCP Tool definition. 