### PR TITLE
load all previous messages if --resume is passed

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -446,6 +446,12 @@ pub async fn cli() -> Result<()> {
                         session.session_file().file_stem().and_then(|s| s.to_str()),
                         None,
                     )?;
+
+                    // Render previous messages if resuming a session
+                    if resume {
+                        session.render_message_history();
+                    }
+
                     let _ = session.interactive(None).await;
                     Ok(())
                 }

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -201,6 +201,14 @@ enum Command {
         )]
         resume: bool,
 
+        /// Show message history when resuming
+        #[arg(
+            long,
+            help = "Show previous messages when resuming a session",
+            requires = "resume"
+        )]
+        history: bool,
+
         /// Enable debug output mode
         #[arg(
             long,
@@ -411,6 +419,7 @@ pub async fn cli() -> Result<()> {
             command,
             identifier,
             resume,
+            history,
             debug,
             extensions,
             remote_extensions,
@@ -447,8 +456,8 @@ pub async fn cli() -> Result<()> {
                         None,
                     )?;
 
-                    // Render previous messages if resuming a session
-                    if resume {
+                    // Render previous messages if resuming a session and history flag is set
+                    if resume && history {
                         session.render_message_history();
                     }
 

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -852,6 +852,31 @@ impl Session {
         self.messages.clone()
     }
 
+    /// Render all past messages from the session history
+    pub fn render_message_history(&self) {
+        if self.messages.is_empty() {
+            return;
+        }
+
+        // Print session restored message
+        println!(
+            "\n{} {} messages loaded into context.",
+            console::style("Session restored:").green().bold(),
+            console::style(self.messages.len()).green()
+        );
+
+        // Render each message
+        for message in &self.messages {
+            output::render_message(message, self.debug);
+        }
+
+        // Add a visual separator after restored messages
+        println!(
+            "\n{}\n",
+            console::style("──────── New Messages ────────").dim()
+        );
+    }
+
     /// Get the session metadata
     pub fn get_metadata(&self) -> Result<session::SessionMetadata> {
         if !self.session_file.exists() {


### PR DESCRIPTION
Small improvement to the UX of CLI `--resume` command.

If the resume flag is passed, render all previous messages, so a user can understand where the agent left off in the previous conversation.

<img width="1577" alt="image" src="https://github.com/user-attachments/assets/039c8ad8-c4d2-4d68-b899-41f8768259dc" />
