### PR TITLE
fix: use the pre-fetched mime type

### DIFF
--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -1153,6 +1153,7 @@ impl GoogleDriveRouter {
     async fn get_google_file(
         &self,
         uri: &str,
+        mime_type: &str,
         include_images: bool,
     ) -> Result<Vec<Content>, ToolError> {
         let result = self
@@ -1171,10 +1172,6 @@ impl GoogleDriveRouter {
                 uri, e
             ))),
             Ok(r) => {
-                let file = r.1;
-                let mime_type = file
-                    .mime_type
-                    .unwrap_or("application/octet-stream".to_string());
                 if mime_type.starts_with("text/") || mime_type == "application/json" {
                     if let Ok(body) = r.0.into_body().collect().await {
                         if let Ok(response) = String::from_utf8(body.to_bytes().to_vec()) {
@@ -1277,7 +1274,8 @@ impl GoogleDriveRouter {
             self.export_google_file(&drive_uri, &mime_type, include_images)
                 .await
         } else {
-            self.get_google_file(&drive_uri, include_images).await
+            self.get_google_file(&drive_uri, &mime_type, include_images)
+                .await
         }
     }
 
@@ -1918,6 +1916,12 @@ impl GoogleDriveRouter {
                     (mime_type.to_string(), mime_type.to_string(), reader)
                 }
             };
+
+        tracing::error!(
+            "source_mime_type and target_mime_type: {:?} vs {:?}",
+            source_mime_type,
+            target_mime_type
+        );
 
         // Upload the file to Google Drive
         self.upload_to_drive(

--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -1917,12 +1917,6 @@ impl GoogleDriveRouter {
                 }
             };
 
-        tracing::error!(
-            "source_mime_type and target_mime_type: {:?} vs {:?}",
-            source_mime_type,
-            target_mime_type
-        );
-
         // Upload the file to Google Drive
         self.upload_to_drive(
             FileOperation::Create {


### PR DESCRIPTION
The file fetch doesn't return the mime type as it is not required in request params, we can use pre fetched mime type

Test: 
![image](https://github.com/user-attachments/assets/50c48006-ef6f-4167-93b6-a5f8c9d82d5e)
