### PR TITLE
chore: handle errors from goose run like we do with goose session

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -486,9 +486,9 @@ pub async fn cli() -> Result<()> {
             )?;
 
             if interactive {
-                session.interactive(input_config.contents).await?;
+                let _ = session.interactive(input_config.contents).await;
             } else if let Some(contents) = input_config.contents {
-                session.headless(contents).await?;
+                let _ = session.headless(contents).await;
             } else {
                 eprintln!("Error: no text provided for prompt in headless mode");
                 std::process::exit(1);


### PR DESCRIPTION
copy how we handle `goose session` for the `run` command https://github.com/block/goose/blob/main/crates/goose-cli/src/cli.rs#L405

in the `goose run --interactive` case when a user `ctrl+d` we would get `Error: EOF`
this doesn't happen in the `goose session` case because we `let _ = session...` and ignore the error

do the same thing as the session case to keep it consistent