### PR TITLE
docs: add project and projects commands

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -309,7 +309,7 @@ goose recipe <COMMAND>
 
 - **`--help, -h`**: Print this message or the help for the subcommand
 
-**Command Usage:**
+**Usage:**
 
 ```bash
 # Validate a recipe file
@@ -321,6 +321,59 @@ goose recipe deeplink $FILE.yaml
 # Print this message or the help for the given command
 goose recipe help
 ```
+
+---
+### project
+
+Start working on your last project or create a new one.
+
+A project is a record of a working directory and recent session metadata. Note that any directory where you run `goose project` becomes a tracked project, so you might want to run the command from the directory where you want to work.
+
+**Alias**: `p`
+
+**Usage:**
+```bash
+goose project
+```
+
+The command provides three options:
+1. **Resume project with session**: Continue the last session in the project
+2. **Resume project with fresh session**: Start a new session in the project
+3. **Start new project in current directory**: Create a new project in the current directory
+
+:::note
+Goose stores your project history in `~/.local/share/goose/projects.json`.
+:::
+
+---
+### projects
+
+Choose one of your projects to start working on.
+
+**Alias**: `ps`
+
+**Usage:**
+```bash
+goose projects
+```
+
+Example output:
+```bash
+┌  Goose Project Manager
+│
+◆  Select a project:
+│  ● .../Users/svera (2025-05-21 18:42:05)
+│  ○ .../Development/goose (2025-05-21 18:38:26)
+│  ○ .../Documents/goose-recipes (2025-05-21q 18:29:15)
+│  ○ .../Desktop/temp (2025-05-21 15:13:48)q
+│  ○ .../doc_projects/shared (2025-05-21 14:32:22)
+│  ○ Cancel
+└
+```
+
+After selecting a project, you'll be asked to either:
+- **Resume previous session**: Continue the last session in the selected project
+- **Start new session**: Start a new session in the selected project
 
 ---
 ## Prompt Completion

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -32,6 +32,10 @@ A session is a single, continuous interaction between you and Goose, providing a
         ```sh
         goose session 
         ```
+
+        :::tip
+        You can also use the [`project`](/docs/guides/goose-cli-commands#project) and [`projects`](/docs/guides/goose-cli-commands#projects) commands to start or resume sessions from a project, which is a tracked working directory with session metadata.
+        :::
     </TabItem>
 </Tabs>
 
@@ -104,6 +108,9 @@ Note that sessions are automatically saved when you exit.
         While you can resume sessions using the commands above, we recommend creating new sessions for new tasks to reduce the chance of [doom spiraling](/docs/troubleshooting#stuck-in-a-loop-or-unresponsive).
         :::
 
+        :::tip
+        You can also use the [`project`](/docs/guides/goose-cli-commands#project) and [`projects`](/docs/guides/goose-cli-commands#projects) commands to start or resume sessions from a project, which is a tracked working directory with session metadata.
+        :::
     </TabItem>
 </Tabs>
 


### PR DESCRIPTION
This pull request documents the `project` and `projects` commands.

Documentation updates:

- `documentation/docs/guides/goose-cli-commands.md`: Added the `project` and `projects` commands
- `documentation/docs/guides/managing-goose-sessions.md`: Added a tip under the "Start Session" and "Resume Session" sections that links to the command descriptions