### PR TITLE
fix: Make MessageCopyLinks clickable again on goose messages

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.22"
+    "version": "1.0.23"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -109,7 +109,7 @@ export default function GooseMessage({
               <div ref={contentRef}>{<MarkdownContent content={textContent} />}</div>
             </div>
             {/* Only show MessageCopyLink if there's text content and no tool requests/responses */}
-            <div className="relative flex justify-start z-[-1]">
+            <div className="relative flex justify-start">
               {toolRequests.length === 0 && (
                 <div className="text-xs text-textSubtle pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
                   {timestamp}


### PR DESCRIPTION
I don't know what change caused this, but `MessageCopyLink` components were not clickable on `GooseMessage`s