### PR TITLE
fix: only remove toolshim paths that we know of to preserve full paths to extension binaries

### DIFF
--- a/ui/desktop/src/components/settings_v2/extensions/utils.ts
+++ b/ui/desktop/src/components/settings_v2/extensions/utils.ts
@@ -167,9 +167,25 @@ export async function replaceWithShims(cmd: string) {
 }
 
 export function removeShims(cmd: string) {
-  const segments = cmd.split('/');
-  // Filter out any empty segments (which can happen with trailing slashes)
-  const nonEmptySegments = segments.filter((segment) => segment.length > 0);
-  // Return the last segment or empty string if there are no segments
-  return nonEmptySegments.length > 0 ? nonEmptySegments[nonEmptySegments.length - 1] : '';
+  // Only remove shims if the path matches our known shim patterns
+  const shimPatterns = [
+    /\/goose-shims\/goosed$/,
+    /\/goose-shims\/jbang$/,
+    /\/goose-shims\/npx$/,
+    /\/goose-shims\/uvx$/,
+  ];
+
+  // Check if the command matches any shim pattern
+  const isShim = shimPatterns.some((pattern) => pattern.test(cmd));
+
+  if (isShim) {
+    const segments = cmd.split('/');
+    // Filter out any empty segments (which can happen with trailing slashes)
+    const nonEmptySegments = segments.filter((segment) => segment.length > 0);
+    // Return the last segment or empty string if there are no segments
+    return nonEmptySegments.length > 0 ? nonEmptySegments[nonEmptySegments.length - 1] : '';
+  }
+
+  // If it's not a shim, return the original command
+  return cmd;
 }


### PR DESCRIPTION
This fix allows for extension commands to be paths to local binaries (e.g. the vantage-mcp). The fully qualified path was being removed when the toolshim's were being used (i.e. when using the UI). This only looks for the existing shims that we support and pass through commands with full paths through.