### PR TITLE
run CI on docs so we can enforce checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,8 @@
 on:
   push:
-    paths-ignore:
-      - "documentation/**"
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - "documentation/**"
     branches:
       - main
   workflow_dispatch:


### PR DESCRIPTION
We would like to enforce checks before merge, but this makes the documentation build looks like it stalls (if only docs changes are made), this corrects that (at the cost of running CI for doc only changes for now, which can be optimised away by caching)