### PR TITLE
fix: Use the existing spinner in interactive mode

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -891,7 +891,11 @@ impl Session {
                                                     v.to_string()
                                             },
                                         };
-                                        progress_bars.log(&message);
+                                        if interactive {
+                                            output::set_thinking_message(&message);
+                                        } else {
+                                            progress_bars.log(&message);
+                                        }
                                     },
                                     "notifications/progress" => {
                                         let progress = o.get("progress").and_then(|v| v.as_f64());

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -117,6 +117,14 @@ pub fn hide_thinking() {
     THINKING.with(|t| t.borrow_mut().hide());
 }
 
+pub fn set_thinking_message(s: &String) {
+    THINKING.with(|t| {
+        if let Some(spinner) = t.borrow_mut().spinner.as_mut() {
+            spinner.set_message(s);
+        }
+    });
+}
+
 pub fn render_message(message: &Message, debug: bool) {
     let theme = get_theme();
 


### PR DESCRIPTION
Cleans up tool streaming output in interactive mode.

Before:

https://github.com/user-attachments/assets/06c1d97e-63bd-4230-b82d-32967e203e6f

After:

https://github.com/user-attachments/assets/601fb700-90d2-4c47-9038-298d4ae9e106

