### PR TITLE
fix: fix regression in welcome screen flicker

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.18"
+    "version": "1.0.19"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -88,7 +88,7 @@ const getInitialView = (): ViewConfig => {
 
   // Default case
   return {
-    view: 'welcome',
+    view: 'loading',
     viewOptions: {},
   };
 };


### PR DESCRIPTION
For users who have already completed the onboarding, there is an annoying welcome screen flicker when the app loads.

## Before

(Video is slowed down so you can see what I mean):

https://github.com/user-attachments/assets/6c92abc1-cbbe-4745-994b-c9512b1babe4

## After

https://github.com/user-attachments/assets/1e505c50-03fc-44e1-a62d-3eb1d1609525

## Changes

Just one line to fix this! I set the initial view state to `loading` (I did this in a previous PR, but somewhere it got reverted by accident). Then the `getInitialState` is called and will either show onboarding (welcome screen) or the chat UI.

Also, for some reason, the `ui/desktop/openapi.json` file is automatically updating when I run `just run-ui`, I'm guessing a PR updated this and forgot to run a build to update everything?