### PR TITLE
feat: remove ^$ anchor in recipe regex for json responses

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -810,7 +810,7 @@ impl Agent {
         let content = result.as_concat_text();
 
         // the response may be contained in ```json ```, strip that before parsing json
-        let re = Regex::new(r"(?s)^```[^\n]*\n(.*?)\n```$").unwrap();
+        let re = Regex::new(r"(?s)```[^\n]*\n(.*?)\n```").unwrap();
         let clean_content = re
             .captures(&content)
             .and_then(|caps| caps.get(1).map(|m| m.as_str()))


### PR DESCRIPTION
allows us to extract `json` if it comes a with a message before or after