### PR TITLE
fix: truncation not working for long for session descriptions

### DIFF
--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -85,26 +85,26 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
                     onClick={() => onSelectSession(session.id)}
                     className="p-2 bg-bgSecondary hover:bg-bgSubtle cursor-pointer transition-all duration-150"
                   >
-                    <div className="flex justify-between items-start">
-                      <div className="w-full">
-                        <h3 className="text-base font-medium text-textStandard truncate">
+                    <div className="flex justify-between items-start gap-4">
+                      <div className="min-w-0 flex-1">
+                        <h3 className="text-base font-medium text-textStandard truncate max-w-[50vw]">
                           {session.metadata.description || session.id}
                         </h3>
-                        <div className="flex gap-3">
-                          <div className="flex items-center text-textSubtle text-sm">
+                        <div className="flex gap-3 min-w-0">
+                          <div className="flex items-center text-textSubtle text-sm shrink-0">
                             <Calendar className="w-3 h-3 mr-1 flex-shrink-0" />
-                            <span className="truncate">
+                            <span>
                               {formatMessageTimestamp(Date.parse(session.modified) / 1000)}
                             </span>
                           </div>
-                          <div className="flex items-center text-textSubtle text-sm">
+                          <div className="flex items-center text-textSubtle text-sm min-w-0">
                             <Folder className="w-3 h-3 mr-1 flex-shrink-0" />
                             <span className="truncate">{session.metadata.working_dir}</span>
                           </div>
                         </div>
                       </div>
 
-                      <div className="flex items-center gap-3">
+                      <div className="flex items-center gap-3 shrink-0">
                         <div className="flex flex-col items-end">
                           <div className="flex items-center text-sm text-textSubtle">
                             <span>{session.path.split('/').pop() || session.path}</span>


### PR DESCRIPTION
The truncation isn't working if there is a long description in sessions list causing the details to be pushed way over and requiring the user to scroll to the right to see them.

Fixed the truncation by:
- Added max-w-[50vw] to the title/description to ensure it takes at most 50% of the viewport width
- Used min-w-0 on the flex containers to ensure proper truncation behavior
- Added flex-1 to the left container to allow it to take available space while still respecting truncation
- Added shrink-0 to the right container to prevent it from shrinking
- Added gap-4 between the left and right sections to ensure proper spacing
- Improved the structure of the flex containers to better handle overflow

Before:
![Screenshot 2025-04-18 at 11 53 53 AM](https://github.com/user-attachments/assets/1c133bfb-6374-456a-baf8-83827787131e)

After:
![Screenshot 2025-04-18 at 12 00 50 PM](https://github.com/user-attachments/assets/1c587953-1863-41c5-aee7-9fca777b14cc)