### PR TITLE
feat: use tool level permission control

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -628,17 +628,15 @@ impl Session {
                                 output::hide_thinking();
 
                                 // Format the confirmation prompt
-                                let prompt = "Goose would like to call the above tool, do you approve?".to_string();
+                                let prompt = "Goose would like to call the above tool, do you allow?".to_string();
 
                                 // Get confirmation from user
-                                let confirmed = cliclack::confirm(prompt).initial_value(true).interact()?;
-                                let permission = if confirmed {
-                                    Permission::AllowOnce
-                                } else {
-                                    Permission::DenyOnce
-                                };
+                                let permission = cliclack::select(prompt)
+                                    .item(Permission::AllowOnce, "Allow", "Allow the tool call once")
+                                    .item(Permission::AlwaysAllow, "Always Allow", "Always allow the tool call")
+                                    .item(Permission::DenyOnce, "Deny", "Deny the tool call")
+                                    .interact()?;
                                 self.agent.handle_confirmation(confirmation.id.clone(), PermissionConfirmation {
-                                    principal_name: "tool_name_placeholder".to_string(),
                                     principal_type: PrincipalType::Tool,
                                     permission,
                                 },).await;
@@ -656,7 +654,6 @@ impl Session {
                                     Permission::DenyOnce
                                 };
                                 self.agent.handle_confirmation(enable_extension_request.id.clone(), PermissionConfirmation {
-                                    principal_name: "extension_name_placeholder".to_string(),
                                     principal_type: PrincipalType::Extension,
                                     permission,
                                 },).await;

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -398,7 +398,6 @@ async fn confirm_handler(
         .handle_confirmation(
             request.id.clone(),
             PermissionConfirmation {
-                principal_name: "tool_name_placeholder".to_string(),
                 principal_type: PrincipalType::Tool,
                 permission,
             },

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -1,6 +1,5 @@
 use super::APP_STRATEGY;
 use etcetera::{choose_app_strategy, AppStrategy};
-use once_cell::sync::OnceCell;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs;
@@ -30,9 +29,6 @@ pub struct PermissionManager {
     config_path: PathBuf, // Path to the permission configuration file
     permission_map: HashMap<String, PermissionConfig>, // Mapping of permission names to configurations
 }
-
-// Global singleton for the PermissionManager
-static GLOBAL_PERMISSION_MANAGER: OnceCell<PermissionManager> = OnceCell::new();
 
 // Constants representing specific permission categories
 const USER_PERMISSION: &str = "user";
@@ -68,11 +64,6 @@ impl Default for PermissionManager {
 }
 
 impl PermissionManager {
-    /// Returns the global instance of the PermissionManager, initializing it if necessary.
-    pub fn global() -> &'static PermissionManager {
-        GLOBAL_PERMISSION_MANAGER.get_or_init(PermissionManager::default)
-    }
-
     /// Creates a new `PermissionManager` with a specified config path.
     pub fn new<P: AsRef<Path>>(config_path: P) -> Self {
         let config_path = config_path.as_ref().to_path_buf();

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -152,7 +152,16 @@ impl PermissionManager {
         // Get or create a new PermissionConfig for the specified category
         let permission_config = self.permission_map.entry(name.to_string()).or_default();
 
-        // Add the tool to the appropriate permission level list
+        // Remove the principal from all existing lists to avoid duplicates
+        permission_config
+            .always_allow
+            .retain(|p| p != principal_name);
+        permission_config.ask_before.retain(|p| p != principal_name);
+        permission_config
+            .never_allow
+            .retain(|p| p != principal_name);
+
+        // Add the principal to the appropriate list
         match level {
             PermissionLevel::AlwaysAllow => permission_config
                 .always_allow

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -70,7 +70,7 @@ impl Default for PermissionManager {
 impl PermissionManager {
     /// Returns the global instance of the PermissionManager, initializing it if necessary.
     pub fn global() -> &'static PermissionManager {
-        GLOBAL_PERMISSION_MANAGER.get_or_init(PermissionManager::default)
+        GLOBAL_PERMISSION_MANAGER.get_or_init(|| PermissionManager::default())
     }
 
     /// Creates a new `PermissionManager` with a specified config path.
@@ -150,18 +150,12 @@ impl PermissionManager {
     /// Helper function to update a permission level for a specific tool in a given permission category.
     fn update_permission(&mut self, name: &str, principal_name: &str, level: PermissionLevel) {
         // Get or create a new PermissionConfig for the specified category
-        let permission_config = self.permission_map.entry(name.to_string()).or_default();
+        let permission_config = self
+            .permission_map
+            .entry(name.to_string())
+            .or_insert(PermissionConfig::default());
 
-        // Remove the principal from all existing lists to avoid duplicates
-        permission_config
-            .always_allow
-            .retain(|p| p != principal_name);
-        permission_config.ask_before.retain(|p| p != principal_name);
-        permission_config
-            .never_allow
-            .retain(|p| p != principal_name);
-
-        // Add the principal to the appropriate list
+        // Add the tool to the appropriate permission level list
         match level {
             PermissionLevel::AlwaysAllow => permission_config
                 .always_allow

--- a/crates/goose/src/config/permission.rs
+++ b/crates/goose/src/config/permission.rs
@@ -70,7 +70,7 @@ impl Default for PermissionManager {
 impl PermissionManager {
     /// Returns the global instance of the PermissionManager, initializing it if necessary.
     pub fn global() -> &'static PermissionManager {
-        GLOBAL_PERMISSION_MANAGER.get_or_init(|| PermissionManager::default())
+        GLOBAL_PERMISSION_MANAGER.get_or_init(PermissionManager::default)
     }
 
     /// Creates a new `PermissionManager` with a specified config path.
@@ -150,10 +150,7 @@ impl PermissionManager {
     /// Helper function to update a permission level for a specific tool in a given permission category.
     fn update_permission(&mut self, name: &str, principal_name: &str, level: PermissionLevel) {
         // Get or create a new PermissionConfig for the specified category
-        let permission_config = self
-            .permission_map
-            .entry(name.to_string())
-            .or_insert(PermissionConfig::default());
+        let permission_config = self.permission_map.entry(name.to_string()).or_default();
 
         // Add the tool to the appropriate permission level list
         match level {

--- a/crates/goose/src/permission/permission_confirmation.rs
+++ b/crates/goose/src/permission/permission_confirmation.rs
@@ -15,7 +15,6 @@ pub enum PrincipalType {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct PermissionConfirmation {
-    pub principal_name: String,
     pub principal_type: PrincipalType,
     pub permission: Permission,
 }


### PR DESCRIPTION
Changes in this PR:
1. Smart approve stops checking the tool call arguments, it only checks the tool name and descriptions(tool level check)
2. Smart approve will only provide the default permission for the tool, if users choose always allow the tool, user permission will override the default one.

Test:

```
( O)> write a demo.txt file to my current dir
I'll help you create a demo.txt file in the current directory.
─── text_editor | developer ──────────────────────────
path: ~/Documents/block/goose/demo.txt
command: write
file_text: ...


◆  Goose would like to call the above tool, do you allow?
│  ● Allow (Allow the tool call once)
│  ○ Always Allow 
│  ○ Deny 
```

```
cat ~/.config/goose/permission.yaml 
smart_approve:
  always_allow:
  - developer__shell
  ask_before:
  - developer__text_editor
  never_allow: []
user:
  always_allow:
  - developer__text_editor
  ask_before: []
  never_allow: []
```