### PR TITLE
Fix bundle download link not working

### DIFF
--- a/.github/workflows/pr-comment-bundle.yml
+++ b/.github/workflows/pr-comment-bundle.yml
@@ -129,17 +129,13 @@ jobs:
           path: arm64-dist
 
       - name: Comment on PR with ARM64 download link
-        env:
-          REPOSITORY: ${{ github.repository }}
-          RUN_ID: ${{ github.run_id }}
-          PR_NUMBER: ${{ needs.trigger-on-command.outputs.pr_number }}
         uses: peter-evans/create-or-update-comment@71345be0265236311c031f5c7866368bd1eff043 # pin@v4
         with:
           issue-number: ${{ needs.trigger-on-command.outputs.pr_number }}
           body: |
             ### macOS ARM64 Desktop App (Apple Silicon)
 
-            [📱 Download macOS Desktop App (arm64, signed)](https://nightly.link/${REPOSITORY}/actions/runs/${RUN_ID}/Goose-darwin-arm64.zip)
+            [📱 Download macOS Desktop App (arm64, signed)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/Goose-darwin-arm64.zip)
 
             **Instructions:**
             After downloading, unzip the file and drag the Goose.app to your Applications folder. The app is signed and notarized for macOS.


### PR DESCRIPTION
Follow up for https://github.com/block/goose/pull/2566 getting close

Fix bundle download link not working