### PR TITLE
fix: propagate errors when attempting to add extensions

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -264,7 +264,7 @@ impl Agent {
             }
             _ => {
                 let mut extension_manager = self.extension_manager.lock().await;
-                let _ = extension_manager.add_extension(extension).await;
+                extension_manager.add_extension(extension).await?;
             }
         };
 


### PR DESCRIPTION
previously it was a let _ = ... which would ignore the error from the result and always look like a success