### PR TITLE
refactor: small piece of agent.reply()

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -28,7 +28,7 @@ use mcp_core::{
 };
 
 use crate::agents::platform_tools::{
-    self, PLATFORM_LIST_RESOURCES_TOOL_NAME, PLATFORM_READ_RESOURCE_TOOL_NAME,
+    PLATFORM_LIST_RESOURCES_TOOL_NAME, PLATFORM_READ_RESOURCE_TOOL_NAME,
     PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME,
 };
 use crate::agents::prompt_manager::PromptManager;

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::{anyhow, Result};
@@ -19,11 +19,7 @@ use crate::permission::permission_judge::check_tool_permissions;
 use crate::permission::{Permission, PermissionConfirmation};
 use crate::providers::base::Provider;
 use crate::providers::errors::ProviderError;
-use crate::providers::toolshim::{
-    augment_message_with_tool_calls, modify_system_prompt_for_tool_json, OllamaInterpreter,
-};
 use crate::recipe::{Author, Recipe};
-use crate::session;
 use crate::token_counter::TokenCounter;
 use crate::truncate::{truncate_messages, OldestFirstTruncation};
 
@@ -118,7 +114,7 @@ impl Agent {
         tool_call: mcp_core::tool::ToolCall,
         request_id: String,
     ) -> (String, Result<Vec<Content>, ToolError>) {
-        let mut extension_manager = self.extension_manager.lock().await;
+        let extension_manager = self.extension_manager.lock().await;
         let result = if tool_call.name == PLATFORM_READ_RESOURCE_TOOL_NAME {
             // Check if the tool is read_resource and handle it separately
             extension_manager
@@ -276,7 +272,7 @@ impl Agent {
     }
 
     pub async fn list_tools(&self) -> Vec<Tool> {
-        let mut extension_manager = self.extension_manager.lock().await;
+        let extension_manager = self.extension_manager.lock().await;
         extension_manager
             .get_prefixed_tools()
             .await
@@ -663,7 +659,7 @@ impl Agent {
     }
 
     pub async fn get_plan_prompt(&self) -> anyhow::Result<String> {
-        let mut extension_manager = self.extension_manager.lock().await;
+        let extension_manager = self.extension_manager.lock().await;
         let tools = extension_manager.get_prefixed_tools().await?;
         let tools_info = tools
             .into_iter()
@@ -689,7 +685,7 @@ impl Agent {
     }
 
     pub async fn create_recipe(&self, mut messages: Vec<Message>) -> Result<Recipe> {
-        let mut extension_manager = self.extension_manager.lock().await;
+        let extension_manager = self.extension_manager.lock().await;
         let extensions_info = extension_manager.get_extensions_info().await;
         let system_prompt = self
             .prompt_manager

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -229,7 +229,7 @@ impl ExtensionManager {
     }
 
     /// Get all tools from all clients with proper prefixing
-    pub async fn get_prefixed_tools(&mut self) -> ExtensionResult<Vec<Tool>> {
+    pub async fn get_prefixed_tools(&self) -> ExtensionResult<Vec<Tool>> {
         let mut tools = Vec::new();
 
         // Add tools from MCP extensions with prefixing

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -3,8 +3,8 @@ pub mod extension;
 pub mod extension_manager;
 pub mod platform_tools;
 pub mod prompt_manager;
-mod types;
 mod reply_parts;
+mod types;
 
 pub use agent::Agent;
 pub use extension::ExtensionConfig;

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -4,6 +4,7 @@ pub mod extension_manager;
 pub mod platform_tools;
 pub mod prompt_manager;
 mod types;
+mod reply_parts;
 
 pub use agent::Agent;
 pub use extension::ExtensionConfig;

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -59,7 +59,7 @@ impl Agent {
         Ok((tools, toolshim_tools, system_prompt))
     }
 
-     /// Categorize tools based on their annotations
+    /// Categorize tools based on their annotations
     /// Returns:
     /// - read_only_tools: Tools with read-only annotations
     /// - non_read_tools: Tools without read-only annotations
@@ -93,9 +93,7 @@ impl Agent {
         let config = provider.get_model_config();
 
         // Call the provider to get a response
-        let (mut response, usage) = provider
-            .complete(system_prompt, messages, tools)
-            .await?;
+        let (mut response, usage) = provider.complete(system_prompt, messages, tools).await?;
 
         // Post-process / structure the response only if tool interpretation is enabled
         if config.toolshim {
@@ -134,12 +132,17 @@ impl Agent {
         let accumulate = |a: Option<i32>, b: Option<i32>| -> Option<i32> {
             match (a, b) {
                 (Some(x), Some(y)) => Some(x + y),
-                _ => a.or(b)
+                _ => a.or(b),
             }
         };
-        metadata.accumulated_total_tokens = accumulate(metadata.accumulated_total_tokens, usage.usage.total_tokens);
-        metadata.accumulated_input_tokens = accumulate(metadata.accumulated_input_tokens, usage.usage.input_tokens);
-        metadata.accumulated_output_tokens = accumulate(metadata.accumulated_output_tokens, usage.usage.output_tokens);
+        metadata.accumulated_total_tokens =
+            accumulate(metadata.accumulated_total_tokens, usage.usage.total_tokens);
+        metadata.accumulated_input_tokens =
+            accumulate(metadata.accumulated_input_tokens, usage.usage.input_tokens);
+        metadata.accumulated_output_tokens = accumulate(
+            metadata.accumulated_output_tokens,
+            usage.usage.output_tokens,
+        );
         session::update_metadata(&session_file, &metadata).await?;
 
         Ok(())

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -1,0 +1,147 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use anyhow::Result;
+
+use crate::agents::{platform_tools, ExtensionManager};
+use crate::message::Message;
+use crate::providers::base::{Provider, ProviderUsage};
+use crate::providers::errors::ProviderError;
+use crate::providers::toolshim::{
+    augment_message_with_tool_calls, modify_system_prompt_for_tool_json, OllamaInterpreter,
+};
+use crate::session;
+use mcp_core::tool::Tool;
+
+use super::super::agents::Agent;
+
+impl Agent {
+    /// Prepares tools and system prompt for a provider request
+    pub(crate) async fn prepare_tools_and_prompt(
+        &self,
+    ) -> anyhow::Result<(Vec<Tool>, Vec<Tool>, String)> {
+        let mut extension_manager = self.extension_manager.lock().await;
+        // Get tools from extension manager
+        let mut tools = extension_manager.get_prefixed_tools().await?;
+
+        // Add resource tools if supported
+        if extension_manager.supports_resources() {
+            tools.push(platform_tools::read_resource_tool());
+            tools.push(platform_tools::list_resources_tool());
+        }
+
+        // Add platform tools
+        tools.push(platform_tools::search_available_extensions_tool());
+        tools.push(platform_tools::enable_extension_tool());
+
+        // Add frontend tools
+        for frontend_tool in self.frontend_tools.values() {
+            tools.push(frontend_tool.tool.clone());
+        }
+
+        // Prepare system prompt
+        let extensions_info = extension_manager.get_extensions_info().await;
+        let mut system_prompt = self
+            .prompt_manager
+            .build_system_prompt(extensions_info, self.frontend_instructions.clone());
+
+        // Handle toolshim if enabled
+        let mut toolshim_tools = vec![];
+        if self.provider.get_model_config().toolshim {
+            // If tool interpretation is enabled, modify the system prompt
+            system_prompt = modify_system_prompt_for_tool_json(&system_prompt, &tools);
+            // Make a copy of tools before emptying
+            toolshim_tools = tools.clone();
+            // Empty the tools vector for provider completion
+            tools = vec![];
+        }
+
+        Ok((tools, toolshim_tools, system_prompt))
+    }
+
+     /// Categorize tools based on their annotations
+    /// Returns:
+    /// - read_only_tools: Tools with read-only annotations
+    /// - non_read_tools: Tools without read-only annotations
+    pub(crate) fn categorize_tools_by_annotation(
+        tools: &[Tool],
+    ) -> (HashSet<String>, HashSet<String>) {
+        tools
+            .iter()
+            .fold((HashSet::new(), HashSet::new()), |mut acc, tool| {
+                match &tool.annotations {
+                    Some(annotations) if annotations.read_only_hint => {
+                        acc.0.insert(tool.name.clone());
+                    }
+                    _ => {
+                        acc.1.insert(tool.name.clone());
+                    }
+                }
+                acc
+            })
+    }
+
+    /// Generate a response from the LLM provider
+    /// Handles toolshim transformations if needed
+    pub(crate) async fn generate_response_from_provider(
+        provider: Arc<dyn Provider>,
+        system_prompt: &str,
+        messages: &[Message],
+        tools: &[Tool],
+        toolshim_tools: &[Tool],
+    ) -> Result<(Message, ProviderUsage), ProviderError> {
+        let config = provider.get_model_config();
+
+        // Call the provider to get a response
+        let (mut response, usage) = provider
+            .complete(system_prompt, messages, tools)
+            .await?;
+
+        // Post-process / structure the response only if tool interpretation is enabled
+        if config.toolshim {
+            let interpreter = OllamaInterpreter::new().map_err(|e| {
+                ProviderError::ExecutionError(format!("Failed to create OllamaInterpreter: {}", e))
+            })?;
+
+            response = augment_message_with_tool_calls(&interpreter, response, toolshim_tools)
+                .await
+                .map_err(|e| {
+                    ProviderError::ExecutionError(format!("Failed to augment message: {}", e))
+                })?;
+        }
+
+        Ok((response, usage))
+    }
+
+    /// Update session metrics after a response
+    pub(crate) async fn update_session_metrics(
+        session_config: crate::agents::types::SessionConfig,
+        usage: &crate::providers::base::ProviderUsage,
+        messages_length: usize,
+    ) -> Result<()> {
+        let session_file = session::get_path(session_config.id);
+        let mut metadata = session::read_metadata(&session_file)?;
+
+        metadata.working_dir = session_config.working_dir.clone();
+        metadata.total_tokens = usage.usage.total_tokens;
+        metadata.input_tokens = usage.usage.input_tokens;
+        metadata.output_tokens = usage.usage.output_tokens;
+        // The message count is the number of messages in the session + 1 for the response
+        // The message count does not include the tool response till next iteration
+        metadata.message_count = messages_length + 1;
+
+        // Keep running sum of tokens to track cost over the entire session
+        let accumulate = |a: Option<i32>, b: Option<i32>| -> Option<i32> {
+            match (a, b) {
+                (Some(x), Some(y)) => Some(x + y),
+                _ => a.or(b)
+            }
+        };
+        metadata.accumulated_total_tokens = accumulate(metadata.accumulated_total_tokens, usage.usage.total_tokens);
+        metadata.accumulated_input_tokens = accumulate(metadata.accumulated_input_tokens, usage.usage.input_tokens);
+        metadata.accumulated_output_tokens = accumulate(metadata.accumulated_output_tokens, usage.usage.output_tokens);
+        session::update_metadata(&session_file, &metadata).await?;
+
+        Ok(())
+    }
+}

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 
-use crate::agents::{platform_tools, ExtensionManager};
+use crate::agents::platform_tools;
 use crate::message::Message;
 use crate::providers::base::{Provider, ProviderUsage};
 use crate::providers::errors::ProviderError;
@@ -20,7 +20,7 @@ impl Agent {
     pub(crate) async fn prepare_tools_and_prompt(
         &self,
     ) -> anyhow::Result<(Vec<Tool>, Vec<Tool>, String)> {
-        let mut extension_manager = self.extension_manager.lock().await;
+        let extension_manager = self.extension_manager.lock().await;
         // Get tools from extension manager
         let mut tools = extension_manager.get_prefixed_tools().await?;
 

--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -31,7 +31,7 @@ pub struct SessionMetadata {
     pub input_tokens: Option<i32>,
     /// The number of output tokens used in the session. Retrieved from the provider's last usage.
     pub output_tokens: Option<i32>,
-    /// The total number of tokens used in the session. Accumulated across all messages.
+    /// The total number of tokens used in the session. Accumulated across all messages (useful for tracking cost over an entire session).
     pub accumulated_total_tokens: Option<i32>,
     /// The number of input tokens used in the session. Accumulated across all messages.
     pub accumulated_input_tokens: Option<i32>,


### PR DESCRIPTION
tried a bigger refactor but that failed before: https://github.com/block/goose/pull/2126 

Challenge:
- You cannot capture or call yield within a normal closure (or an async closure) because yield is tied to the generator’s internal control flow. The code block inside async_stream::try_stream! { ... } is a generator; yield must be invoked directly there. This limits our ability to move a lot of mode for goose_mode = "approval" and permissions 


Improvements:
- move to smaller focused functions on preparing tools and prompt, generating provider response
- not holding onto the extension manager lock for the entire reply() method