### PR TITLE
tool count: fix colors and opacity

### DIFF
--- a/ui/desktop/src/components/ToolCount.tsx
+++ b/ui/desktop/src/components/ToolCount.tsx
@@ -4,7 +4,7 @@ import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { HammerIcon } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 
-const SUGGESTED_MAX_TOOLS = 24;
+const SUGGESTED_MAX_TOOLS = 10;
 
 export default function ToolCount() {
   const [toolCount, setToolCount] = useState(null);
@@ -65,15 +65,9 @@ export default function ToolCount() {
           </PopoverTrigger>
           <PopoverContent className="p-3 bg-white dark:bg-gray-800" side="top">
             <div className="space-y-2">
-              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
-                Warning: High Tool Count
-              </h4>
               <p className="text-xs text-gray-700 dark:text-gray-300">
-                Too many tools can degrade goose's performance. Consider turning a few extensions
-                off.
-              </p>
-              <p className="text-xs font-medium text-gray-800 dark:text-gray-200">
-                Tool count: {toolCount}
+                Too many tools can degrade goose's performance. Consider turning unused extensions
+                off. Tool count: {toolCount} (recommend: {SUGGESTED_MAX_TOOLS})
               </p>
             </div>
           </PopoverContent>

--- a/ui/desktop/src/components/ToolCount.tsx
+++ b/ui/desktop/src/components/ToolCount.tsx
@@ -4,7 +4,7 @@ import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { HammerIcon } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 
-const SUGGESTED_MAX_TOOLS = 10;
+const SUGGESTED_MAX_TOOLS = 24;
 
 export default function ToolCount() {
   const [toolCount, setToolCount] = useState(null);
@@ -18,7 +18,9 @@ export default function ToolCount() {
           console.error('failed to get tool count');
           setError(true);
         } else {
-          setToolCount(response.data.length);
+          if (response) {
+            setToolCount(response.data.length);
+          }
         }
       } catch (err) {
         console.error('Error fetching tools:', err);

--- a/ui/desktop/src/components/ToolCount.tsx
+++ b/ui/desktop/src/components/ToolCount.tsx
@@ -1,7 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { getTools } from '../api';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
-import { HammerIcon } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 
 const SUGGESTED_MAX_TOOLS = 24;
@@ -18,9 +17,7 @@ export default function ToolCount() {
           console.error('failed to get tool count');
           setError(true);
         } else {
-          if (response) {
-            setToolCount(response.data.length);
-          }
+          setToolCount(response.data.length);
         }
       } catch (err) {
         console.error('Error fetching tools:', err);
@@ -39,24 +36,7 @@ export default function ToolCount() {
     return <div>...</div>;
   }
 
-  if (toolCount < SUGGESTED_MAX_TOOLS) {
-    return (
-      <div>
-        <Popover>
-          <PopoverTrigger asChild>
-            <button className="flex items-center justify-center p-0 border-0 bg-transparent cursor-pointer">
-              <HammerIcon size={16} />
-            </button>
-          </PopoverTrigger>
-          <PopoverContent className="p-3 w-auto bg-white dark:bg-gray-800" side="top">
-            <div className="space-y-1">
-              <p className="text-sm text-gray-800 dark:text-gray-200">Tool count: {toolCount}</p>
-            </div>
-          </PopoverContent>
-        </Popover>
-      </div>
-    );
-  } else {
+  if (toolCount > SUGGESTED_MAX_TOOLS) {
     return (
       <div>
         <Popover>
@@ -76,5 +56,7 @@ export default function ToolCount() {
         </Popover>
       </div>
     );
+  } else {
+    return <div></div>;
   }
 }

--- a/ui/desktop/src/components/ToolCount.tsx
+++ b/ui/desktop/src/components/ToolCount.tsx
@@ -4,7 +4,7 @@ import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { HammerIcon } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 
-const SUGGESTED_MAX_TOOLS = 15;
+const SUGGESTED_MAX_TOOLS = 24;
 
 export default function ToolCount() {
   const [toolCount, setToolCount] = useState(null);
@@ -46,9 +46,9 @@ export default function ToolCount() {
               <HammerIcon size={16} />
             </button>
           </PopoverTrigger>
-          <PopoverContent className="p-3 w-auto" side="top">
+          <PopoverContent className="p-3 w-auto bg-white dark:bg-gray-800" side="top">
             <div className="space-y-1">
-              <p className="text-sm text-black dark:text-white">Tool count: {toolCount}</p>
+              <p className="text-sm text-gray-800 dark:text-gray-200">Tool count: {toolCount}</p>
             </div>
           </PopoverContent>
         </Popover>
@@ -63,14 +63,18 @@ export default function ToolCount() {
               <ExclamationTriangleIcon color="orange" />
             </button>
           </PopoverTrigger>
-          <PopoverContent className="p-3" side="top">
+          <PopoverContent className="p-3 bg-white dark:bg-gray-800" side="top">
             <div className="space-y-2">
-              <h4 className="text-sm font-medium">Warning: High Tool Count</h4>
-              <p className="text-xs text-black dark:text-white">
+              <h4 className="text-sm font-medium text-gray-900 dark:text-gray-100">
+                Warning: High Tool Count
+              </h4>
+              <p className="text-xs text-gray-700 dark:text-gray-300">
                 Too many tools can degrade goose's performance. Consider turning a few extensions
                 off.
               </p>
-              <p className="text-xs font-medium">Tool count: {toolCount}</p>
+              <p className="text-xs font-medium text-gray-800 dark:text-gray-200">
+                Tool count: {toolCount}
+              </p>
             </div>
           </PopoverContent>
         </Popover>

--- a/ui/desktop/src/components/ToolCount.tsx
+++ b/ui/desktop/src/components/ToolCount.tsx
@@ -63,9 +63,9 @@ export default function ToolCount() {
               <ExclamationTriangleIcon color="orange" />
             </button>
           </PopoverTrigger>
-          <PopoverContent className="p-3 bg-white dark:bg-gray-800" side="top">
+          <PopoverContent className="p-3 bg-orangit ge-500 " side="top">
             <div className="space-y-2">
-              <p className="text-xs text-gray-700 dark:text-gray-300">
+              <p className="text-xs text-gray-300">
                 Too many tools can degrade goose's performance. Consider turning unused extensions
                 off. Tool count: {toolCount} (recommend: {SUGGESTED_MAX_TOOLS})
               </p>


### PR DESCRIPTION
Popover was translucent and the header/footer text color didnt change for darkmode so it disappeared into the background 