### PR TITLE
allow running `goose run` with no session persistence

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -306,6 +306,16 @@ enum Command {
         )]
         interactive: bool,
 
+        /// Run without storing a session file
+        #[arg(
+            long = "no-session",
+            help = "Run without storing a session file",
+            long_help = "Execute commands without creating or using a session file. Useful for automated runs.",
+            conflicts_with = "resume",
+            conflicts_with = "identifier"
+        )]
+        no_session: bool,
+
         /// Identifier for this run session
         #[command(flatten)]
         identifier: Option<Identifier>,
@@ -445,6 +455,7 @@ pub async fn cli() -> Result<()> {
                     let mut session: crate::Session = build_session(SessionBuilderConfig {
                         identifier: identifier.map(extract_identifier),
                         resume,
+                        no_session: false,
                         extensions,
                         remote_extensions,
                         builtins,
@@ -475,6 +486,7 @@ pub async fn cli() -> Result<()> {
             interactive,
             identifier,
             resume,
+            no_session,
             debug,
             extensions,
             remote_extensions,
@@ -534,6 +546,7 @@ pub async fn cli() -> Result<()> {
             let mut session = build_session(SessionBuilderConfig {
                 identifier: identifier.map(extract_identifier),
                 resume,
+                no_session,
                 extensions,
                 remote_extensions,
                 builtins,
@@ -601,7 +614,18 @@ pub async fn cli() -> Result<()> {
                 Ok(())
             } else {
                 // Run session command by default
-                let mut session = build_session(SessionBuilderConfig::default()).await;
+                let mut session = build_session(SessionBuilderConfig {
+                    identifier: None,
+                    resume: false,
+                    no_session: false,
+                    extensions: Vec::new(),
+                    remote_extensions: Vec::new(),
+                    builtins: Vec::new(),
+                    extensions_override: None,
+                    additional_system_prompt: None,
+                    debug: false,
+                })
+                .await;
                 setup_logging(
                     session.session_file().file_stem().and_then(|s| s.to_str()),
                     None,

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -34,6 +34,7 @@ pub async fn agent_generator(
     let base_session = build_session(SessionBuilderConfig {
         identifier,
         resume: false,
+        no_session: false,
         extensions: requirements.external,
         remote_extensions: requirements.remote,
         builtins: requirements.builtin,

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -527,6 +527,8 @@ fn shorten_path(path: &str, debug: bool) -> String {
 pub fn display_session_info(resume: bool, provider: &str, model: &str, session_file: &Path) {
     let start_session_msg = if resume {
         "resuming session |"
+    } else if session_file.to_str() == Some("/dev/null") || session_file.to_str() == Some("NUL") {
+        "running without session |"
     } else {
         "starting session |"
     };
@@ -538,11 +540,15 @@ pub fn display_session_info(resume: bool, provider: &str, model: &str, session_f
         style("model:").dim(),
         style(model).cyan().dim(),
     );
-    println!(
-        "    {} {}",
-        style("logging to").dim(),
-        style(session_file.display()).dim().cyan(),
-    );
+
+    if session_file.to_str() != Some("/dev/null") && session_file.to_str() != Some("NUL") {
+        println!(
+            "    {} {}",
+            style("logging to").dim(),
+            style(session_file.display()).dim().cyan(),
+        );
+    }
+
     println!(
         "    {} {}",
         style("working directory:").dim(),


### PR DESCRIPTION
this will be a helpful option for massive automations using goose 


![image](https://github.com/user-attachments/assets/ce40f1f7-4e3a-4c07-8c22-c190e8fee217)
