### PR TITLE
Update API generation docs and just task

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,6 +65,21 @@ you can talk to goose!
 
 You can now make changes in the code in ui/desktop to iterate on the GUI half of goose.
 
+### Regenerating the OpenAPI schema
+
+The file `ui/desktop/openapi.json` is automatically generated during the build.
+It is written by the `generate_schema` binary in `crates/goose-server`.
+If you need to update the spec without starting the UI, run:
+
+```
+just generate-openapi
+```
+
+This command regenerates `ui/desktop/openapi.json` and then runs the UI's
+`generate-api` script to rebuild the TypeScript client from that spec.
+
+Changes to the API should be made in the Rust source under `crates/goose-server/src/`.
+
 ## Creating a fork
 
 To fork the repository:

--- a/Justfile
+++ b/Justfile
@@ -107,6 +107,13 @@ run-server:
     @echo "Running server..."
     cargo run -p goose-server
 
+# Generate OpenAPI specification without starting the UI
+generate-openapi:
+    @echo "Generating OpenAPI schema..."
+    cargo run -p goose-server --bin generate_schema
+    @echo "Generating frontend API..."
+    cd ui/desktop && npm run generate-api
+
 # make GUI with latest binary
 make-ui:
     @just release-binary


### PR DESCRIPTION
## Summary
- extend `generate-openapi` task to also generate the TS API
- document that `just generate-openapi` runs the UI `generate-api` script

## Testing
- `cargo fmt --all -- --check` *(fails: 'cargo-fmt' not installed)*
- `cargo test` *(fails to download crates)*