### PR TITLE
feat: handle enabling and disabling multiple extensions

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -3,7 +3,7 @@ use console::style;
 use goose::agents::extension::ToolInfo;
 use goose::agents::extension_manager::get_parameter_names;
 use goose::agents::platform_tools::{
-    PLATFORM_DISABLE_EXTENSION_TOOL_NAME, PLATFORM_ENABLE_EXTENSION_TOOL_NAME,
+    PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME, PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME,
     PLATFORM_LIST_RESOURCES_TOOL_NAME, PLATFORM_READ_RESOURCE_TOOL_NAME,
 };
 use goose::agents::Agent;
@@ -985,10 +985,10 @@ pub async fn configure_tool_permissions_dialog() -> Result<(), Box<dyn Error>> {
         .await
         .into_iter()
         .filter(|tool| {
-            tool.name != PLATFORM_ENABLE_EXTENSION_TOOL_NAME
+            tool.name != PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME
                 && tool.name != PLATFORM_LIST_RESOURCES_TOOL_NAME
                 && tool.name != PLATFORM_READ_RESOURCE_TOOL_NAME
-                && tool.name != PLATFORM_DISABLE_EXTENSION_TOOL_NAME
+                && tool.name != PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME
         })
         .map(|tool| {
             ToolInfo::new(

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -17,7 +17,7 @@ use completion::GooseCompleter;
 use etcetera::choose_app_strategy;
 use etcetera::AppStrategy;
 use goose::agents::extension::{Envs, ExtensionConfig};
-use goose::agents::platform_tools::PLATFORM_ENABLE_EXTENSION_TOOL_NAME;
+use goose::agents::platform_tools::PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME;
 use goose::agents::{Agent, SessionConfig};
 use goose::config::Config;
 use goose::message::{Message, MessageContent};
@@ -624,16 +624,16 @@ impl Session {
                             } else if let Some(MessageContent::ExtensionRequest(extension_request)) = message.content.first() {
                                 output::hide_thinking();
 
-                                let extension_action = if extension_request.tool_name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME {
+                                let extension_action = if extension_request.tool_name == PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME {
                                     "enable"
                                 } else {
                                     "disable"
                                 };
 
-                                let prompt = format!("Goose would like to {} the following extension, do you approve?", extension_action);
+                                let prompt = format!("Goose would like to {} the following extensions, do you approve?", extension_action);
                                 let confirmed = cliclack::select(prompt)
-                                    .item(true, "Yes, for this session", format!("{} the extension for this session", extension_action))
-                                    .item(false, "No", format!("Do not {} the extension", extension_action))
+                                    .item(true, "Yes, for this session", format!("{} the extensions for this session", extension_action))
+                                    .item(false, "No", format!("Do not {} the extensions", extension_action))
                                     .interact()?;
                                 let permission = if confirmed {
                                     Permission::AllowOnce

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -208,13 +208,15 @@ impl Agent {
         for extension_name in &extension_names {
             match ExtensionConfigManager::get_config_by_name(extension_name) {
                 Ok(Some(config)) => configs.push(config),
-                Ok(None) => return (
-                    request_id,
-                    Err(ToolError::ExecutionError(format!(
+                Ok(None) => {
+                    return (
+                        request_id,
+                        Err(ToolError::ExecutionError(format!(
                         "Extension '{}' not found. Please check the extension name and try again.",
                         extension_name
                     ))),
-                ),
+                    )
+                }
                 Err(e) => {
                     return (
                         request_id,

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, instrument, warn};
 use crate::agents::extension::{ExtensionConfig, ExtensionResult, ToolInfo};
 use crate::agents::extension_manager::{get_parameter_names, ExtensionManager};
 use crate::agents::platform_tools::{
-    PLATFORM_DISABLE_EXTENSION_TOOL_NAME, PLATFORM_ENABLE_EXTENSION_TOOL_NAME,
+    PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME, PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME,
     PLATFORM_LIST_RESOURCES_TOOL_NAME, PLATFORM_READ_RESOURCE_TOOL_NAME,
     PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME,
 };
@@ -197,59 +197,87 @@ impl Agent {
 
     pub(super) async fn handle_extension_request(
         &self,
-        extension_name: String,
+        extension_names: Vec<String>,
         request_id: String,
         tool_name: String,
     ) -> (String, Result<Vec<Content>, ToolError>) {
         let mut extension_manager = self.extension_manager.lock().await;
-        let config = match ExtensionConfigManager::get_config_by_name(&extension_name) {
-            Ok(Some(config)) => config,
-            Ok(None) => {
-                return (
+
+        // Get configs for all extension names
+        let mut configs = Vec::new();
+        for extension_name in &extension_names {
+            match ExtensionConfigManager::get_config_by_name(extension_name) {
+                Ok(Some(config)) => configs.push(config),
+                Ok(None) => return (
                     request_id,
                     Err(ToolError::ExecutionError(format!(
                         "Extension '{}' not found. Please check the extension name and try again.",
                         extension_name
                     ))),
-                )
-            }
-            Err(e) => {
-                return (
-                    request_id,
-                    Err(ToolError::ExecutionError(format!(
-                        "Failed to get extension config: {}",
-                        e
-                    ))),
-                )
-            }
-        };
+                ),
+                Err(e) => {
+                    return (
+                        request_id,
+                        Err(ToolError::ExecutionError(format!(
+                            "Failed to get extension config: {}",
+                            e
+                        ))),
+                    )
+                }
+            };
+        }
 
         match tool_name {
-            ref name if name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME => {
-                let result = extension_manager
-                    .add_extension(config)
-                    .await
-                    .map(|_| {
-                        vec![Content::text(format!(
+            ref name if name == PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME => {
+                let mut success_messages = Vec::new();
+                let mut errors = Vec::new();
+
+                // Process each config
+                for config in configs {
+                    let name = config.name();
+                    match extension_manager.add_extension(config).await {
+                        Ok(_) => success_messages.push(format!(
                             "The extension '{}' has been installed successfully",
-                            extension_name
-                        ))]
-                    })
-                    .map_err(|e| ToolError::ExecutionError(e.to_string()));
+                            name
+                        )),
+                        Err(e) => {
+                            errors.push(format!("Failed to install extension '{}': {}", name, e))
+                        }
+                    }
+                }
+
+                let result = if !errors.is_empty() {
+                    Err(ToolError::ExecutionError(errors.join("\n")))
+                } else {
+                    Ok(vec![Content::text(success_messages.join("\n"))])
+                };
 
                 (request_id, result)
             }
-            ref name if name == PLATFORM_DISABLE_EXTENSION_TOOL_NAME => {
-                let result = extension_manager
-                    .remove_extension(&extension_name)
-                    .await
-                    .map(|_| {
-                        vec![Content::text(format!(
+            ref name if name == PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME => {
+                let mut success_messages = Vec::new();
+                let mut errors = Vec::new();
+
+                // Process each config
+                for config in configs {
+                    let name = config.name();
+                    match extension_manager.remove_extension(&name).await {
+                        Ok(_) => success_messages.push(format!(
                             "The extension '{}' has been removed successfully",
-                            extension_name
-                        ))]
-                    })
-                    .map_err(|e| ToolError::ExecutionError(e.to_string()));
+                            name
+                        )),
+                        Err(e) => {
+                            errors.push(format!("Failed to remove extension '{}': {}", name, e))
+                        }
+                    }
+                }
+
+                let result = if !errors.is_empty() {
+                    Err(ToolError::ExecutionError(errors.join("\n")))
+                } else {
+                    Ok(vec![Content::text(success_messages.join("\n"))])
+                };
+
                 (request_id, result)
             }
             _ => {
@@ -309,8 +337,8 @@ impl Agent {
         if extension_name.is_none() || extension_name.as_deref() == Some("platform") {
             // Add platform tools
             prefixed_tools.push(platform_tools::search_available_extensions_tool());
-            prefixed_tools.push(platform_tools::enable_extension_tool());
-            prefixed_tools.push(platform_tools::disable_extension_tool());
+            prefixed_tools.push(platform_tools::enable_extensions_tool());
+            prefixed_tools.push(platform_tools::disable_extensions_tool());
 
             // Add resource tools if supported
             if extension_manager.supports_resources() {

--- a/crates/goose/src/agents/platform_tools.rs
+++ b/crates/goose/src/agents/platform_tools.rs
@@ -6,8 +6,8 @@ pub const PLATFORM_READ_RESOURCE_TOOL_NAME: &str = "platform__read_resource";
 pub const PLATFORM_LIST_RESOURCES_TOOL_NAME: &str = "platform__list_resources";
 pub const PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME: &str =
     "platform__search_available_extensions";
-pub const PLATFORM_ENABLE_EXTENSION_TOOL_NAME: &str = "platform__enable_extension";
-pub const PLATFORM_DISABLE_EXTENSION_TOOL_NAME: &str = "platform__disable_extension";
+pub const PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME: &str = "platform__enables_extension";
+pub const PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME: &str = "platform__disables_extension";
 
 pub fn read_resource_tool() -> Tool {
     Tool::new(
@@ -88,18 +88,22 @@ pub fn search_available_extensions_tool() -> Tool {
     )
 }
 
-pub fn enable_extension_tool() -> Tool {
+pub fn enable_extensions_tool() -> Tool {
     Tool::new(
-        PLATFORM_ENABLE_EXTENSION_TOOL_NAME.to_string(),
+        PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME.to_string(),
         "Enable extensions to help complete tasks.
             Enable an extension by providing the extension name.
             "
         .to_string(),
         json!({
             "type": "object",
-            "required": ["extension_name"],
+            "required": ["extension_names"],
             "properties": {
-                "extension_name": {"type": "string", "description": "The name of the extension to enable"}
+                "extension_names": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "The names of the extensions to enable"
+                }
             }
         }),
         Some(ToolAnnotations {
@@ -112,17 +116,21 @@ pub fn enable_extension_tool() -> Tool {
     )
 }
 
-pub fn disable_extension_tool() -> Tool {
+pub fn disable_extensions_tool() -> Tool {
     Tool::new(
-        PLATFORM_DISABLE_EXTENSION_TOOL_NAME.to_string(),
+        PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME.to_string(),
         "Disable extensions to preserve relevant extensions and tools.
         "
         .to_string(),
         json!({
             "type": "object",
-            "required": ["extension_name"],
+            "required": ["extension_names"],
             "properties": {
-                "extension_name": {"type": "string", "description": "The name of the extension to disable"}
+                "extension_names": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": "The names of the extensions to disable"
+                }
             }
         }),
         Some(ToolAnnotations {

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -58,14 +58,18 @@ impl Agent {
                         if req_id == request.id {
                             if confirmation.permission == Permission::AllowOnce || confirmation.permission == Permission::AlwaysAllow {
                                 if principal_type == PrincipalType::Extension {
-                                    let extension_name = tool_call.arguments.get("extension_name")
-                                                    .and_then(|v| v.as_str())
-                                                    .unwrap_or("")
-                                                    .to_string();
+                                    let extension_names = tool_call
+                                        .arguments
+                                        .get("extension_names")
+                                        .and_then(|v| v.as_array())
+                                        .and_then(|arr| arr.first())
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("")
+                                        .to_string();
                                     let tool_name = tool_call.name.clone();
 
                                     let mut results = install_results.lock().await;
-                                    let install_result = self.handle_extension_request(extension_name, request.id.clone(), tool_name).await;
+                                    let install_result = self.handle_extension_request(vec![extension_names.clone()], request.id.clone(), tool_name).await;
                                     results.push(install_result);
                                 } else {
                                     // Add this tool call to the futures collection

--- a/crates/goose/src/message.rs
+++ b/crates/goose/src/message.rs
@@ -63,7 +63,7 @@ pub struct ToolConfirmationRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ExtensionRequest {
     pub id: String,
-    pub extension_name: String,
+    pub extension_names: Vec<String>,
     pub tool_name: String,
 }
 
@@ -147,12 +147,12 @@ impl MessageContent {
 
     pub fn extension_request<S: Into<String>>(
         id: S,
-        extension_name: String,
+        extension_names: Vec<String>,
         tool_name: String,
     ) -> Self {
         MessageContent::ExtensionRequest(ExtensionRequest {
             id: id.into(),
-            extension_name,
+            extension_names,
             tool_name,
         })
     }
@@ -368,12 +368,12 @@ impl Message {
     pub fn with_extension_request<S: Into<String>>(
         self,
         id: S,
-        extension_name: String,
+        extension_names: Vec<String>,
         tool_name: String,
     ) -> Self {
         self.with_content(MessageContent::extension_request(
             id,
-            extension_name,
+            extension_names,
             tool_name,
         ))
     }

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -170,7 +170,11 @@ pub fn get_confirmation_message(request_id: &str, tool_call: ToolCall) -> (Princ
                     .arguments
                     .get("extension_names")
                     .and_then(|v| v.as_array())
-                    .map(|arr| arr.iter().map(|v| v.as_str().unwrap_or("").to_string()).collect::<Vec<String>>())
+                    .map(|arr| {
+                        arr.iter()
+                            .map(|v| v.as_str().unwrap_or("").to_string())
+                            .collect::<Vec<String>>()
+                    })
                     .unwrap_or_default(),
                 tool_call.name.clone(),
             ),

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -1,5 +1,5 @@
 use crate::agents::platform_tools::{
-    PLATFORM_DISABLE_EXTENSION_TOOL_NAME, PLATFORM_ENABLE_EXTENSION_TOOL_NAME,
+    PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME, PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME,
 };
 use crate::config::permission::PermissionLevel;
 use crate::config::PermissionManager;
@@ -159,8 +159,8 @@ pub async fn detect_read_only_tools(
 /// Gets the boolean value whether the message is enable extension related and
 /// the cconfirmation message based on the tool call
 pub fn get_confirmation_message(request_id: &str, tool_call: ToolCall) -> (PrincipalType, Message) {
-    if tool_call.name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME
-        || tool_call.name == PLATFORM_DISABLE_EXTENSION_TOOL_NAME
+    if tool_call.name == PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME
+        || tool_call.name == PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME
     {
         (
             PrincipalType::Extension,
@@ -168,10 +168,10 @@ pub fn get_confirmation_message(request_id: &str, tool_call: ToolCall) -> (Princ
                 request_id,
                 tool_call
                     .arguments
-                    .get("extension_name")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string(),
+                    .get("extension_names")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| arr.iter().map(|v| v.as_str().unwrap_or("").to_string()).collect::<Vec<String>>())
+                    .unwrap_or_default(),
                 tool_call.name.clone(),
             ),
         )
@@ -211,8 +211,8 @@ pub async fn check_tool_permissions(
     for request in candidate_requests {
         if let Ok(tool_call) = request.tool_call.clone() {
             // Always ask approval for enable extension tool.
-            if tool_call.name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME
-                || tool_call.name == PLATFORM_DISABLE_EXTENSION_TOOL_NAME
+            if tool_call.name == PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME
+                || tool_call.name == PLATFORM_DISABLE_EXTENSIONS_TOOL_NAME
             {
                 // Insert at the front of the list so that enable extension can be run before other tools.
                 needs_approval.insert(0, request.clone());
@@ -468,7 +468,7 @@ mod tests {
         let enable_extension = ToolRequest {
             id: "tool_3".to_string(),
             tool_call: ToolResult::Ok(ToolCall {
-                name: PLATFORM_ENABLE_EXTENSION_TOOL_NAME.to_string(),
+                name: PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME.to_string(),
                 arguments: serde_json::json!({"url": "http://example.com"}),
             }),
         };
@@ -504,7 +504,7 @@ mod tests {
         assert_eq!(
             tool_0.unwrap().id,
             "tool_3",
-            "PLATFORM_ENABLE_EXTENSION_TOOL_NAME should be the first in needs_approval"
+            "PLATFORM_ENABLE_EXTENSIONS_TOOL_NAME should be the first in needs_approval"
         );
     }
 

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -9,7 +9,7 @@ These models have varying knowledge cut-off dates depending on when they were tr
 
 Extensions allow other applications to provide context to Goose. Extensions connect Goose to different data sources and tools.
 You are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level problems using the tools in these extensions, and can interact with multiple at once.
-Use the search_available_extensions tool to find additional extensions to enable to help with your task. To enable extensions, use the enable_extension tool and provide the extension_name. You should only enable extensions found from the search_available_extensions tool.
+Use the search_available_extensions tool to find additional extensions to enable to help with your task. To enable extensions, use the enable_extensions tool and provide the extension_names in a list. You should only enable extensions found from the search_available_extensions tool.
 
 {% if (extensions is defined) and extensions %}
 Because you dynamically load extensions, your conversation history may refer

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.17"
+    "version": "1.0.18"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/src/components/ExtensionConfirmation.tsx
+++ b/ui/desktop/src/components/ExtensionConfirmation.tsx
@@ -6,14 +6,14 @@ interface ExtensionConfirmationProps {
   isCancelledMessage: boolean;
   isClicked: boolean;
   extensionConfirmationId: string;
-  extensionName: string;
+  extensionNames: string[];
   toolName: string;
 }
 export default function ExtensionConfirmation({
   isCancelledMessage,
   isClicked,
   extensionConfirmationId,
-  extensionName,
+  extensionNames,
   toolName,
 }: ExtensionConfirmationProps) {
   const [clicked, setClicked] = useState(isClicked);
@@ -47,7 +47,7 @@ export default function ExtensionConfirmation({
   ) : (
     <>
       <div className="goose-message-content bg-bgSubtle rounded-2xl px-4 py-2 rounded-b-none text-textStandard">
-        Goose would like to {extensionAction} the following extension. Allow?
+        Goose would like to {extensionAction} the following extensions. Allow?
       </div>
       {clicked ? (
         <div className="goose-message-tool bg-bgApp border border-borderSubtle dark:border-gray-700 rounded-b-2xl px-4 pt-4 pb-2 flex gap-4 mt-1">
@@ -79,7 +79,7 @@ export default function ExtensionConfirmation({
             <span className="ml-2 text-textStandard">
               {isClicked
                 ? 'Extension enablement is not available'
-                : `${snakeToTitleCase(extensionName.includes('__') ? extensionName.split('__').pop() || extensionName : extensionName)} is ${status}`}{' '}
+                : `${extensionNames.map((name: string) => snakeToTitleCase(name.includes('__') ? name.split('__').pop() || name : name)).join(', ')} is ${status}`}{' '}
             </span>
           </div>
         </div>
@@ -92,7 +92,7 @@ export default function ExtensionConfirmation({
             onClick={() => handleButtonClick(true)}
           >
             {extensionAction.charAt(0).toUpperCase() + extensionAction.slice(1).toLowerCase()}{' '}
-            extension
+            extensions
           </button>
           <button
             className={

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -162,7 +162,7 @@ export default function GooseMessage({
             isCancelledMessage={messageIndex == messageHistoryIndex - 1}
             isClicked={messageIndex < messageHistoryIndex - 1}
             extensionConfirmationId={extensionContent.id}
-            extensionName={extensionContent.extensionName}
+            extensionNames={extensionContent.extensionNames}
             toolName={extensionContent.toolName}
           />
         )}

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -96,7 +96,7 @@ export interface ExtensionRequestMessageContent {
   type: 'extensionRequest';
   id: string;
   extensionCall: ExtensionCallResult<ExtensionCall>;
-  extensionName: string;
+  extensionNames: string[];
   toolName: string;
 }
 
@@ -220,9 +220,7 @@ export function getToolResponses(message: Message): ToolResponseMessageContent[]
   );
 }
 
-export function getExtensionRequests(
-  message: Message
-): ExtensionRequestMessageContent[] {
+export function getExtensionRequests(message: Message): ExtensionRequestMessageContent[] {
   return message.content.filter(
     (content): content is ExtensionRequestMessageContent => content.type === 'extensionRequest'
   );
@@ -239,8 +237,7 @@ export function getToolConfirmationContent(
 
 export function getExtensionContent(message: Message): ExtensionRequestMessageContent {
   return message.content.find(
-    (content): content is ExtensionRequestMessageContent =>
-      content.type === 'extensionRequest'
+    (content): content is ExtensionRequestMessageContent => content.type === 'extensionRequest'
   );
 }
 


### PR DESCRIPTION
Part of AAI-301

* Allows enabling and disabling of one or more extensions, previously just one
* Simply changes _extension_ naming to -> _extensions_ and passes in a vec instead of string

<img width="900" alt="image" src="https://github.com/user-attachments/assets/7c21f883-e0be-4c67-b6ee-33cd87f19ada" />
