### PR TITLE
feat: mcp router disable extensions

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -22,7 +22,7 @@ use tracing::{debug, error, instrument, warn};
 use crate::agents::extension::{ExtensionConfig, ExtensionResult, ToolInfo};
 use crate::agents::extension_manager::{get_parameter_names, ExtensionManager};
 use crate::agents::platform_tools::{
-    PLATFORM_ENABLE_EXTENSION_TOOL_NAME, PLATFORM_LIST_RESOURCES_TOOL_NAME,
+    PLATFORM_ENABLE_EXTENSION_TOOL_NAME, PLATFORM_DISABLE_EXTENSION_TOOL_NAME, PLATFORM_LIST_RESOURCES_TOOL_NAME,
     PLATFORM_READ_RESOURCE_TOOL_NAME, PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME,
 };
 use crate::agents::prompt_manager::PromptManager;
@@ -120,6 +120,14 @@ impl Agent {
                 .unwrap_or("")
                 .to_string();
             return self.enable_extension(extension_name, request_id).await;
+        } else if tool_call.name == PLATFORM_DISABLE_EXTENSION_TOOL_NAME {
+            let extension_name = tool_call
+                .arguments
+                .get("extension_name")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            return self.disable_extension(extension_name, request_id).await;
         }
 
         let extension_manager = self.extension_manager.lock().await;
@@ -244,6 +252,17 @@ impl Agent {
         (request_id, result)
     }
 
+    pub(super) async fn disable_extension(&self, extension_name: String, request_id: String) -> (String, Result<Vec<Content>, ToolError>) {
+        let mut extension_manager = self.extension_manager.lock().await;
+        let result = extension_manager.remove_extension(&extension_name).await.map(|_| {
+            vec![Content::text(format!(
+                "The extension '{}' has been disabled successfully",
+                extension_name
+            ))]
+        }).map_err(|e| ToolError::ExecutionError(e.to_string()));
+        (request_id, result)
+    }
+
     pub async fn add_extension(&mut self, extension: ExtensionConfig) -> ExtensionResult<()> {
         match &extension {
             ExtensionConfig::Frontend {
@@ -290,6 +309,7 @@ impl Agent {
             // Add platform tools
             prefixed_tools.push(platform_tools::search_available_extensions_tool());
             prefixed_tools.push(platform_tools::enable_extension_tool());
+            prefixed_tools.push(platform_tools::disable_extension_tool());
 
             // Add resource tools if supported
             if extension_manager.supports_resources() {

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -22,9 +22,8 @@ use tracing::{debug, error, instrument, warn};
 use crate::agents::extension::{ExtensionConfig, ExtensionResult, ToolInfo};
 use crate::agents::extension_manager::{get_parameter_names, ExtensionManager};
 use crate::agents::platform_tools::{
-    PLATFORM_MANAGE_EXTENSIONS_TOOL_NAME,
-    PLATFORM_LIST_RESOURCES_TOOL_NAME, PLATFORM_READ_RESOURCE_TOOL_NAME,
-    PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME,
+    PLATFORM_LIST_RESOURCES_TOOL_NAME, PLATFORM_MANAGE_EXTENSIONS_TOOL_NAME,
+    PLATFORM_READ_RESOURCE_TOOL_NAME, PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME,
 };
 use crate::agents::prompt_manager::PromptManager;
 use crate::agents::types::SessionConfig;
@@ -126,7 +125,9 @@ impl Agent {
                 .and_then(|v| v.as_str())
                 .unwrap_or("")
                 .to_string();
-            return self.manage_extensions(action, extension_name, request_id).await;
+            return self
+                .manage_extensions(action, extension_name, request_id)
+                .await;
         }
 
         let extension_manager = self.extension_manager.lock().await;

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -312,8 +312,7 @@ impl Agent {
         if extension_name.is_none() || extension_name.as_deref() == Some("platform") {
             // Add platform tools
             prefixed_tools.push(platform_tools::search_available_extensions_tool());
-            prefixed_tools.push(platform_tools::enable_extension_tool());
-            prefixed_tools.push(platform_tools::disable_extension_tool());
+            prefixed_tools.push(platform_tools::manage_extensions_tool());
 
             // Add resource tools if supported
             if extension_manager.supports_resources() {

--- a/crates/goose/src/agents/platform_tools.rs
+++ b/crates/goose/src/agents/platform_tools.rs
@@ -6,8 +6,7 @@ pub const PLATFORM_READ_RESOURCE_TOOL_NAME: &str = "platform__read_resource";
 pub const PLATFORM_LIST_RESOURCES_TOOL_NAME: &str = "platform__list_resources";
 pub const PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME: &str =
     "platform__search_available_extensions";
-pub const PLATFORM_ENABLE_EXTENSION_TOOL_NAME: &str = "platform__enable_extension";
-pub const PLATFORM_DISABLE_EXTENSION_TOOL_NAME: &str = "platform__disable_extension";
+pub const PLATFORM_MANAGE_EXTENSIONS_TOOL_NAME: &str = "platform__manage_extensions";
 
 pub fn read_resource_tool() -> Tool {
     Tool::new(
@@ -88,45 +87,24 @@ pub fn search_available_extensions_tool() -> Tool {
     )
 }
 
-pub fn enable_extension_tool() -> Tool {
+pub fn manage_extensions_tool() -> Tool {
     Tool::new(
-        PLATFORM_ENABLE_EXTENSION_TOOL_NAME.to_string(),
-        "Enable extensions to help complete tasks.
-            Enable an extension by providing the extension name.
+        PLATFORM_MANAGE_EXTENSIONS_TOOL_NAME.to_string(),
+        "Tool to manage extensions and tools in goose context.
+            Enable or disable extensions to help complete tasks.
+            Enable or disable an extension by providing the extension name.
             "
         .to_string(),
         json!({
             "type": "object",
-            "required": ["extension_name"],
+            "required": ["action", "extension_name"],
             "properties": {
+                "action": {"type": "string", "description": "The action to perform", "enum": ["enable", "disable"]},
                 "extension_name": {"type": "string", "description": "The name of the extension to enable"}
             }
         }),
         Some(ToolAnnotations {
-            title: Some("Enable an extension".to_string()),
-            read_only_hint: false,
-            destructive_hint: false,
-            idempotent_hint: false,
-            open_world_hint: false,
-        }),
-    )
-}
-
-pub fn disable_extension_tool() -> Tool {
-    Tool::new(
-        PLATFORM_DISABLE_EXTENSION_TOOL_NAME.to_string(),
-        "Disable an extension to preserve relevant extensions and tools.
-        "
-        .to_string(),
-        json!({
-            "type": "object",
-            "required": ["extension_name"],
-            "properties": {
-                "extension_name": {"type": "string", "description": "The name of the extension to enable"}
-            }
-        }),
-        Some(ToolAnnotations {
-            title: Some("Disable an extension".to_string()),
+            title: Some("Enable or disable an extension".to_string()),
             read_only_hint: false,
             destructive_hint: false,
             idempotent_hint: false,

--- a/crates/goose/src/agents/platform_tools.rs
+++ b/crates/goose/src/agents/platform_tools.rs
@@ -7,6 +7,7 @@ pub const PLATFORM_LIST_RESOURCES_TOOL_NAME: &str = "platform__list_resources";
 pub const PLATFORM_SEARCH_AVAILABLE_EXTENSIONS_TOOL_NAME: &str =
     "platform__search_available_extensions";
 pub const PLATFORM_ENABLE_EXTENSION_TOOL_NAME: &str = "platform__enable_extension";
+pub const PLATFORM_DISABLE_EXTENSION_TOOL_NAME: &str = "platform__disable_extension";
 
 pub fn read_resource_tool() -> Tool {
     Tool::new(
@@ -102,7 +103,30 @@ pub fn enable_extension_tool() -> Tool {
             }
         }),
         Some(ToolAnnotations {
-            title: Some("Enable extensions".to_string()),
+            title: Some("Enable an extension".to_string()),
+            read_only_hint: false,
+            destructive_hint: false,
+            idempotent_hint: false,
+            open_world_hint: false,
+        }),
+    )
+}
+
+pub fn disable_extension_tool() -> Tool {
+    Tool::new(
+        PLATFORM_DISABLE_EXTENSION_TOOL_NAME.to_string(),
+        "Disable an extension to preserve relevant extensions and tools.
+        "
+        .to_string(),
+        json!({
+            "type": "object",
+            "required": ["extension_name"],
+            "properties": {
+                "extension_name": {"type": "string", "description": "The name of the extension to enable"}
+            }
+        }),
+        Some(ToolAnnotations {
+            title: Some("Disable an extension".to_string()),
             read_only_hint: false,
             destructive_hint: false,
             idempotent_hint: false,

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -62,6 +62,7 @@ impl PromptManager {
         &self,
         extensions_info: Vec<ExtensionInfo>,
         frontend_instructions: Option<String>,
+        suggest_disable_extensions_prompt: Value,
         model_name: Option<&str>,
     ) -> String {
         let mut context: HashMap<&str, Value> = HashMap::new();
@@ -80,6 +81,12 @@ impl PromptManager {
 
         let current_date_time = Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
         context.insert("current_date_time", Value::String(current_date_time));
+
+        // Add the suggestion about disabling extensions if flag is true
+        context.insert(
+            "suggest_disable",
+            Value::String(suggest_disable_extensions_prompt.to_string()),
+        );
 
         // First check the global store, and only if it's not available, fall back to the provided model_name
         let model_to_use: Option<String> =

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -37,6 +37,7 @@ impl Agent {
         let mut system_prompt = self.prompt_manager.build_system_prompt(
             extensions_info,
             self.frontend_instructions.clone(),
+            extension_manager.suggest_disable_extensions_prompt().await,
             Some(model_name),
         );
 

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -1,6 +1,4 @@
-use crate::agents::platform_tools::{
-    PLATFORM_DISABLE_EXTENSION_TOOL_NAME, PLATFORM_ENABLE_EXTENSION_TOOL_NAME,
-};
+use crate::agents::platform_tools::PLATFORM_MANAGE_EXTENSIONS_TOOL_NAME;
 use crate::config::permission::PermissionLevel;
 use crate::config::PermissionManager;
 use crate::message::{Message, MessageContent, ToolRequest};
@@ -181,9 +179,7 @@ pub async fn check_tool_permissions(
             } else if mode == "auto" {
                 approved.push(request.clone());
             } else {
-                if tool_call.name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME
-                    || tool_call.name == PLATFORM_DISABLE_EXTENSION_TOOL_NAME
-                {
+                if tool_call.name == PLATFORM_MANAGE_EXTENSIONS_TOOL_NAME {
                     extension_request_ids.push(request.id.clone());
                 }
 
@@ -434,8 +430,8 @@ mod tests {
         let enable_extension = ToolRequest {
             id: "tool_3".to_string(),
             tool_call: ToolResult::Ok(ToolCall {
-                name: PLATFORM_ENABLE_EXTENSION_TOOL_NAME.to_string(),
-                arguments: serde_json::json!({"url": "http://example.com"}),
+                name: PLATFORM_MANAGE_EXTENSIONS_TOOL_NAME.to_string(),
+                arguments: serde_json::json!({"action": "enable", "extension_name": "data_fetcher"}),
             }),
         };
 

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -1,4 +1,4 @@
-use crate::agents::platform_tools::PLATFORM_ENABLE_EXTENSION_TOOL_NAME;
+use crate::agents::platform_tools::{PLATFORM_ENABLE_EXTENSION_TOOL_NAME, PLATFORM_DISABLE_EXTENSION_TOOL_NAME};
 use crate::config::permission::PermissionLevel;
 use crate::config::PermissionManager;
 use crate::message::{Message, MessageContent, ToolRequest};
@@ -170,7 +170,7 @@ pub async fn check_tool_permissions(
     let mut needs_approval = vec![];
     let mut denied = vec![];
     let mut llm_detect_candidates = vec![];
-    let mut enable_extension_request_ids = vec![];
+    let mut extension_request_ids = vec![];
 
     for request in candidate_requests {
         if let Ok(tool_call) = request.tool_call.clone() {
@@ -179,8 +179,8 @@ pub async fn check_tool_permissions(
             } else if mode == "auto" {
                 approved.push(request.clone());
             } else {
-                if tool_call.name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME {
-                    enable_extension_request_ids.push(request.id.clone());
+                if tool_call.name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME || tool_call.name == PLATFORM_DISABLE_EXTENSION_TOOL_NAME {
+                    extension_request_ids.push(request.id.clone());
                 }
 
                 // 1. Check user-defined permission
@@ -255,7 +255,7 @@ pub async fn check_tool_permissions(
             needs_approval,
             denied,
         },
-        enable_extension_request_ids,
+        extension_request_ids,
     )
 }
 

--- a/crates/goose/src/permission/permission_judge.rs
+++ b/crates/goose/src/permission/permission_judge.rs
@@ -1,4 +1,6 @@
-use crate::agents::platform_tools::{PLATFORM_ENABLE_EXTENSION_TOOL_NAME, PLATFORM_DISABLE_EXTENSION_TOOL_NAME};
+use crate::agents::platform_tools::{
+    PLATFORM_DISABLE_EXTENSION_TOOL_NAME, PLATFORM_ENABLE_EXTENSION_TOOL_NAME,
+};
 use crate::config::permission::PermissionLevel;
 use crate::config::PermissionManager;
 use crate::message::{Message, MessageContent, ToolRequest};
@@ -179,7 +181,9 @@ pub async fn check_tool_permissions(
             } else if mode == "auto" {
                 approved.push(request.clone());
             } else {
-                if tool_call.name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME || tool_call.name == PLATFORM_DISABLE_EXTENSION_TOOL_NAME {
+                if tool_call.name == PLATFORM_ENABLE_EXTENSION_TOOL_NAME
+                    || tool_call.name == PLATFORM_DISABLE_EXTENSION_TOOL_NAME
+                {
                     extension_request_ids.push(request.id.clone());
                 }
 

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -31,6 +31,11 @@ and platform__list_resources on this extension.
 No extensions are defined. You should let the user know that they should add extensions.
 {% endif %}
 
+{% if suggest_disable is defined %}
+# Suggestion
+{{suggest_disable}}
+{% endif %}
+
 # Response Guidelines
 
 - Use Markdown formatting for all responses.

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.19"
+    "version": "1.0.20"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.20"
+    "version": "1.0.19"
   },
   "paths": {
     "/agent/tools": {


### PR DESCRIPTION
* Adds a disable extension capability for mcp router
* Rebases on agent refactor, also extension enabling now falls under tool permissions, which simplifies the code

--- 

**1.** goose will bring up that you have too many extensions enabled unprompted. As well, goose does not bring it up again if you decline.
<img width="737" alt="image" src="https://github.com/user-attachments/assets/ec849ad9-9bd2-42f3-8034-676cad0b2f90" />

--- 

**2.** repurposes `search_available_extensions` to also show extensions available to disable
<img width="730" alt="image" src="https://github.com/user-attachments/assets/8ea47aa6-0f5b-47e5-85d7-94e4ac2b416e" />

--- 

**3.** disable occurs as tool calls, individually
<img width="735" alt="image" src="https://github.com/user-attachments/assets/e0dd9367-7eb6-49f7-805f-42f38169a478" />
