### PR TITLE
docs: debug mode

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -116,6 +116,18 @@ goose configure
     goose session --with-builtin computercontroller
     ```
 
+- Enable debug mode to output complete tool responses, detailed parameter values, and full file paths
+
+    **Options:**
+
+    **`--debug`**
+
+    **Usage:**
+
+    ```bash
+    goose session --name my-session --debug
+    ```
+
 ---
 ### session list [options]
 
@@ -247,6 +259,7 @@ Execute commands from an instruction file or stdin. Check out the [full guide](/
 - **`-p, --path <PATH>`**: Path for this run session (e.g. `./playground.jsonl`)
 - **`--with-extension <COMMAND>`**: Add stdio extensions (can be used multiple times in the same command)
 - **`--with-builtin <n>`**: Add builtin extensions by name (e.g., 'developer' or multiple: 'developer,github')
+- **`--debug`**: Output complete tool responses, detailed parameter values, and full file paths
 
 **Usage:**
 
@@ -264,6 +277,9 @@ goose run --recipe recipe.yaml --interactive
 
 #Generates an error: no text provided for prompt in headless mode
 goose run --recipe recipe_no_prompt.yaml
+
+#Load a recipe in debug mode
+goose run --recipe recipe.yaml --debug
 
 ```
 

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -113,6 +113,27 @@ goose run --with-extension "ENV1=value1 custom-extension-args" -t "your instruct
 goose run --with-remote-extension "url" -t "your instructions"
 ```
 
+### Debug Mode
+
+When troubleshooting or developing complex workflows, you can enable debug mode to get more detailed information about tool execution. The `--debug` flag provides:
+
+- Complete tool responses
+- Detailed parameter values
+- Full file paths
+
+Debug mode can be useful when:
+- Developing new automation scripts
+- Troubleshooting extension behavior
+- Verifying tool parameters and responses
+
+```bash
+# Run a task with debug output enabled
+goose run --debug -t "your instructions"
+
+# Debug a recipe execution
+goose run --debug --recipe recipe.yaml
+```
+
 ## Common Use Cases
 
 ### Running Script Files


### PR DESCRIPTION
This pull request documents how to enable debug mode in the Goose CLI.

Documentation updates:

- `documentation/docs/guides/goose-cli-commands.md`: Doc the `--debug` option for the `session` and `run` commands.
- `documentation/docs/guides/running-tasks.md`: Add "Debug Mode" section.