### PR TITLE
cxt-mgmt: only two retries for summarization and move to prod

### DIFF
--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -524,9 +524,8 @@ function ChatContent({
                     <UserMessage message={message} />
                   ) : (
                     <>
-                      {/* Only render GooseMessage if it's not a CLE message (and we are not in alpha mode) */}
-                      {process.env.NODE_ENV === 'development' &&
-                      hasContextLengthExceededContent(message) ? (
+                      {/* Only render GooseMessage if it's not a CLE message */}
+                      {hasContextLengthExceededContent(message) ? (
                         <ContextLengthExceededHandler
                           messages={messages}
                           messageId={message.id ?? message.created.toString()}
@@ -593,17 +592,16 @@ function ChatContent({
       </Card>
 
       {showGame && <FlappyGoose onClose={() => setShowGame(false)} />}
-      {process.env.NODE_ENV === 'development' && (
-        <SessionSummaryModal
-          isOpen={isSummaryModalOpen}
-          onClose={closeSummaryModal}
-          onSave={(editedContent) => {
-            updateSummary(editedContent);
-            closeSummaryModal();
-          }}
-          summaryContent={summaryContent}
-        />
-      )}
+
+      <SessionSummaryModal
+        isOpen={isSummaryModalOpen}
+        onClose={closeSummaryModal}
+        onSave={(editedContent) => {
+          updateSummary(editedContent);
+          closeSummaryModal();
+        }}
+        summaryContent={summaryContent}
+      />
     </div>
   );
 }


### PR DESCRIPTION
Handles case where summarization fails -- user can retry fetching summary twice and after that user will be prompted to start a new session 

Errors in summarization in my testing have only been caused by giant tool responses -- because these tool responses do not get summarized we can end up with a summary that is still outside the context window for the LLM

<img width="735" alt="Screenshot 2025-05-05 at 7 20 58 PM" src="https://github.com/user-attachments/assets/0b8d818d-789f-4a17-9b8d-612e09d8686f" />


**NOTE: This PR also moves summarization to production**