### PR TITLE
docs: Update workflow to fix broken pr previews

### DIFF
--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  
-  pull_request:
     paths:
       - 'documentation/**'
 
@@ -48,3 +46,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: documentation/build
+          keep_files: true           # This preserves existing files in gh-pages branch especially for previews


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/deploy-docs-and-extensions.yml` file to improve the deployment process for documentation and extensions. The most important changes include removing the `pull_request` trigger and adding a new configuration to preserve existing files in the `gh-pages` branch.

Workflow trigger changes:

* [`.github/workflows/deploy-docs-and-extensions.yml`](diffhunk://#diff-f4f5e7e1f608be6cd836684bc3c5094e63edbedfb2baee8512005bf9fb7450d3L7-L8): Removed the `pull_request` trigger to streamline the deployment process.

Deployment configuration changes:

* [`.github/workflows/deploy-docs-and-extensions.yml`](diffhunk://#diff-f4f5e7e1f608be6cd836684bc3c5094e63edbedfb2baee8512005bf9fb7450d3R49): Added `keep_files: true` to the `publish_dir` configuration to preserve existing files in the `gh-pages` branch, which is especially useful for previews.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209960159539937