### PR TITLE
Changed display of working directory and ellipsis to beginning of path

### DIFF
--- a/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
@@ -176,8 +176,7 @@ export default function BottomMenu({
             <TooltipTrigger asChild>
               <span
                 ref={dirRef}
-                className="max-w-[170px] md:max-w-[200px] lg:max-w-[380px] min-w-0 block overflow-hidden text-ellipsis direction-rtl"
-                style={{ direction: 'rtl', textAlign: 'left' }}
+                className="max-w-[170px] md:max-w-[200px] lg:max-w-[380px] min-w-0 block overflow-hidden text-ellipsis whitespace-nowrap [direction:rtl] text-left"
               >
                 {window.appConfig.get('GOOSE_WORKING_DIR') as string}
               </span>


### PR DESCRIPTION
From user feedback its better to show the end of the path. Removed "Working from" text also.

Before:
![image](https://github.com/user-attachments/assets/5d5027d7-c2b0-4c7f-a00f-dddbe911f027)


After:
![image](https://github.com/user-attachments/assets/dd00e17d-6498-4c1e-be6a-9f2bbf9f5559)
