### PR TITLE
feat(ui): add session content search with wildcard support

### DIFF
--- a/ui/desktop/src/components/conversation/SearchBar.tsx
+++ b/ui/desktop/src/components/conversation/SearchBar.tsx
@@ -157,7 +157,8 @@ export const SearchBar: React.FC<SearchBarProps> = ({
               value={searchTerm}
               onChange={handleSearch}
               onKeyDown={handleKeyDown}
-              placeholder="Search conversation..."
+              placeholder="Search conversation... (use * for wildcards)"
+              title="Search supports wildcards: use * to match any characters. Example: 'react*app' will match 'react app' and 'react native app'"
               className="w-full text-sm pl-9 pr-24 py-3 bg-bgAppInverse
                       placeholder:text-textSubtleInverse focus:outline-none 
                        active:border-borderProminent"

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -7,8 +7,9 @@ import {
   Calendar,
   ChevronRight,
   Folder,
+  Search,
 } from 'lucide-react';
-import { fetchSessions, type Session } from '../../sessions';
+import { fetchSessions, searchSessionsContent, type Session } from '../../sessions';
 import { Card } from '../ui/card';
 import { Button } from '../ui/button';
 import BackButton from '../ui/BackButton';
@@ -18,6 +19,7 @@ import { formatMessageTimestamp } from '../../utils/timeUtils';
 import MoreMenuLayout from '../more_menu/MoreMenuLayout';
 import { SearchView } from '../conversation/SearchView';
 import { SearchHighlighter } from '../../utils/searchHighlighter';
+import { wildcardMatch } from '../../utils/wildcardMatch';
 
 interface SearchContainerElement extends HTMLDivElement {
   _searchHighlighter: SearchHighlighter | null;
@@ -36,10 +38,14 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
   const [filteredSessions, setFilteredSessions] = useState<Session[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState<string>('');
   const [searchResults, setSearchResults] = useState<{
     count: number;
     currentIndex: number;
   } | null>(null);
+  const [isSearchingContent, setIsSearchingContent] = useState(false);
+  const [searchProgress, setSearchProgress] = useState({ current: 0, total: 0 });
+  const [includeContent, setIncludeContent] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const [visibleRange, setVisibleRange] = useState({ start: 0, end: 20 });
 
@@ -78,36 +84,118 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
   }, [filteredSessions.length]);
 
   // Filter sessions when search term or case sensitivity changes
-  const handleSearch = (term: string, caseSensitive: boolean) => {
+  const handleSearch = async (term: string, caseSensitive: boolean) => {
     if (!term) {
-      setFilteredSessions(sessions);
+      // Reset content search match flags when clearing the search
+      const resetSessions = sessions.map(session => ({
+        ...session,
+        contentSearchMatch: false
+      }));
+      setSessions(resetSessions);
+      setFilteredSessions(resetSessions);
       setSearchResults(null);
+      setIsSearchingContent(false);
+      setSearchProgress({ current: 0, total: 0 });
       return;
     }
 
     const searchTerm = caseSensitive ? term : term.toLowerCase();
-    const filtered = sessions.filter((session) => {
+    const hasWildcard = term.includes('*');
+    
+    // First, filter by metadata (quick operation)
+    let filtered = sessions.filter((session) => {
       const description = session.metadata.description || session.id;
       const path = session.path;
       const workingDir = session.metadata.working_dir;
 
-      if (caseSensitive) {
+      // If the search term contains wildcards, use wildcard matching
+      if (hasWildcard) {
         return (
-          description.includes(searchTerm) ||
-          path.includes(searchTerm) ||
-          workingDir.includes(searchTerm)
+          wildcardMatch(description, searchTerm, caseSensitive) ||
+          wildcardMatch(path, searchTerm, caseSensitive) ||
+          wildcardMatch(workingDir, searchTerm, caseSensitive)
         );
       } else {
-        return (
-          description.toLowerCase().includes(searchTerm) ||
-          path.toLowerCase().includes(searchTerm) ||
-          workingDir.toLowerCase().includes(searchTerm)
-        );
+        // Otherwise use regular includes matching
+        if (caseSensitive) {
+          return (
+            description.includes(searchTerm) ||
+            path.includes(searchTerm) ||
+            workingDir.includes(searchTerm)
+          );
+        } else {
+          return (
+            description.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            path.toLowerCase().includes(searchTerm.toLowerCase()) ||
+            workingDir.toLowerCase().includes(searchTerm.toLowerCase())
+          );
+        }
       }
     });
 
+    // Update filtered sessions with metadata matches first
     setFilteredSessions(filtered);
     setSearchResults(filtered.length > 0 ? { count: filtered.length, currentIndex: 1 } : null);
+
+    // If content search is enabled, search session content
+    if (includeContent) {
+      setIsSearchingContent(true);
+      
+      try {
+        // Search session content
+        const sessionsWithContentSearch = await searchSessionsContent(
+          sessions, 
+          term, 
+          caseSensitive,
+          (current, total) => {
+            setSearchProgress({ current, total });
+          }
+        );
+        
+        // Filter sessions that match either metadata or content
+        filtered = sessionsWithContentSearch.filter(session => {
+          // Check if session matches metadata criteria (reuse the logic above)
+          const matchesMetadata = (() => {
+            const description = session.metadata.description || session.id;
+            const path = session.path;
+            const workingDir = session.metadata.working_dir;
+
+            if (hasWildcard) {
+              return (
+                wildcardMatch(description, searchTerm, caseSensitive) ||
+                wildcardMatch(path, searchTerm, caseSensitive) ||
+                wildcardMatch(workingDir, searchTerm, caseSensitive)
+              );
+            } else {
+              if (caseSensitive) {
+                return (
+                  description.includes(searchTerm) ||
+                  path.includes(searchTerm) ||
+                  workingDir.includes(searchTerm)
+                );
+              } else {
+                return (
+                  description.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                  path.toLowerCase().includes(searchTerm.toLowerCase()) ||
+                  workingDir.toLowerCase().includes(searchTerm.toLowerCase())
+                );
+              }
+            }
+          })();
+          
+          // Return true if either metadata or content matches
+          return matchesMetadata || session.contentSearchMatch;
+        });
+        
+        // Update filtered sessions with content matches included
+        setFilteredSessions(filtered);
+        setSearchResults(filtered.length > 0 ? { count: filtered.length, currentIndex: 1 } : null);
+      } catch (err) {
+        console.error('Error searching session content:', err);
+      } finally {
+        setIsSearchingContent(false);
+      }
+    }
 
     // Reset scroll position when search changes
     const viewportEl = containerRef.current?.closest('[data-radix-scroll-area-viewport]');
@@ -122,8 +210,15 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
     setError(null);
     try {
       const sessions = await fetchSessions();
-      setSessions(sessions);
-      setFilteredSessions(sessions);
+      
+      // Ensure all sessions have contentSearchMatch set to false initially
+      const sessionsWithResetFlags = sessions.map(session => ({
+        ...session,
+        contentSearchMatch: false
+      }));
+      
+      setSessions(sessionsWithResetFlags);
+      setFilteredSessions(sessionsWithResetFlags);
     } catch (err) {
       console.error('Failed to load sessions:', err);
       setError('Failed to load sessions. Please try again later.');
@@ -168,6 +263,12 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
           <div className="min-w-0 flex-1">
             <h3 className="text-base font-medium text-textStandard truncate max-w-[50vw]">
               {session.metadata.description || session.id}
+              {session.contentSearchMatch && (
+                <span className="ml-2 inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-blue-100 text-blue-800">
+                  <Search className="w-3 h-3 mr-1" />
+                  Content match
+                </span>
+              )}
             </h3>
             <div className="flex gap-3 min-w-0">
               <div className="flex items-center text-textSubtle text-sm shrink-0">
@@ -276,11 +377,142 @@ const SessionListView: React.FC<SessionListViewProps> = ({ setView, onSelectSess
         </div>
 
         {/* Content Area */}
-        <div className="flex flex-col mb-6 px-8">
+        <div className="flex flex-col mb-4 px-8">
           <h1 className="text-3xl font-medium text-textStandard">Previous goose sessions</h1>
           <h3 className="text-sm text-textSubtle mt-2">
             View previous goose sessions and their contents to pick up where you left off.
           </h3>
+        </div>
+
+        {/* Permanent Search Input */}
+        <div className="px-8 mb-4">
+          <div className="relative">
+            <div className="absolute inset-y-0 left-0 flex items-center pl-3 pointer-events-none">
+              <svg className="w-4 h-4 text-textSubtle" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20">
+                <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m19 19-4-4m0-7A7 7 0 1 1 1 8a7 7 0 0 1 14 0Z"/>
+              </svg>
+            </div>
+            <input
+              type="text" 
+              className="bg-bgSecondary border border-borderSubtle text-textStandard text-sm rounded-lg block w-full pl-10 pr-10 p-2.5 focus:ring-1 focus:ring-borderProminent focus:border-borderProminent"
+              placeholder="Search sessions (use * for wildcards)..."
+              value={searchTerm}
+              onChange={(e) => {
+                const value = e.target.value;
+                setSearchTerm(value);
+                handleSearch(value, false);
+              }}
+              title="Search supports wildcards: use * to match any characters. Example: 'react*app' will match 'react app' and 'react native app'"
+            />
+            {searchTerm && (
+              <button
+                onClick={() => {
+                  setSearchTerm('');
+                  // Reset content search match flags when clearing the search
+                  const resetSessions = sessions.map(session => ({
+                    ...session,
+                    contentSearchMatch: false
+                  }));
+                  setSessions(resetSessions);
+                  setFilteredSessions(resetSessions);
+                  setSearchResults(null);
+                  setIsSearchingContent(false);
+                  setSearchProgress({ current: 0, total: 0 });
+                }}
+                className="absolute inset-y-0 right-0 flex items-center pr-3"
+                title="Clear search"
+              >
+                <svg className="w-4 h-4 text-textSubtle hover:text-textStandard" aria-hidden="true" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 14 14">
+                  <path stroke="currentColor" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="m1 1 6 6m0 0 6 6M7 7l6-6M7 7l-6 6"/>
+                </svg>
+              </button>
+            )}
+          </div>
+          
+          <div className="flex items-center justify-between mt-2">
+            <div className="flex items-center">
+              <input
+                id="search-content"
+                type="checkbox"
+                checked={includeContent}
+                onChange={(e) => {
+                  const newIncludeContent = e.target.checked;
+                  setIncludeContent(newIncludeContent);
+                  
+                  if (searchTerm) {
+                    // If turning off content search, reset content match flags
+                    if (!newIncludeContent) {
+                      const resetSessions = sessions.map(session => ({
+                        ...session,
+                        contentSearchMatch: false
+                      }));
+                      setSessions(resetSessions);
+                      
+                      // Re-filter based on metadata only
+                      const filtered = resetSessions.filter((session) => {
+                        const description = session.metadata.description || session.id;
+                        const path = session.path;
+                        const workingDir = session.metadata.working_dir;
+                        const hasWildcard = searchTerm.includes('*');
+                        const term = searchTerm.toLowerCase();
+
+                        if (hasWildcard) {
+                          return (
+                            wildcardMatch(description, term, false) ||
+                            wildcardMatch(path, term, false) ||
+                            wildcardMatch(workingDir, term, false)
+                          );
+                        } else {
+                          return (
+                            description.toLowerCase().includes(term) ||
+                            path.toLowerCase().includes(term) ||
+                            workingDir.toLowerCase().includes(term)
+                          );
+                        }
+                      });
+                      
+                      setFilteredSessions(filtered);
+                      setSearchResults(filtered.length > 0 ? { count: filtered.length, currentIndex: 1 } : null);
+                    } else {
+                      // If turning on content search, perform the search
+                      handleSearch(searchTerm, false);
+                    }
+                  }
+                }}
+                className="w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500"
+              />
+              <label htmlFor="search-content" className="ml-2 text-xs text-textSubtle">
+                Search within session content
+              </label>
+            </div>
+            
+            <div className="text-xs text-textSubtle">
+              <strong>Tip:</strong> Use * as a wildcard in search. Example: "react*app" matches "react app" and "react native app"
+            </div>
+          </div>
+          
+          {isSearchingContent && (
+            <div className="mt-2 flex items-center text-xs text-textSubtle">
+              <LoaderCircle className="h-3 w-3 animate-spin mr-1" />
+              <span>
+                Searching session content... ({searchProgress.current}/{searchProgress.total})
+              </span>
+            </div>
+          )}
+          
+          {searchTerm && !isSearchingContent && (
+            <div className="mt-2 text-xs">
+              {filteredSessions.length > 0 ? (
+                <span className="text-textSubtle">
+                  Found <strong>{filteredSessions.length}</strong> matching session{filteredSessions.length !== 1 ? 's' : ''}
+                </span>
+              ) : sessions.length > 0 ? (
+                <span className="text-amber-500">
+                  No matching sessions found
+                </span>
+              ) : null}
+            </div>
+          )}
         </div>
 
         <div className="flex-1 min-h-0 relative">

--- a/ui/desktop/src/utils/searchHighlighter.ts
+++ b/ui/desktop/src/utils/searchHighlighter.ts
@@ -95,10 +95,17 @@ export class SearchHighlighter {
     if (!term.trim()) return [];
 
     const range = document.createRange();
-    const regex = new RegExp(
-      term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'),
-      caseSensitive ? 'g' : 'gi'
-    );
+    
+    // Create regex pattern based on whether there are wildcards or not
+    let regex: RegExp;
+    if (term.includes('*')) {
+      // Convert wildcard pattern to regex for substring matching
+      const escapedTerm = term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\\\*/g, '.*');
+      regex = new RegExp(escapedTerm, caseSensitive ? 'g' : 'gi');
+    } else {
+      // Regular search term (no wildcards)
+      regex = new RegExp(term.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), caseSensitive ? 'g' : 'gi');
+    }
 
     // Find all text nodes in the container
     const walker = document.createTreeWalker(this.container, NodeFilter.SHOW_TEXT, {

--- a/ui/desktop/src/utils/wildcardMatch.ts
+++ b/ui/desktop/src/utils/wildcardMatch.ts
@@ -1,0 +1,43 @@
+/**
+ * Utility for wildcard pattern matching using * as wildcard character
+ */
+
+/**
+ * Converts a wildcard pattern to a regular expression for substring matching
+ * @param pattern - The wildcard pattern with * as wildcard character
+ * @returns A RegExp object that matches the pattern as a substring
+ */
+export function wildcardToRegExp(pattern: string): RegExp {
+  // Escape special characters except for *
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, '\\$&');
+  
+  // Replace * with .*
+  const regexPattern = escaped.replace(/\*/g, '.*');
+  
+  // Create the regex without anchors to match any part of the string
+  return new RegExp(regexPattern);
+}
+
+/**
+ * Tests if a string contains a substring that matches a wildcard pattern
+ * @param str - The string to test
+ * @param pattern - The wildcard pattern with * as wildcard character
+ * @param caseSensitive - Whether the match should be case sensitive
+ * @returns True if the string contains a substring matching the pattern, false otherwise
+ */
+export function wildcardMatch(str: string, pattern: string, caseSensitive: boolean = false): boolean {
+  if (!pattern.includes('*')) {
+    // If there's no wildcard, do a simple includes check
+    return caseSensitive ? str.includes(pattern) : str.toLowerCase().includes(pattern.toLowerCase());
+  }
+  
+  // Convert the wildcard pattern to a RegExp
+  const regex = wildcardToRegExp(pattern);
+  
+  // Add case insensitivity flag if needed
+  const flags = caseSensitive ? '' : 'i';
+  const finalRegex = new RegExp(regex, flags);
+  
+  // Test the string against the RegExp
+  return finalRegex.test(str);
+}


### PR DESCRIPTION
## Overview
This PR adds a search feature to the "Previous goose sessions" screen, allowing users to search both session metadata and content with wildcard pattern matching.

## Features
- Add visible search input at the top of the sessions list
- Implement content search across session messages
- Support wildcard matching using the `*` character (e.g., `gr*en` matches `green`)
- Show visual indicators for content matches
- Add progress tracking for content search operations
- Maintain compatibility with existing keyboard shortcut search (Ctrl+F/Cmd+F)

## Screenshots

**No search text entered**
<img width="1001" alt="image" src="https://github.com/user-attachments/assets/8b9adf05-8c4b-4925-b2b3-0b96536334bd" />

**Search text entered**
![image](https://github.com/user-attachments/assets/251d4e70-5e89-44dd-8667-173d1b9b9eb9)

## Video Demo

https://github.com/user-attachments/assets/32a001bf-b8bf-4d9f-be1d-2765cee98db6

## Implementation Details
- Added a new utility for wildcard pattern matching
- Enhanced the session list view with a permanent search input
- Implemented content searching with progress tracking
- Fixed issues with wildcard matching to properly handle patterns
- Added visual indicators to distinguish content matches from metadata matches

## Testing
- Tested various search patterns with and without wildcards
- Verified content search functionality across multiple sessions
- Ensured proper handling of edge cases (empty search, long content, etc.)
- Confirmed that content match labels are properly cleared when search is reset