### PR TITLE
UI Tweaks including border and padding fixes, contrast improvements, and more

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.22"
+    "version": "1.0.23"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -287,7 +287,7 @@ export default function ChatInput({
             maxHeight: `${maxHeight}px`,
             overflowY: 'auto',
           }}
-          className="w-full pl-4 pr-[68px] outline-none border-none focus:ring-0 bg-transparent pt-3 pb-1.5 text-sm resize-none text-textStandard placeholder:text-textPlaceholder placeholder:opacity-50"
+          className="w-full pl-4 pr-[68px] outline-none border-none focus:ring-0 bg-transparent pt-3 pb-1.5 text-sm resize-none text-textStandard placeholder:text-textPlaceholder"
         />
 
         {isLoading ? (

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -310,10 +310,10 @@ export default function ChatInput({
             size="icon"
             variant="ghost"
             disabled={!displayValue.trim()}
-            className={`absolute right-3 top-2 transition-colors rounded-full hover:cursor w-7 h-7 [&_svg]:size-4 ${
+            className={`absolute right-3 top-2 transition-colors rounded-full w-7 h-7 [&_svg]:size-4 ${
               !displayValue.trim()
                 ? 'text-textSubtle cursor-not-allowed'
-                : 'bg-bgAppInverse text-white'
+                : 'bg-bgAppInverse text-textProminentInverse hover:cursor-pointer'
             }`}
           >
             <Send />

--- a/ui/desktop/src/components/more_menu/MoreMenuLayout.tsx
+++ b/ui/desktop/src/components/more_menu/MoreMenuLayout.tsx
@@ -22,7 +22,7 @@ export default function MoreMenuLayout({
       style={{ WebkitAppRegion: 'drag' }}
     >
       {showMenu && (
-        <div className="flex items-center justify-between w-full h-full pl-[86px] pr-4">
+        <div className="flex items-center justify-between w-full h-full pl-2 pr-4">
           <TooltipProvider>
             <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
               <TooltipTrigger asChild>

--- a/ui/desktop/src/components/more_menu/MoreMenuLayout.tsx
+++ b/ui/desktop/src/components/more_menu/MoreMenuLayout.tsx
@@ -27,7 +27,7 @@ export default function MoreMenuLayout({
             <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
               <TooltipTrigger asChild>
                 <button
-                  className="z-[100] no-drag hover:cursor-pointer border border-subtle hover:border-borderStandard rounded-lg p-2 pr-3 text-textSubtle hover:text-textStandard text-sm flex items-center transition-colors [&>svg]:size-4 "
+                  className="z-[100] no-drag hover:cursor-pointer border border-borderSubtle hover:border-borderStandard rounded-lg p-2 pr-3 text-textSubtle hover:text-textStandard text-sm flex items-center transition-colors [&>svg]:size-4 "
                   onClick={async () => {
                     if (hasMessages) {
                       window.electron.directoryChooser();

--- a/ui/desktop/src/components/settings_v2/permission/PermissionSetting.tsx
+++ b/ui/desktop/src/components/settings_v2/permission/PermissionSetting.tsx
@@ -87,12 +87,15 @@ export default function PermissionSettingsView({ onClose }: { onClose: () => voi
               xmlns="http://www.w3.org/2000/svg"
               width="64"
               height="64"
-              viewBox="0 0 64 64"
-              fill="none"
+              viewBox="0 0 24 24"
+              className="stroke-textProminent fill-bgApp"
+              strokeWidth="2"
+              strokeLinecap="round"
+              strokeLinejoin="round"
             >
-              <circle cx="32" cy="32" r="32" fill="#101010" />
-              <rect x="22" y="17" width="8" height="8" rx="4" fill="white" />
-              <rect x="22" y="28" width="20" height="20" rx="10" fill="white" />
+              <path d="m15.5 7.5 2.3 2.3a1 1 0 0 0 1.4 0l2.1-2.1a1 1 0 0 0 0-1.4L19 4" />
+              <path d="m21 2-9.6 9.6" />
+              <circle cx="7.5" cy="15.5" r="5.5" />
             </svg>
             <h1 className="text-3xl font-medium text-textStandard mt-4">Permission Rules</h1>
             <p className="text-textSubtle">


### PR DESCRIPTION
This PR fixes several UI issues. You can expand each category below to see before and after changes.
I'm open to feedback! :heart: 

<details><summary>Change padding of working directory chooser</summary>
<p>

## Before

Is there a reason for this padding? Please let me know!
![image](https://github.com/user-attachments/assets/53856880-9fe1-4494-92ae-7b545944832d)

## After

TO FILL

</p>
</details>

<details><summary>Goose working directory border fixes</summary>
<p>

## Before

The border in dark mode when not hovered looks like the 'focused' border. It should be dimmer.
![image](https://github.com/user-attachments/assets/e6c1db9a-9ccd-4970-a374-e00d88a55660)

## After

TO FILL

</p>
</details>


<details><summary>Fix chat input placeholder contrast</summary>
<p>

## Before

It's hard to see this text in dark mode and light mode. It doesn't need opacity since the text is already a dim color.

![image](https://github.com/user-attachments/assets/bc4f5b2a-a5da-452c-9003-a243717a542b)

## After

TO FILL

</p>
</details> 

<details><summary>Fix send button colors in dark mode</summary>
<p>

## Before

When there is text in the chat input, the send button is all white in dark mode:
![image](https://github.com/user-attachments/assets/624adeff-543a-4ef5-a889-fcbc5d71b7f6)


## After

TO FILL

</p>
</details>

<details><summary>Change permission rules icon</summary>
<p>

## Before

It's not clear what this icon means in dark or light mode.
![image](https://github.com/user-attachments/assets/b527fb56-d367-444b-9a8b-7e1e3e47da1a)


## After

TO FILL

</p>
</details>