### PR TITLE
fix: new models have different messages

### DIFF
--- a/crates/goose-llm/src/providers/databricks.rs
+++ b/crates/goose-llm/src/providers/databricks.rs
@@ -138,6 +138,8 @@ impl DatabricksProvider {
                     "reduce the length",
                     "token count",
                     "exceeds",
+                    "exceed context limit",
+                    "max_tokens",
                 ];
                 if check_phrases.iter().any(|c| payload_str.contains(c)) {
                     return Err(ProviderError::ContextLengthExceeded(payload_str));

--- a/crates/goose/src/providers/databricks.rs
+++ b/crates/goose/src/providers/databricks.rs
@@ -211,6 +211,8 @@ impl DatabricksProvider {
                     "reduce the length",
                     "token count",
                     "exceeds",
+                    "exceed context limit",
+                    "max_tokens",
                 ];
                 if check_phrases.iter().any(|c| payload_str.contains(c)) {
                     return Err(ProviderError::ContextLengthExceeded(payload_str));

--- a/crates/goose/src/providers/snowflake.rs
+++ b/crates/goose/src/providers/snowflake.rs
@@ -333,6 +333,8 @@ impl SnowflakeProvider {
                     "reduce the length",
                     "token count",
                     "exceeds",
+                    "exceed context limit",
+                    "max_tokens",
                 ];
                 if check_phrases.iter().any(|c| payload_str.contains(c)) {
                     return Err(ProviderError::ContextLengthExceeded("Request exceeds maximum context length. Please reduce the number of messages or content size.".to_string()));


### PR DESCRIPTION
Using claude4 on databricks, I kept hitting a limit error where goose should be offering to summarize or truncate, however it wasn't. 

This is as the type of "BAD_REQUEST" is sniffed out from the provider - this updates it for clade4 family of models.