### PR TITLE
docs: update from settings to advanced settings

### DIFF
--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -92,7 +92,7 @@ To configure your chosen provider or see available options, run `goose configure
   <TabItem value="ui" label="Goose Desktop">
   **To update your LLM provider and API key:** 
   1. Click `...` in the upper right corner
-  2. Click `Settings`
+  2. Click `Advanced Settings`
   3. Next to `Models`, click `Browse`
   4. Click `Configure` in the upper right corner
   4. Press the `+` button next to the provider of your choice
@@ -100,7 +100,7 @@ To configure your chosen provider or see available options, run `goose configure
 
   **To change provider model**
   1. Click `...` in the upper right corner
-  2. Click `Settings`
+  2. Click `Advanced Settings`
   3. Next to `Models`, click `Browse`
   4. Scroll down to `Add Model` 
   5. Select a Provider from drop down menu
@@ -183,7 +183,7 @@ Goose supports using custom OpenAI-compatible endpoints, which is particularly u
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
     1. Click `...` in the upper right corner
-    2. Click `Settings`
+    2. Click `Advanced Settings`
     3. Next to `Models`, click the `browse` link
     4. Click the `configure` link in the upper right corner
     5. Press the `+` button next to OpenAI
@@ -453,7 +453,7 @@ ollama run michaelneale/deepseek-r1-goose
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
     3. Click `...` in the top-right corner.
-    4. Navigate to `Settings` -> `Browse Models` -> and select `Ollama` from the list.
+    4. Navigate to `Advanced Settings` -> `Browse Models` -> and select `Ollama` from the list.
     5. Enter `michaelneale/deepseek-r1-goose` for the model name.
   </TabItem>
 </Tabs>

--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -80,7 +80,7 @@ Here are the built-in extensions:
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
   1. Click `...` in the top right corner of the Goose Desktop.
-  2. Select `Settings` from the menu.
+  2. Select `Advanced Settings` from the menu.
   3. Under `Extensions`, you can toggle the built-in extensions on or off.
   </TabItem>
 </Tabs>
@@ -229,7 +229,7 @@ Note: Java and Kotlin extensions are only support on Linux and macOS
   <TabItem value="ui" label="Goose Desktop">
  
   1. Click `...` in the top right corner of the Goose Desktop.
-  2. Select `Settings` from the menu.
+  2. Select `Advanced Settings` from the menu.
   3. Under `Extensions`, click `Add custom extension`.
   4. On the `Add custom extension` modal, enter the necessary details
      - If adding an environment variable, click `Add` button to the right of the variable
@@ -291,7 +291,7 @@ You can enable or disable installed extensions based on your workflow needs.
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
   1. Click the three dots in the top-right corner of the application.
-  2. Select `Settings` from the menu, scroll down to the `Extensions` section.
+  2. Select `Advanced Settings` from the menu, scroll down to the `Extensions` section.
   2. Use the toggle switch next to each extension to enable or disable it.
 
   </TabItem>
@@ -330,7 +330,7 @@ You can remove installed extensions.
   <TabItem value="ui" label="Goose Desktop">
 
   1. Click `...` in the top right corner of the Goose Desktop.
-  2. Select `Settings` from the menu.
+  2. Select `Advanced Settings` from the menu.
   3. Under `Extensions`, find the extension you'd like to remove and click on the settings icon beside it.
   4. In the dialog that appears, click `Remove Extension`.
 

--- a/documentation/docs/guides/handling-llm-rate-limits-with-goose.md
+++ b/documentation/docs/guides/handling-llm-rate-limits-with-goose.md
@@ -31,7 +31,7 @@ OpenRouter provides a unified interface for LLMs that allows you to select and s
   <TabItem value="ui" label="Goose Desktop">
 
     1. Click on the three dots in the top-right corner.
-    2. Select `Settings` from the menu.
+    2. Select `Advanced Settings` from the menu.
     3. Click on "Browse" in the `Models` section.
     4. Click on `Configure`
     5. Select `OpenRouter` from the list of available providers.

--- a/documentation/docs/tutorials/computer-controller-mcp.md
+++ b/documentation/docs/tutorials/computer-controller-mcp.md
@@ -87,7 +87,7 @@ Let Goose complete its tasks without interruption - avoid using your mouse or ke
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
   1. Click `...` in the upper right corner
-  2. Click `Settings`
+  2. Click `Advanced Settings`
   3. Under `Extensions`, toggle `Computer Controller` to on.
   </TabItem>
 </Tabs>

--- a/documentation/docs/tutorials/developer-mcp.md
+++ b/documentation/docs/tutorials/developer-mcp.md
@@ -46,7 +46,7 @@ The Developer extension is already enabled by default when Goose is installed.
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
   1. Click `...` in the upper right corner
-  2. Click `Settings`
+  2. Click `Advanced Settings`
   3. Under `Extensions`, toggle `Developer` to on.
   </TabItem>
 </Tabs>

--- a/documentation/docs/tutorials/filesystem-mcp.md
+++ b/documentation/docs/tutorials/filesystem-mcp.md
@@ -142,7 +142,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   <TabItem value="ui" label="Goose Desktop">
 
     1. Click `...` in the upper right corner
-    2. Click `Settings`
+    2. Click `Advanced Settings`
     3. Under `Extensions`, click the `Add` link
     4. On the `Add Extension Manually` modal, enter the following:
             * **Type**: `Standard IO`

--- a/documentation/docs/tutorials/jetbrains-mcp.md
+++ b/documentation/docs/tutorials/jetbrains-mcp.md
@@ -88,7 +88,7 @@ This tutorial covers how to enable and use the JetBrains MCP Server as a built-i
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
   1. Click `...` in the upper right corner
-  2. Click `Settings`
+  2. Click `Advanced Settings`
   3. Under `Extensions`, toggle `Jetbrains` to on.
   </TabItem>
 </Tabs>

--- a/documentation/docs/tutorials/memory-mcp.md
+++ b/documentation/docs/tutorials/memory-mcp.md
@@ -84,7 +84,7 @@ This tutorial covers enabling and using the Memory MCP Server, which is a built-
   </TabItem>
   <TabItem value="ui" label="Goose Desktop">
   1. Click `...` in the upper right corner
-  2. Click `Settings`
+  2. Click `Advanced Settings`
   3. Under `Extensions`, toggle `Memory` to on.
   4. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>

--- a/documentation/docs/tutorials/tutorial-extension.md
+++ b/documentation/docs/tutorials/tutorial-extension.md
@@ -83,7 +83,7 @@ goose configure
 </TabItem>
   <TabItem value="ui" label="Goose Desktop">
   1. Click `...` in the upper right corner
-  2. Click `Settings`
+  2. Click `Advanced Settings`
   3. Under `Extensions`, toggle `Tutorial` to on.
   </TabItem>
 </Tabs>


### PR DESCRIPTION
User created a Discussion post informing us that the docs don't not matching the UI. Docs say settings. UI says Advanced Settings. https://github.com/block/goose/discussions/2251


I opened an issue to track it #2329 

