### PR TITLE
feat(cli): add system prompt parameter to run command

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -375,6 +375,16 @@ enum Command {
         )]
         input_text: Option<String>,
 
+        /// Additional system prompt to customize agent behavior
+        #[arg(
+            long = "system",
+            value_name = "TEXT",
+            help = "Additional system prompt to customize agent behavior",
+            long_help = "Provide additional system instructions to customize the agent's behavior",
+            conflicts_with = "recipe"
+        )]
+        system: Option<String>,
+
         /// Recipe name or full path to the recipe file
         #[arg(
             short = None,
@@ -666,6 +676,7 @@ pub async fn cli() -> Result<()> {
             instructions,
             input_text,
             recipe,
+            system,
             interactive,
             identifier,
             resume,
@@ -690,7 +701,7 @@ pub async fn cli() -> Result<()> {
                         InputConfig {
                             contents: Some(input),
                             extensions_override: None,
-                            additional_system_prompt: None,
+                            additional_system_prompt: system,
                         },
                         None,
                     )
@@ -716,7 +727,7 @@ pub async fn cli() -> Result<()> {
                     InputConfig {
                         contents: Some(text),
                         extensions_override: None,
-                        additional_system_prompt: None,
+                        additional_system_prompt: system,
                     },
                     None,
                 ),


### PR DESCRIPTION
A system prompt could only be passed through recipes in the `run` command. This param makes it easier
<img width="877" alt="Screenshot 2025-04-18 at 0 12 55" src="https://github.com/user-attachments/assets/4f8e32ef-fc18-44ea-ae02-c69d443f6257" />
