### PR TITLE
fix: will now correctly follow along with tool results

### DIFF
--- a/ui/desktop/src/components/ToolCallArguments.tsx
+++ b/ui/desktop/src/components/ToolCallArguments.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import MarkdownContent from './MarkdownContent';
 import Expand from './ui/Expand';
 
-type ToolCallArgumentValue =
+export type ToolCallArgumentValue =
   | string
   | number
   | boolean

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Card } from './ui/card';
-import { ToolCallArguments } from './ToolCallArguments';
+import { ToolCallArguments, ToolCallArgumentValue } from './ToolCallArguments';
 import MarkdownContent from './MarkdownContent';
 import { Content, ToolRequestMessageContent, ToolResponseMessageContent } from '../types/message';
 import { snakeToTitleCase } from '../utils';
@@ -105,6 +105,35 @@ function ToolCallView({ isCancelledMessage, toolCall, toolResponse }: ToolCallVi
 
   const isShouldExpand = isExpandToolDetails || toolResults.some((v) => v.isExpandToolResults);
 
+  // Function to create a compact representation of arguments
+  const getCompactArguments = () => {
+    const args = toolCall.arguments as Record<string, ToolCallArgumentValue>;
+    const entries = Object.entries(args);
+
+    if (entries.length === 0) return null;
+
+    // For a single parameter, show key and truncated value
+    if (entries.length === 1) {
+      const [key, value] = entries[0];
+      const stringValue = typeof value === 'string' ? value : JSON.stringify(value);
+      const truncatedValue =
+        stringValue.length > 30 ? stringValue.substring(0, 30) + '...' : stringValue;
+
+      return (
+        <span className="ml-2 text-textSubtle truncate text-xs opacity-70">
+          {key}: {truncatedValue}
+        </span>
+      );
+    }
+
+    // For multiple parameters, just show the keys
+    return (
+      <span className="ml-2 text-textSubtle truncate text-xs opacity-70">
+        {entries.map(([key]) => key).join(', ')}
+      </span>
+    );
+  };
+
   return (
     <ToolCallExpandable
       isStartExpanded={isShouldExpand}
@@ -115,6 +144,8 @@ function ToolCallView({ isCancelledMessage, toolCall, toolResponse }: ToolCallVi
           <span className="ml-[10px]">
             {snakeToTitleCase(toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2))}
           </span>
+          {/* Display compact arguments inline */}
+          {isToolDetails && getCompactArguments()}
         </>
       }
     >
@@ -163,7 +194,9 @@ function ToolDetailsView({ toolCall, isStartExpanded }: ToolDetailsViewProps) {
       className="pl-[19px] py-1"
       isStartExpanded={isStartExpanded}
     >
-      {toolCall.arguments && <ToolCallArguments args={toolCall.arguments} />}
+      {toolCall.arguments && (
+        <ToolCallArguments args={toolCall.arguments as Record<string, ToolCallArgumentValue>} />
+      )}
     </ToolCallExpandable>
   );
 }

--- a/ui/desktop/src/components/ui/scroll-area.tsx
+++ b/ui/desktop/src/components/ui/scroll-area.tsx
@@ -32,6 +32,7 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
           block: 'end',
           inline: 'nearest',
         });
+        // When explicitly scrolling to bottom, reset the following state
         setIsFollowing(true);
       }
     }, []);
@@ -66,13 +67,11 @@ const ScrollArea = React.forwardRef<ScrollAreaHandle, ScrollAreaProps>(
       const { scrollHeight, scrollTop, clientHeight } = viewport;
 
       const scrollBottom = scrollTop + clientHeight;
-      const newIsFollowing = scrollHeight === scrollBottom;
+      // Allow a small tolerance (2px) for rounding errors
+      const isAtBottom = scrollHeight - scrollBottom <= 2;
 
-      // Check if scrolled from top
+      setIsFollowing(isAtBottom);
       setIsScrolled(scrollTop > 0);
-
-      // react will internally optimize this to not re-store the same values
-      setIsFollowing(newIsFollowing);
     }, []);
 
     React.useEffect(() => {


### PR DESCRIPTION
Currently goose won't always follow along once you add a subsequent command (this happens with compact or expanded tools)

This PR also adds short tool descriptions that were missing when in compact mode

<img width="740" alt="Screenshot 2025-05-08 at 12 57 29 pm" src="https://github.com/user-attachments/assets/d5c6bd36-069b-49bb-b251-e77bf475db8f" />

dark mode: 

![image](https://github.com/user-attachments/assets/20c2382c-0a4c-429a-9ea8-2ae4543c2810)

