### PR TITLE
feat: migrate config v3, update extensions/add to accept envs map

### DIFF
--- a/crates/goose-server/src/routes/extension.rs
+++ b/crates/goose-server/src/routes/extension.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::sync::OnceLock;
@@ -21,6 +20,9 @@ enum ExtensionConfigRequest {
         name: String,
         /// The URI endpoint for the SSE extension.
         uri: String,
+        #[serde(default)]
+        /// Map of environment variable key to values.
+        envs: Envs,
         /// List of environment variable keys. The server will fetch their values from the keyring.
         #[serde(default)]
         env_keys: Vec<String>,
@@ -36,6 +38,9 @@ enum ExtensionConfigRequest {
         /// Arguments for the command.
         #[serde(default)]
         args: Vec<String>,
+        #[serde(default)]
+        /// Map of environment variable key to values.
+        envs: Envs,
         /// List of environment variable keys. The server will fetch their values from the keyring.
         #[serde(default)]
         env_keys: Vec<String>,
@@ -164,12 +169,13 @@ async fn add_extension(
         ExtensionConfigRequest::Sse {
             name,
             uri,
+            envs,
             env_keys,
             timeout,
         } => ExtensionConfig::Sse {
             name,
             uri,
-            envs: Envs::new(HashMap::new()),
+            envs,
             env_keys,
             description: None,
             timeout,
@@ -179,6 +185,7 @@ async fn add_extension(
             name,
             cmd,
             args,
+            envs,
             env_keys,
             timeout,
         } => {
@@ -199,7 +206,7 @@ async fn add_extension(
                 cmd,
                 args,
                 description: None,
-                envs: Envs::new(HashMap::new()),
+                envs,
                 env_keys,
                 timeout,
                 bundled: None,

--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -125,6 +125,12 @@ impl ExtensionManager {
             let config_instance = Config::global();
 
             for key in env_keys {
+                // If the Envs payload already contains the key, prefer that value
+                // over looking into the keychain/secret store
+                if all_envs.contains_key(key) {
+                    continue;
+                }
+
                 match config_instance.get(key, true) {
                     Ok(value) => {
                         if value.is_null() {

--- a/ui/desktop/src/utils/providerUtils.ts
+++ b/ui/desktop/src/utils/providerUtils.ts
@@ -94,8 +94,8 @@ There may be (but not always) some tools mentioned in the instructions which you
  *
  * @param addExtension Function to add extension to config.yaml
  */
-export const migrateExtensionsToSettingsV2 = async () => {
-  console.log('need to perform extension migration');
+export const migrateExtensionsToSettingsV3 = async () => {
+  console.log('need to perform extension migration v3');
 
   const userSettingsStr = localStorage.getItem('user_settings');
   let localStorageExtensions: FullExtensionConfig[] = [];
@@ -140,8 +140,8 @@ export const migrateExtensionsToSettingsV2 = async () => {
   }
 
   if (migrationErrors.length === 0) {
-    localStorage.setItem('configVersion', '2');
-    console.log('Extension migration complete. Config version set to 2.');
+    localStorage.setItem('configVersion', '3');
+    console.log('Extension migration complete. Config version set to 3.');
   } else {
     const errorSummaryStr = migrationErrors
       .map(({ name, error }) => `- ${name}: ${JSON.stringify(error)}`)
@@ -209,11 +209,11 @@ export const initializeSystem = async (
       // NOTE: remove when we want to stop migration logic
       // Check if we need to migrate extensions from localStorage to config.yaml
       const configVersion = localStorage.getItem('configVersion');
-      const shouldMigrateExtensions = !configVersion || parseInt(configVersion, 10) < 2;
+      const shouldMigrateExtensions = !configVersion || parseInt(configVersion, 10) < 3;
 
       console.log(`shouldMigrateExtensions is ${shouldMigrateExtensions}`);
       if (shouldMigrateExtensions) {
-        await migrateExtensionsToSettingsV2();
+        await migrateExtensionsToSettingsV3();
       }
 
       /* NOTE:


### PR DESCRIPTION
* update config migration to 3, this was already sending env_keys and now the backend handles it to write to the config.yaml, so we just need to call that endpoint again

* update ExtensionConfigRequest to accept envs , looks like we were also already sending envs in the payload, just dropping it