### PR TITLE
Make GOOSE_CLI_THEME persist to config file and stick for future session

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -26,7 +26,7 @@ impl Theme {
         }
     }
 
-    fn from_string(val: &str) -> Self {
+    fn from_config_str(val: &str) -> Self {
         if val.eq_ignore_ascii_case("light") {
             Theme::Light
         } else if val.eq_ignore_ascii_case("ansi") {
@@ -39,14 +39,11 @@ impl Theme {
 
 thread_local! {
     static CURRENT_THEME: RefCell<Theme> = RefCell::new(
-        Config::global()
-            .get_param::<String>("GOOSE_CLI_THEME")
-            .ok()
-            .map(|val| Theme::from_string(&val))
+        std::env::var("GOOSE_CLI_THEME").ok()
+            .map(|val| Theme::from_config_str(&val))
             .unwrap_or_else(||
-                std::env::var("GOOSE_CLI_THEME")
-                    .ok()
-                    .map(|val| Theme::from_string(&val))
+                Config::global().get_param::<String>("GOOSE_CLI_THEME").ok()
+                    .map(|val| Theme::from_config_str(&val))
                     .unwrap_or(Theme::Dark)
             )
     );

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -35,6 +35,14 @@ impl Theme {
             Theme::Dark
         }
     }
+
+    fn to_config_string(&self) -> String {
+        match self {
+            Theme::Light => "light".to_string(),
+            Theme::Dark => "dark".to_string(),
+            Theme::Ansi => "ansi".to_string(),
+        }
+    }
 }
 
 thread_local! {
@@ -52,14 +60,7 @@ thread_local! {
 pub fn set_theme(theme: Theme) {
     let config = Config::global();
     config
-        .set_param(
-            "GOOSE_CLI_THEME",
-            Value::String(match theme {
-                Theme::Light => "light".to_string(),
-                Theme::Dark => "dark".to_string(),
-                Theme::Ansi => "ansi".to_string(),
-            }),
-        )
+        .set_param("GOOSE_CLI_THEME", Value::String(theme.to_config_string()))
         .expect("Failed to set theme");
     CURRENT_THEME.with(|t| *t.borrow_mut() = theme);
 }

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -36,7 +36,7 @@ impl Theme {
         }
     }
 
-    fn to_config_string(&self) -> String {
+    fn as_config_string(&self) -> String {
         match self {
             Theme::Light => "light".to_string(),
             Theme::Dark => "dark".to_string(),
@@ -60,7 +60,7 @@ thread_local! {
 pub fn set_theme(theme: Theme) {
     let config = Config::global();
     config
-        .set_param("GOOSE_CLI_THEME", Value::String(theme.to_config_string()))
+        .set_param("GOOSE_CLI_THEME", Value::String(theme.as_config_string()))
         .expect("Failed to set theme");
     CURRENT_THEME.with(|t| *t.borrow_mut() = theme);
 }


### PR DESCRIPTION
Previously, theme was not persisted across sessions because it was reading from an environment variable. Now, theme is also stored in config and read from there.

Testing:
Changed to Light mode in a session:
<img width="1484" alt="Screenshot 2025-04-08 at 5 20 30 PM" src="https://github.com/user-attachments/assets/cb0f3c7b-61ee-4208-b2e6-a1653b34ab5d" />

In a new terminal, started a new session and verified it stayed in light mode:
<img width="1478" alt="Screenshot 2025-04-08 at 5 22 48 PM" src="https://github.com/user-attachments/assets/1f801a82-aab1-4e4c-b1cc-f1d40a69a6ea" />

