### PR TITLE
recipe welcome message

### DIFF
--- a/ui/desktop/src/components/SplashPills.tsx
+++ b/ui/desktop/src/components/SplashPills.tsx
@@ -5,7 +5,14 @@ function truncateText(text: string, maxLength: number = 100): string {
   return text.slice(0, maxLength) + '...';
 }
 
-function SplashPill({ content, append, className = '', longForm = '' }) {
+interface SplashPillProps {
+  content: string;
+  append: (text: string) => void;
+  className?: string;
+  longForm?: string;
+}
+
+function SplashPill({ content, append, className = '', longForm = '' }: SplashPillProps) {
   const displayText = truncateText(content);
 
   return (
@@ -22,9 +29,29 @@ function SplashPill({ content, append, className = '', longForm = '' }) {
   );
 }
 
-export default function SplashPills({ append, activities = null }) {
+interface ContextBlockProps {
+  content: string;
+}
+
+function ContextBlock({ content }: ContextBlockProps) {
+  // Remove the "message:" prefix and trim whitespace
+  const displayText = content.replace(/^message:/i, '').trim();
+
+  return (
+    <div className="mb-6 p-4 bg-bgSubtle rounded-lg border border-borderStandard animate-[fadein_500ms_ease-in_forwards]">
+      <div className="text-sm text-textStandard whitespace-pre-wrap">{displayText}</div>
+    </div>
+  );
+}
+
+interface SplashPillsProps {
+  append: (text: string) => void;
+  activities: string[] | null;
+}
+
+export default function SplashPills({ append, activities = null }: SplashPillsProps) {
   // If custom activities are provided, use those instead of the default ones
-  const pills = activities || [
+  const defaultPills = [
     'What can you do?',
     'Demo writing and reading files',
     'Make a snake game in a new folder',
@@ -32,11 +59,24 @@ export default function SplashPills({ append, activities = null }) {
     'Take a screenshot and summarize',
   ];
 
+  const pills = activities || defaultPills;
+
+  // Check if the first pill starts with "message:"
+  const hasContextPill = pills.length > 0 && pills[0].toLowerCase().startsWith('message:');
+
+  // Extract the context pill and the remaining pills
+  const contextPill = hasContextPill ? pills[0] : null;
+  const remainingPills = hasContextPill ? pills.slice(1) : pills;
+
   return (
-    <div className="flex flex-wrap gap-2 animate-[fadein_500ms_ease-in_forwards]">
-      {pills.map((content, index) => (
-        <SplashPill key={index} content={content} append={append} />
-      ))}
+    <div className="flex flex-col">
+      {contextPill && <ContextBlock content={contextPill} />}
+
+      <div className="flex flex-wrap gap-2 animate-[fadein_500ms_ease-in_forwards]">
+        {remainingPills.map((content, index) => (
+          <SplashPill key={index} content={content} append={append} />
+        ))}
+      </div>
     </div>
   );
 }

--- a/ui/desktop/src/components/SplashPills.tsx
+++ b/ui/desktop/src/components/SplashPills.tsx
@@ -9,10 +9,9 @@ interface SplashPillProps {
   content: string;
   append: (text: string) => void;
   className?: string;
-  longForm?: string;
 }
 
-function SplashPill({ content, append, className = '', longForm = '' }: SplashPillProps) {
+function SplashPill({ content, append, className = '' }: SplashPillProps) {
   const displayText = truncateText(content);
 
   return (
@@ -20,7 +19,7 @@ function SplashPill({ content, append, className = '', longForm = '' }: SplashPi
       className={`px-4 py-2 text-sm text-center text-textStandard cursor-pointer border border-borderSubtle hover:bg-bgSubtle rounded-full transition-all duration-150 ${className}`}
       onClick={async () => {
         // Always use the full text (longForm or original content) when clicked
-        await append(longForm || content);
+        await append(content);
       }}
       title={content.length > 100 ? content : undefined} // Show full text on hover if truncated
     >


### PR DESCRIPTION
This allows an option `message:` to be specified to show up as a message of the day/welcome message for when a recipe deep link is activated in the GUI: 

<img width="739" alt="Screenshot 2025-05-07 at 12 46 20 pm" src="https://github.com/user-attachments/assets/e88b3c88-db0f-486c-9ca3-ff5e76b31bd9" />

doesn't change usual operation

To use it, have one of the activity messages start with `message:` prefix to have it show up that way, instead of a "splash bubble". This has been asked for as when people click on a deep link, the context may not be obvious, so gives a chance to present it to the user. 

Example for the above to try: 

```
goose://recipe?config=eyJpZCI6Im1lc3NhZ2UtcmVjaXBlIiwibmFtZSI6Ik1lc3NhZ2UgUmVjaXBlIiwidGl0bGUiOiJSZWNpcGUgd2l0aCBNZXNzYWdlIiwiZGVzY3JpcHRpb24iOiJBIHJlY2lwZSB3aXRoIGEgbWVzc2FnZSBkaXNwbGF5ZWQgcHJvbWluZW50bHkiLCJhY3Rpdml0aWVzIjpbIm1lc3NhZ2U6IFRoaXMgcmVjaXBlIGRlbW9uc3RyYXRlcyBob3cgdG8gdXNlIHRoZSBtZXNzYWdpbmcgZmVhdHVyZSB0byBkaXNwbGF5IGltcG9ydGFudCBpbmZvcm1hdGlvbi4gVGhpcyB0ZXh0IHdpbGwgYXBwZWFyIGFib3ZlIHRoZSBhY3Rpdml0eSBidWJibGVzIGluIGEgcHJvbWluZW50IGJveC4iLCJTaG93IG1lIGhvdyB0byB1c2UgdGhpcyByZWNpcGUiLCJMaXN0IGZpbGVzIGluIHRoZSBjdXJyZW50IGRpcmVjdG9yeSIsIkNyZWF0ZSBhIHNhbXBsZSBQeXRob24gc2NyaXB0Il19
```

