### PR TITLE
ctx_management: summarize on command button

### DIFF
--- a/crates/goose-server/src/openapi.rs
+++ b/crates/goose-server/src/openapi.rs
@@ -5,7 +5,7 @@ use goose::config::permission::PermissionLevel;
 use goose::config::ExtensionEntry;
 use goose::message::{
     ContextLengthExceeded, FrontendToolRequest, Message, MessageContent, RedactedThinkingContent,
-    ThinkingContent, ToolConfirmationRequest, ToolRequest, ToolResponse,
+    SummarizationRequested, ThinkingContent, ToolConfirmationRequest, ToolRequest, ToolResponse,
 };
 use goose::permission::permission_confirmation::PrincipalType;
 use goose::providers::base::{ConfigKey, ModelInfo, ProviderMetadata};
@@ -70,6 +70,7 @@ use utoipa::OpenApi;
         FrontendToolRequest,
         ResourceContents,
         ContextLengthExceeded,
+        SummarizationRequested,
         Role,
         ProviderMetadata,
         ExtensionEntry,

--- a/crates/goose/src/message.rs
+++ b/crates/goose/src/message.rs
@@ -92,6 +92,11 @@ pub struct ContextLengthExceeded {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
+pub struct SummarizationRequested {
+    pub msg: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, ToSchema)]
 /// Content passed inside a message, which can be both simple content and tool content
 #[serde(tag = "type", rename_all = "camelCase")]
 pub enum MessageContent {
@@ -104,6 +109,7 @@ pub enum MessageContent {
     Thinking(ThinkingContent),
     RedactedThinking(RedactedThinkingContent),
     ContextLengthExceeded(ContextLengthExceeded),
+    SummarizationRequested(SummarizationRequested),
 }
 
 impl MessageContent {
@@ -170,6 +176,19 @@ impl MessageContent {
 
     pub fn context_length_exceeded<S: Into<String>>(msg: S) -> Self {
         MessageContent::ContextLengthExceeded(ContextLengthExceeded { msg: msg.into() })
+    }
+
+    pub fn summarization_requested<S: Into<String>>(msg: S) -> Self {
+        MessageContent::SummarizationRequested(SummarizationRequested { msg: msg.into() })
+    }
+
+    // Add this new method to check for summarization requested content
+    pub fn as_summarization_requested(&self) -> Option<&SummarizationRequested> {
+        if let MessageContent::SummarizationRequested(ref summarization_requested) = self {
+            Some(summarization_requested)
+        } else {
+            None
+        }
     }
 
     pub fn as_tool_request(&self) -> Option<&ToolRequest> {
@@ -450,6 +469,11 @@ impl Message {
         self.content
             .iter()
             .all(|c| matches!(c, MessageContent::Text(_)))
+    }
+
+    /// Add summarization requested to the message
+    pub fn with_summarization_requested<S: Into<String>>(self, msg: S) -> Self {
+        self.with_content(MessageContent::summarization_requested(msg))
     }
 }
 

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -63,6 +63,9 @@ pub fn format_messages(messages: &[Message]) -> Vec<Value> {
                 MessageContent::ContextLengthExceeded(_) => {
                     // Skip
                 }
+                MessageContent::SummarizationRequested(_) => {
+                    // Skip
+                }
                 MessageContent::Thinking(thinking) => {
                     content.push(json!({
                         "type": "thinking",

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -45,6 +45,9 @@ pub fn to_bedrock_message_content(content: &MessageContent) -> Result<bedrock::C
         MessageContent::ContextLengthExceeded(_) => {
             bail!("ContextLengthExceeded should not get passed to the provider")
         }
+        MessageContent::SummarizationRequested(_) => {
+            bail!("SummarizationRequested should not get passed to the provider")
+        }
         MessageContent::ToolRequest(tool_req) => {
             let tool_use_id = tool_req.id.to_string();
             let tool_use = if let Ok(call) = tool_req.tool_call.as_ref() {

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -113,6 +113,9 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
                 MessageContent::ContextLengthExceeded(_) => {
                     continue;
                 }
+                MessageContent::SummarizationRequested(_) => {
+                    continue;
+                }
                 MessageContent::ToolResponse(response) => {
                     match &response.tool_result {
                         Ok(contents) => {

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -55,6 +55,9 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
                 MessageContent::ContextLengthExceeded(_) => {
                     continue;
                 }
+                MessageContent::SummarizationRequested(_) => {
+                    continue;
+                }
                 MessageContent::ToolRequest(request) => match &request.tool_call {
                     Ok(tool_call) => {
                         let sanitized_name = sanitize_function_name(&tool_call.name);

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -1244,6 +1244,27 @@
                 }
               }
             ]
+          },
+          {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SummarizationRequested"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "type"
+                ],
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "summarizationRequested"
+                    ]
+                  }
+                }
+              }
+            ]
           }
         ],
         "description": "Content passed inside a message, which can be both simple content and tool content",
@@ -1568,6 +1589,17 @@
             "type": "string",
             "description": "Working directory for the session",
             "example": "/home/user/sessions/session1"
+          }
+        }
+      },
+      "SummarizationRequested": {
+        "type": "object",
+        "required": [
+          "msg"
+        ],
+        "properties": {
+          "msg": {
+            "type": "string"
           }
         }
       },

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -503,9 +503,6 @@ export default function App() {
   // If GOOSE_ALLOWLIST_WARNING is true, use warning-only mode (STRICT_ALLOWLIST=false)
   // If GOOSE_ALLOWLIST_WARNING is not set or false, use strict blocking mode (STRICT_ALLOWLIST=true)
   const STRICT_ALLOWLIST = config.GOOSE_ALLOWLIST_WARNING === true ? false : true;
-  console.log(
-    `Extension security mode: ${STRICT_ALLOWLIST ? 'Strict' : 'Warning-only'} (GOOSE_ALLOWLIST_WARNING=${config.GOOSE_ALLOWLIST_WARNING})`
-  );
 
   useEffect(() => {
     console.log('Setting up extension handler');

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -196,6 +196,8 @@ export type MessageContent = (TextContent & {
     type: 'redactedThinking';
 }) | (ContextLengthExceeded & {
     type: 'contextLengthExceeded';
+}) | (SummarizationRequested & {
+    type: 'summarizationRequested';
 });
 
 /**
@@ -358,6 +360,10 @@ export type SessionMetadata = {
      * Working directory for the session
      */
     working_dir: string;
+};
+
+export type SummarizationRequested = {
+    msg: string;
 };
 
 export type TextContent = {

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -6,6 +6,7 @@ import { Attach, Send } from './icons';
 import { debounce } from 'lodash';
 import BottomMenu from './bottom_menu/BottomMenu';
 import { LocalMessageStorage } from '../utils/localMessageStorage';
+import { Message } from '../types/message';
 
 interface ChatInputProps {
   handleSubmit: (e: React.FormEvent) => void;
@@ -16,6 +17,8 @@ interface ChatInputProps {
   droppedFiles?: string[];
   setView: (view: View) => void;
   numTokens?: number;
+  hasMessages?: boolean;
+  messages?: Message[]; // Add this line to accept messages
 }
 
 export default function ChatInput({
@@ -27,6 +30,7 @@ export default function ChatInput({
   setView,
   numTokens,
   droppedFiles = [],
+  messages = [],
 }: ChatInputProps) {
   const [_value, setValue] = useState(initialValue);
   const [displayValue, setDisplayValue] = useState(initialValue); // For immediate visual feedback
@@ -327,7 +331,12 @@ export default function ChatInput({
             <Attach />
           </Button>
 
-          <BottomMenu setView={setView} numTokens={numTokens} />
+          <BottomMenu
+            setView={setView}
+            numTokens={numTokens}
+            messages={messages}
+            isLoading={isLoading}
+          />
         </div>
       </div>
     </div>

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -18,7 +18,8 @@ interface ChatInputProps {
   setView: (view: View) => void;
   numTokens?: number;
   hasMessages?: boolean;
-  messages?: Message[]; // Add this line to accept messages
+  messages?: Message[];
+  setMessages: (messages: Message[]) => void;
 }
 
 export default function ChatInput({
@@ -31,6 +32,7 @@ export default function ChatInput({
   numTokens,
   droppedFiles = [],
   messages = [],
+  setMessages,
 }: ChatInputProps) {
   const [_value, setValue] = useState(initialValue);
   const [displayValue, setDisplayValue] = useState(initialValue); // For immediate visual feedback
@@ -336,6 +338,7 @@ export default function ChatInput({
             numTokens={numTokens}
             messages={messages}
             isLoading={isLoading}
+            setMessages={setMessages}
           />
         </div>
       </div>

--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -106,6 +106,7 @@ function ChatContent({
     closeSummaryModal,
     updateSummary,
     hasContextLengthExceededContent,
+      preparingManualSummary,
   } = useChatContextManager();
 
   useEffect(() => {
@@ -606,3 +607,14 @@ function ChatContent({
     </div>
   );
 }
+
+export const SummaryPreparationIndicator: React.FC = () => {
+  return (
+      <div className="flex items-center justify-center p-4">
+        <div className="flex items-center text-sm text-gray-400 bg-bgSubtle p-3 rounded-lg">
+          <span className="mr-2">Preparing conversation summary...</span>
+          <span className="animate-spin h-4 w-4 border-2 border-gray-400 rounded-full border-t-transparent"></span>
+        </div>
+      </div>
+  );
+};

--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -22,8 +22,8 @@ import { Recipe } from '../recipe';
 import {
   ChatContextManagerProvider,
   useChatContextManager,
-} from './context_management/ContextManager';
-import { ContextLengthExceededHandler } from './context_management/ContextLengthExceededHandler';
+} from './context_management/ChatContextManager';
+import { ContextHandler } from './context_management/ContextHandler';
 import { LocalMessageStorage } from '../utils/localMessageStorage';
 import {
   Message,
@@ -105,8 +105,8 @@ function ChatContent({
     resetMessagesWithSummary,
     closeSummaryModal,
     updateSummary,
-    hasContextLengthExceededContent,
-      preparingManualSummary,
+    hasContextHandlerContent,
+    getContextHandlerType,
   } = useChatContextManager();
 
   useEffect(() => {
@@ -522,16 +522,29 @@ function ChatContent({
                   data-testid="message-container"
                 >
                   {isUserMessage(message) ? (
-                    <UserMessage message={message} />
-                  ) : (
                     <>
-                      {/* Only render GooseMessage if it's not a CLE message */}
-                      {hasContextLengthExceededContent(message) ? (
-                        <ContextLengthExceededHandler
+                      {hasContextHandlerContent(message) ? (
+                        <ContextHandler
                           messages={messages}
                           messageId={message.id ?? message.created.toString()}
                           chatId={chat.id}
                           workingDir={window.appConfig.get('GOOSE_WORKING_DIR') as string}
+                          contextType={getContextHandlerType(message)}
+                        />
+                      ) : (
+                        <UserMessage message={message} />
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      {/* Only render GooseMessage if it's not a message invoking some context management */}
+                      {hasContextHandlerContent(message) ? (
+                        <ContextHandler
+                          messages={messages}
+                          messageId={message.id ?? message.created.toString()}
+                          chatId={chat.id}
+                          workingDir={window.appConfig.get('GOOSE_WORKING_DIR') as string}
+                          contextType={getContextHandlerType(message)}
                         />
                       ) : (
                         <GooseMessage
@@ -589,6 +602,7 @@ function ChatContent({
             numTokens={sessionTokenCount}
             droppedFiles={droppedFiles}
             messages={messages}
+            setMessages={setMessages}
           />
         </div>
       </Card>
@@ -607,14 +621,3 @@ function ChatContent({
     </div>
   );
 }
-
-export const SummaryPreparationIndicator: React.FC = () => {
-  return (
-      <div className="flex items-center justify-center p-4">
-        <div className="flex items-center text-sm text-gray-400 bg-bgSubtle p-3 rounded-lg">
-          <span className="mr-2">Preparing conversation summary...</span>
-          <span className="animate-spin h-4 w-4 border-2 border-gray-400 rounded-full border-t-transparent"></span>
-        </div>
-      </div>
-  );
-};

--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -587,6 +587,7 @@ function ChatContent({
             hasMessages={hasMessages}
             numTokens={sessionTokenCount}
             droppedFiles={droppedFiles}
+            messages={messages}
           />
         </div>
       </Card>

--- a/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
@@ -12,6 +12,8 @@ import { BottomMenuModeSelection } from './BottomMenuModeSelection';
 import ModelsBottomBar from '../settings_v2/models/bottom_bar/ModelsBottomBar';
 import { useConfig } from '../ConfigContext';
 import { getCurrentModelAndProvider } from '../settings_v2/models';
+import { Message } from '../../types/message';
+import { ManualSummarizeButton } from '../context_management/ManualSummaryButton';
 
 const TOKEN_LIMIT_DEFAULT = 128000; // fallback for custom models that the backend doesn't know about
 const TOKEN_WARNING_THRESHOLD = 0.8; // warning shows at 80% of the token limit
@@ -20,9 +22,13 @@ const TOOLS_MAX_SUGGESTED = 60; // max number of tools before we show a warning
 export default function BottomMenu({
   setView,
   numTokens = 0,
+  messages = [],
+  isLoading = false,
 }: {
   setView: (view: View, viewOptions?: ViewOptions) => void;
   numTokens?: number;
+  messages?: Message[];
+  isLoading?: boolean;
 }) {
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
   const { currentModel } = useModel();
@@ -218,6 +224,14 @@ export default function BottomMenu({
 
         {/* Goose Mode Selector Dropdown */}
         <BottomMenuModeSelection setView={setView} />
+
+        {/* Summarize Context Button - ADD THIS */}
+        {messages.length > 0 && (
+          <>
+            <div className="w-[1px] h-4 bg-borderSubtle mx-2" />
+            <ManualSummarizeButton messages={messages} isLoading={isLoading} />
+          </>
+        )}
       </div>
     </div>
   );

--- a/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenu.tsx
@@ -24,11 +24,13 @@ export default function BottomMenu({
   numTokens = 0,
   messages = [],
   isLoading = false,
+  setMessages,
 }: {
   setView: (view: View, viewOptions?: ViewOptions) => void;
   numTokens?: number;
   messages?: Message[];
   isLoading?: boolean;
+  setMessages: (messages: Message[]) => void;
 }) {
   const [isModelMenuOpen, setIsModelMenuOpen] = useState(false);
   const { currentModel } = useModel();
@@ -229,7 +231,11 @@ export default function BottomMenu({
         {messages.length > 0 && (
           <>
             <div className="w-[1px] h-4 bg-borderSubtle mx-2" />
-            <ManualSummarizeButton messages={messages} isLoading={isLoading} />
+            <ManualSummarizeButton
+              messages={messages}
+              isLoading={isLoading}
+              setMessages={setMessages}
+            />
           </>
         )}
       </div>

--- a/ui/desktop/src/components/context_management/ContextHandler.tsx
+++ b/ui/desktop/src/components/context_management/ContextHandler.tsx
@@ -1,19 +1,21 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { Message } from '../../types/message';
-import { useChatContextManager } from './ContextManager';
+import { useChatContextManager } from './ChatContextManager';
 
-interface ContextLengthExceededHandlerProps {
+interface ContextHandlerProps {
   messages: Message[];
   messageId: string;
   chatId: string;
   workingDir: string;
+  contextType: 'contextLengthExceeded' | 'summarizationRequested';
 }
 
-export const ContextLengthExceededHandler: React.FC<ContextLengthExceededHandlerProps> = ({
+export const ContextHandler: React.FC<ContextHandlerProps> = ({
   messages,
   messageId,
   chatId,
   workingDir,
+  contextType,
 }) => {
   const {
     summaryContent,
@@ -22,9 +24,10 @@ export const ContextLengthExceededHandler: React.FC<ContextLengthExceededHandler
     openSummaryModal,
     handleContextLengthExceeded,
   } = useChatContextManager();
-
   const [hasFetchStarted, setHasFetchStarted] = useState(false);
   const [retryCount, setRetryCount] = useState(0);
+
+  const isContextLengthExceeded = contextType === 'contextLengthExceeded';
 
   // Find the relevant message to check if it's the latest
   const isCurrentMessageLatest =
@@ -43,7 +46,7 @@ export const ContextLengthExceededHandler: React.FC<ContextLengthExceededHandler
     fetchStartedRef.current = true;
 
     // Call the async function without awaiting it in useEffect
-    handleContextLengthExceeded(messages, chatId, workingDir).catch((err) => {
+    handleContextLengthExceeded(messages).catch((err) => {
       console.error('Error handling context length exceeded:', err);
     });
   };
@@ -109,8 +112,16 @@ export const ContextLengthExceededHandler: React.FC<ContextLengthExceededHandler
 
   const renderFailedState = () => (
     <>
-      <span className="text-xs text-gray-400">{`Your conversation has exceeded the model's context capacity`}</span>
-      <span className="text-xs text-gray-400">{`This conversation has too much information to continue. Extension data often takes up significant space.`}</span>
+      <span className="text-xs text-gray-400">
+        {isContextLengthExceeded
+          ? `Your conversation has exceeded the model's context capacity`
+          : `Summarization requested`}
+      </span>
+      <span className="text-xs text-gray-400">
+        {isContextLengthExceeded
+          ? `This conversation has too much information to continue. Extension data often takes up significant space.`
+          : `Summarization failed. Continue chatting or start a new session.`}
+      </span>
       <button
         onClick={openNewSession}
         className="text-xs text-textStandard hover:text-textSubtle transition-colors mt-1 flex items-center"
@@ -122,7 +133,11 @@ export const ContextLengthExceededHandler: React.FC<ContextLengthExceededHandler
 
   const renderRetryState = () => (
     <>
-      <span className="text-xs text-gray-400">{`Your conversation has exceeded the model's context capacity`}</span>
+      <span className="text-xs text-gray-400">
+        {isContextLengthExceeded
+          ? `Your conversation has exceeded the model's context capacity`
+          : `Summarization requested`}
+      </span>
       <button
         onClick={handleRetry}
         className="text-xs text-textStandard hover:text-textSubtle transition-colors mt-1 flex items-center"
@@ -134,13 +149,22 @@ export const ContextLengthExceededHandler: React.FC<ContextLengthExceededHandler
 
   const renderSuccessState = () => (
     <>
-      <span className="text-xs text-gray-400">{`Your conversation has exceeded the model's context capacity and a summary was prepared.`}</span>
-      <span className="text-xs text-gray-400">{`Messages above this line remain viewable but specific details are not included in active context.`}</span>
+      <span className="text-xs text-gray-400">
+        {isContextLengthExceeded
+          ? `Your conversation has exceeded the model's context capacity and a summary was prepared.`
+          : `A summary of your conversation was prepared as requested.`}
+      </span>
+      <span className="text-xs text-gray-400">
+        {isContextLengthExceeded
+          ? `Messages above this line remain viewable but specific details are not included in active context.`
+          : `This summary includes key points from your conversation.`}
+      </span>
       <button
         onClick={openSummaryModal}
         className="text-xs text-textStandard hover:text-textSubtle transition-colors mt-1 flex items-center"
       >
-        View or edit summary (you may continue your conversation based on the summary)
+        View or edit summary{' '}
+        {isContextLengthExceeded ? '(you may continue your conversation based on the summary)' : ''}
       </button>
     </>
   );

--- a/ui/desktop/src/components/context_management/ContextHandler.tsx
+++ b/ui/desktop/src/components/context_management/ContextHandler.tsx
@@ -159,26 +159,47 @@ export const ContextHandler: React.FC<ContextHandlerProps> = ({
           ? `Messages above this line remain viewable but specific details are not included in active context.`
           : `This summary includes key points from your conversation.`}
       </span>
-      <button
-        onClick={openSummaryModal}
-        className="text-xs text-textStandard hover:text-textSubtle transition-colors mt-1 flex items-center"
-      >
-        View or edit summary{' '}
-        {isContextLengthExceeded ? '(you may continue your conversation based on the summary)' : ''}
-      </button>
+      {shouldAllowSummaryInteraction && (
+        <button
+          onClick={openSummaryModal}
+          className="text-xs text-textStandard hover:text-textSubtle transition-colors mt-1 flex items-center"
+        >
+          View or edit summary{' '}
+          {isContextLengthExceeded
+            ? '(you may continue your conversation based on the summary)'
+            : ''}
+        </button>
+      )}
     </>
   );
 
+  // Render persistent summarized notification when we shouldn't show interaction options
+  const renderPersistentMarker = () => (
+    <span className="text-xs text-gray-400">
+      Session summarized — messages above this line are not included in the conversation
+    </span>
+  );
+
   const renderContentState = () => {
-    if (!shouldAllowSummaryInteraction) {
-      return null;
+    // If this is not the latest context event message but we have a valid summary,
+    // show the persistent marker
+    if (!shouldAllowSummaryInteraction && summaryContent) {
+      return renderPersistentMarker();
     }
 
-    if (errorLoadingSummary) {
-      return retryCount >= 2 ? renderFailedState() : renderRetryState();
+    // For the latest message with the context event
+    if (shouldAllowSummaryInteraction) {
+      if (errorLoadingSummary) {
+        return retryCount >= 2 ? renderFailedState() : renderRetryState();
+      }
+
+      if (summaryContent) {
+        return renderSuccessState();
+      }
     }
 
-    return renderSuccessState();
+    // Fallback to showing at least the persistent marker
+    return renderPersistentMarker();
   };
 
   return (

--- a/ui/desktop/src/components/context_management/ManualSummaryButton.tsx
+++ b/ui/desktop/src/components/context_management/ManualSummaryButton.tsx
@@ -2,24 +2,21 @@ import React, { useState } from 'react';
 import { FileText } from 'lucide-react';
 import Modal from '../Modal';
 import { Button } from '../ui/button';
-import { useChatContextManager } from './ContextManager';
+import { useChatContextManager } from './ChatContextManager';
 import { Message } from '../../types/message';
-import { toastService } from '../../toasts';
 
 interface ManualSummarizeButtonProps {
   messages: Message[];
-  isLoading?: boolean; // Only need this prop to know if Goose is responding
+  isLoading?: boolean; // need this prop to know if Goose is responding
+  setMessages: (messages: Message[]) => void; // context management is triggered via special message content types
 }
 
 export const ManualSummarizeButton: React.FC<ManualSummarizeButtonProps> = ({
-                                                                              messages,
-                                                                              isLoading = false,
-                                                                            }) => {
-  const {
-    handleManualSummarization,
-    preparingManualSummary,
-      openSummaryModal
-  } = useChatContextManager();
+  messages,
+  isLoading = false,
+  setMessages,
+}) => {
+  const { handleManualSummarization, isLoadingSummary } = useChatContextManager();
 
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
 
@@ -30,87 +27,72 @@ export const ManualSummarizeButton: React.FC<ManualSummarizeButtonProps> = ({
   const handleSummarize = async () => {
     setIsConfirmationOpen(false);
 
-    const toastId = toastService.loading({
-      title: 'Preparing Summary',
-      msg: 'Analyzing and summarizing your conversation...'
-    });
-
     try {
-      await handleManualSummarization(messages);
-      toastService.dismiss(toastId);
-      toastService.success({
-        title: 'Summary Ready',
-        msg: 'Your conversation has been summarized successfully.'
-      });
-      openSummaryModal()
+      handleManualSummarization(messages, setMessages);
     } catch (error) {
       console.error('Error in handleSummarize:', error);
-      toastService.dismiss(toastId);
-      toastService.error({
-        title: 'Summary Error',
-        msg: 'Failed to generate conversation summary.',
-        traceback: String(error)
-      });
     }
   };
 
   // Footer content for the confirmation modal
   const footerContent = (
-      <>
-        <Button
-            onClick={handleSummarize}
-            className="w-full h-[60px] rounded-none border-b border-borderSubtle bg-transparent hover:bg-bgSubtle text-textProminent font-medium text-md"
-        >
-          Summarize context
-        </Button>
-        <Button
-            onClick={() => setIsConfirmationOpen(false)}
-            variant="ghost"
-            className="w-full h-[60px] rounded-none hover:bg-bgSubtle text-textSubtle hover:text-textStandard text-md font-regular"
-        >
-          Cancel
-        </Button>
-      </>
+    <>
+      <Button
+        onClick={handleSummarize}
+        className="w-full h-[60px] rounded-none border-b border-borderSubtle bg-transparent hover:bg-bgSubtle text-textProminent font-medium text-md"
+      >
+        Summarize context
+      </Button>
+      <Button
+        onClick={() => setIsConfirmationOpen(false)}
+        variant="ghost"
+        className="w-full h-[60px] rounded-none hover:bg-bgSubtle text-textSubtle hover:text-textStandard text-md font-regular"
+      >
+        Cancel
+      </Button>
+    </>
   );
 
   return (
-      <>
-        <div className="relative flex items-center">
-          <button
-              className={`flex items-center justify-center text-textSubtle hover:text-textStandard h-6 [&_svg]:size-4 ${
-                  preparingManualSummary || isLoading ? 'opacity-50 cursor-not-allowed' : ''
-              }`}
-              onClick={handleClick}
-              disabled={preparingManualSummary || isLoading}
-              title="Summarize conversation context"
-          >
-            <span className="pr-1.5">summarize</span>
-            <FileText size={16} />
-          </button>
-        </div>
+    <>
+      <div className="relative flex items-center">
+        <button
+          className={`flex items-center justify-center text-textSubtle hover:text-textStandard h-6 [&_svg]:size-4 ${
+            isLoadingSummary || isLoading ? 'opacity-50 cursor-not-allowed' : ''
+          }`}
+          onClick={handleClick}
+          disabled={isLoadingSummary || isLoading}
+          title="Summarize conversation context"
+        >
+          <span className="pr-1.5">summarize</span>
+          <FileText size={16} />
+        </button>
+      </div>
 
-        {/* Confirmation Modal */}
-        {isConfirmationOpen && (
-            <Modal footer={footerContent} onClose={() => setIsConfirmationOpen(false)}>
-              <div className="flex flex-col mb-6">
-                <div>
-                  <FileText className="text-iconStandard" size={24} />
-                </div>
-                <div className="mt-2">
-                  <h2 className="text-2xl font-regular text-textStandard">Summarize Context</h2>
-                </div>
-              </div>
+      {/* Confirmation Modal */}
+      {isConfirmationOpen && (
+        <Modal footer={footerContent} onClose={() => setIsConfirmationOpen(false)}>
+          <div className="flex flex-col mb-6">
+            <div>
+              <FileText className="text-iconStandard" size={24} />
+            </div>
+            <div className="mt-2">
+              <h2 className="text-2xl font-regular text-textStandard">Summarize Context</h2>
+            </div>
+          </div>
 
-              <div className="mb-6">
-                <p className="text-textStandard mb-4">
-                  This will summarize your conversation history to save context space.
-                </p>
-                <p className="text-textStandard">
-                  Previous messages will remain visible but only the summary will be included in the active context for Goose. This is useful for long conversations that are approaching the context limit.
-                </p>
-              </div>
-            </Modal>
-        )}
-      </>
+          <div className="mb-6">
+            <p className="text-textStandard mb-4">
+              This will summarize your conversation history to save context space.
+            </p>
+            <p className="text-textStandard">
+              Previous messages will remain visible but only the summary will be included in the
+              active context for Goose. This is useful for long conversations that are approaching
+              the context limit.
+            </p>
+          </div>
+        </Modal>
+      )}
+    </>
   );
 };

--- a/ui/desktop/src/components/context_management/ManualSummaryButton.tsx
+++ b/ui/desktop/src/components/context_management/ManualSummaryButton.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { FileText } from 'lucide-react';
+import { ScrollText } from 'lucide-react';
 import Modal from '../Modal';
 import { Button } from '../ui/button';
 import { useChatContextManager } from './ChatContextManager';
@@ -39,14 +39,14 @@ export const ManualSummarizeButton: React.FC<ManualSummarizeButtonProps> = ({
     <>
       <Button
         onClick={handleSummarize}
-        className="w-full h-[60px] rounded-none border-b border-borderSubtle bg-transparent hover:bg-bgSubtle text-textProminent font-medium text-md"
+        className="w-full h-[60px] rounded-none border-b border-borderSubtle bg-transparent hover:bg-bgSubtle text-textProminent font-medium text-large"
       >
-        Summarize context
+        Summarize
       </Button>
       <Button
         onClick={() => setIsConfirmationOpen(false)}
         variant="ghost"
-        className="w-full h-[60px] rounded-none hover:bg-bgSubtle text-textSubtle hover:text-textStandard text-md font-regular"
+        className="w-full h-[60px] rounded-none hover:bg-bgSubtle text-textSubtle hover:text-textStandard text-large font-regular"
       >
         Cancel
       </Button>
@@ -64,8 +64,7 @@ export const ManualSummarizeButton: React.FC<ManualSummarizeButtonProps> = ({
           disabled={isLoadingSummary || isLoading}
           title="Summarize conversation context"
         >
-          <span className="pr-1.5">summarize</span>
-          <FileText size={16} />
+          <ScrollText size={16} />
         </button>
       </div>
 
@@ -74,10 +73,10 @@ export const ManualSummarizeButton: React.FC<ManualSummarizeButtonProps> = ({
         <Modal footer={footerContent} onClose={() => setIsConfirmationOpen(false)}>
           <div className="flex flex-col mb-6">
             <div>
-              <FileText className="text-iconStandard" size={24} />
+              <ScrollText className="text-iconStandard" size={24} />
             </div>
             <div className="mt-2">
-              <h2 className="text-2xl font-regular text-textStandard">Summarize Context</h2>
+              <h2 className="text-2xl font-regular text-textStandard">Summarize Conversation</h2>
             </div>
           </div>
 

--- a/ui/desktop/src/components/context_management/ManualSummaryButton.tsx
+++ b/ui/desktop/src/components/context_management/ManualSummaryButton.tsx
@@ -1,21 +1,25 @@
 import React, { useState } from 'react';
-import { ClipboardList } from 'lucide-react';
+import { FileText } from 'lucide-react';
 import Modal from '../Modal';
 import { Button } from '../ui/button';
 import { useChatContextManager } from './ContextManager';
 import { Message } from '../../types/message';
+import { toastService } from '../../toasts';
 
 interface ManualSummarizeButtonProps {
   messages: Message[];
-  isLoading?: boolean; // Add this prop to indicate when Goose is responding
+  isLoading?: boolean; // Only need this prop to know if Goose is responding
 }
 
 export const ManualSummarizeButton: React.FC<ManualSummarizeButtonProps> = ({
-  messages,
-  isLoading = false,
-}) => {
-  const { summaryContent, isLoadingSummary, fetchSummary, openSummaryModal } =
-    useChatContextManager();
+                                                                              messages,
+                                                                              isLoading = false,
+                                                                            }) => {
+  const {
+    handleManualSummarization,
+    preparingManualSummary,
+      openSummaryModal
+  } = useChatContextManager();
 
   const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
 
@@ -26,83 +30,87 @@ export const ManualSummarizeButton: React.FC<ManualSummarizeButtonProps> = ({
   const handleSummarize = async () => {
     setIsConfirmationOpen(false);
 
-    try {
-      await fetchSummary(messages);
+    const toastId = toastService.loading({
+      title: 'Preparing Summary',
+      msg: 'Analyzing and summarizing your conversation...'
+    });
 
-      // If there's a summary available, open the modal to view/edit it
-      if (summaryContent) {
-        openSummaryModal();
-      } else {
-        // The summary might not be immediately available due to async nature
-        // We'll check for it after a delay
-        setTimeout(() => {
-          openSummaryModal();
-        }, 500);
-      }
+    try {
+      await handleManualSummarization(messages);
+      toastService.dismiss(toastId);
+      toastService.success({
+        title: 'Summary Ready',
+        msg: 'Your conversation has been summarized successfully.'
+      });
+      openSummaryModal()
     } catch (error) {
-      console.error('Error triggering context summary:', error);
+      console.error('Error in handleSummarize:', error);
+      toastService.dismiss(toastId);
+      toastService.error({
+        title: 'Summary Error',
+        msg: 'Failed to generate conversation summary.',
+        traceback: String(error)
+      });
     }
   };
 
   // Footer content for the confirmation modal
   const footerContent = (
-    <>
-      <Button
-        onClick={handleSummarize}
-        className="w-full h-[60px] rounded-none border-b border-borderSubtle bg-transparent hover:bg-bgSubtle text-textProminent font-medium text-md"
-      >
-        Summarize context
-      </Button>
-      <Button
-        onClick={() => setIsConfirmationOpen(false)}
-        variant="ghost"
-        className="w-full h-[60px] rounded-none hover:bg-bgSubtle text-textSubtle hover:text-textStandard text-md font-regular"
-      >
-        Cancel
-      </Button>
-    </>
+      <>
+        <Button
+            onClick={handleSummarize}
+            className="w-full h-[60px] rounded-none border-b border-borderSubtle bg-transparent hover:bg-bgSubtle text-textProminent font-medium text-md"
+        >
+          Summarize context
+        </Button>
+        <Button
+            onClick={() => setIsConfirmationOpen(false)}
+            variant="ghost"
+            className="w-full h-[60px] rounded-none hover:bg-bgSubtle text-textSubtle hover:text-textStandard text-md font-regular"
+        >
+          Cancel
+        </Button>
+      </>
   );
 
   return (
-    <>
-      <div className="relative flex items-center">
-        <button
-          className={`flex items-center justify-center text-textSubtle hover:text-textStandard h-6 [&_svg]:size-4 ${
-            isLoadingSummary || isLoading ? 'opacity-50 cursor-not-allowed' : ''
-          }`}
-          onClick={handleClick}
-          disabled={isLoadingSummary || isLoading}
-          title="Summarize conversation context"
-        >
-          <span className="pr-1.5">summarize</span>
-          <ClipboardList size={16} />
-        </button>
-      </div>
+      <>
+        <div className="relative flex items-center">
+          <button
+              className={`flex items-center justify-center text-textSubtle hover:text-textStandard h-6 [&_svg]:size-4 ${
+                  preparingManualSummary || isLoading ? 'opacity-50 cursor-not-allowed' : ''
+              }`}
+              onClick={handleClick}
+              disabled={preparingManualSummary || isLoading}
+              title="Summarize conversation context"
+          >
+            <span className="pr-1.5">summarize</span>
+            <FileText size={16} />
+          </button>
+        </div>
 
-      {/* Confirmation Modal */}
-      {isConfirmationOpen && (
-        <Modal footer={footerContent} onClose={() => setIsConfirmationOpen(false)}>
-          <div className="flex flex-col mb-6">
-            <div>
-              <ClipboardList className="text-iconStandard" size={24} />
-            </div>
-            <div className="mt-2">
-              <h2 className="text-2xl font-regular text-textStandard">Summarize Context</h2>
-            </div>
-          </div>
+        {/* Confirmation Modal */}
+        {isConfirmationOpen && (
+            <Modal footer={footerContent} onClose={() => setIsConfirmationOpen(false)}>
+              <div className="flex flex-col mb-6">
+                <div>
+                  <FileText className="text-iconStandard" size={24} />
+                </div>
+                <div className="mt-2">
+                  <h2 className="text-2xl font-regular text-textStandard">Summarize Context</h2>
+                </div>
+              </div>
 
-          <div className="mb-6">
-            <p className="text-textStandard mb-4">
-              This will summarize your conversation history to save context space.
-            </p>
-            <p className="text-textStandard">
-              Previous messages will remain visible but only the summary will be included in the
-              active context for Goose. This is useful for long conversations that are approaching
-              the context limit.
-            </p>
-          </div>
-        </Modal>
-      )}
-    </>
+              <div className="mb-6">
+                <p className="text-textStandard mb-4">
+                  This will summarize your conversation history to save context space.
+                </p>
+                <p className="text-textStandard">
+                  Previous messages will remain visible but only the summary will be included in the active context for Goose. This is useful for long conversations that are approaching the context limit.
+                </p>
+              </div>
+            </Modal>
+        )}
+      </>
   );
 };

--- a/ui/desktop/src/components/context_management/ManualSummaryButton.tsx
+++ b/ui/desktop/src/components/context_management/ManualSummaryButton.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import { ClipboardList } from 'lucide-react';
+import Modal from '../Modal';
+import { Button } from '../ui/button';
+import { useChatContextManager } from './ContextManager';
+import { Message } from '../../types/message';
+
+interface ManualSummarizeButtonProps {
+  messages: Message[];
+  isLoading?: boolean; // Add this prop to indicate when Goose is responding
+}
+
+export const ManualSummarizeButton: React.FC<ManualSummarizeButtonProps> = ({
+  messages,
+  isLoading = false,
+}) => {
+  const { summaryContent, isLoadingSummary, fetchSummary, openSummaryModal } =
+    useChatContextManager();
+
+  const [isConfirmationOpen, setIsConfirmationOpen] = useState(false);
+
+  const handleClick = () => {
+    setIsConfirmationOpen(true);
+  };
+
+  const handleSummarize = async () => {
+    setIsConfirmationOpen(false);
+
+    try {
+      await fetchSummary(messages);
+
+      // If there's a summary available, open the modal to view/edit it
+      if (summaryContent) {
+        openSummaryModal();
+      } else {
+        // The summary might not be immediately available due to async nature
+        // We'll check for it after a delay
+        setTimeout(() => {
+          openSummaryModal();
+        }, 500);
+      }
+    } catch (error) {
+      console.error('Error triggering context summary:', error);
+    }
+  };
+
+  // Footer content for the confirmation modal
+  const footerContent = (
+    <>
+      <Button
+        onClick={handleSummarize}
+        className="w-full h-[60px] rounded-none border-b border-borderSubtle bg-transparent hover:bg-bgSubtle text-textProminent font-medium text-md"
+      >
+        Summarize context
+      </Button>
+      <Button
+        onClick={() => setIsConfirmationOpen(false)}
+        variant="ghost"
+        className="w-full h-[60px] rounded-none hover:bg-bgSubtle text-textSubtle hover:text-textStandard text-md font-regular"
+      >
+        Cancel
+      </Button>
+    </>
+  );
+
+  return (
+    <>
+      <div className="relative flex items-center">
+        <button
+          className={`flex items-center justify-center text-textSubtle hover:text-textStandard h-6 [&_svg]:size-4 ${
+            isLoadingSummary || isLoading ? 'opacity-50 cursor-not-allowed' : ''
+          }`}
+          onClick={handleClick}
+          disabled={isLoadingSummary || isLoading}
+          title="Summarize conversation context"
+        >
+          <span className="pr-1.5">summarize</span>
+          <ClipboardList size={16} />
+        </button>
+      </div>
+
+      {/* Confirmation Modal */}
+      {isConfirmationOpen && (
+        <Modal footer={footerContent} onClose={() => setIsConfirmationOpen(false)}>
+          <div className="flex flex-col mb-6">
+            <div>
+              <ClipboardList className="text-iconStandard" size={24} />
+            </div>
+            <div className="mt-2">
+              <h2 className="text-2xl font-regular text-textStandard">Summarize Context</h2>
+            </div>
+          </div>
+
+          <div className="mb-6">
+            <p className="text-textStandard mb-4">
+              This will summarize your conversation history to save context space.
+            </p>
+            <p className="text-textStandard">
+              Previous messages will remain visible but only the summary will be included in the
+              active context for Goose. This is useful for long conversations that are approaching
+              the context limit.
+            </p>
+          </div>
+        </Modal>
+      )}
+    </>
+  );
+};

--- a/ui/desktop/src/components/context_management/index.ts
+++ b/ui/desktop/src/components/context_management/index.ts
@@ -138,8 +138,6 @@ export function createSummarizationRequestMessage(
   // Determine the next role (opposite of the last message)
   const nextRole: Role = lastMessage.role === 'user' ? 'assistant' : 'user';
 
-  console.log(nextRole);
-
   // Create the new message with SummarizationRequestedContent
   return {
     id: generateId(),

--- a/ui/desktop/src/components/context_management/index.ts
+++ b/ui/desktop/src/components/context_management/index.ts
@@ -4,6 +4,7 @@ import {
   MessageContent as FrontendMessageContent,
   ToolCallResult,
   ToolCall,
+  Role,
 } from '../../types/message';
 import {
   ContextManageRequest,
@@ -115,9 +116,42 @@ function mapApiContentToFrontendMessageContent(
       type: 'contextLengthExceeded',
       msg: apiContent.msg,
     };
+  } else if (apiContent.type === 'summarizationRequested') {
+    return {
+      type: 'summarizationRequested',
+      msg: apiContent.msg,
+    };
   }
 
   // For types that exist in API but not in frontend, either skip or convert
   console.warn(`Skipping unsupported content type: ${apiContent.type}`);
   return null;
+}
+
+export function createSummarizationRequestMessage(
+  messages: FrontendMessage[],
+  requestMessage: string
+): FrontendMessage {
+  // Get the last message
+  const lastMessage = messages[messages.length - 1];
+
+  // Determine the next role (opposite of the last message)
+  const nextRole: Role = lastMessage.role === 'user' ? 'assistant' : 'user';
+
+  console.log(nextRole);
+
+  // Create the new message with SummarizationRequestedContent
+  return {
+    id: generateId(),
+    role: nextRole,
+    created: Math.floor(Date.now() / 1000),
+    content: [
+      {
+        type: 'summarizationRequested',
+        msg: requestMessage,
+      },
+    ],
+    sendToLLM: false,
+    display: true,
+  };
 }

--- a/ui/desktop/src/hooks/useMessageStream.ts
+++ b/ui/desktop/src/hooks/useMessageStream.ts
@@ -312,7 +312,7 @@ export function useMessageStream({
             ...extraMetadataRef.current.headers,
           },
           body: JSON.stringify({
-            messages: requestMessages,
+            messages: filteredMessages,
             ...extraMetadataRef.current.body,
           }),
           signal: abortController.signal,
@@ -439,7 +439,6 @@ export function useMessageStream({
       event?.preventDefault?.();
       if (!input.trim()) return;
 
-      console.log('handleSubmit called with input:', input);
       await append(input);
       setInput('');
     },

--- a/ui/desktop/src/types/message.ts
+++ b/ui/desktop/src/types/message.ts
@@ -78,21 +78,27 @@ export interface ContextLengthExceededContent {
   msg: string;
 }
 
+export interface SummarizationRequestedContent {
+  type: 'summarizationRequested';
+  msg: string;
+}
+
 export type MessageContent =
   | TextContent
   | ImageContent
   | ToolRequestMessageContent
   | ToolResponseMessageContent
   | ToolConfirmationRequestMessageContent
-  | ContextLengthExceededContent;
+  | ContextLengthExceededContent
+  | SummarizationRequestedContent;
 
 export interface Message {
   id?: string;
   role: Role;
   created: number;
   content: MessageContent[];
-  display: boolean;
-  sendToLLM: boolean;
+  display?: boolean;
+  sendToLLM?: boolean;
 }
 
 // Helper functions to create messages


### PR DESCRIPTION
This allows users to summarize their conversations on command. Uses similar flow as CLE events

1. User clicks button
2. This button click inserts a 'summarizationRequested' message into the message list 
3. The rest of the flow is the same as how we handle CLE events, I just added an additional check for the `summarizationRequested` message type in addition to the `contextLengthExceededMessage` type. If either of those conditions are met, then we go the same summarization process
4. I modified the text around the summarization (see video) to differentiate it from the CLE events 
5. 
https://github.com/user-attachments/assets/cf842bf5-864e-4e4f-ba99-b811f34f11b2

