### PR TITLE
fix: expose not support tool call error

### DIFF
--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -149,7 +149,7 @@ pub async fn handle_response_google_compat(response: Response) -> Result<Value, 
             Err(ProviderError::Authentication(format!("Authentication failed. Please ensure your API keys are valid and have the required permissions. \
                 Status: {}. Response: {:?}", final_status, payload )))
         }
-        StatusCode::BAD_REQUEST => {
+        StatusCode::BAD_REQUEST | StatusCode::NOT_FOUND => {
             let mut error_msg = "Unknown error".to_string();
             if let Some(payload) = &payload {
                 if let Some(error) = payload.get("error") {


### PR DESCRIPTION
Similar to https://github.com/block/goose/pull/2228

Fix #1589

Before:
![image](https://github.com/user-attachments/assets/89d05ff5-6c63-4a65-9bac-38959a5a2bf4)

After:
![image](https://github.com/user-attachments/assets/f9f6e71b-8172-4382-aa37-0d7445e59964)

