### PR TITLE
docs: remove fetch limitation

### DIFF
--- a/documentation/docs/tutorials/fetch-mcp.md
+++ b/documentation/docs/tutorials/fetch-mcp.md
@@ -9,10 +9,6 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/_WMm4kDYMog" />
 
-:::warning Known Limitation
-The Fetch extension [does not work](https://github.com/block/goose/issues/1184) with Google models (e.g. gemini-2.0-flash) because this extension uses `format: uri` in its JSON schema which Google doesn't support.
-:::
-
 This tutorial covers how to add the [Fetch MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) as a Goose extension to retrieve and process content from the web.
 
 :::tip TLDR


### PR DESCRIPTION
removing the warning about gemini models when using the fetch mcp