### PR TITLE
Remove outdated truncation of tool descriptions in OpenAI and Databricks providers

### DIFF
--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -246,15 +246,12 @@ pub fn format_tools(tools: &[Tool]) -> anyhow::Result<Vec<Value>> {
             return Err(anyhow!("Duplicate tool name: {}", tool.name));
         }
 
-        let mut description = tool.description.clone();
-        description.truncate(1024);
-
-        // OpenAI's tool description max str len is 1024
         result.push(json!({
             "type": "function",
             "function": {
                 "name": tool.name,
-                "description": description,
+                // do not silently truncate description
+                "description": tool.description,
                 "parameters": tool.input_schema,
             }
         }));

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -202,15 +202,12 @@ pub fn format_tools(tools: &[Tool]) -> anyhow::Result<Vec<Value>> {
             return Err(anyhow!("Duplicate tool name: {}", tool.name));
         }
 
-        let mut description = tool.description.clone();
-        description.truncate(1024);
-
-        // OpenAI's tool description max str len is 1024
         result.push(json!({
             "type": "function",
             "function": {
                 "name": tool.name,
-                "description": description,
+                // do not silently truncate description
+                "description": tool.description,
                 "parameters": tool.input_schema,
             }
         }));


### PR DESCRIPTION
Previously, tool descriptions were truncated to 1024 characters to conform to an assumed OpenAI limit. This truncation is now removed to avoid silent behavior changes and make debugging easier. OpenAI no longer appears to enforce this limit, so it's better to allow full descriptions and surface any real errors explicitly.