### PR TITLE
Don't require prompt in headless mode for recipes

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -483,10 +483,18 @@ pub async fn cli() -> Result<()> {
                         eprintln!("{}: {}", console::style("Error").red().bold(), err);
                         std::process::exit(1);
                     });
+
+                    let (contents, additional_system_prompt) = match recipe.prompt {
+                        Some(ref p) if !p.trim().is_empty() => {
+                            (Some(p.clone()), Some(recipe.instructions.clone()))
+                        }
+                        _ => (Some(recipe.instructions.clone()), None),
+                    };
+
                     InputConfig {
-                        contents: recipe.prompt,
+                        contents,
                         extensions_override: recipe.extensions,
-                        additional_system_prompt: Some(recipe.instructions),
+                        additional_system_prompt,
                     }
                 }
                 (None, None, None) => {


### PR DESCRIPTION
Prompt is optional in recipes, which makes sense for the UI version, but that doesn't really work in headless mode. So instead here we use the instructions as the first user message instead of adding it the system prompt, which effectively makes prompt optional also for headles