### PR TITLE
feat(ui): put the scheduler behind an alpha

### DIFF
--- a/ui/desktop/src/components/RecipeEditor.tsx
+++ b/ui/desktop/src/components/RecipeEditor.tsx
@@ -332,13 +332,15 @@ export default function RecipeEditor({ config }: RecipeEditorProps) {
           </div>
           {/* Action Buttons */}
           <div className="flex flex-col space-y-2 pt-1">
-            <button
-              onClick={() => setIsScheduleModalOpen(true)}
-              disabled={!requiredFieldsAreFilled()}
-              className="w-full p-3 bg-green-500 text-white rounded-lg hover:bg-green-600 disabled:opacity-50 disabled:hover:bg-green-500"
-            >
-              Create Schedule from Recipe
-            </button>
+            {process.env.ALPHA && (
+              <button
+                onClick={() => setIsScheduleModalOpen(true)}
+                disabled={!requiredFieldsAreFilled()}
+                className="w-full p-3 bg-green-500 text-white rounded-lg hover:bg-green-600 disabled:opacity-50 disabled:hover:bg-green-500"
+              >
+                Create Schedule from Recipe
+              </button>
+            )}
             <button
               onClick={() => {
                 localStorage.removeItem('recipe_editor_extensions');


### PR DESCRIPTION
gate the scheduler behind an alpha flag so we can release 1.0.25 - scheduler aimed release 1.0.26

<img width="744" alt="image" src="https://github.com/user-attachments/assets/f063b4b9-dcb3-48aa-b7e1-e6869bf6a500" /> -> 
<img width="854" alt="image" src="https://github.com/user-attachments/assets/94628d16-affa-4f22-a703-25ff5c75d413" />

note the dark mode colors may need to be tweaked
