### PR TITLE
settingsv2: fix process for deeplinks with env vars

### DIFF
--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -86,6 +86,9 @@
         "prettier": "^3.4.2",
         "tailwindcss": "^3.4.14",
         "vite": "^5.4.17"
+      },
+      "engines": {
+        "node": "^23.0.0"
       }
     },
     "node_modules/@ai-sdk/openai": {

--- a/ui/desktop/src/components/settings_v2/SettingsView.tsx
+++ b/ui/desktop/src/components/settings_v2/SettingsView.tsx
@@ -22,7 +22,6 @@ export default function SettingsView({
   setView: (view: View) => void;
   viewOptions: SettingsViewOptions;
 }) {
-  console.log('In settings view and got this', viewOptions.deepLinkConfig, viewOptions.showEnvVars);
   return (
     <div className="h-screen w-full animate-[fadein_200ms_ease-in_forwards]">
       <div className="relative flex items-center h-[36px] w-full bg-bgSubtle"></div>

--- a/ui/desktop/src/components/settings_v2/SettingsView.tsx
+++ b/ui/desktop/src/components/settings_v2/SettingsView.tsx
@@ -6,19 +6,23 @@ import ExtensionsSection from './extensions/ExtensionsSection';
 import ModelsSection from './models/ModelsSection';
 import { ModeSection } from './mode/ModeSection';
 import SessionSharingSection from './sessions/SessionSharingSection';
+import {ExtensionConfig} from "../../api";
 
 export type SettingsViewOptions = {
-  extensionId?: string;
-  showEnvVars?: boolean;
+  deepLinkConfig?: ExtensionConfig;
+  needEnvVars?: boolean;
 };
 
 export default function SettingsView({
   onClose,
   setView,
+    viewOptions
 }: {
   onClose: () => void;
   setView: (view: View) => void;
+  viewOptions: SettingsViewOptions
 }) {
+  console.log("In settings view and got this", viewOptions.deepLinkConfig, viewOptions.needEnvVars)
   return (
     <div className="h-screen w-full animate-[fadein_200ms_ease-in_forwards]">
       <div className="relative flex items-center h-[36px] w-full bg-bgSubtle"></div>
@@ -36,7 +40,7 @@ export default function SettingsView({
               {/* Models Section */}
               <ModelsSection setView={setView} />
               {/* Extensions Section */}
-              <ExtensionsSection />
+              <ExtensionsSection deepLinkConfig={viewOptions.deepLinkConfig} needsEnvVars={viewOptions.needEnvVars} />
               {/* Goose Modes */}
               <ModeSection />
               {/*Session sharing*/}

--- a/ui/desktop/src/components/settings_v2/SettingsView.tsx
+++ b/ui/desktop/src/components/settings_v2/SettingsView.tsx
@@ -6,23 +6,23 @@ import ExtensionsSection from './extensions/ExtensionsSection';
 import ModelsSection from './models/ModelsSection';
 import { ModeSection } from './mode/ModeSection';
 import SessionSharingSection from './sessions/SessionSharingSection';
-import {ExtensionConfig} from "../../api";
+import { ExtensionConfig } from '../../api';
 
 export type SettingsViewOptions = {
   deepLinkConfig?: ExtensionConfig;
-  needEnvVars?: boolean;
+  showEnvVars?: boolean;
 };
 
 export default function SettingsView({
   onClose,
   setView,
-    viewOptions
+  viewOptions,
 }: {
   onClose: () => void;
   setView: (view: View) => void;
-  viewOptions: SettingsViewOptions
+  viewOptions: SettingsViewOptions;
 }) {
-  console.log("In settings view and got this", viewOptions.deepLinkConfig, viewOptions.needEnvVars)
+  console.log('In settings view and got this', viewOptions.deepLinkConfig, viewOptions.showEnvVars);
   return (
     <div className="h-screen w-full animate-[fadein_200ms_ease-in_forwards]">
       <div className="relative flex items-center h-[36px] w-full bg-bgSubtle"></div>
@@ -40,7 +40,10 @@ export default function SettingsView({
               {/* Models Section */}
               <ModelsSection setView={setView} />
               {/* Extensions Section */}
-              <ExtensionsSection deepLinkConfig={viewOptions.deepLinkConfig} needsEnvVars={viewOptions.needEnvVars} />
+              <ExtensionsSection
+                deepLinkConfig={viewOptions.deepLinkConfig}
+                showEnvVars={viewOptions.showEnvVars}
+              />
               {/* Goose Modes */}
               <ModeSection />
               {/*Session sharing*/}

--- a/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
+++ b/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { Button } from '../../ui/button';
 import { Plus } from 'lucide-react';
 import { GPSIcon } from '../../ui/icons';
@@ -14,22 +14,26 @@ import {
 } from './utils';
 
 import { activateExtension, deleteExtension, toggleExtension, updateExtension } from './index';
-import {ExtensionConfig} from "../../../api/types.gen";
+import { ExtensionConfig } from '../../../api/types.gen';
 
 interface ExtensionSectionProps {
-  deepLinkConfig?: ExtensionConfig,
-  needsEnvVars?: boolean,
+  deepLinkConfig?: ExtensionConfig;
+  needsEnvVars?: boolean;
 }
 
-export default function ExtensionsSection({deepLinkConfig, needsEnvVars}: ExtensionSectionProps) {
+export default function ExtensionsSection({ deepLinkConfig, needsEnvVars }: ExtensionSectionProps) {
   const { getExtensions, addExtension, removeExtension } = useConfig();
   const [extensions, setExtensions] = useState<FixedExtensionEntry[]>([]);
   const [selectedExtension, setSelectedExtension] = useState<FixedExtensionEntry | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  const [deepLinkConfigStateVar, setDeepLinkConfigStateVar] = useState<ExtensionConfig | undefined | null>(deepLinkConfig)
-  const [needsEnvVarsStateVar, setNeedsEnvVarsStateVar] = useState<boolean | undefined | null>(needsEnvVars)
-  
+  const [deepLinkConfigStateVar, setDeepLinkConfigStateVar] = useState<
+    ExtensionConfig | undefined | null
+  >(deepLinkConfig);
+  const [needsEnvVarsStateVar, setNeedsEnvVarsStateVar] = useState<boolean | undefined | null>(
+    needsEnvVars
+  );
+
   const fetchExtensions = useCallback(async () => {
     const extensionsList = await getExtensions(true); // Force refresh
     // Sort extensions by name to maintain consistent order
@@ -122,8 +126,8 @@ export default function ExtensionsSection({deepLinkConfig, needsEnvVars}: Extens
   };
 
   const handleModalClose = () => {
-    setDeepLinkConfigStateVar(null)
-    setNeedsEnvVarsStateVar(null)
+    setDeepLinkConfigStateVar(null);
+    setNeedsEnvVarsStateVar(null);
 
     setIsModalOpen(false);
     setIsAddModalOpen(false);
@@ -191,14 +195,14 @@ export default function ExtensionsSection({deepLinkConfig, needsEnvVars}: Extens
 
         {/* Modal for adding extension from deeplink*/}
         {deepLinkConfigStateVar && needsEnvVarsStateVar && (
-            <ExtensionModal
-                title="Add custom extension"
-                initialData={extensionToFormData({...deepLinkConfig, enabled: true})}
-                onClose={handleModalClose}
-                onSubmit={handleAddExtension}
-                submitLabel="Add Extension"
-                modalType={'add'}
-            />
+          <ExtensionModal
+            title="Add custom extension"
+            initialData={extensionToFormData({ ...deepLinkConfig, enabled: true })}
+            onClose={handleModalClose}
+            onSubmit={handleAddExtension}
+            submitLabel="Add Extension"
+            modalType={'add'}
+          />
         )}
       </div>
     </section>

--- a/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
+++ b/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
@@ -14,15 +14,22 @@ import {
 } from './utils';
 
 import { activateExtension, deleteExtension, toggleExtension, updateExtension } from './index';
+import {ExtensionConfig} from "../../../api/types.gen";
 
-export default function ExtensionsSection() {
+interface ExtensionSectionProps {
+  deepLinkConfig?: ExtensionConfig,
+  needsEnvVars?: boolean,
+}
+
+export default function ExtensionsSection({deepLinkConfig, needsEnvVars}: ExtensionSectionProps) {
   const { getExtensions, addExtension, removeExtension } = useConfig();
   const [extensions, setExtensions] = useState<FixedExtensionEntry[]>([]);
   const [selectedExtension, setSelectedExtension] = useState<FixedExtensionEntry | null>(null);
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isAddModalOpen, setIsAddModalOpen] = useState(false);
-  // We don't need errorFormData anymore since we're not reopening modals on failure
-
+  const [deepLinkConfigStateVar, setDeepLinkConfigStateVar] = useState<ExtensionConfig | undefined | null>(deepLinkConfig)
+  const [needsEnvVarsStateVar, setNeedsEnvVarsStateVar] = useState<boolean | undefined | null>(needsEnvVars)
+  
   const fetchExtensions = useCallback(async () => {
     const extensionsList = await getExtensions(true); // Force refresh
     // Sort extensions by name to maintain consistent order
@@ -115,6 +122,9 @@ export default function ExtensionsSection() {
   };
 
   const handleModalClose = () => {
+    setDeepLinkConfigStateVar(null)
+    setNeedsEnvVarsStateVar(null)
+
     setIsModalOpen(false);
     setIsAddModalOpen(false);
     setSelectedExtension(null);
@@ -177,6 +187,18 @@ export default function ExtensionsSection() {
             submitLabel="Add Extension"
             modalType={'add'}
           />
+        )}
+
+        {/* Modal for adding extension from deeplink*/}
+        {deepLinkConfigStateVar && needsEnvVarsStateVar && (
+            <ExtensionModal
+                title="Add custom extension"
+                initialData={extensionToFormData({...deepLinkConfig, enabled: true})}
+                onClose={handleModalClose}
+                onSubmit={handleAddExtension}
+                submitLabel="Add Extension"
+                modalType={'add'}
+            />
         )}
       </div>
     </section>

--- a/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
+++ b/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
@@ -18,10 +18,10 @@ import { ExtensionConfig } from '../../../api/types.gen';
 
 interface ExtensionSectionProps {
   deepLinkConfig?: ExtensionConfig;
-  needsEnvVars?: boolean;
+  showEnvVars?: boolean;
 }
 
-export default function ExtensionsSection({ deepLinkConfig, needsEnvVars }: ExtensionSectionProps) {
+export default function ExtensionsSection({ deepLinkConfig, showEnvVars }: ExtensionSectionProps) {
   const { getExtensions, addExtension, removeExtension } = useConfig();
   const [extensions, setExtensions] = useState<FixedExtensionEntry[]>([]);
   const [selectedExtension, setSelectedExtension] = useState<FixedExtensionEntry | null>(null);
@@ -30,9 +30,12 @@ export default function ExtensionsSection({ deepLinkConfig, needsEnvVars }: Exte
   const [deepLinkConfigStateVar, setDeepLinkConfigStateVar] = useState<
     ExtensionConfig | undefined | null
   >(deepLinkConfig);
-  const [needsEnvVarsStateVar, setNeedsEnvVarsStateVar] = useState<boolean | undefined | null>(
-    needsEnvVars
+  const [showEnvVarsStateVar, setShowEnvVarsStateVar] = useState<boolean | undefined | null>(
+    showEnvVars
   );
+
+  console.log('needsEnvVarsStateVar', showEnvVarsStateVar);
+  console.log('deepLinkConfigStateVar', deepLinkConfigStateVar);
 
   const fetchExtensions = useCallback(async () => {
     const extensionsList = await getExtensions(true); // Force refresh
@@ -127,7 +130,7 @@ export default function ExtensionsSection({ deepLinkConfig, needsEnvVars }: Exte
 
   const handleModalClose = () => {
     setDeepLinkConfigStateVar(null);
-    setNeedsEnvVarsStateVar(null);
+    setShowEnvVarsStateVar(null);
 
     setIsModalOpen(false);
     setIsAddModalOpen(false);
@@ -194,7 +197,7 @@ export default function ExtensionsSection({ deepLinkConfig, needsEnvVars }: Exte
         )}
 
         {/* Modal for adding extension from deeplink*/}
-        {deepLinkConfigStateVar && needsEnvVarsStateVar && (
+        {deepLinkConfigStateVar && showEnvVarsStateVar && (
           <ExtensionModal
             title="Add custom extension"
             initialData={extensionToFormData({ ...deepLinkConfig, enabled: true })}

--- a/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
+++ b/ui/desktop/src/components/settings_v2/extensions/ExtensionsSection.tsx
@@ -34,9 +34,6 @@ export default function ExtensionsSection({ deepLinkConfig, showEnvVars }: Exten
     showEnvVars
   );
 
-  console.log('needsEnvVarsStateVar', showEnvVarsStateVar);
-  console.log('deepLinkConfigStateVar', deepLinkConfigStateVar);
-
   const fetchExtensions = useCallback(async () => {
     const extensionsList = await getExtensions(true); // Force refresh
     // Sort extensions by name to maintain consistent order

--- a/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
@@ -130,7 +130,6 @@ export async function addExtensionFromDeepLink(
   if (config.envs && Object.keys(config.envs).length > 0) {
     console.log('Environment variables required, redirecting to settings');
     if (settingsV2Enabled) {
-      console.log('!!! redirecting to settings', { deepLinkConfig: config, showEnvVars: true });
       setView('settings', { deepLinkConfig: config, showEnvVars: true });
     } else {
       setView('settings', { extensionId: nameToKey(name), showEnvVars: true });

--- a/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
@@ -2,6 +2,7 @@ import type { ExtensionConfig } from '../../../api/types.gen';
 import { toastService } from '../../../toasts';
 import { activateExtension } from './extension-manager';
 import { DEFAULT_EXTENSION_TIMEOUT, nameToKey } from './utils';
+import {settingsV2Enabled} from "../../../flags";
 
 /**
  * Build an extension config for stdio from the deeplink URL
@@ -82,7 +83,7 @@ export async function addExtensionFromDeepLink(
     extensionConfig: ExtensionConfig,
     enabled: boolean
   ) => Promise<void>,
-  setView: (view: string, options: { extensionId: string; showEnvVars: boolean }) => void
+  setView: (view: string, options: { extensionId: string; showEnvVars: boolean } | {deepLinkConfig: ExtensionConfig, needsEnvVars: boolean}) => void
 ) {
   const parsedUrl = new URL(url);
 
@@ -123,7 +124,13 @@ export async function addExtensionFromDeepLink(
   // Check if extension requires env vars and go to settings if so
   if (config.envs && Object.keys(config.envs).length > 0) {
     console.log('Environment variables required, redirecting to settings');
-    setView('settings', { extensionId: nameToKey(name), showEnvVars: true });
+    if (settingsV2Enabled) {
+      setView('settings', { deepLinkConfig: config, needsEnvVars: true });
+
+    } else {
+      setView('settings', { extensionId: nameToKey(name), showEnvVars: true });
+
+    }
     return;
   }
 

--- a/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/deeplink.ts
@@ -2,7 +2,7 @@ import type { ExtensionConfig } from '../../../api/types.gen';
 import { toastService } from '../../../toasts';
 import { activateExtension } from './extension-manager';
 import { DEFAULT_EXTENSION_TIMEOUT, nameToKey } from './utils';
-import {settingsV2Enabled} from "../../../flags";
+import { settingsV2Enabled } from '../../../flags';
 
 /**
  * Build an extension config for stdio from the deeplink URL
@@ -83,7 +83,12 @@ export async function addExtensionFromDeepLink(
     extensionConfig: ExtensionConfig,
     enabled: boolean
   ) => Promise<void>,
-  setView: (view: string, options: { extensionId: string; showEnvVars: boolean } | {deepLinkConfig: ExtensionConfig, needsEnvVars: boolean}) => void
+  setView: (
+    view: string,
+    options:
+      | { extensionId: string; showEnvVars: boolean }
+      | { deepLinkConfig: ExtensionConfig; showEnvVars: boolean }
+  ) => void
 ) {
   const parsedUrl = new URL(url);
 
@@ -125,11 +130,10 @@ export async function addExtensionFromDeepLink(
   if (config.envs && Object.keys(config.envs).length > 0) {
     console.log('Environment variables required, redirecting to settings');
     if (settingsV2Enabled) {
-      setView('settings', { deepLinkConfig: config, needsEnvVars: true });
-
+      console.log('!!! redirecting to settings', { deepLinkConfig: config, showEnvVars: true });
+      setView('settings', { deepLinkConfig: config, showEnvVars: true });
     } else {
       setView('settings', { extensionId: nameToKey(name), showEnvVars: true });
-
     }
     return;
   }


### PR DESCRIPTION
We had deeplink support for extensions with _no_ env vars, but if we do have env vars, we need a way for users to fill them out. Video below: 


https://github.com/user-attachments/assets/c81e0e07-72ea-413d-ae8e-455d42e4c8a8

