### PR TITLE
docs: Put cli install homebrew command in quickstart.md

### DIFF
--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -69,6 +69,12 @@ You can use Goose via CLI or Desktop application.
     ```sh
     curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
     ```
+    or install Goose via homebrew
+    
+    ```sh
+    brew install block-goose-cli
+    ```
+    
   </TabItem>
 </Tabs>
 


### PR DESCRIPTION
When I installed Goose for the command line I wanted to install it via homebrew but found it was not documented. Future users will now see the command.