### PR TITLE
docs: add description for Quick Tips guide

### DIFF
--- a/documentation/docs/guides/tips.md
+++ b/documentation/docs/guides/tips.md
@@ -2,6 +2,7 @@
 title: Quick Goose Tips
 sidebar_position: 6
 sidebar_label: Quick Tips
+description: Best practices for working with Goose
 ---
 
 ### Goose works on your behalf


### PR DESCRIPTION
updated description. currently it shows as this

<img width="379" alt="image" src="https://github.com/user-attachments/assets/f465809e-ed50-4139-80cb-f79ba8fe5a8c" />
