### PR TITLE
docs: Remove "agent" subcommand which does not exist.

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -237,16 +237,6 @@ goose run --recipe recipe_no_prompt.yaml
 
 ---
 
-### agents
-
-Used to show the available implementations of the agent loop itself
-
-**Usage:**
-
-```bash
-goose agents
-```
-
 ### bench
 
 Used to evaluate system-configuration across a range of practical tasks. See the [detailed guide](/docs/guides/benchmarking) for more information.


### PR DESCRIPTION
Apparently it was removed at #2091.