### PR TITLE
no more esc toasts

### DIFF
--- a/ui/desktop/src/components/settings_v2/extensions/extension-manager.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/extension-manager.ts
@@ -18,7 +18,7 @@ export async function activateExtension({
 }: ActivateExtensionProps): Promise<void> {
   try {
     // AddToAgent
-    await addToAgent(extensionConfig, { silent: false, showEscMessage: true });
+    await addToAgent(extensionConfig, { silent: false });
   } catch (error) {
     console.error('Failed to add extension to agent:', error);
     // add to config with enabled = false
@@ -89,18 +89,15 @@ export async function addToAgentOnStartup({
   extensionConfig,
 }: AddToAgentOnStartupProps): Promise<void> {
   try {
-    await retryWithBackoff(
-      () => addToAgent(extensionConfig, { silent: true, showEscMessage: false }),
-      {
-        retries: 3,
-        delayMs: 1000,
-        shouldRetry: (error: any) =>
-          error.message &&
-          (error.message.includes('428') ||
-            error.message.includes('Precondition Required') ||
-            error.message.includes('Agent is not initialized')),
-      }
-    );
+    await retryWithBackoff(() => addToAgent(extensionConfig, { silent: true }), {
+      retries: 3,
+      delayMs: 1000,
+      shouldRetry: (error: any) =>
+        error.message &&
+        (error.message.includes('428') ||
+          error.message.includes('Precondition Required') ||
+          error.message.includes('Agent is not initialized')),
+    });
   } catch (finalError) {
     toastService.configure({ silent: false });
     toastService.error({
@@ -190,8 +187,6 @@ export async function toggleExtension({
       // add to agent with toast options
       await addToAgent(extensionConfig, {
         ...toastOptions,
-        // For toggle operations, we want to show toast but no ESC message
-        showEscMessage: false,
       });
     } catch (error) {
       console.error('Error adding extension to agent. Will try to toggle back off.');

--- a/ui/desktop/src/toasts.tsx
+++ b/ui/desktop/src/toasts.tsx
@@ -4,13 +4,11 @@ import { Button } from './components/ui/button';
 
 export interface ToastServiceOptions {
   silent?: boolean;
-  showEscMessage?: boolean;
   shouldThrow?: boolean;
 }
 
 export default class ToastService {
   private silent: boolean = false;
-  private showEscMessage: boolean = true;
   private shouldThrow: boolean = false;
 
   // Create a singleton instance
@@ -27,9 +25,7 @@ export default class ToastService {
     if (options.silent !== undefined) {
       this.silent = options.silent;
     }
-    if (options.showEscMessage !== undefined) {
-      this.showEscMessage = options.showEscMessage;
-    }
+
     if (options.shouldThrow !== undefined) {
       this.shouldThrow = options.shouldThrow;
     }
@@ -52,11 +48,6 @@ export default class ToastService {
 
     const toastId = toastLoading({ title, msg });
 
-    if (this.showEscMessage) {
-      toast.info(
-        'Press the ESC key on your keyboard to continue using goose while extension loads'
-      );
-    }
     return toastId;
   }
 


### PR DESCRIPTION
Removes the escape toasts

When adding / deleting an extension, the modal will close automatically while it loads and a loading toast will appear. If the addition/deletion succeeds, then the success toast will appear. If it fails, a failure toast will appear 