### PR TITLE
Tokens in session file should accumulate for accurate reporting of token usage

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -398,7 +398,7 @@ impl Agent {
                             let session_file = session::get_path(session.id);
                             let mut metadata = session::read_metadata(&session_file)?;
                             metadata.working_dir = session.working_dir;
-                            
+
                             // Accumulate all token counts using the same functional pattern
                             let accumulate = |a: Option<i32>, b: Option<i32>| -> Option<i32> {
                                 match (a, b) {
@@ -406,11 +406,11 @@ impl Agent {
                                     _ => a.or(b)
                                 }
                             };
-                            
+
                             metadata.total_tokens = accumulate(metadata.total_tokens, usage.usage.total_tokens);
                             metadata.input_tokens = accumulate(metadata.input_tokens, usage.usage.input_tokens);
                             metadata.output_tokens = accumulate(metadata.output_tokens, usage.usage.output_tokens);
-                            
+
                             // The message count is the number of messages in the session + 1 for the response
                             // The message count does not include the tool response till next iteration
                             metadata.message_count = messages.len() + 1;

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -398,9 +398,19 @@ impl Agent {
                             let session_file = session::get_path(session.id);
                             let mut metadata = session::read_metadata(&session_file)?;
                             metadata.working_dir = session.working_dir;
-                            metadata.total_tokens = usage.usage.total_tokens;
-                            metadata.input_tokens = usage.usage.input_tokens;
-                            metadata.output_tokens = usage.usage.output_tokens;
+                            
+                            // Accumulate all token counts using the same functional pattern
+                            let accumulate = |a: Option<i32>, b: Option<i32>| -> Option<i32> {
+                                match (a, b) {
+                                    (Some(x), Some(y)) => Some(x + y),
+                                    _ => a.or(b)
+                                }
+                            };
+                            
+                            metadata.total_tokens = accumulate(metadata.total_tokens, usage.usage.total_tokens);
+                            metadata.input_tokens = accumulate(metadata.input_tokens, usage.usage.input_tokens);
+                            metadata.output_tokens = accumulate(metadata.output_tokens, usage.usage.output_tokens);
+                            
                             // The message count is the number of messages in the session + 1 for the response
                             // The message count does not include the tool response till next iteration
                             metadata.message_count = messages.len() + 1;

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -398,8 +398,10 @@ impl Agent {
                             let session_file = session::get_path(session.id);
                             let mut metadata = session::read_metadata(&session_file)?;
                             metadata.working_dir = session.working_dir;
+                            metadata.total_tokens = usage.usage.total_tokens;
+                            metadata.input_tokens = usage.usage.input_tokens;
+                            metadata.output_tokens = usage.usage.output_tokens;
 
-                            // Accumulate all token counts using the same functional pattern
                             let accumulate = |a: Option<i32>, b: Option<i32>| -> Option<i32> {
                                 match (a, b) {
                                     (Some(x), Some(y)) => Some(x + y),
@@ -407,9 +409,9 @@ impl Agent {
                                 }
                             };
 
-                            metadata.total_tokens = accumulate(metadata.total_tokens, usage.usage.total_tokens);
-                            metadata.input_tokens = accumulate(metadata.input_tokens, usage.usage.input_tokens);
-                            metadata.output_tokens = accumulate(metadata.output_tokens, usage.usage.output_tokens);
+                            metadata.accumulated_total_tokens = accumulate(metadata.accumulated_total_tokens, usage.usage.total_tokens);
+                            metadata.accumulated_input_tokens = accumulate(metadata.accumulated_input_tokens, usage.usage.input_tokens);
+                            metadata.accumulated_output_tokens = accumulate(metadata.accumulated_output_tokens, usage.usage.output_tokens);
 
                             // The message count is the number of messages in the session + 1 for the response
                             // The message count does not include the tool response till next iteration

--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -31,6 +31,12 @@ pub struct SessionMetadata {
     pub input_tokens: Option<i32>,
     /// The number of output tokens used in the session. Retrieved from the provider's last usage.
     pub output_tokens: Option<i32>,
+    /// The total number of tokens used in the session. Accumulated across all messages.
+    pub accumulated_total_tokens: Option<i32>,
+    /// The number of input tokens used in the session. Accumulated across all messages.
+    pub accumulated_input_tokens: Option<i32>,
+    /// The number of output tokens used in the session. Accumulated across all messages.
+    pub accumulated_output_tokens: Option<i32>,
 }
 
 // Custom deserializer to handle old sessions without working_dir
@@ -46,6 +52,9 @@ impl<'de> Deserialize<'de> for SessionMetadata {
             total_tokens: Option<i32>,
             input_tokens: Option<i32>,
             output_tokens: Option<i32>,
+            accumulated_total_tokens: Option<i32>,
+            accumulated_input_tokens: Option<i32>,
+            accumulated_output_tokens: Option<i32>,
             working_dir: Option<PathBuf>,
         }
 
@@ -57,6 +66,9 @@ impl<'de> Deserialize<'de> for SessionMetadata {
             total_tokens: helper.total_tokens,
             input_tokens: helper.input_tokens,
             output_tokens: helper.output_tokens,
+            accumulated_total_tokens: helper.accumulated_total_tokens,
+            accumulated_input_tokens: helper.accumulated_input_tokens,
+            accumulated_output_tokens: helper.accumulated_output_tokens,
             working_dir: helper.working_dir.unwrap_or_else(get_home_dir),
         })
     }
@@ -71,6 +83,9 @@ impl SessionMetadata {
             total_tokens: None,
             input_tokens: None,
             output_tokens: None,
+            accumulated_total_tokens: None,
+            accumulated_input_tokens: None,
+            accumulated_output_tokens: None,
         }
     }
 }


### PR DESCRIPTION
Currently, the token usage metadata in the session file only reflects the usage from the last turn-of-conversation. Having accumulated data of input and output token usage is a useful metric for tracking cost over the course of an entire session.

This PR adds `accumulated_input_tokens`, `accumulated_output_tokens` and `accumulated_total_tokens` fields to the `SessionMetadata` and persists them to the session file.

Test Plan:
1. Started a session and terminated it. Session file line 1 at the end:

`{"working_dir":"/Users/sana.verma/goose-fork","description":"Code review discussion","message_count":34,"total_tokens":44226,"input_tokens":43898,"output_tokens":328,"accumulated_total_tokens":343542,"accumulated_input_tokens":341161,"accumulated_output_tokens":2381}`

2. Resumed the session. Session file line 2 at the end:

`{"working_dir":"/Users/sana.verma/goose-fork","description":"Code review discussion","message_count":36,"total_tokens":44419,"input_tokens":44234,"output_tokens":185,"accumulated_total_tokens":387961,"accumulated_input_tokens":385395,"accumulated_output_tokens":2566}`