### PR TITLE
this is so much nicer

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -209,7 +209,7 @@ fn render_tool_response(resp: &ToolResponse, theme: Theme, debug: bool) {
                 let min_priority = config
                     .get_param::<f32>("GOOSE_CLI_MIN_PRIORITY")
                     .ok()
-                    .unwrap_or(0.0);
+                    .unwrap_or(0.5);
 
                 if content
                     .priority()


### PR DESCRIPTION
A default priority of 0.0 for CLI is just too verbose - 0.5 seems much nicer as a default value (these can be overridden but probably better to start with something that doesn't fill the screen for routine editing/work)