### PR TITLE
docs: Adding YT short to Pieces and Postgres Tutorial

### DIFF
--- a/documentation/docs/tutorials/pieces-mcp.md
+++ b/documentation/docs/tutorials/pieces-mcp.md
@@ -6,6 +6,10 @@ description: Add Pieces for Developers MCP Server as a Goose Extension
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
+import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
+
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/V8zp9m9__t4" />
+
 This tutorial covers how to add the [Pieces for Developers MCP Server](https://docs.pieces.app/products/mcp/get-started?utm_source=goose&utm_medium=collab&utm_campaign=mcp) as a Goose extension to enable interaction with your Pieces Long-Term Memory.
 
 ## Configuration

--- a/documentation/docs/tutorials/postgres-mcp.md
+++ b/documentation/docs/tutorials/postgres-mcp.md
@@ -7,6 +7,8 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/PZlYQ5IthYM" />
+
 The PostgreSQL MCP Server extension allows Goose to interact directly with your PostgreSQL databases, enabling database operations, querying, and schema management capabilities. This makes it easy to work with your databases through natural language interactions.
 
 :::tip TLDR


### PR DESCRIPTION
This pull request updates the documentation for two tutorials by embedding YouTube short videos to enhance the learning experience. The changes include the addition of a reusable `YouTubeShortEmbed` component and its integration into the respective tutorial files.

### Enhancements to Tutorials:

* **Pieces for Developers MCP Server Tutorial**:
  - Embedded a YouTube short video using the `YouTubeShortEmbed` component to provide a visual walkthrough. (`documentation/docs/tutorials/pieces-mcp.md`, [documentation/docs/tutorials/pieces-mcp.mdR9-R12](diffhunk://#diff-522415b372265f73c241b58601f431b589c393b28b391090badceba47ff5b2cbR9-R12))

* **PostgreSQL MCP Server Tutorial**:
  - Added a YouTube short video embed to visually demonstrate the PostgreSQL MCP Server extension's functionality. (`documentation/docs/tutorials/postgres-mcp.md`, [documentation/docs/tutorials/postgres-mcp.mdR10-R11](diffhunk://#diff-d56dfc8d62a1f7767e8897169b8d294f683b79b8b3b81df715e36e76dbb437ccR10-R11))