### PR TITLE
feat: bottom bar text truncation and tooltips

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.19"
+    "version": "1.0.20"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
@@ -152,20 +152,16 @@ export default function BottomMenu({
         }}
       >
         <Document className="mr-1" />
-        <span className="truncate max-w-[170px]">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <span className="truncate max-w-[170px] min-w-0 block">
-                  Working in {window.appConfig.get('GOOSE_WORKING_DIR')}
-                </span>
-              </TooltipTrigger>
-              <TooltipContent side="top">
-                {window.appConfig.get('GOOSE_WORKING_DIR')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        </span>
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="truncate max-w-[170px] md:max-w-[240px] lg:max-w-[380px] min-w-0 block">
+                Working in {window.appConfig.get('GOOSE_WORKING_DIR')}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent side="top">{window.appConfig.get('GOOSE_WORKING_DIR')}</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
         <ChevronUp className="ml-1" />
       </span>
 

--- a/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
@@ -12,6 +12,7 @@ import { BottomMenuModeSelection } from './BottomMenuModeSelection';
 import ModelsBottomBar from '../settings_v2/models/bottom_bar/ModelsBottomBar';
 import { useConfig } from '../ConfigContext';
 import { getCurrentModelAndProvider } from '../settings_v2/models';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/Tooltip';
 
 const TOKEN_LIMIT_DEFAULT = 128000; // fallback for custom models that the backend doesn't know about
 const TOKEN_WARNING_THRESHOLD = 0.8; // warning shows at 80% of the token limit
@@ -152,7 +153,18 @@ export default function BottomMenu({
       >
         <Document className="mr-1" />
         <span className="truncate max-w-[170px]">
-          Working in {window.appConfig.get('GOOSE_WORKING_DIR')}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="truncate max-w-[170px] min-w-0 block">
+                  Working in {window.appConfig.get('GOOSE_WORKING_DIR')}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">
+                {window.appConfig.get('GOOSE_WORKING_DIR')}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </span>
         <ChevronUp className="ml-1" />
       </span>

--- a/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
@@ -151,7 +151,9 @@ export default function BottomMenu({
         }}
       >
         <Document className="mr-1" />
-        Working in {window.appConfig.get('GOOSE_WORKING_DIR')}
+        <span className="truncate max-w-[170px]">
+          Working in {window.appConfig.get('GOOSE_WORKING_DIR')}
+        </span>
         <ChevronUp className="ml-1" />
       </span>
 

--- a/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
@@ -155,7 +155,7 @@ export default function BottomMenu({
         <TooltipProvider>
           <Tooltip>
             <TooltipTrigger asChild>
-              <span className="truncate max-w-[170px] md:max-w-[240px] lg:max-w-[380px] min-w-0 block">
+              <span className="truncate max-w-[170px] md:max-w-[200px] lg:max-w-[380px] min-w-0 block">
                 Working in {window.appConfig.get('GOOSE_WORKING_DIR')}
               </span>
             </TooltipTrigger>

--- a/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
@@ -123,7 +123,7 @@ export const BottomMenuModeSelection = ({ setView }: BottomMenuModeSelectionProp
         className="flex items-center cursor-pointer"
         onClick={() => setIsGooseModeMenuOpen(!isGooseModeMenuOpen)}
       >
-        <span className="truncate w-[170px]">Goose Mode: {getValueByKey(gooseMode)}</span>
+        <span className="truncate max-w-[170px]">Goose Mode: {getValueByKey(gooseMode)}</span>
         {isGooseModeMenuOpen ? (
           <ChevronDown className="w-4 h-4 ml-1" />
         ) : (

--- a/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
@@ -123,7 +123,9 @@ export const BottomMenuModeSelection = ({ setView }: BottomMenuModeSelectionProp
         className="flex items-center cursor-pointer"
         onClick={() => setIsGooseModeMenuOpen(!isGooseModeMenuOpen)}
       >
-        <span className="truncate max-w-[170px]">Goose Mode: {getValueByKey(gooseMode)}</span>
+        <span className="truncate max-w-[170px] md:max-w-[240px]">
+          Goose Mode: {getValueByKey(gooseMode)}
+        </span>
         {isGooseModeMenuOpen ? (
           <ChevronDown className="w-4 h-4 ml-1" />
         ) : (

--- a/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
@@ -123,7 +123,7 @@ export const BottomMenuModeSelection = ({ setView }: BottomMenuModeSelectionProp
         className="flex items-center cursor-pointer"
         onClick={() => setIsGooseModeMenuOpen(!isGooseModeMenuOpen)}
       >
-        <span className="truncate max-w-[170px] md:max-w-[240px]">
+        <span className="truncate max-w-[170px] md:max-w-[200px] lg:max-w-[380px]">
           Goose Mode: {getValueByKey(gooseMode)}
         </span>
         {isGooseModeMenuOpen ? (

--- a/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
@@ -118,7 +118,7 @@ export const BottomMenuModeSelection = ({ setView }: BottomMenuModeSelectionProp
   }
 
   return (
-    <div className="relative flex items-center ml-6" ref={gooseModeDropdownRef}>
+    <div className="relative flex items-center" ref={gooseModeDropdownRef}>
       <div
         className="flex items-center cursor-pointer"
         onClick={() => setIsGooseModeMenuOpen(!isGooseModeMenuOpen)}

--- a/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
@@ -59,7 +59,7 @@ export default function ModelsBottomBar({ dropdownRef, setView }: ModelsBottomBa
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="truncate max-w-[170px] min-w-0 block">
+                <span className="truncate max-w-[130px] min-w-0 block">
                   {model || 'Select Model'}
                 </span>
               </TooltipTrigger>

--- a/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
@@ -5,6 +5,7 @@ import { useConfig } from '../../../ConfigContext';
 import { getCurrentModelAndProviderForDisplay } from '../index';
 import { AddModelModal } from '../subcomponents/AddModelModal';
 import { View } from '../../../../App';
+import { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider } from '../../../ui/Tooltip';
 
 interface ModelsBottomBarProps {
   dropdownRef: React.RefObject<HTMLDivElement>;
@@ -52,14 +53,23 @@ export default function ModelsBottomBar({ dropdownRef, setView }: ModelsBottomBa
     <div className="relative flex items-center ml-auto mr-4" ref={dropdownRef}>
       <div ref={menuRef} className="relative">
         <div
-          className="flex items-center cursor-pointer"
+          className="flex items-center cursor-pointer max-w-[180px] min-w-0 group"
           onClick={() => setIsModelMenuOpen(!isModelMenuOpen)}
         >
-          {model}
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <span className="truncate max-w-[130px] min-w-0 block">
+                  {model || 'Select Model'}
+                </span>
+              </TooltipTrigger>
+              <TooltipContent side="top">{model || 'Select Model'}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           {isModelMenuOpen ? (
-            <ChevronDown className="w-4 h-4 ml-1" />
+            <ChevronDown className="w-4 h-4 ml-1 flex-shrink-0" />
           ) : (
-            <ChevronUp className="w-4 h-4 ml-1" />
+            <ChevronUp className="w-4 h-4 ml-1 flex-shrink-0" />
           )}
         </div>
 

--- a/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
@@ -53,13 +53,13 @@ export default function ModelsBottomBar({ dropdownRef, setView }: ModelsBottomBa
     <div className="relative flex items-center ml-auto mr-4" ref={dropdownRef}>
       <div ref={menuRef} className="relative">
         <div
-          className="flex items-center cursor-pointer max-w-[180px] min-w-0 group"
+          className="flex items-center cursor-pointer max-w-[180px] md:max-w-[240px] lg:max-w-[380px] min-w-0 group"
           onClick={() => setIsModelMenuOpen(!isModelMenuOpen)}
         >
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="truncate max-w-[130px] min-w-0 block">
+                <span className="truncate max-w-[130px] md:max-w-[240px] lg:max-w-[360px] min-w-0 block">
                   {model || 'Select Model'}
                 </span>
               </TooltipTrigger>

--- a/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
@@ -53,13 +53,13 @@ export default function ModelsBottomBar({ dropdownRef, setView }: ModelsBottomBa
     <div className="relative flex items-center ml-auto mr-4" ref={dropdownRef}>
       <div ref={menuRef} className="relative">
         <div
-          className="flex items-center cursor-pointer max-w-[180px] md:max-w-[240px] lg:max-w-[380px] min-w-0 group"
+          className="flex items-center cursor-pointer max-w-[180px] md:max-w-[200px] lg:max-w-[380px] min-w-0 group"
           onClick={() => setIsModelMenuOpen(!isModelMenuOpen)}
         >
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="truncate max-w-[130px] md:max-w-[240px] lg:max-w-[360px] min-w-0 block">
+                <span className="truncate max-w-[130px] md:max-w-[200px] lg:max-w-[360px] min-w-0 block">
                   {model || 'Select Model'}
                 </span>
               </TooltipTrigger>

--- a/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings_v2/models/bottom_bar/ModelsBottomBar.tsx
@@ -59,7 +59,7 @@ export default function ModelsBottomBar({ dropdownRef, setView }: ModelsBottomBa
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
-                <span className="truncate max-w-[130px] min-w-0 block">
+                <span className="truncate max-w-[170px] min-w-0 block">
                   {model || 'Select Model'}
                 </span>
               </TooltipTrigger>


### PR DESCRIPTION
> [!NOTE]
> This PR is a draft for now until I get feedback on 3 points (see the end).


## Before

You can see an issue in the bottom bar when model names or the working directory are too long to fit in the UI:

Long model name:
![image](https://github.com/user-attachments/assets/472cf9c0-82af-47ac-bd9d-e164d5bf014d)

Long directory name:
![image](https://github.com/user-attachments/assets/d64cdbec-6915-402c-b935-95bc79134279)


## After

To solve this, I updated the CSS so that the text gets truncated. You can hover the truncated text to reveal a tooltip containing the full text.
Demo video:

https://github.com/user-attachments/assets/a9378b9d-b989-4807-99fd-35b5486e1ad7

----


## Questions for reviewers

I need feedback! Please tell me what you think about:

* The “Goose Mode” indicator having a tooltip as well (for now, it doesn't have one because it can pretty well be inferred what the selected option is based on context)
* Edge cases where the tooltip is so wide that it takes up the whole viewport; how should it be handled? We could set a max width and height with a scroll overflow. Example edge case:
![image](https://github.com/user-attachments/assets/5e42a35e-270e-49ed-bdeb-86e6d842b80b)

* Hiding tooltips when the text is not truncated; this can either be roughly estimated using CSS or more precisely estimated using JS (in React), both of which add utilities to the code for a trivial tweak.