### PR TITLE
Update provider configuration handling from new endpoint

### DIFF
--- a/ui/desktop/src/components/settings/api_keys/types.ts
+++ b/ui/desktop/src/components/settings/api_keys/types.ts
@@ -11,11 +11,3 @@ export interface ConfigDetails {
   is_set: boolean;
   location?: string;
 }
-
-export interface Provider {
-  id: string; // Lowercase key (e.g., "openai")
-  name: string; // Provider name (e.g., "OpenAI")
-  description: string; // Description of the provider
-  models: string[]; // List of supported models
-  requiredKeys: string[]; // List of required keys
-}

--- a/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
+++ b/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx
@@ -1,41 +1,3 @@
-export const openai_models = ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo', 'o1'];
-
-export const anthropic_models = [
-  'claude-3-5-sonnet-latest',
-  'claude-3-5-sonnet-2',
-  'claude-3-5-haiku-latest',
-  'claude-3-opus-latest',
-];
-
-export const google_models = [
-  'gemini-1.5-pro',
-  'gemini-1.5-flash',
-  'gemini-2.0-flash',
-  'gemini-2.0-flash-lite-preview-02-05',
-  'gemini-2.0-flash-thinking-exp-01-21',
-  'gemini-2.0-pro-exp-02-05',
-  'gemini-2.5-pro-exp-03-25',
-];
-
-export const groq_models = ['llama-3.3-70b-versatile'];
-
-export const ollama_mdoels = ['qwen2.5'];
-
-export const openrouter_models = ['anthropic/claude-3.5-sonnet'];
-
-export const azure_openai_models = ['gpt-4o'];
-
-export const gcp_vertex_ai_models = [
-  'claude-3-7-sonnet@20250219',
-  'claude-3-5-sonnet-v2@20241022',
-  'claude-3-5-sonnet@20240620',
-  'claude-3-5-haiku@20241022',
-  'gemini-1.5-pro-002',
-  'gemini-2.0-flash-001',
-  'gemini-2.0-pro-exp-02-05',
-  'gemini-2.5-pro-exp-03-25',
-];
-
 export const default_models = {
   openai: 'gpt-4o',
   anthropic: 'claude-3-5-sonnet-latest',
@@ -52,8 +14,6 @@ export const default_models = {
 export function getDefaultModel(key: string): string | undefined {
   return default_models[key as keyof typeof default_models] || undefined;
 }
-
-export const short_list = ['gpt-4o', 'claude-3-5-sonnet-latest'];
 
 export const required_keys = {
   OpenAI: ['OPENAI_API_KEY', 'OPENAI_HOST', 'OPENAI_BASE_PATH'],


### PR DESCRIPTION
Follow up from https://github.com/block/goose/pull/2484 realized we missed a spot where we were relying on the old /configs/providers format.

## Changes
- Updated frontend code to use the new `/config/providers` GET endpoint instead of the old `/configs/providers` POST endpoint
- Simplified the provider configuration code by:
  - Removing unused `getProvidersList` function
  - Removing unused `Provider` interface from types.ts
  - Using hardcoded required keys list for consistency with rest of the codebase
  - Transforming the new backend response format to maintain compatibility with existing frontend code

## Context
In commit 7027de62, we removed the `/configs` endpoint as part of moving token limits to the backend. However, we missed updating the frontend code that was still trying to use `/configs/providers`. This PR completes that refactor by updating the frontend to use the new endpoint and cleaning up related unused code.

## Testing
- Verified provider configuration status is correctly displayed
- Confirmed active providers are properly detected
- Tested provider configuration changes are saved and reflected in the UI