### PR TITLE
feat: add a way to check Goose Desktop's version on Linux

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -928,6 +928,47 @@ app.whenReady().then(async () => {
     );
   }
 
+  if (menu && process.platform !== 'darwin') {
+    let helpMenu = menu.items.find((item) => item.label === 'Help');
+
+    // If Help menu doesn't exist, create it and add it to the menu
+    if (!helpMenu) {
+      helpMenu = new MenuItem({
+        label: 'Help',
+        submenu: Menu.buildFromTemplate([]), // Start with an empty submenu
+      });
+      // Find a reasonable place to insert the Help menu, usually near the end
+      const insertIndex = menu.items.length > 0 ? menu.items.length - 1 : 0;
+      menu.items.splice(insertIndex, 0, helpMenu);
+    }
+
+    // Ensure the Help menu has a submenu before appending
+    if (helpMenu.submenu) {
+      // Add a separator before the About item if the submenu is not empty
+      if (helpMenu.submenu.items.length > 0) {
+        helpMenu.submenu.append(new MenuItem({ type: 'separator' }));
+      }
+
+      // Create the About Goose menu item with a submenu
+      const aboutGooseMenuItem = new MenuItem({
+        label: 'About Goose',
+        submenu: Menu.buildFromTemplate([]), // Start with an empty submenu for About
+      });
+
+      // Add the Version menu item (display only) to the About Goose submenu
+      if (aboutGooseMenuItem.submenu) {
+        aboutGooseMenuItem.submenu.append(
+          new MenuItem({
+            label: `Version ${app.getVersion()}`,
+            enabled: false,
+          })
+        );
+      }
+
+      helpMenu.submenu.append(aboutGooseMenuItem);
+    }
+  }
+
   if (menu) {
     Menu.setApplicationMenu(menu);
   }


### PR DESCRIPTION
This PR adds a way to check the version of Goose Desktop in the topbar that appears on Linux.

![image](https://github.com/user-attachments/assets/75313d92-c718-499d-8be3-48f2690d8fd1)
