### PR TITLE
changed default model for databricks to goose-claude-3-5-sonnet

### DIFF
--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -22,7 +22,7 @@ const DEFAULT_REDIRECT_URL: &str = "http://localhost:8020";
 // https://openid.net/specs/openid-connect-core-1_0.html#OfflineAccess
 const DEFAULT_SCOPES: &[&str] = &["all-apis", "offline_access"];
 
-pub const DATABRICKS_DEFAULT_MODEL: &str = "goose-claude-3-5-sonnet";
+pub const DATABRICKS_DEFAULT_MODEL: &str = "databricks-claude-3-7-sonnet";
 // Databricks can passthrough to a wide range of models, we only provide the default
 pub const DATABRICKS_KNOWN_MODELS: &[&str] = &[
     "databricks-meta-llama-3-3-70b-instruct",


### PR DESCRIPTION
changed default model for databricks to goose-claude-3-5-sonnet, the previous default llama stopped working for e2e tests