### PR TITLE
feat: enhance extension environment variable security

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -583,6 +583,9 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 cliclack::confirm("Would you like to add environment variables?").interact()?;
 
             let mut envs = HashMap::new();
+            let mut env_keys = Vec::new();
+            let config = Config::global();
+
             if add_env {
                 loop {
                     let key: String = cliclack::input("Environment variable name:")
@@ -593,7 +596,18 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                         .mask('▪')
                         .interact()?;
 
-                    envs.insert(key, value);
+                    // Try to store in keychain
+                    let keychain_key = format!("{}_{}", name.to_uppercase(), key);
+                    match config.set_secret(&keychain_key, Value::String(value.clone())) {
+                        Ok(_) => {
+                            // Successfully stored in keychain, add to env_keys
+                            env_keys.push(keychain_key);
+                        }
+                        Err(_) => {
+                            // Failed to store in keychain, store directly in envs
+                            envs.insert(key, value);
+                        }
+                    }
 
                     if !cliclack::confirm("Add another environment variable?").interact()? {
                         break;
@@ -608,7 +622,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     cmd,
                     args,
                     envs: Envs::new(envs),
-                    env_keys: Vec::new(),
+                    env_keys,
                     description,
                     timeout: Some(timeout),
                     bundled: None,
@@ -672,6 +686,9 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 cliclack::confirm("Would you like to add environment variables?").interact()?;
 
             let mut envs = HashMap::new();
+            let mut env_keys = Vec::new();
+            let config = Config::global();
+
             if add_env {
                 loop {
                     let key: String = cliclack::input("Environment variable name:")
@@ -682,7 +699,18 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                         .mask('▪')
                         .interact()?;
 
-                    envs.insert(key, value);
+                    // Try to store in keychain
+                    let keychain_key = format!("{}_{}", name.to_uppercase(), key);
+                    match config.set_secret(&keychain_key, Value::String(value.clone())) {
+                        Ok(_) => {
+                            // Successfully stored in keychain, add to env_keys
+                            env_keys.push(keychain_key);
+                        }
+                        Err(_) => {
+                            // Failed to store in keychain, store directly in envs
+                            envs.insert(key, value);
+                        }
+                    }
 
                     if !cliclack::confirm("Add another environment variable?").interact()? {
                         break;
@@ -696,7 +724,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     name: name.clone(),
                     uri,
                     envs: Envs::new(envs),
-                    env_keys: Vec::new(),
+                    env_keys,
                     description,
                     timeout: Some(timeout),
                     bundled: None,

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -24,6 +24,8 @@ pub enum ExtensionError {
     Transport(#[from] mcp_client::transport::Error),
     #[error("Environment variable `{0}` is not allowed to be overridden.")]
     InvalidEnvVar(String),
+    #[error("Error during extension setup: {0}")]
+    SetupError(String),
     #[error("Join error occurred during task execution: {0}")]
     TaskJoinError(#[from] tokio::task::JoinError),
 }

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -10,10 +10,11 @@ use std::sync::LazyLock;
 use std::time::Duration;
 use tokio::sync::Mutex;
 use tokio::task;
-use tracing::debug;
+use tracing::{debug, error, warn};
 
 use super::extension::{ExtensionConfig, ExtensionError, ExtensionInfo, ExtensionResult, ToolInfo};
-use crate::config::ExtensionConfigManager;
+use crate::agents::extension::Envs;
+use crate::config::{Config, ExtensionConfigManager};
 use crate::prompt_template;
 use mcp_client::client::{ClientCapabilities, ClientInfo, McpClient, McpClientTrait};
 use mcp_client::transport::{SseTransport, StdioTransport, Transport};
@@ -113,11 +114,68 @@ impl ExtensionManager {
     // TODO IMPORTANT need to ensure this times out if the extension command is broken!
     pub async fn add_extension(&mut self, config: ExtensionConfig) -> ExtensionResult<()> {
         let sanitized_name = normalize(config.key().to_string());
+
+        /// Helper function to merge environment variables from direct envs and keychain-stored env_keys
+        async fn merge_environments(
+            envs: &Envs,
+            env_keys: &[String],
+            ext_name: &str,
+        ) -> Result<HashMap<String, String>, ExtensionError> {
+            let mut all_envs = envs.get_env();
+            let config_instance = Config::global();
+
+            for key in env_keys {
+                match config_instance.get(key, true) {
+                    Ok(value) => {
+                        if value.is_null() {
+                            warn!(
+                                key = %key,
+                                ext_name = %ext_name,
+                                "Secret key not found in config (returned null)."
+                            );
+                            continue;
+                        }
+
+                        // Try to get string value
+                        if let Some(str_val) = value.as_str() {
+                            all_envs.insert(key.clone(), str_val.to_string());
+                        } else {
+                            warn!(
+                                key = %key,
+                                ext_name = %ext_name,
+                                value_type = %value.get("type").and_then(|t| t.as_str()).unwrap_or("unknown"),
+                                "Secret value is not a string; skipping."
+                            );
+                        }
+                    }
+                    Err(e) => {
+                        error!(
+                            key = %key,
+                            ext_name = %ext_name,
+                            error = %e,
+                            "Failed to fetch secret from config."
+                        );
+                        return Err(ExtensionError::SetupError(format!(
+                            "Failed to fetch secret '{}' from config: {}",
+                            key, e
+                        )));
+                    }
+                }
+            }
+
+            Ok(all_envs)
+        }
+
         let mut client: Box<dyn McpClientTrait> = match &config {
             ExtensionConfig::Sse {
-                uri, envs, timeout, ..
+                uri,
+                envs,
+                env_keys,
+                timeout,
+                ..
             } => {
-                let transport = SseTransport::new(uri, envs.get_env());
+                let all_envs = merge_environments(envs, env_keys, &sanitized_name).await?;
+                let transport = SseTransport::new(uri, all_envs);
                 let handle = transport.start().await?;
                 let service = McpService::with_timeout(
                     handle,
@@ -131,10 +189,12 @@ impl ExtensionManager {
                 cmd,
                 args,
                 envs,
+                env_keys,
                 timeout,
                 ..
             } => {
-                let transport = StdioTransport::new(cmd, args.to_vec(), envs.get_env());
+                let all_envs = merge_environments(envs, env_keys, &sanitized_name).await?;
+                let transport = StdioTransport::new(cmd, args.to_vec(), all_envs);
                 let handle = transport.start().await?;
                 let service = McpService::with_timeout(
                     handle,
@@ -150,7 +210,6 @@ impl ExtensionManager {
                 timeout,
                 bundled: _,
             } => {
-                // For builtin extensions, we run the current executable with mcp and extension name
                 let cmd = std::env::current_exe()
                     .expect("should find the current executable")
                     .to_str()
@@ -185,19 +244,16 @@ impl ExtensionManager {
             .await
             .map_err(|e| ExtensionError::Initialization(config.clone(), e))?;
 
-        // Store instructions if provided
         if let Some(instructions) = init_result.instructions {
             self.instructions
                 .insert(sanitized_name.clone(), instructions);
         }
 
-        // if the server is capable if resources we track it
         if init_result.capabilities.resources.is_some() {
             self.resource_capable_extensions
                 .insert(sanitized_name.clone());
         }
 
-        // Store the client using the provided name
         self.clients
             .insert(sanitized_name.clone(), Arc::new(Mutex::new(client)));
 


### PR DESCRIPTION
Expectations:
- `goose configure`: when configuring extensions only write the env key to config.yaml and write to values to keychain. If keychain write fails, default to writing env key/value pair to config as envs
- `agent.add_extension`: uses the extension configuration to set the full envs before starting server. it'll use envs (empty if not there), and then for env_keys it will pull the values from keychain and append to the envs hash map, which is passed along to transport
- `add_extension` route on goose-server: remove logic for pulling in keychain secrets and sending full envs as this is handled on the agent side now. only pass through env_keys. 