### PR TITLE
fix: increase limit for direct to disk for performance

### DIFF
--- a/crates/goose/src/agents/large_response_handler.rs
+++ b/crates/goose/src/agents/large_response_handler.rs
@@ -3,8 +3,8 @@ use mcp_core::{Content, ToolError};
 use std::fs::File;
 use std::io::Write;
 
-// Constant for the size threshold (20K characters)
-const LARGE_TEXT_THRESHOLD: usize = 20_000;
+
+const LARGE_TEXT_THRESHOLD: usize = 200_000;
 
 /// Process tool response and handle large text content
 pub fn process_tool_response(

--- a/crates/goose/src/agents/large_response_handler.rs
+++ b/crates/goose/src/agents/large_response_handler.rs
@@ -3,7 +3,6 @@ use mcp_core::{Content, ToolError};
 use std::fs::File;
 use std::io::Write;
 
-
 const LARGE_TEXT_THRESHOLD: usize = 200_000;
 
 /// Process tool response and handle large text content


### PR DESCRIPTION
The limit was set to 20K chars, which was a bit low, well below context windows, but for some tools (eg JIRA) it was hurting performance by a large factor. 

This will still keep it under context windows so should be useful but hopefully not practically hurt performance.