### PR TITLE
fix(cli): Clear current input on ctrl-c instead of exiting

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -44,7 +44,7 @@ pub fn get_input(
     let input = match editor.readline(&prompt) {
         Ok(text) => text,
         Err(e) => match e {
-            rustyline::error::ReadlineError::Interrupted => return Ok(InputResult::Exit),
+            rustyline::error::ReadlineError::Interrupted => return Ok(InputResult::Retry),
             _ => return Err(e.into()),
         },
     };


### PR DESCRIPTION
Most readline-style programs allow the user to clear the current line by using `ctrl-c`, prior to this change `ctrl-c` would immediately exit goose.

This change makes it so that `ctrl-c` just empties the input and puts the user on an empty prompt line. The user can sill exit by using `ctrl-d` or `/exit` or `/quit`.