### PR TITLE
docs: switching Goose Desktop and Goose CLI tabs

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -18,28 +18,7 @@ import DesktopInstallButtons from '@site/src/components/DesktopInstallButtons';
     Choose to install Goose on CLI and/or Desktop:
 
     <Tabs groupId="interface">
-      <TabItem value="cli" label="Goose CLI" default>
-        Run the following command to install the latest version of Goose on macOS:
-
-        ```sh
-        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
-        ```
-        This script will fetch the latest version of Goose and set it up on your system.
-
-        If you'd like to install without interactive configuration, disable `CONFIGURE`:
-
-        ```sh
-        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
-        ```
-
-        :::tip Updating Goose
-        It's best to keep Goose updated. To update Goose, run:
-        ```sh
-        goose update
-        ```
-        :::
-      </TabItem>
-      <TabItem value="ui" label="Goose Desktop">
+      <TabItem value="ui" label="Goose Desktop" default>
         Install Goose directly from the browser or with [Homebrew](https://brew.sh/).
         
         <h3 style={{ marginTop: '1rem' }}>Option 1: Install via Download</h3>
@@ -61,13 +40,34 @@ import DesktopInstallButtons from '@site/src/components/DesktopInstallButtons';
         ---
         <div style={{ marginTop: '1rem' }}>
           :::note Permissions
-          If you’re on an Apple Mac M3 and the Goose desktop app shows no window on launch, check and update the following:
+          If you're on an Apple Mac M3 and the Goose desktop app shows no window on launch, check and update the following:
 
           Ensure the `~/.config` directory has read and write access.
 
           Goose needs this access to create the log directory and file. Once permissions are granted, the app should load correctly. For steps on how to do this, refer to the  [Troubleshooting Guide](/docs/troubleshooting.md#macos-permission-issues)
           :::
         </div>
+      </TabItem>
+      <TabItem value="cli" label="Goose CLI">
+        Run the following command to install the latest version of Goose on macOS:
+
+        ```sh
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+        ```
+        This script will fetch the latest version of Goose and set it up on your system.
+
+        If you'd like to install without interactive configuration, disable `CONFIGURE`:
+
+        ```sh
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+        ```
+
+        :::tip Updating Goose
+        It's best to keep Goose updated. To update Goose, run:
+        ```sh
+        goose update
+        ```
+        :::
       </TabItem>
     </Tabs>
   </TabItem>
@@ -119,10 +119,17 @@ import DesktopInstallButtons from '@site/src/components/DesktopInstallButtons';
 </Tabs>
 
 ## Set LLM Provider
-Goose works with a set of [supported LLM providers][providers], and you’ll need an API key to get started. When you use Goose for the first time, you’ll be prompted to select a provider and enter your API key.
+Goose works with a set of [supported LLM providers][providers], and you'll need an API key to get started. When you use Goose for the first time, you'll be prompted to select a provider and enter your API key.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+    Upon installing, the Provider screen will appear. Here is where you can choose your LLM Provider.
+
+    ![Set Up a Provider UI](../assets/guides/set-up-provider-ui.png)
+
+    Once selecting your provider, you'll be prompted to enter an API key if applicable. Do so, and click `Submit`.
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
     Upon installing, Goose will automatically enter its configuration screen. Here is where you can set up your LLM provider.
 
     :::tip Windows Users
@@ -167,18 +174,20 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
   ```
   :::
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-    Upon installing, the Provider screen will appear. Here is where you can choose your LLM Provider.
-
-    ![Set Up a Provider UI](../assets/guides/set-up-provider-ui.png)
-
-    Once selecting your provider, you'll be prompted to enter an API key if applicable. Do so, and click `Submit`.
-  </TabItem>
 </Tabs>
 
 ## Update Provider
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  **To update your LLM provider and API key:**
+
+    1. Click on the three dots in the top-right corner.
+    2. Select `Provider Settings` from the menu.
+    2. Choose a provider from the list.
+    3. Click Edit, enter your API key, and click `Set as Active`.
+
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
     **To update your LLM provider and API key:**
     1. Run the following command:
     ```sh
@@ -211,15 +220,6 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
     └  Configuration saved successfully
     ```
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  **To update your LLM provider and API key:**
-
-    1. Click on the three dots in the top-right corner.
-    2. Select `Provider Settings` from the menu.
-    2. Choose a provider from the list.
-    3. Click Edit, enter your API key, and click `Set as Active`.
-
-  </TabItem>
 </Tabs>
 
 <RateLimits />
@@ -227,16 +227,16 @@ Goose works with a set of [supported LLM providers][providers], and you’ll nee
 ## Running Goose
 
 <Tabs groupId="interface">
-    <TabItem value="cli" label="Goose CLI" default>
+    <TabItem value="ui" label="Goose Desktop" default>
+        Starting a session in the Goose Desktop is straightforward. After choosing your provider, you'll see the session interface ready for use.
+
+        Type your questions, tasks, or instructions directly into the input field, and Goose will get to work immediately.
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
         From your terminal, navigate to the directory you'd like to start from and run:
         ```sh
         goose session
         ```
-    </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
-        Starting a session in the Goose Desktop is straightforward. After choosing your provider, you’ll see the session interface ready for use.
-
-        Type your questions, tasks, or instructions directly into the input field, and Goose will get to work immediately.
     </TabItem>
 </Tabs>
 
@@ -249,16 +249,16 @@ While core configurations are shared between interfaces, extensions have flexibi
 ::: 
 
 <Tabs groupId="interface">
-    <TabItem value="cli" label="Goose CLI" default>
+    <TabItem value="ui" label="Goose Desktop" default>
+        Navigate to shared configurations through:
+        1. Click `...` in the upper right corner
+        2. Click `Advanced Settings`
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
         Use the following command to manage shared configurations:
         ```sh
         goose configure
         ```
-    </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
-        Navigate to shared configurations through:
-        1. Click `...` in the upper right corner
-        2. Click `Advanced Settings`
     </TabItem>
 </Tabs>
 

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -37,7 +37,27 @@ Goose relies heavily on tool calling capabilities and currently works best with 
 To configure your chosen provider or see available options, run `goose configure` in the CLI or visit the `Provider Settings` page in the Goose Desktop.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  **To update your LLM provider and API key:** 
+  1. Click `...` in the upper right corner
+  2. Click `Advanced Settings`
+  3. Next to `Models`, click `Browse`
+  4. Click `Configure` in the upper right corner
+  4. Press the `+` button next to the provider of your choice
+  5. Add additional configurations (API key, host, etc) then press `submit`
+
+  **To change provider model**
+  1. Click `...` in the upper right corner
+  2. Click `Advanced Settings`
+  3. Next to `Models`, click `Browse`
+  4. Scroll down to `Add Model` 
+  5. Select a Provider from drop down menu
+  6. Enter Model name
+  7. Press `+ Add Model`
+
+  You can explore more models by selecting a `provider` name under `Browse by Provider`. A link will appear, directing you to the provider's website. Once you've found the model you want, return to step 6 and paste the model name.
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
     1. Run the following command: 
 
     ```sh
@@ -89,27 +109,6 @@ To configure your chosen provider or see available options, run `goose configure
    └  
 ```
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  **To update your LLM provider and API key:** 
-  1. Click `...` in the upper right corner
-  2. Click `Advanced Settings`
-  3. Next to `Models`, click `Browse`
-  4. Click `Configure` in the upper right corner
-  4. Press the `+` button next to the provider of your choice
-  5. Add additional configurations (API key, host, etc) then press `submit`
-
-  **To change provider model**
-  1. Click `...` in the upper right corner
-  2. Click `Advanced Settings`
-  3. Next to `Models`, click `Browse`
-  4. Scroll down to `Add Model` 
-  5. Select a Provider from drop down menu
-  6. Enter Model name
-  7. Press `+ Add Model`
-
-  You can explore more models by selecting a `provider` name under `Browse by Provider`. A link will appear, directing you to the provider's website. Once you've found the model you want, return to step 6 and paste the model name.
-  </TabItem>
-
 </Tabs>
 
 ## Using Custom OpenAI Endpoints
@@ -171,17 +170,7 @@ Goose supports using custom OpenAI-compatible endpoints, which is particularly u
 ### Setup Instructions
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
-    1. Run `goose configure`
-    2. Select `Configure Providers`
-    3. Choose `OpenAI` as the provider
-    4. Enter your configuration when prompted:
-       - API key
-       - Host URL (if using custom endpoint)
-       - Organization ID (if using organization tracking)
-       - Project identifier (if using project management)
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
+  <TabItem value="ui" label="Goose Desktop" default>
     1. Click `...` in the upper right corner
     2. Click `Advanced Settings`
     3. Next to `Models`, click the `browse` link
@@ -193,6 +182,16 @@ Goose supports using custom OpenAI-compatible endpoints, which is particularly u
        - Organization ID (for usage tracking)
        - Project (for resource management)
     7. Press `submit`
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
+    1. Run `goose configure`
+    2. Select `Configure Providers`
+    3. Choose `OpenAI` as the provider
+    4. Enter your configuration when prompted:
+       - API key
+       - Host URL (if using custom endpoint)
+       - Organization ID (if using organization tracking)
+       - Project identifier (if using project management)
   </TabItem>
 </Tabs>
 
@@ -217,7 +216,16 @@ Google Gemini provides a free tier. To start using the Gemini API with Goose, yo
 To set up Google Gemini with Goose, follow these steps:
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  **To update your LLM provider and API key:** 
+
+    1. Click on the three dots in the top-right corner.
+    2. Select `Provider Settings` from the menu.
+    2. Choose `Google Gemini` as provider from the list.
+    3. Click Edit, enter your API key, and click `Set as Active`.
+
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
     1. Run: 
     ```sh
     goose configure
@@ -246,16 +254,6 @@ To set up Google Gemini with Goose, follow these steps:
     │
     └ Configuration saved successfully
     ```
-    
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  **To update your LLM provider and API key:** 
-
-    1. Click on the three dots in the top-right corner.
-    2. Select `Provider Settings` from the menu.
-    2. Choose `Google Gemini` as provider from the list.
-    3. Click Edit, enter your API key, and click `Set as Active`.
-
   </TabItem>
 </Tabs>
 
@@ -375,7 +373,12 @@ ollama run michaelneale/deepseek-r1-goose
 ```
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+    3. Click `...` in the top-right corner.
+    4. Navigate to `Advanced Settings` -> `Browse Models` -> and select `Ollama` from the list.
+    5. Enter `michaelneale/deepseek-r1-goose` for the model name.
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
     3. In a separate terminal window, configure with Goose:
 
     ```sh
@@ -450,11 +453,6 @@ ollama run michaelneale/deepseek-r1-goose
     │
     └  Configuration saved successfully
     ```
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-    3. Click `...` in the top-right corner.
-    4. Navigate to `Advanced Settings` -> `Browse Models` -> and select `Ollama` from the list.
-    5. Enter `michaelneale/deepseek-r1-goose` for the model name.
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -30,8 +30,13 @@ Here are the built-in extensions:
 #### Toggling Built-in Extensions
 
 <Tabs groupId="interface">
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. Click `...` in the top right corner of the Goose Desktop.
+  2. Select `Advanced Settings` from the menu.
+  3. Under `Extensions`, you can toggle the built-in extensions on or off.
+  </TabItem>
 
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="cli" label="Goose CLI">
     
     If you know the exact name of the extension you'd like to add, run:
 
@@ -46,7 +51,7 @@ Here are the built-in extensions:
     goose configure
     ```
     2. Select `Add Extension` from the menu.
-    3. Choose the type of extension you’d like to add:
+    3. Choose the type of extension you'd like to add:
         - `Built-In Extension`: Use an extension that comes pre-installed with Goose.
         - `Command-Line Extension`: Add a local command or script to run as an extension.
         - `Remote Extension`: Connect to a remote system via SSE (Server-Sent Events).
@@ -78,11 +83,6 @@ Here are the built-in extensions:
     └  Enabled jetbrains extension    
     ```
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the top right corner of the Goose Desktop.
-  2. Select `Advanced Settings` from the menu.
-  3. Under `Extensions`, you can toggle the built-in extensions on or off.
-  </TabItem>
 </Tabs>
 
 
@@ -112,7 +112,25 @@ See available servers in the **[MCP Server Directory](https://www.pulsemcp.com/s
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+ 
+  1. Click `...` in the top right corner of the Goose Desktop.
+  2. Select `Advanced Settings` from the menu.
+  3. Under `Extensions`, click `Add custom extension`.
+  4. On the `Add custom extension` modal, enter the necessary details
+     - If adding an environment variable, click `Add` button to the right of the variable
+     - The `Timeout` field lets you set how long Goose should wait for a tool call from this extension to complete
+  5. Click `Add` button
+  
+  #### Example of adding the [Knowledge Graph Memory MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory):
+    * **Type**: `Standard IO`
+    * **ID**: `kgm-mcp` (_set this to whatever you want_)
+    * **Name**: `Knowledge Graph Memory` (_set this to whatever you want_)
+    * **Description**: `maps and stores complex relationships between concepts` (_set this to whatever you want_)
+    * **Command**: `npx -y @modelcontextprotocol/server-memory`
+  </TabItem>
+
+  <TabItem value="cli" label="Goose CLI">
   
   1. Run the following command: 
 
@@ -226,23 +244,6 @@ Note: Java and Kotlin extensions are only support on Linux and macOS
   </Tabs>
 
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
- 
-  1. Click `...` in the top right corner of the Goose Desktop.
-  2. Select `Advanced Settings` from the menu.
-  3. Under `Extensions`, click `Add custom extension`.
-  4. On the `Add custom extension` modal, enter the necessary details
-     - If adding an environment variable, click `Add` button to the right of the variable
-     - The `Timeout` field lets you set how long Goose should wait for a tool call from this extension to complete
-  5. Click `Add` button
-  
-  #### Example of adding the [Knowledge Graph Memory MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory):
-    * **Type**: `Standard IO`
-    * **ID**: `kgm-mcp` (_set this to whatever you want_)
-    * **Name**: `Knowledge Graph Memory` (_set this to whatever you want_)
-    * **Description**: `maps and stores complex relationships between concepts` (_set this to whatever you want_)
-    * **Command**: `npx -y @modelcontextprotocol/server-memory`
-  </TabItem>
 </Tabs>
 
 ### Config Entry
@@ -266,7 +267,14 @@ extensions:
 You can enable or disable installed extensions based on your workflow needs.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. Click the three dots in the top-right corner of the application.
+  2. Select `Advanced Settings` from the menu, scroll down to the `Extensions` section.
+  2. Use the toggle switch next to each extension to enable or disable it.
+
+  </TabItem>
+
+  <TabItem value="cli" label="Goose CLI">
     1. Run the following command to open up Goose's configurations:
     ```sh
     goose configure
@@ -289,12 +297,6 @@ You can enable or disable installed extensions based on your workflow needs.
     └   
     ```
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. Click the three dots in the top-right corner of the application.
-  2. Select `Advanced Settings` from the menu, scroll down to the `Extensions` section.
-  2. Use the toggle switch next to each extension to enable or disable it.
-
-  </TabItem>
 </Tabs>
 
 
@@ -303,7 +305,16 @@ You can enable or disable installed extensions based on your workflow needs.
 You can remove installed extensions. 
 
 <Tabs groupId="interface">
-<TabItem value="cli" label="Config file" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+
+  1. Click `...` in the top right corner of the Goose Desktop.
+  2. Select `Advanced Settings` from the menu.
+  3. Under `Extensions`, find the extension you'd like to remove and click on the settings icon beside it.
+  4. In the dialog that appears, click `Remove Extension`.
+
+  </TabItem>
+
+  <TabItem value="cli" label="Config file">
   :::info
   To remove an extension, you must [disable](#enablingdisabling-extensions) it first.
   :::
@@ -326,14 +337,6 @@ You can remove installed extensions.
     └  
     ```
     5. Press Enter to save
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-
-  1. Click `...` in the top right corner of the Goose Desktop.
-  2. Select `Advanced Settings` from the menu.
-  3. Under `Extensions`, find the extension you'd like to remove and click on the settings icon beside it.
-  4. In the dialog that appears, click `Remove Extension`.
-
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/guides/goose-permissions.md
+++ b/documentation/docs/guides/goose-permissions.md
@@ -28,7 +28,22 @@ Goose’s permissions determine how much autonomy it has when modifying files, u
 Here's how to configure:
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+
+    You can change modes before or during a session and it will take effect immediately.
+
+     <Tabs>
+      <TabItem value="session" label="In Session" default>
+      Click the Goose Mode option from the bottom menu. 
+      </TabItem>
+      <TabItem value="settings" label="From Settings">
+        1. Click `...` in the upper right corner
+        2. Click `Settings`
+        3. Under `Mode Selection`, choose the mode you'd like
+      </TabItem>
+    </Tabs>   
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
     <Tabs>
       <TabItem value="session" label="In Session" default>
@@ -100,21 +115,6 @@ Here's how to configure:
         ```     
       </TabItem>
     </Tabs>
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-
-    You can change modes before or during a session and it will take effect immediately.
-
-     <Tabs>
-      <TabItem value="session" label="In Session" default>
-      Click the Goose Mode option from the bottom menu. 
-      </TabItem>
-      <TabItem value="settings" label="From Settings">
-        1. Click `...` in the upper right corner
-        2. Click `Settings`
-        3. Under `Mode Selection`, choose the mode you'd like
-      </TabItem>
-    </Tabs>   
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/guides/handling-llm-rate-limits-with-goose.md
+++ b/documentation/docs/guides/handling-llm-rate-limits-with-goose.md
@@ -20,16 +20,7 @@ OpenRouter provides a unified interface for LLMs that allows you to select and s
 2. Once verified, create your [API key](https://openrouter.ai/settings/keys).
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
-    1. Run the Goose configuration command:
-    ```sh
-    goose configure
-    ```
-    2. Select `Configure Providers` from the menu.
-    3. Follow the prompts to choose OpenRouter as your provider and enter your OpenRouter API key when prompted.
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-
+  <TabItem value="ui" label="Goose Desktop" default>
     1. Click on the three dots in the top-right corner.
     2. Select `Advanced Settings` from the menu.
     3. Click on "Browse" in the `Models` section.
@@ -37,8 +28,15 @@ OpenRouter provides a unified interface for LLMs that allows you to select and s
     5. Select `OpenRouter` from the list of available providers.
     6. Enter your OpenRouter API key in the dialog that appears.
   </TabItem>
+  <TabItem value="cli" label="Goose CLI">
+    1. Run the Goose configuration command:
+    ```sh
+    goose configure
+    ```
+    2. Select `Configure Providers` from the menu.
+    3. Follow the prompts to choose OpenRouter as your provider and enter your OpenRouter API key when prompted.
+  </TabItem>
 </Tabs>
 
 
 Now Goose will send your requests through OpenRouter which will automatically switch models when necessary to avoid interruptions due to rate limiting.
-

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -13,17 +13,17 @@ A session is a single, continuous interaction between you and Goose, providing a
 ## Start Session 
 
 <Tabs>
-    <TabItem value="cli" label="Goose CLI" default>
+    <TabItem value="ui" label="Goose Desktop" default>
+        After choosing an LLM provider, you'll see the session interface ready for use. Type your questions, tasks, or instructions directly into the input field, and Goose will immediately get to work. 
+
+        To start a new session at any time, click the three dots in the top-right corner of the application and select **New Session** from the dropdown menu.
+
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
         From your terminal, navigate to the directory from which you'd like to start, and run:
         ```sh
         goose session 
         ```
-    </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
-        After choosing an LLM provider, you’ll see the session interface ready for use. Type your questions, tasks, or instructions directly into the input field, and Goose will immediately get to work. 
-
-        To start a new session at any time, click the three dots in the top-right corner of the application and select **New Session** from the dropdown menu.
-
     </TabItem>
 </Tabs>
 
@@ -33,7 +33,10 @@ If this is your first session, Goose will prompt you for an API key to access an
 
 ## Name Session
 <Tabs>
-    <TabItem value="cli" label="Goose CLI" default>
+    <TabItem value="ui" label="Goose Desktop" default>
+        Within the Desktop app, sessions are automatically named using the current timestamp in the format `YYYYMMDD_HHMMSS`. Goose also provides a description of the session based on context.
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
         By default, Goose names your session using the current timestamp in the format `YYYYMMDD_HHMMSS`. If you'd like to provide a specific name, this is where you'd do so. For example to name your session `react-migration`, you would run:
 
         ```
@@ -47,29 +50,31 @@ If this is your first session, Goose will prompt you for an API key to access an
         logging to ~/.local/share/goose/sessions/react-migration.json1
         ```
     </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
-        Within the Desktop app, sessions are automatically named using the current timestamp in the format `YYYYMMDD_HHMMSS`. Goose also provides a description of the session based on context.
-    </TabItem>
 </Tabs>
 
 ## Exit Session
 Note that sessions are automatically saved when you exit.
 <Tabs>
-    <TabItem value="cli" label="Goose CLI" default>
+    <TabItem value="ui" label="Goose Desktop" default>
+    To exit a session, simply close the application.
+    </TabItem>    
+    <TabItem value="cli" label="Goose CLI">
         To exit a session, type `exit`. Alternatively, you exit the session by holding down `Ctrl+C`.
 
         Your session will be stored locally in `~/.local/share/goose/sessions`.
     </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
-    To exit a session, simply close the application.
-    </TabItem>    
-
 </Tabs>
 
 ## Resume Session
 
 <Tabs>
-    <TabItem value="cli" label="Goose CLI" default>
+    <TabItem value="ui" label="Goose Desktop" default>
+    1. Click `...` in the upper right corner
+    2. Click `Previous Sessions`
+    3. Click a session
+    4. Click `Resume Session` in the upper right corner
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
         To resume your latest session, you can run the following command:
 
         ```
@@ -79,7 +84,7 @@ Note that sessions are automatically saved when you exit.
         To resume a specific session, run the following command: 
 
         ```
-        goose session -r --name <name>
+        goose session -r --name <n>
         ```
         For example, to resume the session named `react-migration`, you would run:
 
@@ -92,12 +97,6 @@ Note that sessions are automatically saved when you exit.
         :::
 
     </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
-    1. Click `...` in the upper right corner
-    2. Click `Previous Sessions`
-    3. Click a session
-    4. Click `Resume Session` in the upper right corner
-    </TabItem>
 </Tabs>
 
 ### Resume Session Across Interfaces
@@ -105,30 +104,7 @@ Note that sessions are automatically saved when you exit.
 You can resume a CLI session in Desktop and vice versa.
 
 <Tabs>
-    <TabItem value="cli" label="Goose CLI" default>
-    To resume a Desktop session within CLI, get the name of the session from the Desktop app. Note that unless you specifically named the session, its default name is a timestamp in the format `YYYYMMDD_HHMMSS`.
-
-    1. Open Goose Desktop
-    2. Click `...` in the upper right corner
-    3. Click `Previous Sessions`
-    4. Find the session that you want to resume, and copy the basename (without the `.jsonl` extension). 
-    :::note Example
-
-    **Desktop Session**
-
-    | Session Description    | Session Filename             |
-    |------------------------|------------------------------|
-    | GitHub PR Access Issue | **20250305_113223**.jsonl    | 
-
-
-    **CLI Command**
-    ```sh
-    goose session -r --name 20250305_113223
-    ```
-    :::
-
-    </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
+    <TabItem value="ui" label="Goose Desktop" default>
     All saved sessions are listed in the Desktop app, even CLI sessions. To resume a CLI session within the Desktop:
 
     1. Click `...` in the upper right corner
@@ -159,6 +135,29 @@ You can resume a CLI session in Desktop and vice versa.
 
     :::
     </TabItem>
+    <TabItem value="cli" label="Goose CLI">
+    To resume a Desktop session within CLI, get the name of the session from the Desktop app. Note that unless you specifically named the session, its default name is a timestamp in the format `YYYYMMDD_HHMMSS`.
+
+    1. Open Goose Desktop
+    2. Click `...` in the upper right corner
+    3. Click `Previous Sessions`
+    4. Find the session that you want to resume, and copy the basename (without the `.jsonl` extension). 
+    :::note Example
+
+    **Desktop Session**
+
+    | Session Description    | Session Filename             |
+    |------------------------|------------------------------|
+    | GitHub PR Access Issue | **20250305_113223**.jsonl    | 
+
+
+    **CLI Command**
+    ```sh
+    goose session -r --name 20250305_113223
+    ```
+    :::
+
+    </TabItem>
 </Tabs>
 
 ## Search Within Sessions
@@ -166,7 +165,19 @@ You can resume a CLI session in Desktop and vice versa.
 Search allows you to find specific content within your current session. The search functionality is available in both CLI and Desktop interfaces.
 
 <Tabs>
-    <TabItem value="cli" label="Goose CLI" default>
+    <TabItem value="ui" label="Goose Desktop" default>
+        Trigger search using keyboard shortcuts or the search icon:
+
+        | Action | macOS | Windows/Linux |
+        |--------|-------|---------------|
+        | Open Search | `Cmd+F`  | `Ctrl+F`  |
+        | Previous Match | `↑` | `↑` |
+        | Next Match | `↓` | `↓` |
+        | Toggle Case-Sensitivity | `Aa` | `Aa` |
+        | Close Search | `Esc` or X | `Esc` or X |
+
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
         Search functionality is provided by your terminal interface. Use the appropriate shortcut for your environment:
 
         | Terminal | Operating System | Shortcut |
@@ -179,17 +190,5 @@ Search allows you to find specific content within your current session. The sear
         :::info
         Your specific terminal emulator may use a different keyboard shortcut. Check your terminal's documentation or settings for the search command.
         :::
-    </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
-        Trigger search using keyboard shortcuts or the search icon:
-
-        | Action | macOS | Windows/Linux |
-        |--------|-------|---------------|
-        | Open Search | `Cmd+F`  | `Ctrl+F`  |
-        | Previous Match | `↑` | `↑` |
-        | Next Match | `↓` | `↓` |
-        | Toggle Case-Sensitivity | `Aa` | `Aa` |
-        | Close Search | `Esc` or X | `Esc` or X |
-
     </TabItem>
 </Tabs>

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -84,7 +84,7 @@ Note that sessions are automatically saved when you exit.
         To resume a specific session, run the following command: 
 
         ```
-        goose session -r --name <n>
+        goose session -r --name <name>
         ```
         For example, to resume the session named `react-migration`, you would run:
 

--- a/documentation/docs/guides/tool-permissions.md
+++ b/documentation/docs/guides/tool-permissions.md
@@ -42,7 +42,31 @@ Tool permissions work alongside [Goose Permission Modes](/docs/guides/goose-perm
 ## Configuring Tool Permissions
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+
+    You can configure tool permissions through either Manual or Smart Approval modes:
+
+     <Tabs>
+      <TabItem value="manual" label="Manual Approval" default>
+        1. Click `...` in the upper right corner
+        2. Click `Advanced Settings`
+        3. Under `Mode Selection`, choose `Manual Approval`
+        4. Click on an extension name
+        5. Use the dropdown next to each tool to set its permission level
+      </TabItem>
+      <TabItem value="smart" label="Smart Approval">
+      :::tip
+        In Smart Approval mode, Goose will automatically detect and allow read-only operations while requiring approval for state-changing actions.
+      :::
+        1. Click `...` in the upper right corner
+        2. Click `Advanced Settings`
+        3. Under `Mode Selection`, choose `Smart Approval`
+        4. Click on an extension name
+        5. Use the dropdown next to each tool to set its permission level
+      </TabItem>
+    </Tabs>   
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
     1. Run the configure command:
     ```sh
@@ -101,30 +125,6 @@ Tool permissions work alongside [Goose Permission Modes](/docs/guides/goose-perm
     │  ○ Never Allow 
     └
     ```
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-
-    You can configure tool permissions through either Manual or Smart Approval modes:
-
-     <Tabs>
-      <TabItem value="manual" label="Manual Approval" default>
-        1. Click `...` in the upper right corner
-        2. Click `Advanced Settings`
-        3. Under `Mode Selection`, choose `Manual Approval`
-        4. Click on an extension name
-        5. Use the dropdown next to each tool to set its permission level
-      </TabItem>
-      <TabItem value="smart" label="Smart Approval">
-      :::tip
-        In Smart Approval mode, Goose will automatically detect and allow read-only operations while requiring approval for state-changing actions.
-      :::
-        1. Click `...` in the upper right corner
-        2. Click `Advanced Settings`
-        3. Under `Mode Selection`, choose `Smart Approval`
-        4. Click on an extension name
-        5. Use the dropdown next to each tool to set its permission level
-      </TabItem>
-    </Tabs>   
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/guides/updating-goose.md
+++ b/documentation/docs/guides/updating-goose.md
@@ -11,7 +11,19 @@ import DesktopInstallButtons from '@site/src/components/DesktopInstallButtons';
 The Goose CLI and desktop apps are under active and continuous development. To get the newest features and fixes, you should periodically update your Goose client using the following instructions.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+        :::info
+        To update Goose to the latest stable version, reinstall using the instructions below
+        :::
+        <div style={{ marginTop: '1rem' }}>
+          1. <DesktopInstallButtons/>
+          2. Unzip the downloaded zip file.
+          3. Run the executable file to launch the Goose Desktop application.
+          4. Overwrite the existing Goose application with the new version.
+          5. Run the executable file to launch the Goose desktop application.
+        </div>
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
     You can update Goose by running:
 
     ```sh
@@ -40,17 +52,5 @@ The Goose CLI and desktop apps are under active and continuous development. To g
     goose --version
     ```
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-        :::info
-        To update Goose to the latest stable version, reinstall using the instructions below
-        :::
-        <div style={{ marginTop: '1rem' }}>
-          1. <DesktopInstallButtons/>
-          2. Unzip the downloaded zip file.
-          3. Run the executable file to launch the Goose Desktop application.
-          4. Overwrite the existing Goose application with the new version.
-          5. Run the executable file to launch the Goose desktop application.
-        </div>
   </TabItem>
 </Tabs>

--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -28,13 +28,7 @@ You can use both global and local hints at the same time. When both exist, Goose
 :::
 
 <Tabs>
-    <TabItem value="manual" label="Manual" default>
-    
-    - **Global hints file** - Create a `.goosehints` file in `~/.config/goose`.
-    - **Local hints file** -  Create a `.goosehints` file at the root of the directory you'd like it applied to.
-
-    </TabItem>
-    <TabItem value="ui" label="Goose Desktop">
+    <TabItem value="ui" label="Goose Desktop" default>
 
     #### Global hints file
     1. Create a `.goosehints` file in `~/.config/goose`.
@@ -50,6 +44,12 @@ You can use both global and local hints at the same time. When both exist, Goose
     :::tip
     You may have to adjust the screen size to fully see the Save and Cancel buttons.
     :::
+
+    </TabItem>
+    <TabItem value="manual" label="Manual">
+    
+    - **Global hints file** - Create a `.goosehints` file in `~/.config/goose`.
+    - **Local hints file** -  Create a `.goosehints` file at the root of the directory you'd like it applied to.
 
     </TabItem>
 </Tabs>

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -24,25 +24,6 @@ Goose is an open source AI agent that supercharges your software development by 
 You can use Goose via CLI or Desktop application.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI">
-  <details>
-  <summary>Quickstart Video Demo</summary>
-    <iframe
-    class="aspect-ratio"
-    src="https://www.youtube.com/embed/SbomoGzTRQY"
-    title="Getting started with the Goose CLI"
-    frameBorder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowFullScreen
-    ></iframe>
-  </details>
-
-    Run the following command to install the latest version of Goose:
-
-    ```sh
-    curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
-    ```
-  </TabItem>
   <TabItem value="ui" label="Goose Desktop (macOS only)" default>
     <details>
     <summary>Quickstart Video Demo</summary>
@@ -70,6 +51,25 @@ You can use Goose via CLI or Desktop application.
       2. Run the executable file to launch the Goose desktop application.
     </div>
   </TabItem>
+  <TabItem value="cli" label="Goose CLI">
+  <details>
+  <summary>Quickstart Video Demo</summary>
+    <iframe
+    class="aspect-ratio"
+    src="https://www.youtube.com/embed/SbomoGzTRQY"
+    title="Getting started with the Goose CLI"
+    frameBorder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+    ></iframe>
+  </details>
+
+    Run the following command to install the latest version of Goose:
+
+    ```sh
+    curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+    ```
+  </TabItem>
 </Tabs>
 
 ## Configure Provider
@@ -77,6 +77,9 @@ You can use Goose via CLI or Desktop application.
 Goose works with [supported LLM providers][providers]. When you install Goose, you'll be prompted to choose your preferred LLM and supply an API key.
 
 <Tabs groupId="interface">
+  <TabItem value="ui" label="Goose Desktop" default>
+    ![Set Up a Provider UI](./assets/guides/set-up-provider-ui.png)
+  </TabItem>
   <TabItem value="cli" label="Goose CLI">
     Use the up and down arrow keys to navigate the CLI menu, and press Enter once you've selected a choice.
 
@@ -99,9 +102,6 @@ Goose works with [supported LLM providers][providers]. When you install Goose, y
     │
     └ Configuration saved successfully
   ```
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop" default>
-    ![Set Up a Provider UI](./assets/guides/set-up-provider-ui.png)
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/_template_.md
+++ b/documentation/docs/tutorials/_template_.md
@@ -41,7 +41,14 @@ Note that you'll need [JBang](https://www.jbang.dev/download) installed on your 
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40hapins%2Ffigma-mcp&id=figma&name=Figma&description=Figma%20design%20tool%20integration&env=FIGMA_ACCESS_TOKEN%3DAccess%20token%20from%20Figma%20user%20settings)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [XYZ Access Token](/) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -194,13 +201,6 @@ Note that you'll need [JBang](https://www.jbang.dev/download) installed on your 
   ```  
 
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40hapins%2Ffigma-mcp&id=figma&name=Figma&description=Figma%20design%20tool%20integration&env=FIGMA_ACCESS_TOKEN%3DAccess%20token%20from%20Figma%20user%20settings)
-  2. Press `Yes` to confirm the installation
-  3. Obtain a [XYZ Access Token](/) and paste it in
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
-  </TabItem>
 </Tabs>
 
 ## Example Usage
@@ -214,7 +214,7 @@ Note that you'll need [JBang](https://www.jbang.dev/download) installed on your 
 
 ### Goose Output
 
-:::note CLI
+:::note Desktop
 
 {exact output}
 

--- a/documentation/docs/tutorials/agentql-mcp.md
+++ b/documentation/docs/tutorials/agentql-mcp.md
@@ -30,7 +30,14 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=agentql-mcp&id=agentql&name=AgentQL&description=Transform%20unstructured%20web%20content%20into%20structured%20data&env=AGENTQL_API_KEY%3DAgentQL%20API%20Key)
+  2. Press `Yes` to confirm the installation
+  3. Obtain an [AGENTQL_API_KEY](https://dev.agentql.com/api-keys) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -148,13 +155,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added agentql extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=agentql-mcp&id=agentql&name=AgentQL&description=Transform%20unstructured%20web%20content%20into%20structured%20data&env=AGENTQL_API_KEY%3DAgentQL%20API%20Key)
-  2. Press `Yes` to confirm the installation
-  3. Obtain an [AGENTQL_API_KEY](https://dev.agentql.com/api-keys) and paste it in
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/asana-mcp.md
+++ b/documentation/docs/tutorials/asana-mcp.md
@@ -34,7 +34,17 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40roychri%2Fmcp-server-asana&id=asana&name=Asana&description=enable%20task%20automation%2C%20project%20tracking%2C%20and%20team%20collaboration&env=ASANA_ACCESS_TOKEN%3DAsana%20Access%20Token)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [Asana Access Token](https://app.asana.com/0/my-apps) and paste it in
+  :::info
+  See [Asana's developer docs](https://developers.asana.com/docs/personal-access-token) if you need detailed instructions on creating an access token.
+  :::
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -156,16 +166,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added Asana extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40roychri%2Fmcp-server-asana&id=asana&name=Asana&description=enable%20task%20automation%2C%20project%20tracking%2C%20and%20team%20collaboration&env=ASANA_ACCESS_TOKEN%3DAsana%20Access%20Token)
-  2. Press `Yes` to confirm the installation
-  3. Obtain a [Asana Access Token](https://app.asana.com/0/my-apps) and paste it in
-  :::info
-  See [Asana's developer docs](https://developers.asana.com/docs/personal-access-token) if you need detailed instructions on creating an access token.
-  :::
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/blender-mcp.md
+++ b/documentation/docs/tutorials/blender-mcp.md
@@ -46,7 +46,13 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 ### Add Blender MCP Server
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=uvx&arg=blender-mcp&id=blender&name=Blender&description=Blender%203D%20scene%20creation%20integration)
+  2. Press `Yes` to confirm the installation
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -157,12 +163,6 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     └  Added blender extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=uvx&arg=blender-mcp&id=blender&name=Blender&description=Blender%203D%20scene%20creation%20integration)
-  2. Press `Yes` to confirm the installation
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/brave-mcp.md
+++ b/documentation/docs/tutorials/brave-mcp.md
@@ -30,7 +30,14 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-brave-search&id=brave-search&name=Brave%20Search&description=Brave%20Search%20API&env=BRAVE_API_KEY%3DYour%20API%20Key)
+  2. Press `Yes` to confirm the installation
+  3. Get your [Brave Search API Key](https://api-dashboard.search.brave.com/app/keys) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -182,13 +189,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added brave-search extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-brave-search&id=brave-search&name=Brave%20Search&description=Brave%20Search%20API&env=BRAVE_API_KEY%3DYour%20API%20Key)
-  2. Press `Yes` to confirm the installation
-  3. Get your [Brave Search API Key](https://api-dashboard.search.brave.com/app/keys) and paste it in
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/computer-controller-mcp.md
+++ b/documentation/docs/tutorials/computer-controller-mcp.md
@@ -22,7 +22,12 @@ Let Goose complete its tasks without interruption - avoid using your mouse or ke
 1. Ensure extension is enabled:
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. Click `...` in the upper right corner
+  2. Click `Advanced Settings`
+  3. Under `Extensions`, toggle `Computer Controller` to on.
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
   1. Run the `configure` command:
   ```sh
@@ -85,11 +90,6 @@ Let Goose complete its tasks without interruption - avoid using your mouse or ke
   └  Enabled Computer Controller extension
   ```  
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Advanced Settings`
-  3. Under `Extensions`, toggle `Computer Controller` to on.
-  </TabItem>
 </Tabs>
 
 ## Example Usage
@@ -101,7 +101,10 @@ Anthropic's Claude 3.5 Sonnet was used for this task.
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+   1. Open a new session in Goose Desktop
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
   1. Open a terminal and start a new Goose session:
 
@@ -109,9 +112,6 @@ Anthropic's Claude 3.5 Sonnet was used for this task.
   goose session
   ```
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-   1. Open a new session in Goose Desktop
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/developer-mcp.md
+++ b/documentation/docs/tutorials/developer-mcp.md
@@ -23,7 +23,12 @@ The Developer extension is already enabled by default when Goose is installed.
 1. Ensure extension is enabled:
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. Click `...` in the upper right corner
+  2. Click `Advanced Settings`
+  3. Under `Extensions`, toggle `Developer` to on.
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
   1. Run the `configure` command:
   ```sh
@@ -44,11 +49,6 @@ The Developer extension is already enabled by default when Goose is installed.
   └  Extension settings updated successfully
   ```
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Advanced Settings`
-  3. Under `Extensions`, toggle `Developer` to on.
-  </TabItem>
 </Tabs>
 
 ## Example Usage
@@ -61,7 +61,10 @@ Anthropic's Claude 3.5 Sonnet was used for this task.
 
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+   1. Open a new session in Goose Desktop
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
   1. Open a terminal and start a new Goose session:
 
@@ -69,9 +72,6 @@ Anthropic's Claude 3.5 Sonnet was used for this task.
   goose session
   ```
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-   1. Open a new session in Goose Desktop
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/elevenlabs-mcp.md
+++ b/documentation/docs/tutorials/elevenlabs-mcp.md
@@ -33,7 +33,13 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=uvx&arg=elevenlabs-mcp&id=elevenlabs&name=ElevenLabs&description=ElevenLabs%20voice%20synthesis%20server&env=ELEVENLABS_API_KEY)
+  2. Press `Yes` to confirm the installation
+  3. Click `Save Configuration`
+  4. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -180,12 +186,6 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     └  Added elevenlabs extension
   ```   
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=uvx&arg=elevenlabs-mcp&id=elevenlabs&name=ElevenLabs&description=ElevenLabs%20voice%20synthesis%20server&env=ELEVENLABS_API_KEY)
-  2. Press `Yes` to confirm the installation
-  3. Click `Save Configuration`
-  4. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/fetch-mcp.md
+++ b/documentation/docs/tutorials/fetch-mcp.md
@@ -32,7 +32,11 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Web%20content%20fetching%20and%20processing%20capabilities)
+  2. Press `Yes` to confirm the installation
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -142,10 +146,6 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     └  Added fetch extension 
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Web%20content%20fetching%20and%20processing%20capabilities)
-  2. Press `Yes` to confirm the installation
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/figma-mcp.md
+++ b/documentation/docs/tutorials/figma-mcp.md
@@ -33,7 +33,14 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40hapins%2Ffigma-mcp&id=figma&name=Figma&description=Figma%20design%20tool%20integration&env=FIGMA_ACCESS_TOKEN%3DAccess%20token%20from%20Figma%20user%20settings)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [Figma Access Token](https://www.figma.com/developers/api#access-tokens) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -155,13 +162,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added figma extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40hapins%2Ffigma-mcp&id=figma&name=Figma&description=Figma%20design%20tool%20integration&env=FIGMA_ACCESS_TOKEN%3DAccess%20token%20from%20Figma%20user%20settings)
-  2. Press `Yes` to confirm the installation
-  3. Obtain a [Figma Access Token](https://www.figma.com/developers/api#access-tokens) and paste it in
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/filesystem-mcp.md
+++ b/documentation/docs/tutorials/filesystem-mcp.md
@@ -26,7 +26,26 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+
+    1. Click `...` in the upper right corner
+    2. Click `Advanced Settings`
+    3. Under `Extensions`, click the `Add` link
+    4. On the `Add Extension Manually` modal, enter the following:
+            * **Type**: `Standard IO`
+            * **ID**: `filesystem-mcp` (_set this to whatever you want_)
+            * **Name**: `filesystem` (_set this to whatever you want_)
+            * **Description**: `filesystem MCP Server` (_set this to whatever you want_)
+            * **Command**: `npx -y @modelcontextprotocol/server-filesystem /path/to/allowed/directory`
+    5. Click `Add Extension` button
+
+        :::tip Multiple Directories
+        You can specify multiple directories by separating them with a space.
+        ::: 
+
+  </TabItem>
+
+  <TabItem value="cli" label="Goose CLI">
     1. Run the `configure` command:
     ```sh
     goose configure
@@ -137,25 +156,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
         // highlight-end
         └  Added filesystem extension
     ```  
-  </TabItem>
-
-  <TabItem value="ui" label="Goose Desktop">
-
-    1. Click `...` in the upper right corner
-    2. Click `Advanced Settings`
-    3. Under `Extensions`, click the `Add` link
-    4. On the `Add Extension Manually` modal, enter the following:
-            * **Type**: `Standard IO`
-            * **ID**: `filesystem-mcp` (_set this to whatever you want_)
-            * **Name**: `filesystem` (_set this to whatever you want_)
-            * **Description**: `filesystem MCP Server` (_set this to whatever you want_)
-            * **Command**: `npx -y @modelcontextprotocol/server-filesystem /path/to/allowed/directory`
-    5. Click `Add Extension` button
-
-        :::tip Multiple Directories
-        You can specify multiple directories by separating them with a space.
-        ::: 
-
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/github-mcp.md
+++ b/documentation/docs/tutorials/github-mcp.md
@@ -32,7 +32,14 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-github&id=github&name=GitHub&description=GitHub%20API&env=GITHUB_PERSONAL_ACCESS_TOKEN%3DGitHub%20Personal%20Access%20Token)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -154,13 +161,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added github extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-github&id=github&name=GitHub&description=GitHub%20API&env=GITHUB_PERSONAL_ACCESS_TOKEN%3DGitHub%20Personal%20Access%20Token)
-  2. Press `Yes` to confirm the installation
-  3. Obtain a [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens) and paste it in
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/google-drive-mcp.md
+++ b/documentation/docs/tutorials/google-drive-mcp.md
@@ -86,7 +86,21 @@ You'll need to re-authenticate once a day when using the Google Drive extension.
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-gdrive&id=google-drive&name=Google%20Drive&description=Google%20Drive%20integration&env=GDRIVE_CREDENTIALS_PATH%3DPath%20to%20Google%20Drive%20credentials&env=GDRIVE_OAUTH_PATH%3DPath%20to%20OAuth%20token)
+  2. Press `Yes` to confirm the installation
+  3. For `GDRIVE_CREDENTIALS_PATH`, enter the following:
+  ```
+  ~/.config/.gdrive-server-credentials.json
+  ```
+  4. For `GDRIVE_OAUTH_PATH`, enter the following:
+  ```
+  ~/.config/gcp-oauth.keys.json
+  ```
+  5. Click `Save Configuration`
+  6. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -216,20 +230,6 @@ You may need to use absolute paths (rather than relying on shell exapansion for 
     └  Added google drive extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-gdrive&id=google-drive&name=Google%20Drive&description=Google%20Drive%20integration&env=GDRIVE_CREDENTIALS_PATH%3DPath%20to%20Google%20Drive%20credentials&env=GDRIVE_OAUTH_PATH%3DPath%20to%20OAuth%20token)
-  2. Press `Yes` to confirm the installation
-  3. For `GDRIVE_CREDENTIALS_PATH`, enter the following:
-  ```
-  ~/.config/.gdrive-server-credentials.json
-  ```
-  4. For `GDRIVE_OAUTH_PATH`, enter the following:
-  ```
-  ~/.config/gcp-oauth.keys.json
-  ```
-  5. Click `Save Configuration`
-  6. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/google-maps-mcp.md
+++ b/documentation/docs/tutorials/google-maps-mcp.md
@@ -30,8 +30,15 @@ GOOGLE_MAPS_API_KEY: <YOUR_TOKEN>
 Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
 :::
 
-<Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+<Tabs groupId="interface" defaultValue="ui">
+  <TabItem value="ui" label="Goose Desktop">
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-google-maps&id=google-maps&name=Google%20Maps&description=Google%20Maps%20API%20integration&env=GOOGLE_MAPS_API_KEY%3DGoogle%20Maps%20API%20key)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [GOOGLE_MAPS_API_KEY](https://developers.google.com/maps/documentation/javascript/get-api-key) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -150,13 +157,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added github extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-google-maps&id=google-maps&name=Google%20Maps&description=Google%20Maps%20API%20integration&env=GOOGLE_MAPS_API_KEY%3DGoogle%20Maps%20API%20key)
-  2. Press `Yes` to confirm the installation
-  3. Obtain a [GOOGLE_MAPS_API_KEY](https://developers.google.com/maps/documentation/javascript/get-api-key) and paste it in
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/jetbrains-mcp.md
+++ b/documentation/docs/tutorials/jetbrains-mcp.md
@@ -20,7 +20,12 @@ This tutorial covers how to enable and use the JetBrains MCP Server as a built-i
 2. Enable built-in Goose extension:
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. Click `...` in the upper right corner
+  2. Click `Advanced Settings`
+  3. Under `Extensions`, toggle `Jetbrains` to on.
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
   1. Run the `configure` command:
   ```sh
@@ -86,11 +91,6 @@ This tutorial covers how to enable and use the JetBrains MCP Server as a built-i
   └  Enabled jetbrains extension
   ```
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Advanced Settings`
-  3. Under `Extensions`, toggle `Jetbrains` to on.
-  </TabItem>
 </Tabs>
 
 ## Example Usage
@@ -103,7 +103,15 @@ Anthropic's Claude 3.5 Sonnet was used for this task.
 
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+   1. Open [IntelliJ](https://www.jetbrains.com/idea/download) (JetBrains' Java and Kotlin IDE)
+   2. Open a new session in Goose Desktop
+   :::note
+   You will interact with two separate apps: the Goose Desktop app and the IntelliJ IDE.
+   :::
+
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
   1. Open [IntelliJ](https://www.jetbrains.com/idea/download) (JetBrains' Java and Kotlin IDE)
   2. Open a terminal within your IDE and start a new Goose session:
@@ -111,14 +119,6 @@ Anthropic's Claude 3.5 Sonnet was used for this task.
   ```sh
   goose session
   ```
-
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-   1. Open [IntelliJ](https://www.jetbrains.com/idea/download) (JetBrains' Java and Kotlin IDE)
-   2. Open a new session in Goose Desktop
-   :::note
-   You will interact with two separate apps: the Goose Desktop app and the IntelliJ IDE.
-   :::
 
   </TabItem>
 </Tabs>

--- a/documentation/docs/tutorials/knowledge-graph-mcp.md
+++ b/documentation/docs/tutorials/knowledge-graph-mcp.md
@@ -27,7 +27,12 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-memory&id=knowledge_graph_memory&name=Knowledge%20Graph%20Memory&description=Graph-based%20memory%20system%20for%20persistent%20knowledge%20storage)
+  2. Press `Yes` to confirm the installation
+  3. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -136,11 +141,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added knowledge graph memory extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-memory&id=knowledge_graph_memory&name=Knowledge%20Graph%20Memory&description=Graph-based%20memory%20system%20for%20persistent%20knowledge%20storage)
-  2. Press `Yes` to confirm the installation
-  3. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/memory-mcp.md
+++ b/documentation/docs/tutorials/memory-mcp.md
@@ -18,7 +18,13 @@ This tutorial covers enabling and using the Memory MCP Server, which is a built-
 1. Ensure extension is enabled:
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. Click `...` in the upper right corner
+  2. Click `Advanced Settings`
+  3. Under `Extensions`, toggle `Memory` to on.
+  4. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
   1. Run the `configure` command:
   ```sh
@@ -82,12 +88,6 @@ This tutorial covers enabling and using the Memory MCP Server, which is a built-
   └  Enabled Memory extension
   ```  
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Advanced Settings`
-  3. Under `Extensions`, toggle `Memory` to on.
-  4. Scroll to the top and click `Exit` from the upper left corner
-  </TabItem>
 </Tabs>
 
 ## Why Use Memory?  
@@ -125,7 +125,10 @@ If you frequently work with API standards or other structured knowledge, Goose m
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+   1. Open a new session in Goose Desktop
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
   1. Open a terminal and start a new Goose session:
 
@@ -133,9 +136,6 @@ If you frequently work with API standards or other structured knowledge, Goose m
   goose session
   ```
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-   1. Open a new session in Goose Desktop
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/pdf-mcp.md
+++ b/documentation/docs/tutorials/pdf-mcp.md
@@ -28,7 +28,13 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=uvx&arg=mcp-read-pdf&id=pdf_read&name=PDF%20Reader&description=Read%20large%20and%20complex%20PDF%20documents)
+  2. Press `Yes` to confirm the installation
+  3. Click `Save Configuration`
+  4. Scroll to the top and click `Exit` from the upper left corner
+</TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -143,12 +149,6 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 └  Added pdf extension
 ```
 
-</TabItem>
-<TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=uvx&arg=mcp-read-pdf&id=pdf_read&name=PDF%20Reader&description=Read%20large%20and%20complex%20PDF%20documents)
-  2. Press `Yes` to confirm the installation
-  3. Click `Save Configuration`
-  4. Scroll to the top and click `Exit` from the upper left corner
 </TabItem>
    </Tabs>
 

--- a/documentation/docs/tutorials/pieces-mcp.md
+++ b/documentation/docs/tutorials/pieces-mcp.md
@@ -29,7 +29,11 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
 ### Add Pieces MCP Server
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?url=http%3A%2F%2Flocalhost%3A39300%2Fmodel_context_protocol%2F2024-11-05%2Fsse&id=pieces&name=Pieces%20for%20Developers&description=Provides%20access%20to%20your%20Pieces%20Long-Term%20Memory.%20You%20need%20to%20have%20Pieces%20installed%20to%20use%20this.)
+  2. Press `Yes` to confirm the installation
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
 
       ```sh
@@ -175,10 +179,6 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
         └ 
       ```
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?url=http%3A%2F%2Flocalhost%3A39300%2Fmodel_context_protocol%2F2024-11-05%2Fsse&id=pieces&name=Pieces%20for%20Developers&description=Provides%20access%20to%20your%20Pieces%20Long-Term%20Memory.%20You%20need%20to%20have%20Pieces%20installed%20to%20use%20this.)
-  2. Press `Yes` to confirm the installation
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/postgres-mcp.md
+++ b/documentation/docs/tutorials/postgres-mcp.md
@@ -51,7 +51,14 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@modelcontextprotocol/server-postgres&id=postgres&name=PostgreSQL&description=PostgreSQL%20database%20integration&env=POSTGRES_URL%3DYour%20PostgreSQL%20connection%20URL)
+  2. Press `Yes` to confirm the installation
+  3. Enter your PostgreSQL connection URL in the format: `postgresql://username:password@hostname:5432/database`
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -150,13 +157,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added PostgreSQL extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@modelcontextprotocol/server-postgres&id=postgres&name=PostgreSQL&description=PostgreSQL%20database%20integration&env=POSTGRES_URL%3DYour%20PostgreSQL%20connection%20URL)
-  2. Press `Yes` to confirm the installation
-  3. Enter your PostgreSQL connection URL in the format: `postgresql://username:password@hostname:5432/database`
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/puppeteer-mcp.md
+++ b/documentation/docs/tutorials/puppeteer-mcp.md
@@ -27,7 +27,12 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-puppeteer&id=puppeteer&name=Puppeteer&description=Headless%20browser%20automation)
+  2. Press `Yes` to confirm the installation
+  3. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -138,11 +143,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   ```  
 
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-puppeteer&id=puppeteer&name=Puppeteer&description=Headless%20browser%20automation)
-  2. Press `Yes` to confirm the installation
-  3. Scroll to the top and click `Exit` from the upper left corner
-  </TabItem>
 </Tabs>
 
 
@@ -152,17 +152,16 @@ In this example, I’ll show you how to use Goose with the Puppeteer Extension t
 This allows you to quickly identify and resolve accessibility issues without manually inspecting each page.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
-
+  <TabItem value="ui" label="Goose Desktop" default>
+   1. Open a new session in Goose Desktop
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Open a terminal and start a new Goose session:
 
   ```sh
   goose session
   ```
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-   1. Open a new session in Goose Desktop
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/repomix-mcp.md
+++ b/documentation/docs/tutorials/repomix-mcp.md
@@ -29,7 +29,13 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=repomix&arg=--mcp&id=repomix&name=Repomix&description=Pack%20repositories%20into%20AI-friendly%20formats%20for%20Goose)
+  2. Press `Yes` to confirm the installation
+  3. Click `Save Configuration`
+  4. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -140,12 +146,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added repomix extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=repomix&arg=--mcp&id=repomix&name=Repomix&description=Pack%20repositories%20into%20AI-friendly%20formats%20for%20Goose)
-  2. Press `Yes` to confirm the installation
-  3. Click `Save Configuration`
-  4. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/selenium-mcp.md
+++ b/documentation/docs/tutorials/selenium-mcp.md
@@ -29,7 +29,13 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40angiejones%2Fmcp-selenium&id=selenium-mcp&name=Selenium%20MCP&description=automates%20browser%20interactions)
+  2. Press `Yes` to confirm the installation
+  3. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -140,12 +146,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added Selenium extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40angiejones%2Fmcp-selenium&id=selenium-mcp&name=Selenium%20MCP&description=automates%20browser%20interactions)
-  2. Press `Yes` to confirm the installation
-  3. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/speech-mcp.md
+++ b/documentation/docs/tutorials/speech-mcp.md
@@ -33,7 +33,13 @@ Before adding this extension, make sure [PortAudio](https://github.com/GoogleClo
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=uvx&&arg=-p&arg=3.10.14&arg=speech-mcp@latest&id=speech_mcp&name=Speech%20Interface&description=Voice%20interaction%20with%20audio%20visualization%20for%20Goose)
+  2. Press `Yes` to confirm the installation
+  3. Click `Save Configuration`
+  4. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -142,12 +148,6 @@ Before adding this extension, make sure [PortAudio](https://github.com/GoogleClo
   ```  
 
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=uvx&&arg=-p&arg=3.10.14&arg=speech-mcp@latest&id=speech_mcp&name=Speech%20Interface&description=Voice%20interaction%20with%20audio%20visualization%20for%20Goose)
-  2. Press `Yes` to confirm the installation
-  3. Click `Save Configuration`
-  4. Scroll to the top and click `Exit` from the upper left corner
-  </TabItem>
 </Tabs>
 
 
@@ -157,17 +157,16 @@ In this example, you'll see how to use Goose with the Speech MCP Server Extensio
 This allows you to build with Goose hands-free, making development more accessible and interactive.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
-
+  <TabItem value="ui" label="Goose Desktop" default>
+   1. Open a new session in Goose Desktop
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Open a terminal and start a new Goose session:
 
   ```sh
   goose session
   ```
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-   1. Open a new session in Goose Desktop
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/tavily-mcp.md
+++ b/documentation/docs/tutorials/tavily-mcp.md
@@ -31,7 +31,14 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=tavily-mcp&id=tavily&name=Tavily%20Web%20Search&description=Search%20the%20web%20with%20Tavily%20MCP&env=TAVILY_API_KEY%3DTavily%20API%20Key)
+  2. Press `Yes` to confirm the installation
+  3. Obtain a [TAVILY_API_KEY](https://tavily.com/) and paste it in
+  4. Click `Save Configuration`
+  5. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -152,13 +159,6 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     └  Added tavily extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=tavily-mcp&id=tavily&name=Tavily%20Web%20Search&description=Search%20the%20web%20with%20Tavily%20MCP&env=TAVILY_API_KEY%3DTavily%20API%20Key)
-  2. Press `Yes` to confirm the installation
-  3. Obtain a [TAVILY_API_KEY](https://tavily.com/) and paste it in
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/tutorial-extension.md
+++ b/documentation/docs/tutorials/tutorial-extension.md
@@ -18,7 +18,12 @@ The Tutorial extension serves as an interactive learning tool that:
 1. Ensure the Tutorial extension is enabled:
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. Click `...` in the upper right corner
+  2. Click `Advanced Settings`
+  3. Under `Extensions`, toggle `Tutorial` to on.
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
 
 ```sh
 goose configure
@@ -81,11 +86,6 @@ goose configure
    └  Enabled Tutorials extension
 ``` 
 </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. Click `...` in the upper right corner
-  2. Click `Advanced Settings`
-  3. Under `Extensions`, toggle `Tutorial` to on.
-  </TabItem>
 </Tabs>
 
 ## Available Tutorials

--- a/documentation/docs/tutorials/vscode-mcp.md
+++ b/documentation/docs/tutorials/vscode-mcp.md
@@ -33,7 +33,13 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 1. Add the [VS Code MCP Extension](https://marketplace.visualstudio.com/items?itemName=block.vscode-mcp-extension) to your VS Code. No additional settings required in VS Code.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=vscode-mcp-server&id=vscode-mcp&name=VS%20Code%20MCP&description=VS%20Code%20integration%20and%20file%20operations)
+  2. Press `Yes` to confirm the installation
+  3. Click `Save Configuration`
+  4. Click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -118,12 +124,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   
   6. No additional environment variables are required for basic setup
   
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=vscode-mcp-server&id=vscode-mcp&name=VS%20Code%20MCP&description=VS%20Code%20integration%20and%20file%20operations)
-  2. Press `Yes` to confirm the installation
-  3. Click `Save Configuration`
-  4. Click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/tutorials/youtube-transcript.md
+++ b/documentation/docs/tutorials/youtube-transcript.md
@@ -28,7 +28,13 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="ui" label="Goose Desktop" default>
+  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40jkawamoto%2Fmcp-youtube-transcript&id=youtube-transcript&name=YouTube%20Transcript&description=Access%20YouTube%20video%20transcripts)
+  2. Press `Yes` to confirm the installation
+  3. Click `Save Configuration`
+  4. Scroll to the top and click `Exit` from the upper left corner
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -137,12 +143,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     └  Added youtube-transcript extension
   ```  
 
-  </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40jkawamoto%2Fmcp-youtube-transcript&id=youtube-transcript&name=YouTube%20Transcript&description=Access%20YouTube%20video%20transcripts)
-  2. Press `Yes` to confirm the installation
-  3. Click `Save Configuration`
-  4. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
This pull request reorganizes the documentation for Goose's installation, configuration, and usage to prioritize the Goose Desktop interface as the default option. The changes also improve clarity and consistency in instructions for both the CLI and Desktop interfaces. Below is a summary of the most important changes:
