### PR TITLE
Add GIF unsupported format test

### DIFF
--- a/crates/goose-llm/src/providers/utils.rs
+++ b/crates/goose-llm/src/providers/utils.rs
@@ -172,6 +172,8 @@ fn is_image_file(path: &Path) -> bool {
                 [0x89, 0x50, 0x4E, 0x47] => true,
                 // JPEG: FF D8 FF
                 [0xFF, 0xD8, 0xFF, _] => true,
+                // GIF: 47 49 46 38
+                [0x47, 0x49, 0x46, 0x38] => true,
                 _ => false,
             };
         }

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -214,6 +214,8 @@ fn is_image_file(path: &Path) -> bool {
                 [0x89, 0x50, 0x4E, 0x47] => true,
                 // JPEG: FF D8 FF
                 [0xFF, 0xD8, 0xFF, _] => true,
+                // GIF: 47 49 46 38
+                [0x47, 0x49, 0x46, 0x38] => true,
                 _ => false,
             };
         }
@@ -411,6 +413,21 @@ mod tests {
         // Test non-existent file
         let result = load_image_file("nonexistent.png");
         assert!(result.is_err());
+
+        // Create a GIF file with valid header bytes
+        let gif_path = temp_dir.path().join("test.gif");
+        // Minimal GIF89a header
+        let gif_data = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61];
+        std::fs::write(&gif_path, &gif_data).unwrap();
+        let gif_path_str = gif_path.to_str().unwrap();
+
+        // Test loading unsupported GIF format
+        let result = load_image_file(gif_path_str);
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Unsupported image format"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- extend `test_load_image_file` to verify `.gif` files are rejected
- detect GIF header bytes so unsupported format is reached

## Testing
- `cargo test -p goose providers::utils::tests::test_load_image_file -- --nocapture` *(fails: could not connect to crates.io)*