### PR TITLE
added recipe_dir

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2110,7 +2110,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5768da2206272c81ef0b5e951a41862938a6070da63bcea197899942d3b947"
 dependencies = [
  "cfg-if",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.52.0",
 ]
 
@@ -2121,6 +2121,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2611,6 +2623,7 @@ dependencies = [
  "serde_json",
  "serde_yaml",
  "shlex",
+ "tar",
  "temp-env",
  "tempfile",
  "test-case",
@@ -3649,7 +3662,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3660,6 +3673,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
+ "redox_syscall",
 ]
 
 [[package]]
@@ -3685,6 +3699,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
@@ -5209,7 +5229,20 @@ dependencies = [
  "bitflags 2.9.0",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -5946,6 +5979,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5971,7 +6015,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.1",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -5990,7 +6034,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5352447f921fda68cf61b4101566c0bdb5104eff6804d0678e5227580ab6a4e9"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "windows-sys 0.59.0",
 ]
 
@@ -7061,7 +7105,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -7534,6 +7578,16 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xattr"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d65cbf2f12c15564212d48f4e3dfb87923d25d611f2aed18f4cb23f0413d89e"
+dependencies = [
+ "libc",
+ "rustix 1.0.7",
+]
 
 [[package]]
 name = "xcap"

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -54,6 +54,7 @@ base64 = "0.22.1"
 regex = "1.11.1"
 minijinja = "2.8.0"
 nix = { version = "0.30.1", features = ["process", "signal"] }
+tar = "0.4"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -116,7 +116,7 @@ fn fetch_origin(local_repo_path: &Path) -> Result<()> {
 }
 
 fn get_folder_from_github(local_repo_path: &Path, recipe_name: &str) -> Result<PathBuf> {
-    let ref_and_path = format!("origin/lifei/test-recipe-dir:{}", recipe_name);
+    let ref_and_path = format!("origin/main:{}", recipe_name);
     let output_dir = env::temp_dir().join(recipe_name);
 
     if output_dir.exists() {

--- a/crates/goose-cli/src/recipes/github_recipe.rs
+++ b/crates/goose-cli/src/recipes/github_recipe.rs
@@ -30,7 +30,10 @@ pub fn retrieve_recipe_from_github(
             println!(
                 "retrieved recipe from github repo {}/{}",
                 recipe_repo_full_name,
-                candidate_file_path.strip_prefix(&download_dir).unwrap().display()
+                candidate_file_path
+                    .strip_prefix(&download_dir)
+                    .unwrap()
+                    .display()
             );
             return Ok((content, download_dir));
         }
@@ -112,10 +115,7 @@ fn fetch_origin(local_repo_path: &Path) -> Result<()> {
     }
 }
 
-fn get_folder_from_github(
-    local_repo_path: &Path,
-    recipe_name: &str,
-) -> Result<PathBuf> {
+fn get_folder_from_github(local_repo_path: &Path, recipe_name: &str) -> Result<PathBuf> {
     let ref_and_path = format!("origin/lifei/test-recipe-dir:{}", recipe_name);
     let output_dir = env::temp_dir().join(recipe_name);
 
@@ -130,9 +130,9 @@ fn get_folder_from_github(
         .stdout(Stdio::piped())
         .spawn()?;
 
-    let stdout = archive_output.stdout.ok_or_else(|| {
-        anyhow::anyhow!("Failed to capture stdout from git archive")
-    })?;
+    let stdout = archive_output
+        .stdout
+        .ok_or_else(|| anyhow::anyhow!("Failed to capture stdout from git archive"))?;
 
     let mut archive = Archive::new(stdout);
     archive.unpack(&output_dir)?;

--- a/crates/goose-cli/src/recipes/print_recipe.rs
+++ b/crates/goose-cli/src/recipes/print_recipe.rs
@@ -3,6 +3,8 @@ use std::collections::HashMap;
 use console::style;
 use goose::recipe::Recipe;
 
+use crate::recipes::recipe::BUILT_IN_RECIPE_DIR_PARAM;
+
 pub fn print_recipe_explanation(recipe: &Recipe) {
     println!(
         "{} {}",
@@ -43,7 +45,12 @@ pub fn print_required_parameters_for_template(
             style("📥 Parameters used to load this recipe:").bold()
         );
         for (key, value) in params_for_template {
-            println!("   {}: {}", key, value);
+            let label = if key == BUILT_IN_RECIPE_DIR_PARAM {
+                " (built-in)"
+            } else {
+                ""
+            };
+            println!("   {}{}: {}", key, label, value);
         }
     }
     if !missing_params.is_empty() {

--- a/crates/goose-cli/src/recipes/print_recipe.rs
+++ b/crates/goose-cli/src/recipes/print_recipe.rs
@@ -35,6 +35,17 @@ pub fn print_recipe_explanation(recipe: &Recipe) {
     }
 }
 
+pub fn print_parameters_with_values(params: HashMap<String, String>) {
+    for (key, value) in params {
+        let label = if key == BUILT_IN_RECIPE_DIR_PARAM {
+            " (built-in)"
+        } else {
+            ""
+        };
+        println!("   {}{}: {}", key, label, value);
+    }
+}
+
 pub fn print_required_parameters_for_template(
     params_for_template: HashMap<String, String>,
     missing_params: Vec<String>,
@@ -44,14 +55,7 @@ pub fn print_required_parameters_for_template(
             "{}",
             style("📥 Parameters used to load this recipe:").bold()
         );
-        for (key, value) in params_for_template {
-            let label = if key == BUILT_IN_RECIPE_DIR_PARAM {
-                " (built-in)"
-            } else {
-                ""
-            };
-            println!("   {}{}: {}", key, label, value);
-        }
+        print_parameters_with_values(params_for_template)
     }
     if !missing_params.is_empty() {
         println!(

--- a/crates/goose-cli/src/recipes/recipe.rs
+++ b/crates/goose-cli/src/recipes/recipe.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use console::style;
 
 use crate::recipes::print_recipe::{
-    missing_parameters_command_line, print_recipe_explanation,
+    missing_parameters_command_line, print_parameters_with_values, print_recipe_explanation,
     print_required_parameters_for_template,
 };
 use crate::recipes::search_recipe::retrieve_recipe_file;
@@ -58,9 +58,7 @@ pub fn load_recipe_as_template(recipe_name: &str, params: Vec<(String, String)>)
 
     if !params_for_template.is_empty() {
         println!("{}", style("Parameters used to load this recipe:").bold());
-        for (key, value) in params_for_template {
-            println!("{}: {}", key, value);
-        }
+        print_parameters_with_values(params_for_template);
     }
     println!();
     Ok(recipe)

--- a/crates/goose-cli/src/recipes/recipe.rs
+++ b/crates/goose-cli/src/recipes/recipe.rs
@@ -11,7 +11,9 @@ use minijinja::{Environment, Error, Template, UndefinedBehavior};
 use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
 
+const BUILT_IN_RECIPE_DIR_PARAM: &str = "recipe_dir";
 /// Loads, validates a recipe from a YAML or JSON file, and renders it with the given parameters
 ///
 /// # Arguments
@@ -29,12 +31,12 @@ use std::collections::{HashMap, HashSet};
 /// - Recipe is not valid
 /// - The required fields are missing
 pub fn load_recipe_as_template(recipe_name: &str, params: Vec<(String, String)>) -> Result<Recipe> {
-    let recipe_file_content = retrieve_recipe_file(recipe_name)?;
+    let (recipe_file_content, recipe_parent_dir) = retrieve_recipe_file(recipe_name)?;
 
     let recipe = validate_recipe_file_parameters(&recipe_file_content)?;
 
     let (params_for_template, missing_params) =
-        apply_values_to_parameters(&params, recipe.parameters, true)?;
+        apply_values_to_parameters(&params, recipe.parameters, recipe_parent_dir, true)?;
     if !missing_params.is_empty() {
         return Err(anyhow::anyhow!(
             "Please provide the following parameters in the command line: {}",
@@ -83,7 +85,7 @@ pub fn load_recipe_as_template(recipe_name: &str, params: Vec<(String, String)>)
 /// - The YAML/JSON is invalid
 /// - The parameter definition does not match the template variables in the recipe file
 pub fn load_recipe(recipe_name: &str) -> Result<Recipe> {
-    let recipe_file_content = retrieve_recipe_file(recipe_name)?;
+    let (recipe_file_content, _) = retrieve_recipe_file(recipe_name)?;
 
     validate_recipe_file_parameters(&recipe_file_content)
 }
@@ -92,13 +94,13 @@ pub fn explain_recipe_with_parameters(
     recipe_name: &str,
     params: Vec<(String, String)>,
 ) -> Result<()> {
-    let recipe_file_content = retrieve_recipe_file(recipe_name)?;
+    let (recipe_file_content, recipe_parent_dir) = retrieve_recipe_file(recipe_name)?;
 
     let raw_recipe = validate_recipe_file_parameters(&recipe_file_content)?;
     print_recipe_explanation(&raw_recipe);
     let recipe_parameters = raw_recipe.parameters;
     let (params_for_template, missing_params) =
-        apply_values_to_parameters(&params, recipe_parameters, false)?;
+        apply_values_to_parameters(&params, recipe_parameters, recipe_parent_dir, false)?;
     print_required_parameters_for_template(params_for_template, missing_params);
 
     Ok(())
@@ -115,7 +117,8 @@ fn validate_parameters_in_template(
     recipe_parameters: &Option<Vec<RecipeParameter>>,
     recipe_file_content: &str,
 ) -> Result<()> {
-    let template_variables = extract_template_variables(recipe_file_content)?;
+    let mut template_variables = extract_template_variables(recipe_file_content)?;
+    template_variables.remove(BUILT_IN_RECIPE_DIR_PARAM);
 
     let param_keys: HashSet<String> = recipe_parameters
         .as_ref()
@@ -207,9 +210,12 @@ fn extract_template_variables(template_str: &str) -> Result<HashSet<String>> {
 fn apply_values_to_parameters(
     user_params: &[(String, String)],
     recipe_parameters: Option<Vec<RecipeParameter>>,
+    recipe_parent_dir: PathBuf,
     enable_user_prompt: bool,
 ) -> Result<(HashMap<String, String>, Vec<String>)> {
     let mut param_map: HashMap<String, String> = user_params.iter().cloned().collect();
+    let recipe_parent_dir_str = recipe_parent_dir.to_str().ok_or_else(|| anyhow::anyhow!("Invalid UTF-8 in recipe_dir"))?;
+    param_map.insert(BUILT_IN_RECIPE_DIR_PARAM.to_string(), recipe_parent_dir_str.to_string());
     let mut missing_params: Vec<String> = Vec::new();
     for param in recipe_parameters.unwrap_or_default() {
         if !param_map.contains_key(&param.key) {

--- a/crates/goose-cli/src/recipes/recipe.rs
+++ b/crates/goose-cli/src/recipes/recipe.rs
@@ -214,8 +214,13 @@ fn apply_values_to_parameters(
     enable_user_prompt: bool,
 ) -> Result<(HashMap<String, String>, Vec<String>)> {
     let mut param_map: HashMap<String, String> = user_params.iter().cloned().collect();
-    let recipe_parent_dir_str = recipe_parent_dir.to_str().ok_or_else(|| anyhow::anyhow!("Invalid UTF-8 in recipe_dir"))?;
-    param_map.insert(BUILT_IN_RECIPE_DIR_PARAM.to_string(), recipe_parent_dir_str.to_string());
+    let recipe_parent_dir_str = recipe_parent_dir
+        .to_str()
+        .ok_or_else(|| anyhow::anyhow!("Invalid UTF-8 in recipe_dir"))?;
+    param_map.insert(
+        BUILT_IN_RECIPE_DIR_PARAM.to_string(),
+        recipe_parent_dir_str.to_string(),
+    );
     let mut missing_params: Vec<String> = Vec::new();
     for param in recipe_parameters.unwrap_or_default() {
         if !param_map.contains_key(&param.key) {

--- a/crates/goose-cli/src/recipes/recipe.rs
+++ b/crates/goose-cli/src/recipes/recipe.rs
@@ -13,7 +13,7 @@ use serde_yaml::Value as YamlValue;
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
-const BUILT_IN_RECIPE_DIR_PARAM: &str = "recipe_dir";
+pub const BUILT_IN_RECIPE_DIR_PARAM: &str = "recipe_dir";
 /// Loads, validates a recipe from a YAML or JSON file, and renders it with the given parameters
 ///
 /// # Arguments


### PR DESCRIPTION
**Why**
https://github.com/block/goose/issues/2559

[Jira ticket](https://block.atlassian.net/browse/DX-790).

Make it easy for users to refer additional files in the recipe. For example: https://github.com/squareup/goose-recipes/tree/lifei/test-recipe-dir/test-recipe. 

In the example, the theme.txt is very simple, but user can have files to provide additional context or data and refer them in the recipe.

**What**
Introduced a built-in param `recipe_dir`, the value is the parent directory of the recipe file, user can use the parameter value to refer the location of the files they needed in the recipe such as extra context or data.   

If the recipe is shared on github, these files can be added in the same directory.  When Goose pulls the recipe from the github, and these files will be pulled together and downloaded into the same local directory as the recipe file.

At the moment `recipe_dir` param cannot be overwritten by passing the param from command line. We may enable it after getting feedback from users

<img width="1459" alt="Screenshot 2025-05-16 at 11 27 37 am" src="https://github.com/user-attachments/assets/e54a70f0-2a82-4101-9289-65cdeb4b82c2" />

