### PR TITLE
fix: expose tool not support error

### DIFF
--- a/crates/goose/src/providers/errors.rs
+++ b/crates/goose/src/providers/errors.rs
@@ -93,7 +93,7 @@ where
 
     struct CodeVisitor;
 
-    impl<'de> Visitor<'de> for CodeVisitor {
+    impl Visitor<'_> for CodeVisitor {
         type Value = Option<String>;
 
         fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {

--- a/crates/goose/src/providers/errors.rs
+++ b/crates/goose/src/providers/errors.rs
@@ -75,12 +75,54 @@ impl GoogleErrorCode {
     }
 }
 
-#[derive(serde::Deserialize)]
+#[derive(serde::Deserialize, Debug)]
 pub struct OpenAIError {
+    #[serde(deserialize_with = "code_as_string")]
     pub code: Option<String>,
     pub message: Option<String>,
     #[serde(rename = "type")]
     pub error_type: Option<String>,
+}
+
+fn code_as_string<'de, D>(deserializer: D) -> Result<Option<String>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    use serde::de::{self, Visitor};
+    use std::fmt;
+
+    struct CodeVisitor;
+
+    impl<'de> Visitor<'de> for CodeVisitor {
+        type Value = Option<String>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a string or a number for the code field")
+        }
+
+        fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Some(value.to_string()))
+        }
+
+        fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(Some(value.to_string()))
+        }
+
+        fn visit_none<E>(self) -> Result<Self::Value, E>
+        where
+            E: de::Error,
+        {
+            Ok(None)
+        }
+    }
+
+    deserializer.deserialize_any(CodeVisitor)
 }
 
 impl OpenAIError {

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -20,7 +20,12 @@ pub const OPENROUTER_DEFAULT_MODEL: &str = "anthropic/claude-3.5-sonnet";
 pub const OPENROUTER_MODEL_PREFIX_ANTHROPIC: &str = "anthropic";
 
 // OpenRouter can run many models, we suggest the default
-pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[OPENROUTER_DEFAULT_MODEL];
+pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
+    "anthropic/claude-3.5-sonnet",
+    "anthropic/claude-3.7-sonnet",
+    "google/gemini-2.5-pro-exp-03-25:free",
+    "deepseek/deepseek-r1",
+];
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 
 #[derive(serde::Serialize)]

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.17"
+    "version": "1.0.18"
   },
   "paths": {
     "/agent/tools": {


### PR DESCRIPTION
Support parsing error code as number, in openrouter, the error code is number instead of string, so we will not expose the error detail to user.

Before:
![image](https://github.com/user-attachments/assets/b917c3fb-9781-4924-859e-60453315f85e)

After:
![image](https://github.com/user-attachments/assets/ec97f269-2837-484b-88e6-57267953623f)
