### PR TITLE
feat: add/change model without reinit of extensions

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.19"
+    "version": "1.0.20"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/src/components/settings_v2/models/index.ts
+++ b/ui/desktop/src/components/settings_v2/models/index.ts
@@ -1,9 +1,8 @@
-import { initializeSystem } from '../../../utils/providerUtils';
+import { initializeAgent } from '../../../agent';
 import { toastError, toastSuccess } from '../../../toasts';
 import { ProviderDetails } from '@/src/api';
 import Model, { getProviderMetadata } from './modelInterface';
 import { ProviderMetadata } from '../../../api';
-import type { ExtensionConfig, FixedExtensionEntry } from '../../ConfigContext';
 
 // titles
 export const UNKNOWN_PROVIDER_TITLE = 'Provider name lookup';
@@ -22,23 +21,16 @@ const SWITCH_MODEL_SUCCESS_MSG = 'Successfully switched models';
 interface changeModelProps {
   model: Model;
   writeToConfig: (key: string, value: unknown, is_secret: boolean) => Promise<void>;
-  getExtensions?: (b: boolean) => Promise<FixedExtensionEntry[]>;
-  addExtension?: (name: string, config: ExtensionConfig, enabled: boolean) => Promise<void>;
 }
 
 // TODO: error handling
-export async function changeModel({
-  model,
-  writeToConfig,
-  getExtensions,
-  addExtension,
-}: changeModelProps) {
+export async function changeModel({ model, writeToConfig }: changeModelProps) {
   const modelName = model.name;
   const providerName = model.provider;
   try {
-    await initializeSystem(providerName, modelName, {
-      getExtensions,
-      addExtension,
+    await initializeAgent({
+      model: model.name,
+      provider: model.provider,
     });
   } catch (error) {
     console.error(`Failed to change model at agent step -- ${modelName} ${providerName}`);

--- a/ui/desktop/src/components/settings_v2/models/model_list/BaseModelsList.tsx
+++ b/ui/desktop/src/components/settings_v2/models/model_list/BaseModelsList.tsx
@@ -30,7 +30,7 @@ export function BaseModelsList({
   } else {
     modelList = providedModelList;
   }
-  const { read, upsert, getExtensions, addExtension } = useConfig();
+  const { read, upsert } = useConfig();
   const [selectedModel, setSelectedModel] = useState<Model | null>(null);
   const [isInitialized, setIsInitialized] = useState(false);
 
@@ -75,7 +75,7 @@ export function BaseModelsList({
   }, [read, modelList, upsert]);
 
   const handleModelSelection = async (model: Model) => {
-    await changeModel({ model: model, writeToConfig: upsert, getExtensions, addExtension });
+    await changeModel({ model: model, writeToConfig: upsert });
   };
 
   const handleRadioChange = async (model: Model) => {

--- a/ui/desktop/src/components/settings_v2/models/subcomponents/AddModelModal.tsx
+++ b/ui/desktop/src/components/settings_v2/models/subcomponents/AddModelModal.tsx
@@ -38,7 +38,7 @@ type AddModelModalProps = {
   setView: (view: View) => void;
 };
 export const AddModelModal = ({ onClose, setView }: AddModelModalProps) => {
-  const { getProviders, upsert, getExtensions, addExtension } = useConfig();
+  const { getProviders, upsert } = useConfig();
   const { switchModel } = useModel();
   const [providerOptions, setProviderOptions] = useState([]);
   const [modelOptions, setModelOptions] = useState([]);
@@ -88,8 +88,6 @@ export const AddModelModal = ({ onClose, setView }: AddModelModalProps) => {
       await changeModel({
         model: modelObj,
         writeToConfig: upsert,
-        getExtensions,
-        addExtension,
       });
 
       // Update the model context


### PR DESCRIPTION
* Leverage the new `/agent/update_provider` endpoint to make it a simpler process when we add/change models
* Replace the call to `initializeSystem` in `changeModel` with a simpler call to `initializeAgent` which doesn't need to do anything with extensions
* Simplify signature of `changeModel` now that it doesn't need extension management methods passed through