### PR TITLE
GUI warning when installing extension from deeplink

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -98,6 +98,10 @@ export default function App() {
   const [modalVisible, setModalVisible] = useState(false);
   const [pendingLink, setPendingLink] = useState<string | null>(null);
   const [modalMessage, setModalMessage] = useState<string>('');
+  const [extensionConfirmLabel, setExtensionConfirmLabel] = useState<string>('OK');
+  const [extensionConfirmTitle, setExtensionConfirmTitle] = useState<string>(
+    'Confirm Extension Installation'
+  );
   const [{ view, viewOptions }, setInternalView] = useState<ViewConfig>(getInitialView());
   const { getExtensions, addExtension, disableAllExtensions, read } = useConfig();
   const initAttemptedRef = useRef(false);
@@ -502,6 +506,8 @@ export default function App() {
             );
 
             if (!isCommandAllowed) {
+              setExtensionConfirmLabel('Override and install');
+              setExtensionConfirmTitle('⛔️ DANGER: Untrusted Extension');
               warningMessage =
                 '\n\n⚠️ WARNING: This extension command is not in the allowed list. Installing extensions from untrusted sources may pose security risks.';
             }
@@ -691,8 +697,9 @@ export default function App() {
       {modalVisible && (
         <ConfirmationModal
           isOpen={modalVisible}
-          title="Confirm Extension Installation"
           message={modalMessage}
+          confirmLabel={extensionConfirmLabel}
+          title={extensionConfirmTitle}
           onConfirm={handleConfirm}
           onCancel={handleCancel}
         />

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -98,10 +98,8 @@ export default function App() {
   const [modalVisible, setModalVisible] = useState(false);
   const [pendingLink, setPendingLink] = useState<string | null>(null);
   const [modalMessage, setModalMessage] = useState<string>('');
-  const [extensionConfirmLabel, setExtensionConfirmLabel] = useState<string>('OK');
-  const [extensionConfirmTitle, setExtensionConfirmTitle] = useState<string>(
-    'Confirm Extension Installation'
-  );
+  const [extensionConfirmLabel, setExtensionConfirmLabel] = useState<string>('');
+  const [extensionConfirmTitle, setExtensionConfirmTitle] = useState<string>('');
   const [{ view, viewOptions }, setInternalView] = useState<ViewConfig>(getInitialView());
   const { getExtensions, addExtension, disableAllExtensions, read } = useConfig();
   const initAttemptedRef = useRef(false);
@@ -496,6 +494,8 @@ export default function App() {
 
         // Fetch the allowlist and check if the command is allowed
         let warningMessage = '';
+        let label = 'OK';
+        let title = 'Confirm Extension Installation';
         try {
           const allowedCommands = await window.electron.getAllowedExtensions();
 
@@ -506,10 +506,10 @@ export default function App() {
             );
 
             if (!isCommandAllowed) {
-              setExtensionConfirmLabel('Override and install');
-              setExtensionConfirmTitle('⛔️ Untrusted Extension ⛔️');
+              title = '⛔️ Untrusted Extension ⛔️';
+              label = 'Override and install';
               warningMessage =
-                '\n\n⚠️ WARNING: This extension command is not in the allowed list. Installing extensions from untrusted sources may pose security risks. Please contact an admin if you are unsure or want to allow this extension.';
+                '\n\n⚠️ WARNING: This extension command is not in the allowed list. Installing extensions from untrusted sources may pose security risks. Please contact and admin if you are unsusure or want to allow this extension.';
             }
           }
         } catch (error) {
@@ -520,6 +520,8 @@ export default function App() {
         setModalMessage(
           `Are you sure you want to install the ${extName} extension?\n\n${messageDetails}${warningMessage}`
         );
+        setExtensionConfirmLabel(label);
+        setExtensionConfirmTitle(title);
         setModalVisible(true);
       } catch (error) {
         console.error('Error handling add-extension event:', error);

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -494,18 +494,21 @@ export default function App() {
         let warningMessage = '';
         try {
           const allowedCommands = await window.electron.getAllowedExtensions();
-          const isCommandAllowed = allowedCommands.some((allowedCmd) =>
-            command.startsWith(allowedCmd)
-          );
 
-          if (!isCommandAllowed) {
-            warningMessage =
-              '\n\n⚠️ WARNING: This extension command is not in the allowed list. Installing extensions from untrusted sources may pose security risks.';
+          // Only check and show warning if we have a non-empty allowlist
+          if (allowedCommands && allowedCommands.length > 0) {
+            const isCommandAllowed = allowedCommands.some((allowedCmd) =>
+              command.startsWith(allowedCmd)
+            );
+
+            if (!isCommandAllowed) {
+              warningMessage =
+                '\n\n⚠️ WARNING: This extension command is not in the allowed list. Installing extensions from untrusted sources may pose security risks.';
+            }
           }
         } catch (error) {
           console.error('Error checking allowlist:', error);
-          warningMessage =
-            '\n\n⚠️ WARNING: Could not verify if this extension is allowed. Proceed with caution.';
+          // Don't show a warning if we couldn't check the allowlist
         }
 
         const messageDetails = remoteUrl ? `Remote URL: ${remoteUrl}` : `Command: ${command}`;

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -507,9 +507,9 @@ export default function App() {
 
             if (!isCommandAllowed) {
               setExtensionConfirmLabel('Override and install');
-              setExtensionConfirmTitle('⛔️ DANGER: Untrusted Extension');
+              setExtensionConfirmTitle('⛔️ Untrusted Extension ⛔️');
               warningMessage =
-                '\n\n⚠️ WARNING: This extension command is not in the allowed list. Installing extensions from untrusted sources may pose security risks.';
+                '\n\n⚠️ WARNING: This extension command is not in the allowed list. Installing extensions from untrusted sources may pose security risks. Please contact an admin if you are unsure or want to allow this extension.';
             }
           }
         } catch (error) {

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -508,7 +508,6 @@ export default function App() {
           }
         } catch (error) {
           console.error('Error checking allowlist:', error);
-          // Don't show a warning if we couldn't check the allowlist
         }
 
         const messageDetails = remoteUrl ? `Remote URL: ${remoteUrl}` : `Command: ${command}`;

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -796,6 +796,25 @@ app.whenReady().then(async () => {
         },
       })
     );
+
+    // NOTE: Add Extension menu item DEVELOPMENT TIME ONLY REMOVE THIS
+    fileMenu.submenu.append(
+      new MenuItem({
+        label: 'Add Extension',
+        click() {
+          // Create extension deeplink
+          const extensionUrl =
+            'goose://extension?cmd=npx&arg=-y&arg=tavily-mcp&id=tavily&name=Tavily%20Web%20Search&description=Web%20search%20capabilities%20powered%20by%20Tavily&env=TAVILY_API_KEY%3DAPI%20key%20for%20Tavily%20web%20search%20service';
+
+          // Get the focused window or create a new one if none exists
+          const existingWindows = BrowserWindow.getAllWindows();
+          const window = existingWindows[0];
+          if (window.isMinimized()) window.restore();
+          window.focus();
+          window.webContents.send('add-extension', extensionUrl);
+        },
+      })
+    );
   }
 
   if (menu) {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -780,53 +780,6 @@ app.whenReady().then(async () => {
         },
       })
     );
-
-    fileMenu.submenu.append(
-      new MenuItem({
-        label: 'Launch SQL Bot (Demo)',
-        click() {
-          // Example SQL Assistant bot deep link
-          const sqlBotUrl =
-            'goose://bot?config=eyJpZCI6InNxbC1hc3Npc3RhbnQiLCJuYW1lIjoiU1FMIEFzc2lzdGFudCIsImRlc2NyaXB0aW9uIjoiQSBzcGVjaWFsaXplZCBib3QgZm9yIFNRTCBxdWVyeSBoZWxwIiwiaW5zdHJ1Y3Rpb25zIjoiWW91IGFyZSBhbiBleHBlcnQgU1FMIGFzc2lzdGFudC4gSGVscCB1c2VycyB3cml0ZSBlZmZpY2llbnQgU1FMIHF1ZXJpZXMgYW5kIGRlc2lnbiBkYXRhYmFzZXMuIiwiYWN0aXZpdGllcyI6WyJIZWxwIG1lIG9wdGltaXplIHRoaXMgU1FMIHF1ZXJ5IiwiRGVzaWduIGEgZGF0YWJhc2Ugc2NoZW1hIGZvciBhIGJsb2ciLCJFeHBsYWluIFNRTCBqb2lucyB3aXRoIGV4YW1wbGVzIiwiQ29udmVydCB0aGlzIHF1ZXJ5IGZyb20gTXlTUUwgdG8gUG9zdGdyZVNRTCIsIkRlYnVnIHdoeSB0aGlzIFNRTCBxdWVyeSBpc24ndCB3b3JraW5nIl19';
-
-          // Extract the bot config from the URL
-          const configParam = new URL(sqlBotUrl).searchParams.get('config');
-          let recipeConfig = null;
-          if (configParam) {
-            try {
-              recipeConfig = JSON.parse(Buffer.from(configParam, 'base64').toString('utf-8'));
-            } catch (e) {
-              console.error('Failed to parse bot config:', e);
-            }
-          }
-
-          // Create a new window
-          const recentDirs = loadRecentDirs();
-          const openDir = recentDirs.length > 0 ? recentDirs[0] : null;
-
-          createChat(app, undefined, openDir, undefined, undefined, recipeConfig);
-        },
-      })
-    );
-
-    // NOTE: Add Extension menu item DEVELOPMENT TIME ONLY REMOVE THIS
-    fileMenu.submenu.append(
-      new MenuItem({
-        label: 'Add Extension',
-        click() {
-          // Create extension deeplink
-          const extensionUrl =
-            'goose://extension?cmd=npx&arg=-y&arg=tavily-mcp&id=tavily&name=Tavily%20Web%20Search&description=Web%20search%20capabilities%20powered%20by%20Tavily&env=TAVILY_API_KEY%3DAPI%20key%20for%20Tavily%20web%20search%20service';
-
-          // Get the focused window or create a new one if none exists
-          const existingWindows = BrowserWindow.getAllWindows();
-          const window = existingWindows[0];
-          if (window.isMinimized()) window.restore();
-          window.focus();
-          window.webContents.send('add-extension', extensionUrl);
-        },
-      })
-    );
   }
 
   if (menu) {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -935,15 +935,31 @@ app.whenReady().then(async () => {
 });
 
 /**
- * Fetches the allowed extensions list from the remote YAML file
- * @returns A promise that resolves to an array of extension commands
+ * Fetches the allowed extensions list from the remote YAML file if GOOSE_ALLOWLIST is set.
+ * If the ALLOWLIST is not set, any are allowed. If one is set, it will warn if the deeplink 
+ * doesn't match a command from the list. 
+ * If it fails to load, then it will return an empty list.
+ * If the format is incorrect, it will return an empty list.
+ * Format of yaml is:
+ *  
+ ```yaml:
+ extensions:
+  - id: slack
+    command: uvx mcp_slack
+  - id: knowledge_graph_memory
+    command: npx -y @modelcontextprotocol/server-memory
+  ```
+ * 
+ * @returns A promise that resolves to an array of extension commands that are allowed.
  */
 async function getAllowList(): Promise<string[]> {
-  const ALLOWED_EXTENSIONS_URL = 'https://d138qt27bkxomz.cloudfront.net/allowed_extensions.yaml';
+  if (!process.env.GOOSE_ALLOWLIST) {
+    return [];
+  }
 
   try {
     // Fetch the YAML file
-    const response = await fetch(ALLOWED_EXTENSIONS_URL);
+    const response = await fetch(process.env.GOOSE_ALLOWLIST);
 
     if (!response.ok) {
       throw new Error(

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -49,6 +49,7 @@ type ElectronAPI = {
   getBinaryPath: (binaryName: string) => Promise<string>;
   readFile: (directory: string) => Promise<FileResponse>;
   writeFile: (directory: string, content: string) => Promise<boolean>;
+  getAllowedExtensions: () => Promise<string[]>;
   on: (
     channel: string,
     callback: (event: Electron.IpcRendererEvent, ...args: unknown[]) => void
@@ -100,6 +101,7 @@ const electronAPI: ElectronAPI = {
   readFile: (filePath: string) => ipcRenderer.invoke('read-file', filePath),
   writeFile: (filePath: string, content: string) =>
     ipcRenderer.invoke('write-file', filePath, content),
+  getAllowedExtensions: () => ipcRenderer.invoke('get-allowed-extensions'),
   on: (
     channel: string,
     callback: (event: Electron.IpcRendererEvent, ...args: unknown[]) => void

--- a/ui/desktop/test-extension-dialog.js
+++ b/ui/desktop/test-extension-dialog.js
@@ -1,0 +1,10 @@
+// Test script for the extension confirmation dialog
+// This simulates clicking the "Add Extension" menu item
+
+const { ipcRenderer } = require('electron');
+
+// Create a fake extension URL
+const extensionUrl = 'goose://extension?cmd=npx&arg=-y&arg=tavily-mcp&id=tavily&name=Tavily%20Web%20Search&description=Web%20search%20capabilities%20powered%20by%20Tavily&env=TAVILY_API_KEY%3DAPI%20key%20for%20Tavily%20web%20search%20service';
+
+// Send the add-extension event
+ipcRenderer.send('add-extension', extensionUrl);


### PR DESCRIPTION
This uses the GOOSE_ALLOWLIST (if set) to check that the extension being proposed from a deeplink is valid: 

<img width="719" alt="Screenshot 2025-04-18 at 3 55 26 pm" src="https://github.com/user-attachments/assets/3a662cfd-39cc-4c08-b319-946d1fdd8f58" />

(you can override and install it after this warning). if there is no allowlist or not valid, it will not show
This will not affect already installed extensions