### PR TITLE
feat: adding more detailed info to Goose's getting started documentation

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -165,6 +165,11 @@ Goose works with a set of [supported LLM providers][providers], and you'll need 
   export OPENAI_API_KEY={your_api_key}
   ```
 
+  Run `goose configure` again and follow the steps until key value section, the system will tell you the key is already set as an environment variable and you can then move forwards:
+  ```
+  ● OPENAI_API_KEY is set via environment variable
+  ```
+
   To make the changes persist in WSL across sessions, add the goose path and export commands to your `.bashrc` or `.bash_profile` file so you can load it later.
 
   ```bash


### PR DESCRIPTION
This pull request updates the installation documentation to improve clarity and provide additional guidance for configuring the `OPENAI_API_KEY` environment variable.

Documentation update:

* [`documentation/docs/getting-started/installation.md`](diffhunk://#diff-1da95befef448a968841697bffcbb8f9c53f1238842a36a63444ca5d4ea0499aR168-R172): Added instructions for running `goose configure` and clarified how the system recognizes environment variables, including an example message indicating that the `OPENAI_API_KEY` is set via an environment variable.