### PR TITLE
docs: Removing sessions

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -149,9 +149,6 @@ Remove one or more saved sessions.
 **Options:**
 - **`-i, --id <id>`**: Remove a specific session by its ID
 - **`-r, --regex <pattern>`**: Remove sessions matching a regex pattern. For example:
-  - `"project-.*"` matches any session starting with "project-"
-  - `".*migration.*"` matches any session containing "migration"
-  - `"20250305.*"` matches any session from March 5th, 2025
 
 **Usage:**
 

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -139,6 +139,35 @@ goose session list --verbose
 # List sessions in JSON format
 goose session list --format json
 ```
+
+---
+
+### session remove [options]
+
+Remove one or more saved sessions.
+
+**Options:**
+- **`-i, --id <id>`**: Remove a specific session by its ID
+- **`-r, --regex <pattern>`**: Remove sessions matching a regex pattern. For example:
+  - `"project-.*"` matches any session starting with "project-"
+  - `".*migration.*"` matches any session containing "migration"
+  - `"20250305.*"` matches any session from March 5th, 2025
+
+**Usage:**
+
+```bash
+# Remove a specific session by ID
+goose session remove -i 20250305_113223
+
+# Remove all sessions starting with "project-"
+goose session remove -r "project-.*"
+
+# Remove all sessions containing "migration"
+goose session remove -r ".*migration.*"
+```
+
+Goose will show which sessions will be removed and ask for confirmation before deleting.
+
 ---
 
 ### info [options]

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -163,7 +163,9 @@ goose session remove -r "project-.*"
 goose session remove -r ".*migration.*"
 ```
 
-Goose will show which sessions will be removed and ask for confirmation before deleting.
+:::caution
+Session removal is permanent and cannot be undone. Goose will show which sessions will be removed and ask for confirmation before deleting.
+::: 
 
 ---
 

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -162,35 +162,7 @@ You can resume a CLI session in Desktop and vice versa.
 
 ## Remove Sessions
 
-You can remove one or more sessions using the CLI commands. Goose will show you which sessions will be removed and ask for confirmation before deleting.
-
-<Tabs>
-    <TabItem value="ui" label="Goose Desktop" default>
-        Session removal is currently only available through the CLI interface.
-    </TabItem>
-    <TabItem value="cli" label="Goose CLI">
-        To remove a specific session by its ID:
-        ```bash
-        goose session remove -i 20250305_113223
-        ```
-
-        To remove multiple sessions matching a pattern:
-        ```bash
-        # Remove all sessions starting with "project-"
-        goose session remove -r "project-.*"
-
-        # Remove all sessions containing "migration"
-        goose session remove -r ".*migration.*"
-
-        # Remove all sessions from March 5th, 2025
-        goose session remove -r "20250305.*"
-        ```
-
-        :::caution
-        Session removal is permanent and cannot be undone. Make sure to confirm the sessions you want to remove when prompted.
-        :::
-    </TabItem>
-</Tabs>
+You can remove sessions using CLI commands. For detailed instructions on session removal, see the [CLI Commands documentation](/docs/guides/goose-cli-commands#session-remove-options).
 
 ## Search Within Sessions
 

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -160,6 +160,38 @@ You can resume a CLI session in Desktop and vice versa.
     </TabItem>
 </Tabs>
 
+## Remove Sessions
+
+You can remove one or more sessions using the CLI commands. Goose will show you which sessions will be removed and ask for confirmation before deleting.
+
+<Tabs>
+    <TabItem value="ui" label="Goose Desktop" default>
+        Session removal is currently only available through the CLI interface.
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
+        To remove a specific session by its ID:
+        ```bash
+        goose session remove -i 20250305_113223
+        ```
+
+        To remove multiple sessions matching a pattern:
+        ```bash
+        # Remove all sessions starting with "project-"
+        goose session remove -r "project-.*"
+
+        # Remove all sessions containing "migration"
+        goose session remove -r ".*migration.*"
+
+        # Remove all sessions from March 5th, 2025
+        goose session remove -r "20250305.*"
+        ```
+
+        :::caution
+        Session removal is permanent and cannot be undone. Make sure to confirm the sessions you want to remove when prompted.
+        :::
+    </TabItem>
+</Tabs>
+
 ## Search Within Sessions
 
 Search allows you to find specific content within your current session. The search functionality is available in both CLI and Desktop interfaces.


### PR DESCRIPTION
This pull request adds documentation for the new `goose session remove` CLI command, which allows users to delete saved sessions either by specific ID or using a regex pattern. The changes include updates to both the CLI command reference and the session management guide.

### Documentation for new `goose session remove` command:

* **CLI Command Reference (`documentation/docs/guides/goose-cli-commands.md`)**:
  - Added a new section detailing the `goose session remove` command, its options (`-i` for ID and `-r` for regex), and usage examples. The command includes a confirmation step before deletion.

* **Session Management Guide (`documentation/docs/guides/managing-goose-sessions.md`)**:
  - Introduced a "Remove Sessions" section explaining how to use the `goose session remove` command in the CLI. This includes examples for removing sessions by ID or regex and a cautionary note about the permanence of session removal.