### PR TITLE
fix: menu bar and dock icon settings

### DIFF
--- a/ui/desktop/src/components/settings_v2/SettingsView.tsx
+++ b/ui/desktop/src/components/settings_v2/SettingsView.tsx
@@ -6,6 +6,7 @@ import ModelsSection from './models/ModelsSection';
 import { ModeSection } from './mode/ModeSection';
 import SessionSharingSection from './sessions/SessionSharingSection';
 import { ResponseStylesSection } from './response_styles/ResponseStylesSection';
+import AppSettingsSection from './app/AppSettingsSection';
 import { ExtensionConfig } from '../../api';
 import MoreMenuLayout from '../more_menu/MoreMenuLayout';
 
@@ -50,6 +51,8 @@ export default function SettingsView({
               <SessionSharingSection />
               {/* Response Styles */}
               <ResponseStylesSection />
+              {/* App Settings */}
+              <AppSettingsSection />
             </div>
           </div>
         </div>

--- a/ui/desktop/src/components/settings_v2/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings_v2/app/AppSettingsSection.tsx
@@ -1,0 +1,102 @@
+import React, { useState, useEffect } from 'react';
+import { Switch } from '../../ui/switch';
+
+export default function AppSettingsSection() {
+  const [menuBarIconEnabled, setMenuBarIconEnabled] = useState(true);
+  const [dockIconEnabled, setDockIconEnabled] = useState(true);
+  const [isMacOS, setIsMacOS] = useState(false);
+
+  // Check if running on macOS
+  useEffect(() => {
+    setIsMacOS(window.electron.platform === 'darwin');
+  }, []);
+
+  // Load menu bar and dock icon states
+  useEffect(() => {
+    window.electron.getMenuBarIconState().then((enabled) => {
+      setMenuBarIconEnabled(enabled);
+    });
+
+    if (isMacOS) {
+      window.electron.getDockIconState().then((enabled) => {
+        setDockIconEnabled(enabled);
+      });
+    }
+  }, [isMacOS]);
+
+  const handleMenuBarIconToggle = async () => {
+    const newState = !menuBarIconEnabled;
+    // If we're turning off the menu bar icon and the dock icon is hidden,
+    // we need to show the dock icon to maintain accessibility
+    if (!newState && !dockIconEnabled && isMacOS) {
+      const success = await window.electron.setDockIcon(true);
+      if (success) {
+        setDockIconEnabled(true);
+      }
+    }
+    const success = await window.electron.setMenuBarIcon(newState);
+    if (success) {
+      setMenuBarIconEnabled(newState);
+    }
+  };
+
+  const handleDockIconToggle = async () => {
+    const newState = !dockIconEnabled;
+    // If we're turning off the dock icon and the menu bar icon is hidden,
+    // we need to show the menu bar icon to maintain accessibility
+    if (!newState && !menuBarIconEnabled) {
+      const success = await window.electron.setMenuBarIcon(true);
+      if (success) {
+        setMenuBarIconEnabled(true);
+      }
+    }
+    const success = await window.electron.setDockIcon(newState);
+    if (success) {
+      setDockIconEnabled(newState);
+    }
+  };
+
+  return (
+    <section id="appSettings" className="px-8">
+      <div className="flex justify-between items-center mb-2">
+        <h2 className="text-xl font-medium text-textStandard">App Settings</h2>
+      </div>
+      <div className="pb-8">
+        <p className="text-sm text-textStandard mb-6">Configure Goose app</p>
+        <div>
+          <div className="flex items-center justify-between mb-4">
+            <div>
+              <h3 className="text-textStandard">Menu Bar Icon</h3>
+              <p className="text-xs text-textSubtle max-w-md mt-[2px]">
+                Show Goose in the menu bar
+              </p>
+            </div>
+            <div className="flex items-center">
+              <Switch
+                checked={menuBarIconEnabled}
+                onCheckedChange={handleMenuBarIconToggle}
+                variant="mono"
+              />
+            </div>
+          </div>
+
+          {isMacOS && (
+            <div className="flex items-center justify-between mb-4">
+              <div>
+                <h3 className="text-textStandard">Dock Icon</h3>
+                <p className="text-xs text-textSubtle max-w-md mt-[2px]">Show Goose in the dock</p>
+              </div>
+              <div className="flex items-center">
+                <Switch
+                  checked={dockIconEnabled}
+                  onCheckedChange={handleDockIconToggle}
+                  variant="mono"
+                />
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ui/desktop/src/components/settings_v2/response_styles/ResponseStylesSection.tsx
+++ b/ui/desktop/src/components/settings_v2/response_styles/ResponseStylesSection.tsx
@@ -25,7 +25,7 @@ export const ResponseStylesSection = () => {
       <div className="flex justify-between items-center mb-2">
         <h2 className="text-xl font-medium text-textStandard">Response Styles</h2>
       </div>
-      <div className="pb-8">
+      <div className="border-b border-borderSubtle pb-8">
         <p className="text-sm text-textStandard mb-6">
           Choose how Goose should format and style its responses
         </p>

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -502,7 +502,17 @@ const createChat = async (
 // Track tray instance
 let tray: Tray | null = null;
 
+const destroyTray = () => {
+  if (tray) {
+    tray.destroy();
+    tray = null;
+  }
+};
+
 const createTray = () => {
+  // If tray already exists, destroy it first
+  destroyTray();
+
   const isDev = process.env.NODE_ENV === 'development';
   let iconPath: string;
 
@@ -627,6 +637,70 @@ ipcMain.on('react-ready', () => {
 // Handle directory chooser
 ipcMain.handle('directory-chooser', (_event, replace: boolean = false) => {
   return openDirectoryDialog(replace);
+});
+
+// Handle menu bar icon visibility
+ipcMain.handle('set-menu-bar-icon', async (_event, show: boolean) => {
+  try {
+    const settings = loadSettings();
+    settings.showMenuBarIcon = show;
+    saveSettings(settings);
+
+    if (show) {
+      createTray();
+    } else {
+      destroyTray();
+    }
+    return true;
+  } catch (error) {
+    console.error('Error setting menu bar icon:', error);
+    return false;
+  }
+});
+
+ipcMain.handle('get-menu-bar-icon-state', () => {
+  try {
+    const settings = loadSettings();
+    return settings.showMenuBarIcon ?? true;
+  } catch (error) {
+    console.error('Error getting menu bar icon state:', error);
+    return true;
+  }
+});
+
+// Handle dock icon visibility (macOS only)
+ipcMain.handle('set-dock-icon', async (_event, show: boolean) => {
+  try {
+    if (process.platform !== 'darwin') return false;
+
+    const settings = loadSettings();
+    settings.showDockIcon = show;
+    saveSettings(settings);
+
+    if (show) {
+      app.dock.show();
+    } else {
+      // Only hide the dock if we have a menu bar icon to maintain accessibility
+      if (settings.showMenuBarIcon) {
+        app.dock.hide();
+      }
+    }
+    return true;
+  } catch (error) {
+    console.error('Error setting dock icon:', error);
+    return false;
+  }
+});
+
+ipcMain.handle('get-dock-icon-state', () => {
+  try {
+    if (process.platform !== 'darwin') return true;
+    const settings = loadSettings();
+    return settings.showDockIcon ?? true;
+  } catch (error) {
+    console.error('Error getting dock icon state:', error);
+    return true;
+  }
 });
 
 // Add file/directory selection handler
@@ -779,10 +853,20 @@ app.whenReady().then(async () => {
     }, 5000);
   }
 
+  // Create tray if enabled in settings
+  const settings = loadSettings();
+  if (settings.showMenuBarIcon) {
+    createTray();
+  }
+
+  // Handle dock icon visibility (macOS only)
+  if (process.platform === 'darwin' && !settings.showDockIcon && settings.showMenuBarIcon) {
+    app.dock.hide();
+  }
+
   // Parse command line arguments
   const { dirPath } = parseArgs();
 
-  createTray();
   createNewWindow(app, dirPath);
 
   // Get the existing menu
@@ -1043,6 +1127,48 @@ app.whenReady().then(async () => {
     return getBinaryPath(app, binaryName);
   });
 
+  // Handle menu bar icon visibility
+  ipcMain.handle('set-menu-bar-icon', (_event, show: boolean) => {
+    const settings = loadSettings();
+    settings.showMenuBarIcon = show;
+    saveSettings(settings);
+
+    if (show) {
+      createTray();
+    } else {
+      destroyTray();
+    }
+    return true;
+  });
+
+  ipcMain.handle('get-menu-bar-icon-state', () => {
+    return loadSettings().showMenuBarIcon;
+  });
+
+  // Handle dock icon visibility (macOS only)
+  ipcMain.handle('set-dock-icon', (_event, show: boolean) => {
+    if (process.platform !== 'darwin') return false;
+
+    const settings = loadSettings();
+    settings.showDockIcon = show;
+    saveSettings(settings);
+
+    if (show) {
+      app.dock.show();
+    } else {
+      // Only hide the dock if we have a menu bar icon to maintain accessibility
+      if (settings.showMenuBarIcon) {
+        app.dock.hide();
+      }
+    }
+    return true;
+  });
+
+  ipcMain.handle('get-dock-icon-state', () => {
+    if (process.platform !== 'darwin') return true;
+    return loadSettings().showDockIcon;
+  });
+
   // Handle metadata fetching from main process
   ipcMain.handle('fetch-metadata', async (_event, url) => {
     try {
@@ -1061,6 +1187,112 @@ app.whenReady().then(async () => {
       console.error('Error fetching metadata:', error);
       throw error;
     }
+  });
+
+  // Handle menu bar icon visibility
+  ipcMain.handle('set-menu-bar-icon', async (_event, show: boolean) => {
+    try {
+      const settings = loadSettings();
+      settings.showMenuBarIcon = show;
+      saveSettings(settings);
+
+      if (show) {
+        createTray();
+      } else {
+        destroyTray();
+      }
+      return true;
+    } catch (error) {
+      console.error('Error setting menu bar icon:', error);
+      return false;
+    }
+  });
+
+  ipcMain.handle('get-menu-bar-icon-state', () => {
+    try {
+      const settings = loadSettings();
+      return settings.showMenuBarIcon ?? true;
+    } catch (error) {
+      console.error('Error getting menu bar icon state:', error);
+      return true;
+    }
+  });
+
+  // Handle dock icon visibility (macOS only)
+  ipcMain.handle('set-dock-icon', async (_event, show: boolean) => {
+    try {
+      if (process.platform !== 'darwin') return false;
+
+      const settings = loadSettings();
+      settings.showDockIcon = show;
+      saveSettings(settings);
+
+      if (show) {
+        app.dock.show();
+      } else {
+        // Only hide the dock if we have a menu bar icon to maintain accessibility
+        if (settings.showMenuBarIcon) {
+          app.dock.hide();
+        }
+      }
+      return true;
+    } catch (error) {
+      console.error('Error setting dock icon:', error);
+      return false;
+    }
+  });
+
+  ipcMain.handle('get-dock-icon-state', () => {
+    try {
+      if (process.platform !== 'darwin') return true;
+      const settings = loadSettings();
+      return settings.showDockIcon ?? true;
+    } catch (error) {
+      console.error('Error getting dock icon state:', error);
+      return true;
+    }
+  });
+
+  // Handle menu bar icon visibility
+  ipcMain.handle('set-menu-bar-icon', (_event, show: boolean) => {
+    const settings = loadSettings();
+    settings.showMenuBarIcon = show;
+    saveSettings(settings);
+
+    if (show) {
+      createTray();
+    } else {
+      destroyTray();
+    }
+    return true;
+  });
+
+  ipcMain.handle('get-menu-bar-icon-state', () => {
+    return loadSettings().showMenuBarIcon;
+  });
+
+  // Handle dock icon visibility (macOS only)
+  ipcMain.handle('set-dock-icon', (_event, show: boolean) => {
+    if (process.platform !== 'darwin') return false;
+
+    const settings = loadSettings();
+    settings.showDockIcon = show;
+    saveSettings(settings);
+
+    if (show) {
+      app.dock.show();
+    } else {
+      // Only hide the dock if we have a menu bar icon to maintain accessibility
+      if (settings.showMenuBarIcon) {
+        app.dock.hide();
+      }
+    }
+    return true;
+  });
+
+  ipcMain.handle('get-dock-icon-state', () => {
+    if (process.platform !== 'darwin') return true;
+    return loadSettings().showDockIcon;
   });
 
   ipcMain.on('open-in-chrome', (_event, url) => {

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -52,6 +52,10 @@ type ElectronAPI = {
   writeFile: (directory: string, content: string) => Promise<boolean>;
   getAllowedExtensions: () => Promise<string[]>;
   getPathForFile: (file: File) => string;
+  setMenuBarIcon: (show: boolean) => Promise<boolean>;
+  getMenuBarIconState: () => Promise<boolean>;
+  setDockIcon: (show: boolean) => Promise<boolean>;
+  getDockIconState: () => Promise<boolean>;
   on: (
     channel: string,
     callback: (event: Electron.IpcRendererEvent, ...args: unknown[]) => void
@@ -106,6 +110,10 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.invoke('write-file', filePath, content),
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
   getAllowedExtensions: () => ipcRenderer.invoke('get-allowed-extensions'),
+  setMenuBarIcon: (show: boolean) => ipcRenderer.invoke('set-menu-bar-icon', show),
+  getMenuBarIconState: () => ipcRenderer.invoke('get-menu-bar-icon-state'),
+  setDockIcon: (show: boolean) => ipcRenderer.invoke('set-dock-icon', show),
+  getDockIconState: () => ipcRenderer.invoke('get-dock-icon-state'),
   on: (
     channel: string,
     callback: (event: Electron.IpcRendererEvent, ...args: unknown[]) => void

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -10,6 +10,8 @@ export interface EnvToggles {
 
 export interface Settings {
   envToggles: EnvToggles;
+  showMenuBarIcon: boolean;
+  showDockIcon: boolean;
 }
 
 // Constants
@@ -20,6 +22,8 @@ const defaultSettings: Settings = {
     GOOSE_SERVER__MEMORY: false,
     GOOSE_SERVER__COMPUTER_CONTROLLER: false,
   },
+  showMenuBarIcon: true,
+  showDockIcon: true,
 };
 
 // Settings management


### PR DESCRIPTION
# Description
This PR introduces a new "App Settings" section in the settings UI to manage visibility options for the menu bar and dock icons. fix #1464

## Frontend Changes:

* **New `AppSettingsSection` Component**:
  - Added a new React component, `AppSettingsSection`, to manage menu bar and dock icon visibility settings. It includes toggles for enabling/disabling these icons and ensures accessibility by enforcing at least one icon to remain visible. 
  - Integrated the `AppSettingsSection` into the `SettingsView` component. 

## Backend Changes:

* **Menu Bar and Dock Icon Management**:
  - Added IPC handlers in the main process to manage menu bar and dock icon visibility (`set-menu-bar-icon`, `get-menu-bar-icon-state`, `set-dock-icon`, `get-dock-icon-state`). These handlers update the settings and adjust the tray or dock visibility accordingly. 
  - Introduced `destroyTray` to safely remove the tray icon when toggled off. 

* **Electron API Extensions**:
  - Extended the `ElectronAPI` to include methods for setting and retrieving menu bar and dock icon states. 

* **Settings Schema Update**:
  - Added `showMenuBarIcon` and `showDockIcon` properties to the `Settings` interface with default values set to `true`. 