### PR TITLE
ui: make sure all bundled extensions use the display name

### DIFF
--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "goose-app",
-  "version": "1.0.18",
+  "version": "1.0.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "goose-app",
-      "version": "1.0.18",
+      "version": "1.0.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai": "^0.0.72",

--- a/ui/desktop/src/components/settings_v2/extensions/subcomponents/ExtensionList.tsx
+++ b/ui/desktop/src/components/settings_v2/extensions/subcomponents/ExtensionList.tsx
@@ -32,7 +32,7 @@ export function getFriendlyTitle(extension: FixedExtensionEntry): string {
   let name = '';
 
   // if it's a builtin, check if there's a display_name (old configs didn't have this field)
-  if (extension.type === 'builtin' && 'display_name' in extension && extension.display_name) {
+  if (extension.bundled === true && 'display_name' in extension && extension.display_name) {
     // If we have a display_name for a builtin, use it directly
     return extension.display_name;
   } else {


### PR DESCRIPTION
We used to only check extensions that were of type `builtin` for a `display_name` and if yes, use that to label the Extension card in the setting page -- this is because bundled extensions (defined in json) may have a specific display name we want to show to users

However, some bundled extensions may be of type `stdio` or `sse` so rather than check that `extension.type == 'builtin'` we should check that `extension.bundled == true`. This will make sure that all bundled extensions use the display name if a display name is present in the extension object