### PR TITLE
allowlist blocks and shift SSE to warning

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -79,6 +79,11 @@ run-ui:
     @echo "Running UI..."
     cd ui/desktop && npm install && npm run start-gui
 
+run-ui-only:
+    @echo "Running UI..."
+    cd ui/desktop && npm install && npm run start-gui
+
+
 # Run UI with alpha changes
 run-ui-alpha:
     @just release-binary

--- a/crates/goose-server/ALLOWLIST.md
+++ b/crates/goose-server/ALLOWLIST.md
@@ -1,3 +1,5 @@
+IMPORTANT: currently GOOSE_ALLOWLIST is used in main.ts in ui/desktop, and not in goose-server. The following is for reference in case it is used on the server side for launch time enforcement.
+
 # Goose Extension Allowlist
 
 The allowlist feature provides a security mechanism for controlling which MCP commands can be used by goose. 
@@ -24,8 +26,10 @@ If this environment variable is not set, no allowlist restrictions will be appli
 In certain development or testing scenarios, you may need to bypass the allowlist restrictions. You can do this by setting the `GOOSE_ALLOWLIST_BYPASS` environment variable to `true`:
 
 ```bash
-export GOOSE_ALLOWLIST_BYPASS=true
+# For the GUI, you can have it show a warning instead of blocking (but it will always show a warning):
+export GOOSE_ALLOWLIST_WARNING=true
 ```
+
 
 When this environment variable is set to `true` (case insensitive), the allowlist check will be bypassed and all commands will be allowed, even if the `GOOSE_ALLOWLIST` environment variable is set.
 

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -499,7 +499,13 @@ export default function App() {
   }, [view]);
 
   // Configuration for extension security
-  const STRICT_ALLOWLIST = true; // Set to false to revert to warning-only mode
+  const config = window.electron.getConfig();
+  // If GOOSE_ALLOWLIST_WARNING is true, use warning-only mode (STRICT_ALLOWLIST=false)
+  // If GOOSE_ALLOWLIST_WARNING is not set or false, use strict blocking mode (STRICT_ALLOWLIST=true)
+  const STRICT_ALLOWLIST = config.GOOSE_ALLOWLIST_WARNING === true ? false : true;
+  console.log(
+    `Extension security mode: ${STRICT_ALLOWLIST ? 'Strict' : 'Warning-only'} (GOOSE_ALLOWLIST_WARNING=${config.GOOSE_ALLOWLIST_WARNING})`
+  );
 
   useEffect(() => {
     console.log('Setting up extension handler');

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -498,27 +498,8 @@ export default function App() {
     }
   }, [view]);
 
-  // TODO: modify
-  // State to track if the secret key combo has been pressed
-  const [allowOverride, setAllowOverride] = useState(false);
-
   // Configuration for extension security
   const STRICT_ALLOWLIST = true; // Set to false to revert to warning-only mode
-
-  useEffect(() => {
-    // Secret key combo handler (Alt+Shift+O for "Override")
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.altKey && event.shiftKey && event.key === 'O') {
-        console.log('Secret override key combo detected');
-        setAllowOverride(true);
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown);
-    return () => {
-      window.removeEventListener('keydown', handleKeyDown);
-    };
-  }, []);
 
   useEffect(() => {
     console.log('Setting up extension handler');
@@ -557,7 +538,7 @@ export default function App() {
                 useDetailedMessage = true;
                 title = '⛔️ Untrusted Extension ⛔️';
 
-                if (STRICT_ALLOWLIST && !allowOverride) {
+                if (STRICT_ALLOWLIST) {
                   // Block installation completely unless override is active
                   isBlocked = true;
                   label = 'Extension Blocked';
@@ -607,11 +588,6 @@ export default function App() {
         }
 
         setModalVisible(true);
-
-        // Reset override after showing the dialog
-        if (allowOverride) {
-          setAllowOverride(false);
-        }
       } catch (error) {
         console.error('Error handling add-extension event:', error);
       }
@@ -621,7 +597,7 @@ export default function App() {
     return () => {
       window.electron.off('add-extension', handleAddExtension);
     };
-  }, [STRICT_ALLOWLIST, allowOverride]);
+  }, [STRICT_ALLOWLIST]);
 
   // Focus the first found input field
   useEffect(() => {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -272,6 +272,8 @@ let appConfig = {
   GOOSE_API_HOST: 'http://127.0.0.1',
   GOOSE_PORT: 0,
   GOOSE_WORKING_DIR: '',
+  // If GOOSE_ALLOWLIST_WARNING env var is not set, defaults to false (strict blocking mode)
+  GOOSE_ALLOWLIST_WARNING: process.env.GOOSE_ALLOWLIST_WARNING === 'true',
   secretKey: generateSecretKey(),
 };
 


### PR DESCRIPTION
SSE extensions just get a warning notice (as risk profile is different)
MCP stdio will now block if an allowlist is enabled.