### PR TITLE
fix: multiple goose instances running at once

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -39,13 +39,15 @@ if (started) app.quit();
 
 app.setAsDefaultProtocolClient('goose');
 
-const gotTheLock = app.requestSingleInstanceLock();
+// Only apply single instance lock on Windows where it's needed for deep links
+let gotTheLock = true;
+if (process.platform === 'win32') {
+  gotTheLock = app.requestSingleInstanceLock();
 
-if (!gotTheLock) {
-  app.quit();
-} else {
-  app.on('second-instance', (event, commandLine) => {
-    if (process.platform === 'win32') {
+  if (!gotTheLock) {
+    app.quit();
+  } else {
+    app.on('second-instance', (event, commandLine) => {
       const protocolUrl = commandLine.find((arg) => arg.startsWith('goose://'));
       if (protocolUrl) {
         const parsedUrl = new URL(protocolUrl);
@@ -84,15 +86,15 @@ if (!gotTheLock) {
         }
         mainWindow.focus();
       }
-    }
-  });
-  if (process.platform === 'win32') {
-    const protocolUrl = process.argv.find((arg) => arg.startsWith('goose://'));
-    if (protocolUrl) {
-      app.whenReady().then(() => {
-        handleProtocolUrl(protocolUrl);
-      });
-    }
+    });
+  }
+
+  // Handle protocol URLs on Windows startup
+  const protocolUrl = process.argv.find((arg) => arg.startsWith('goose://'));
+  if (protocolUrl) {
+    app.whenReady().then(() => {
+      handleProtocolUrl(protocolUrl);
+    });
   }
 }
 


### PR DESCRIPTION
Noticed after installing v1.0.18 that I couldn't run my local build at the same time when it was running. All windows logic is preserved its just moved into its own conditional so it doesn't affect other systems.

This code was added as part of implementing proper deep link handling for Windows in https://github.com/block/goose/pull/2125, but it enforces a single instance lock for all platforms. When a second instance tries to start, it will fail to get the lock and quit immediately.

I verified that deeplinking still works in Mac but I don't have a Windows machine to test.