### PR TITLE
fix: use less strict timestamp in system prompt

### DIFF
--- a/crates/goose-llm/src/completion.rs
+++ b/crates/goose-llm/src/completion.rs
@@ -61,7 +61,7 @@ fn construct_system_prompt(system_preamble: &str, extensions: &[Extension]) -> S
     );
     context.insert("extensions", serde_json::to_value(extensions).unwrap());
 
-    let current_date_time = Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let current_date_time = Utc::now().format("%Y-%m-%d").to_string();
     context.insert("current_date_time", Value::String(current_date_time));
 
     prompt_template::render_global_file("system.md", &context).expect("Prompt should render")

--- a/crates/goose-llm/src/completion.rs
+++ b/crates/goose-llm/src/completion.rs
@@ -61,7 +61,7 @@ fn construct_system_prompt(system_preamble: &str, extensions: &[Extension]) -> S
     );
     context.insert("extensions", serde_json::to_value(extensions).unwrap());
 
-    let current_date_time = Utc::now().format("%Y-%m-%d").to_string();
+    let current_date_time = Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
     context.insert("current_date_time", Value::String(current_date_time));
 
     prompt_template::render_global_file("system.md", &context).expect("Prompt should render")

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -9,6 +9,7 @@ use crate::{config::Config, prompt_template};
 pub struct PromptManager {
     system_prompt_override: Option<String>,
     system_prompt_extras: Vec<String>,
+    current_date_timestamp: String,
 }
 
 impl Default for PromptManager {
@@ -22,6 +23,7 @@ impl PromptManager {
         PromptManager {
             system_prompt_override: None,
             system_prompt_extras: Vec::new(),
+            current_date_timestamp: Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
         }
     }
 
@@ -79,8 +81,10 @@ impl PromptManager {
 
         context.insert("extensions", serde_json::to_value(extensions_info).unwrap());
 
-        let current_date_time = Utc::now().format("%Y-%m-%d").to_string();
-        context.insert("current_date_time", Value::String(current_date_time));
+        context.insert(
+            "current_date_time",
+            Value::String(self.current_date_timestamp.clone()),
+        );
 
         // Add the suggestion about disabling extensions if flag is true
         context.insert(

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -79,7 +79,7 @@ impl PromptManager {
 
         context.insert("extensions", serde_json::to_value(extensions_info).unwrap());
 
-        let current_date_time = Utc::now().format("%Y-%m-%d %H:%M:%S").to_string();
+        let current_date_time = Utc::now().format("%Y-%m-%d %H").to_string();
         context.insert("current_date_time", Value::String(current_date_time));
 
         // Add the suggestion about disabling extensions if flag is true

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -23,6 +23,7 @@ impl PromptManager {
         PromptManager {
             system_prompt_override: None,
             system_prompt_extras: Vec::new(),
+            // Use the fixed current date time so that prompt cache can be used.
             current_date_timestamp: Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
         }
     }

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -79,7 +79,7 @@ impl PromptManager {
 
         context.insert("extensions", serde_json::to_value(extensions_info).unwrap());
 
-        let current_date_time = Utc::now().format("%Y-%m-%d %H").to_string();
+        let current_date_time = Utc::now().format("%Y-%m-%d").to_string();
         context.insert("current_date_time", Value::String(current_date_time));
 
         // Add the suggestion about disabling extensions if flag is true


### PR DESCRIPTION
Fix #2431

We have the current [timestamp](https://github.com/block/goose/blob/8ba40bdccc3bc5b1068394ea52f45c3de773ec35/crates/goose/src/prompts/system.md?plain=1#L3) in our system prompt, the timestamp was the real timestamp of the reply, this would lead the prompt cache invalidation as our system prompt has such dynamic content. Since the prompt cache only lasts 5 minutes, we can use the timestamp with hours to avoid the frequent cache invalidation 