### PR TITLE
docs: adding Square MCP video to tutorial page

### DIFF
--- a/documentation/docs/tutorials/square-mcp.md
+++ b/documentation/docs/tutorials/square-mcp.md
@@ -7,6 +7,18 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
+<details>
+  <summary>Square MCP Server Video Walkthrough</summary>
+  <iframe
+  class="aspect-ratio"
+  src="https://www.youtube.com/embed/y6pklrzhzNg"
+  title="Run your Business with AI | Square MCP Server"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  ></iframe>
+</details>
+
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/ynoXx8aBP-4" />
 
 This tutorial will get you started with the Square MCP server to enable interactive and automated work for your Square seller account. The Square MCP server is an open source project that allows you to interact with the Square API using Goose.

--- a/documentation/docs/tutorials/square-mcp.md
+++ b/documentation/docs/tutorials/square-mcp.md
@@ -19,7 +19,6 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
   ></iframe>
 </details>
 
-<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/ynoXx8aBP-4" />
 
 This tutorial will get you started with the Square MCP server to enable interactive and automated work for your Square seller account. The Square MCP server is an open source project that allows you to interact with the Square API using Goose.
 

--- a/documentation/docs/tutorials/square-mcp.md
+++ b/documentation/docs/tutorials/square-mcp.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
 <details>
-  <summary>Square MCP Server Video Walkthrough</summary>
+  <summary> 🎥 Square MCP Server Video Walkthrough</summary>
   <iframe
   class="aspect-ratio"
   src="https://www.youtube.com/embed/y6pklrzhzNg"


### PR DESCRIPTION
Adding [Square MCP walkthrough video](https://www.youtube.com/watch?v=y6pklrzhzNg) to tutorial page. 

There's something smelly about how the two video components sit side by side. Would love any thoughts on how we can make this look a bit better.