### PR TITLE
fix: resolve the deadlock while listing tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,7 +2377,7 @@ dependencies = [
 
 [[package]]
 name = "goose"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2432,7 +2432,7 @@ dependencies = [
 
 [[package]]
 name = "goose-bench"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2455,7 +2455,7 @@ dependencies = [
 
 [[package]]
 name = "goose-cli"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2493,7 +2493,7 @@ dependencies = [
 
 [[package]]
 name = "goose-ffi"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "cbindgen",
  "futures",
@@ -2507,7 +2507,7 @@ dependencies = [
 
 [[package]]
 name = "goose-mcp"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2553,7 +2553,7 @@ dependencies = [
 
 [[package]]
 name = "goose-server"
-version = "1.0.17"
+version = "1.0.18"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -198,8 +198,8 @@ async fn get_tools(
 
     let config = Config::global();
     let goose_mode = config.get_param("GOOSE_MODE").unwrap_or("auto".to_string());
-    let mut agent = state.agent.write().await;
-    let agent = agent.as_mut().ok_or(StatusCode::PRECONDITION_REQUIRED)?;
+    let agent = state.agent.read().await;
+    let agent = agent.as_ref().ok_or(StatusCode::PRECONDITION_REQUIRED)?;
     let permission_manager = PermissionManager::default();
 
     let mut tools: Vec<ToolInfo> = agent


### PR DESCRIPTION
Previously we use the write lock which may cause the deadlock issue when listing tools during chat