### PR TITLE
docs: Add Context7 YouTube Video

### DIFF
--- a/documentation/docs/tutorials/context7-mcp.mdx
+++ b/documentation/docs/tutorials/context7-mcp.mdx
@@ -10,7 +10,7 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
 
-<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/VIDEO_ID" />
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/LNmPi6YCocI" /> 
 
 
 This tutorial covers how to add the [Context7 MCP Server](https://github.com/upstash/context7) as a Goose extension to pull up-to-date, version-specific code and docs so Goose can vibe code with real context, not hallucinated or outdated answers.


### PR DESCRIPTION
Replaced the placeholder video embed with the actual YouTube Short for the Context7 MCP tutorial.

### 📹 Update details

- Updated `videoUrl` in `Context7 MCP` tutorial:
  - From: `"https://www.youtube.com/embed/VIDEO_ID"`
  - To: `"https://www.youtube.com/embed/LNmPi6YCocI"`

### Why it matters

The embedded video now shows the actual tutorial walkthrough, helping users better understand how to set up the Context7 MCP extension in Goose. No more broken video embeds!
