### PR TITLE
feat: add google_drive uri verification, and example instructions

### DIFF
--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -1118,6 +1118,14 @@ impl GoogleDriveRouter {
 
         let drive_uri = uri.replace("gdrive:///", "");
 
+        // Validation: check for / path separators as invalid uris
+        if drive_uri.contains('/') {
+            return Err(ToolError::InvalidParameters(format!(
+                "The uri '{}' conatins extra '/'. Only the base URI is allowed.",
+                uri
+            )));
+        }
+
         let include_images = params
             .get("includeImages")
             .and_then(|i| i.as_bool())

--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -224,6 +224,11 @@ impl GoogleDriveRouter {
             indoc! {r#"
                 Read a file from google drive using the file uri.
                 Optionally include base64 encoded images, false by default.
+
+                Example extracting URIs from URLs:
+                Given "https://docs.google.com/document/d/1QG8d8wtWe7ZfmG93sW-1h2WXDJDUkOi-9hDnvJLmWrc/edit?tab=t.0#heading=h.5v419d3h97tr"
+                Pass in "gdrive:///1QG8d8wtWe7ZfmG93sW-1h2WXDJDUkOi-9hDnvJLmWrc"
+                Do not include any other path parameters.
             "#}
             .to_string(),
             json!({
@@ -658,6 +663,19 @@ impl GoogleDriveRouter {
             ### 2. Read File Tool
             Read a file's contents using its ID, and optionally include images as base64 encoded data.
             The default is to exclude images, to include images set includeImages to true in the query.
+
+            Example mappings for Google Drive resources to `gdrive:///$URI` format:
+            - Google Document File:
+              Example URL: https://docs.google.com/document/d/1QG8d8wtWe7ZfmG93sW-1h2WXDJDUkOi-9hDnvJLmWrc/edit?tab=t.0#heading=h.5v419d3h97tr
+              URI Format: gdrive:///1QG8d8wtWe7ZfmG93sW-1h2WXDJDUkOi-9hDnvJLmWrc
+
+            - Google Sheet:
+              Example URL: https://docs.google.com/spreadsheets/d/1J5KHqWsGFzweuiQboX7dlm8Ejv90Po16ocEBahzCt4W/edit?gid=1249300797#gid=1249300797
+              URI Format: gdrive:///1J5KHqWsGFzweuiQboX7dlm8Ejv90Po16ocEBahzCt4W
+
+            - Google Slides:
+              Example URL: https://docs.google.com/presentation/d/1zXWqsGpHJEu40oqb1omh68sW9liu7EKFBCdnPaJVoQ5et/edit#slide=id.p1
+              URI Format: gdrive:///1zXWqsGpHJEu40oqb1omh68sW9liu7EKFBCdnPaJVoQ5et
 
             Images take up a large amount of context, this should only be used if a
             user explicity needs the image data.


### PR DESCRIPTION
# google_drive uri verification

saw multiple instances where goose would try
```
gdrive:///document/$SOME_DOC_ID
```
and fail, not knowing that it needed to only pass in `$SOME_DOC_ID`

* add instructions on mapping URLs to URI format expected (examples are random IDs that don't exist)
* add a check in tool call to look for any extra `/` chars and error out on that

could not find a spec on what a valid ID is, so this is best effort