### PR TITLE
feat: add tool repetition monitoring to prevent infinite loops

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -220,6 +220,15 @@ enum Command {
         )]
         debug: bool,
 
+        /// Maximum number of consecutive identical tool calls allowed
+        #[arg(
+            long = "max-tool-repetitions",
+            value_name = "NUMBER",
+            help = "Maximum number of consecutive identical tool calls allowed",
+            long_help = "Set a limit on how many times the same tool can be called consecutively with identical parameters. Helps prevent infinite loops."
+        )]
+        max_tool_repetitions: Option<u32>,
+
         /// Add stdio extensions with environment variables and commands
         #[arg(
             long = "with-extension",
@@ -324,6 +333,15 @@ enum Command {
             conflicts_with = "identifier"
         )]
         no_session: bool,
+
+        /// Maximum number of consecutive identical tool calls allowed
+        #[arg(
+            long = "max-tool-repetitions",
+            value_name = "NUMBER",
+            help = "Maximum number of consecutive identical tool calls allowed",
+            long_help = "Set a limit on how many times the same tool can be called consecutively with identical parameters. Helps prevent infinite loops."
+        )]
+        max_tool_repetitions: Option<u32>,
 
         /// Identifier for this run session
         #[command(flatten)]
@@ -447,6 +465,7 @@ pub async fn cli() -> Result<()> {
             resume,
             history,
             debug,
+            max_tool_repetitions,
             extensions,
             remote_extensions,
             builtins,
@@ -476,6 +495,7 @@ pub async fn cli() -> Result<()> {
                         extensions_override: None,
                         additional_system_prompt: None,
                         debug,
+                        max_tool_repetitions,
                     })
                     .await;
                     setup_logging(
@@ -512,6 +532,7 @@ pub async fn cli() -> Result<()> {
             resume,
             no_session,
             debug,
+            max_tool_repetitions,
             extensions,
             remote_extensions,
             builtins,
@@ -577,6 +598,7 @@ pub async fn cli() -> Result<()> {
                 extensions_override: input_config.extensions_override,
                 additional_system_prompt: input_config.additional_system_prompt,
                 debug,
+                max_tool_repetitions,
             })
             .await;
 
@@ -648,6 +670,7 @@ pub async fn cli() -> Result<()> {
                     extensions_override: None,
                     additional_system_prompt: None,
                     debug: false,
+                    max_tool_repetitions: None,
                 })
                 .await;
                 setup_logging(

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -41,6 +41,7 @@ pub async fn agent_generator(
         extensions_override: None,
         additional_system_prompt: None,
         debug: false,
+        max_tool_repetitions: None,
     })
     .await;
 

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -35,6 +35,8 @@ pub struct SessionBuilderConfig {
     pub additional_system_prompt: Option<String>,
     /// Enable debug printing
     pub debug: bool,
+    /// Maximum number of consecutive identical tool calls allowed
+    pub max_tool_repetitions: Option<u32>,
 }
 
 pub async fn build_session(session_config: SessionBuilderConfig) -> Session {
@@ -54,6 +56,11 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> Session {
     let agent: Agent = Agent::new();
     let new_provider = create(&provider_name, model_config).unwrap();
     let _ = agent.update_provider(new_provider).await;
+
+    // Configure tool monitoring if max_tool_repetitions is set
+    if let Some(max_repetitions) = session_config.max_tool_repetitions {
+        agent.configure_tool_monitor(Some(max_repetitions)).await;
+    }
 
     // Handle session file resolution and resuming
     let session_file = if session_config.no_session {

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -9,4 +9,5 @@ pub mod providers;
 pub mod recipe;
 pub mod session;
 pub mod token_counter;
+pub mod tool_monitor;
 pub mod tracing;

--- a/crates/goose/src/tool_monitor.rs
+++ b/crates/goose/src/tool_monitor.rs
@@ -1,0 +1,74 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCall {
+    name: String,
+    parameters: serde_json::Value,
+}
+
+impl ToolCall {
+    pub fn new(name: String, parameters: serde_json::Value) -> Self {
+        Self { name, parameters }
+    }
+
+    fn matches(&self, other: &ToolCall) -> bool {
+        self.name == other.name && self.parameters == other.parameters
+    }
+}
+
+#[derive(Debug)]
+pub struct ToolMonitor {
+    max_repetitions: Option<u32>,
+    last_call: Option<ToolCall>,
+    repeat_count: u32,
+    call_counts: HashMap<String, u32>,
+}
+
+impl ToolMonitor {
+    pub fn new(max_repetitions: Option<u32>) -> Self {
+        Self {
+            max_repetitions,
+            last_call: None,
+            repeat_count: 0,
+            call_counts: HashMap::new(),
+        }
+    }
+
+    pub fn check_tool_call(&mut self, tool_call: ToolCall) -> bool {
+        let total_calls = self.call_counts.entry(tool_call.name.clone()).or_insert(0);
+        *total_calls += 1;
+
+        if self.max_repetitions.is_none() {
+            self.last_call = Some(tool_call);
+            self.repeat_count = 1;
+            return true;
+        }
+
+        if let Some(last) = &self.last_call {
+            if last.matches(&tool_call) {
+                self.repeat_count += 1;
+                if self.repeat_count > self.max_repetitions.unwrap() {
+                    return false;
+                }
+            } else {
+                self.repeat_count = 1;
+            }
+        } else {
+            self.repeat_count = 1;
+        }
+
+        self.last_call = Some(tool_call);
+        true
+    }
+
+    pub fn get_stats(&self) -> HashMap<String, u32> {
+        self.call_counts.clone()
+    }
+
+    pub fn reset(&mut self) {
+        self.last_call = None;
+        self.repeat_count = 0;
+        self.call_counts.clear();
+    }
+}


### PR DESCRIPTION
Adds a new tool monitoring system that can detect and prevent infinite loops caused by repeated identical tool calls. The implementation includes:

- New ToolMonitor struct for tracking tool call patterns
- CLI flag --max-tool-repetitions to configure limits
- Integration with Agent dispatch system
- Session configuration support

The monitor tracks consecutive identical tool calls and can prevent them after a configurable limit is reached, helping prevent cases where the AI gets stuck in a loop making the same tool call repeatedly.

Example usage:
  goose run --max-tool-repetitions 5 ...

![image](https://github.com/user-attachments/assets/6a650f06-8518-4e2c-92d0-126f43b0b360)