### PR TITLE
feat: improve tool loading

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -973,6 +973,7 @@ pub async fn configure_tool_permissions_dialog() -> Result<(), Box<dyn Error>> {
             style("Warning").yellow().italic(),
             selected_extension_name
         );
+        return Ok(());
     }
 
     let mut permission_manager = PermissionManager::default();

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -2,7 +2,10 @@ use cliclack::spinner;
 use console::style;
 use goose::agents::extension::ToolInfo;
 use goose::agents::extension_manager::get_parameter_names;
-use goose::agents::platform_tools::PLATFORM_ENABLE_EXTENSION_TOOL_NAME;
+use goose::agents::platform_tools::{
+    PLATFORM_ENABLE_EXTENSION_TOOL_NAME, PLATFORM_LIST_RESOURCES_TOOL_NAME,
+    PLATFORM_READ_RESOURCE_TOOL_NAME,
+};
 use goose::agents::Agent;
 use goose::agents::{extension::Envs, ExtensionConfig};
 use goose::config::extensions::name_to_key;
@@ -981,7 +984,11 @@ pub async fn configure_tool_permissions_dialog() -> Result<(), Box<dyn Error>> {
         .list_tools(Some(selected_extension_name.clone()))
         .await
         .into_iter()
-        .filter(|tool| tool.name != PLATFORM_ENABLE_EXTENSION_TOOL_NAME)
+        .filter(|tool| {
+            tool.name != PLATFORM_ENABLE_EXTENSION_TOOL_NAME
+                && tool.name != PLATFORM_LIST_RESOURCES_TOOL_NAME
+                && tool.name != PLATFORM_READ_RESOURCE_TOOL_NAME
+        })
         .map(|tool| {
             ToolInfo::new(
                 &tool.name,

--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -203,17 +203,9 @@ async fn get_tools(
     let permission_manager = PermissionManager::default();
 
     let mut tools: Vec<ToolInfo> = agent
-        .list_tools()
+        .list_tools(query.extension_name)
         .await
         .into_iter()
-        .filter(|tool| {
-            // Apply the filter only if the extension name is present in the query
-            if let Some(extension_name) = &query.extension_name {
-                tool.name.starts_with(extension_name)
-            } else {
-                true
-            }
-        })
         .map(|tool| {
             let permission = permission_manager
                 .get_user_permission(&tool.name)

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -274,18 +274,20 @@ impl Agent {
     pub async fn list_tools(&self, extension_name: Option<String>) -> Vec<Tool> {
         let extension_manager = self.extension_manager.lock().await;
         let mut prefixed_tools = extension_manager
-            .get_prefixed_tools(extension_name)
+            .get_prefixed_tools(extension_name.clone())
             .await
             .unwrap_or_default();
 
-        // Add platform tools
-        prefixed_tools.push(platform_tools::search_available_extensions_tool());
-        prefixed_tools.push(platform_tools::enable_extension_tool());
+        if extension_name.is_none() || extension_name.as_deref() == Some("platform") {
+            // Add platform tools
+            prefixed_tools.push(platform_tools::search_available_extensions_tool());
+            prefixed_tools.push(platform_tools::enable_extension_tool());
 
-        // Add resource tools if supported
-        if extension_manager.supports_resources() {
-            prefixed_tools.push(platform_tools::read_resource_tool());
-            prefixed_tools.push(platform_tools::list_resources_tool());
+            // Add resource tools if supported
+            if extension_manager.supports_resources() {
+                prefixed_tools.push(platform_tools::read_resource_tool());
+                prefixed_tools.push(platform_tools::list_resources_tool());
+            }
         }
 
         prefixed_tools

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -96,7 +96,7 @@ impl Agent {
             .extension_manager
             .lock()
             .await
-            .get_prefixed_tools()
+            .get_prefixed_tools(None)
             .await?;
 
         // Add frontend tools directly - they don't need prefixing since they're already uniquely named
@@ -271,10 +271,10 @@ impl Agent {
         Ok(())
     }
 
-    pub async fn list_tools(&self) -> Vec<Tool> {
+    pub async fn list_tools(&self, extension_name: Option<String>) -> Vec<Tool> {
         let extension_manager = self.extension_manager.lock().await;
         let mut prefixed_tools = extension_manager
-            .get_prefixed_tools()
+            .get_prefixed_tools(extension_name)
             .await
             .unwrap_or_default();
 
@@ -580,7 +580,7 @@ impl Agent {
 
     pub async fn get_plan_prompt(&self) -> anyhow::Result<String> {
         let extension_manager = self.extension_manager.lock().await;
-        let tools = extension_manager.get_prefixed_tools().await?;
+        let tools = extension_manager.get_prefixed_tools(None).await?;
         let tools_info = tools
             .into_iter()
             .map(|tool| {
@@ -612,7 +612,7 @@ impl Agent {
             .build_system_prompt(extensions_info, self.frontend_instructions.clone());
 
         let recipe_prompt = self.prompt_manager.get_recipe_prompt().await;
-        let tools = extension_manager.get_prefixed_tools().await?;
+        let tools = extension_manager.get_prefixed_tools(None).await?;
 
         messages.push(Message::user().with_text(recipe_prompt));
 

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -231,8 +231,20 @@ impl ExtensionManager {
     }
 
     /// Get all tools from all clients with proper prefixing
-    pub async fn get_prefixed_tools(&self) -> ExtensionResult<Vec<Tool>> {
-        let client_futures = self.clients.iter().map(|(name, client)| {
+    pub async fn get_prefixed_tools(
+        &self,
+        extension_name: Option<String>,
+    ) -> ExtensionResult<Vec<Tool>> {
+        // Filter clients based on the provided extension_name or include all if None
+        let filtered_clients = self.clients.iter().filter(|(name, _)| {
+            if let Some(ref name_filter) = extension_name {
+                *name == name_filter
+            } else {
+                true
+            }
+        });
+
+        let client_futures = filtered_clients.map(|(name, client)| {
             let name = name.clone();
             let client = client.clone();
 

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -19,7 +19,7 @@ impl Agent {
         &self,
     ) -> anyhow::Result<(Vec<Tool>, Vec<Tool>, String)> {
         // Get tools from extension manager
-        let mut tools = self.list_tools().await;
+        let mut tools = self.list_tools(None).await;
 
         // Add frontend tools
         for frontend_tool in self.frontend_tools.values() {

--- a/ui/desktop/src/components/settings_v2/permission/PermissionModal.tsx
+++ b/ui/desktop/src/components/settings_v2/permission/PermissionModal.tsx
@@ -33,7 +33,10 @@ export default function PermissionModal({ extensionName, onClose }: PermissionMo
           console.error('Failed to get tools');
         } else {
           const filteredTools = (response.data || []).filter(
-            (tool) => tool.name !== 'platform__enable_extension'
+            (tool) =>
+              tool.name !== 'platform__enable_extension' &&
+              tool.name !== 'platform__read_resource' &&
+              tool.name !== 'platform__list_resources'
           );
           setTools(filteredTools);
         }


### PR DESCRIPTION
Previously we first list all tool and do the filter, it takes longer time than filter by extension name first.

Test:

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Goose Settings 
│
◇  What setting would you like to configure?
│  Tool Permission 
│
◇  Choose an extension to configure tools
│  developer 
│
◇  Choose a tool to update permission
│  developer__list_windows 
│
◇  Set permission level for tool developer__list_windows, current permission level: Always Allow
│  Always Allow 
│
└  Updated permission level for tool developer__list_windows to Always Allow.
```