### PR TITLE
Fix error on installation of Youtube Transcript extension

### DIFF
--- a/documentation/docs/tutorials/youtube-transcript.md
+++ b/documentation/docs/tutorials/youtube-transcript.md
@@ -19,7 +19,7 @@ This tutorial covers how to add the [YouTube Transcript MCP Server](https://gith
   <TabItem value="cli" label="Goose CLI">
   **Command**
   ```sh
-  npx -y @jkawamoto/mcp-youtube-transcript
+  uvx --from git+https://github.com/jkawamoto/mcp-youtube-transcript mcp-youtube-transcript
   ```
   </TabItem>
 </Tabs>


### PR DESCRIPTION
Currently the [Youtube Transcript](https://block.github.io/goose/docs/tutorials/youtube-transcript) extension page installer is broken. Returning an error like this:

`Error: Error activating extension: Failed to add extension configuration, error: Initialization(Stdio { name: "youtubetranscript", cmd: "/private/var/folders/45/n6wzns216zl85v_c_37cmhyc0000gn/T/AppTranslocation/BF82C9F6-4794-45E3-919B-5824D8C2FC64/d/Goose.app/Contents/Resources/bin/npx", args: ["-y", "@jkawamoto/mcp-youtube-transcript"], envs: Envs { map: {} }, env_keys: [], timeout: Some(300), description: None, bundled: None }, McpServerError { method: "initialize", server: "", source: ServerBoxError(StdioProcessError("npm error code E404\nnpm error 404 Not Found - GET https://registry.npmjs.org/@jkawamoto%2fmcp-youtube-transcript - Not found\nnpm error 404\nnpm error 404  '@jkawamoto/mcp-youtube-transcript@*' is not in this registry.\nnpm error 404\nnpm error 404 Note that you can also install from a\nnpm error 404 tarball, folder, http url, or git url.\nnpm error A complete log of this run can be found in: /Users/<redacted>/.config/goose/mcp-hermit/.hermit/node/cache/_logs/2025-05-12T09_21_08_048Z-debug-0.log\n")) })`

The reason is it’s trying to find the extension as an npm package while it’s a python package.

The documentation of the MCP server recommend to install the extension like this:
`uvx --from git+https://github.com/jkawamoto/mcp-youtube-transcript mcp-youtube-transcript`
