### PR TITLE
docs: Temporarily hide tool router doc

### DIFF
--- a/documentation/docs/guides/tool-router.md
+++ b/documentation/docs/guides/tool-router.md
@@ -1,3 +1,7 @@
+---
+draft: true
+---
+
 # Tool Router (preview)
 
 ## Overview


### PR DESCRIPTION
Devs kindly created and merged this doc, but this feature is unreleased and not using some of our format, so let's hide it for now