### PR TITLE
feat: allow empty extensions to return an empty Vec

### DIFF
--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -125,7 +125,9 @@ impl ExtensionManager {
     /// Get all extensions and their configurations
     pub fn get_all() -> Result<Vec<ExtensionEntry>> {
         let config = Config::global();
-        let extensions: HashMap<String, ExtensionEntry> = config.get_param("extensions")?;
+        let extensions: HashMap<String, ExtensionEntry> = config
+            .get_param("extensions")
+            .unwrap_or_else(|_| HashMap::new());
         Ok(Vec::from_iter(extensions.values().cloned()))
     }
 


### PR DESCRIPTION
Resolves issues when `config.yaml` exists but does not contain an `extensions` value

Previously `goose-server` would return a 500 from `/config/extensions` in this case. Now it simply returns an empty array, and the rest of the app's logic for syncing extensions functions normally afterward.