### PR TITLE
Add Speech MCP extension to extensions directory

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -144,6 +144,18 @@
     "environmentVariables": []
   },
   {
+    "id": "speech_mcp",
+    "name": "Speech Interface",
+    "description": "Voice interaction with audio visualization for Goose - enables real-time voice interaction, audio/video transcription, text-to-speech conversion, and multi-speaker audio generation",
+    "command": "uvx -p 3.10.14 speech-mcp@latest",
+    "link": "https://github.com/Kvadratni/speech-mcp",
+    "installation_notes": "Install using uvx package manager. Requires PortAudio to be installed on your system for PyAudio to capture audio from your microphone.",
+    "is_builtin": false,
+    "endorsed": true,
+    "githubStars": 43,
+    "environmentVariables": []
+  },
+  {
     "id": "pieces",
     "name": "Pieces",
     "description": "Provides access to your Pieces Long-Term Memory. You need to have Pieces installed to use this.",


### PR DESCRIPTION
## Summary
This PR adds the Speech MCP extension to the extensions directory, making it discoverable through the  page.

## Changes
- Added  entry to 
- Includes comprehensive extension details:
  - Voice interaction with audio visualization
  - Real-time voice interaction, audio/video transcription, text-to-speech
  - Multi-speaker audio generation capabilities
  - Installation via `uvx -p 3.10.14 speech-mcp@latest`
  - PortAudio requirement noted in installation notes
  - 43 GitHub stars, marked as endorsed

## Context
The Speech MCP extension already has:
- ✅ Comprehensive tutorial at `documentation/docs/tutorials/speech-mcp.md`
- ✅ Blog post about "Vibe Coding with Goose and the Speech MCP"
- ✅ Active GitHub repository: https://github.com/Kvadratni/speech-mcp
- ✅ Working deep-link installation for Goose Desktop

This PR completes the integration by making it discoverable in the extensions directory alongside other available extensions.

## Testing
- ✅ JSON validation passes
- ✅ Extension details match tutorial documentation
- ✅ Installation command tested and working

## Impact
Users can now:
- Browse and discover the Speech MCP extension in the extensions directory
- Search for it using terms like "speech", "voice", or "audio"
- Access installation instructions directly from the extensions page
- See it alongside other endorsed extensions