### PR TITLE
docs: add search session history section

### DIFF
--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -107,6 +107,56 @@ Note that sessions are automatically saved when you exit.
     </TabItem>
 </Tabs>
 
+### Search Session History
+
+<Tabs>
+    <TabItem value="ui" label="Goose Desktop" default>
+        In Goose Desktop, you can search session metadata including the description, filename, and working directory path. The search is text-based and supports case-sensitive matching, but doesn't search session content or support regex patterns.
+
+        1. Click `...` in the upper right corner
+        2. Click `Previous Sessions`
+        3. Use `Cmd+F` to open the search bar
+        4. Enter your search term
+        5. Use search features to refine and navigate results
+
+        | Action | macOS | Windows/Linux |
+        |--------|-------|---------------|
+        | Next Match | `Cmd+G`<br />or `↓` | `Ctrl+G`<br />or `↓` |
+        | Previous Match | `Shift+Cmd+G`<br />or `↑` | `Shift+Ctrl+G`<br />or `↑` |
+        | Toggle Case-Sensitivity | `Aa` | `Aa` |
+        | Focus Search Bar | `Cmd+F` | `Ctrl+F` |
+        | Close Search | `Esc` or X | `Esc` or X |
+
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
+        The Goose CLI supports [listing session history](/docs/guides/goose-cli-commands/#session-list-options) but doesn't provide search functionality. As a workaround, you can use your terminal's search capabilities (including regex support). Examples for macOS:
+
+        ```bash
+        # Search session IDs (filenames)
+        ls ~/.local/share/goose/sessions/ | grep "full or partial session id"
+
+        # List sessions modified in last 7 days
+        find ~/.local/share/goose/sessions/ -mtime -7 -name "*.jsonl"
+
+        # Show first line (metadata) of each session file
+        for f in ~/.local/share/goose/sessions/*.jsonl; do
+            head -n1 "$f" | grep "your search term" && echo "Found in: $(basename "$f" .jsonl)"
+        done
+
+        # Find search term in session content
+        rg "your search term" ~/.local/share/goose/sessions/
+
+        # Search and show session IDs that contain search term
+        for f in ~/.local/share/goose/sessions/*.jsonl; do
+          if grep -q "your search term" "$f"; then
+            echo "Found in session: $(basename "$f" .jsonl)"
+          fi
+        done
+        ```
+
+    </TabItem>
+</Tabs>
+
 ### Resume Session Across Interfaces
 
 You can resume a CLI session in Desktop and vice versa.


### PR DESCRIPTION
Add "Search Session History" session to documentation/docs/guides/managing-goose-sessions.md