### PR TITLE
fix: correct the goose mode name

### DIFF
--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -184,7 +184,7 @@ pub async fn check_tool_permissions(
 
             // 2. Fallback based on mode
             match mode {
-                "manual_approve" => {
+                "approve" => {
                     needs_approval.push(request.clone());
                 }
                 "smart_approve" => {


### PR DESCRIPTION
Manual approve should be `approve`