### PR TITLE
docs: Added Keyring Tip to Troubleshooting page

### DIFF
--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -158,6 +158,13 @@ Welcome to goose! Let's get you set up with a provider.
 │  gemini-2.0-flash-exp
 ```
 
+You may also use the `GOOSE_DISABLE_KEYRING` environment variable, which disables the system keyring for secret storage. Set to any value (e.g., "1", "true", "yes"), to disable. The actual value doesn't matter, only whether the variable is set.
+
+When the keyring is disabled, secrets are stored here:
+
+* macOS/Linux: `~/.config/goose/secrets.yaml`
+* Windows: `%APPDATA%\Block\goose\config\secrets.yaml`
+
 ---
 
 ### Package Runners


### PR DESCRIPTION
A community member on Discord was having an error caused by keyring stored in secrets issue. Even though, if you look up how to disable keyring, this tip comes up:

<img width="701" alt="Screenshot 2025-05-07 at 10 30 35 AM" src="https://github.com/user-attachments/assets/f161ba32-eaf4-49fc-b958-91f00ad50518" />

While this absolutely resolved the member's issue, if you click on either link from the above Ask AI result, it takes you to the [Environment Variables guide](https://block.github.io/goose/docs/guides/environment-variables/) (which mentions you can use `GOOSE_DISABLE_KEYRING`), or to the [Troubleshooting guide](https://block.github.io/goose/docs/troubleshooting#keychainkeyring-errors) (which shows you how to set provider specific environment variable(s)).

I wanted to make this easy solve clear and easy to read verbatim in Troubleshooting. 