### PR TITLE
fix: correct spelling in error messages and documentation

### DIFF
--- a/crates/goose-bench/src/assets/kubernetes_swagger.json
+++ b/crates/goose-bench/src/assets/kubernetes_swagger.json
@@ -15051,7 +15051,7 @@
       "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
       "properties": {
         "config": {
-          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1alpha3.DeviceClassConfiguration"
           },
@@ -15884,7 +15884,7 @@
       "description": "DeviceClassSpec is used in a [DeviceClass] to define what can be allocated and how to configure it.",
       "properties": {
         "config": {
-          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classses may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
+          "description": "Config defines configuration parameters that apply to each device that is claimed via this class. Some classes may potentially be satisfied by multiple drivers, so each instance of a vendor configuration applies to exactly one driver.\n\nThey are passed to the driver, but are not considered while allocating the claim.",
           "items": {
             "$ref": "#/definitions/io.k8s.api.resource.v1beta1.DeviceClassConfiguration"
           },

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -18,7 +18,7 @@ pub enum ExtensionError {
     Initialization(ExtensionConfig, ClientError),
     #[error("Failed a client call to an MCP server: {0}")]
     Client(#[from] ClientError),
-    #[error("User Message exceeded context-limit. History could not be truncated to accomodate.")]
+    #[error("User Message exceeded context-limit. History could not be truncated to accommodate.")]
     ContextLimit,
     #[error("Transport error: {0}")]
     Transport(#[from] mcp_client::transport::Error),

--- a/crates/goose/src/agents/router_tools.rs
+++ b/crates/goose/src/agents/router_tools.rs
@@ -38,7 +38,7 @@ pub fn vector_search_tool() -> Tool {
 
 pub fn vector_search_tool_prompt() -> String {
     r#"# Tool Selection Instructions
-    Imporant: the user has opted to dynamically enable tools, so although an extension could be enabled, \
+    Important: the user has opted to dynamically enable tools, so although an extension could be enabled, \
     please invoke the vector search tool to actually retrieve the most relevant tools to use according to the user's messages.
     For example, if the user has 3 extensions enabled, but they are asking for a tool to read a pdf file, \
     you would invoke the vector_search tool to find the most relevant read pdf tool.

--- a/crates/goose/src/prompts/system_gpt_4.1.md
+++ b/crates/goose/src/prompts/system_gpt_4.1.md
@@ -6,7 +6,7 @@ Please keep going until the user’s query is completely resolved, before ending
 
 If you are not sure about file content or codebase structure, or other information pertaining to the user’s request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer. It is important you use tools that can assist with providing the right context.
 
-CRITIAL: The str_replace command in the text_editor tool (when available) should be used most of the time, with the write tool only for new files. ALWAYS check the content of the file before editing. NEVER overwrite the whole content of a file unless directed to, always edit carefully by adding and changing content. Never leave content unfinished with comments like "rest of the file here"
+CRITICAL: The str_replace command in the text_editor tool (when available) should be used most of the time, with the write tool only for new files. ALWAYS check the content of the file before editing. NEVER overwrite the whole content of a file unless directed to, always edit carefully by adding and changing content. Never leave content unfinished with comments like "rest of the file here"
 
 The user may direct or imply that you are to take actions, in this case, it is important to note the following guidelines:
 

--- a/crates/goose/src/providers/oauth.rs
+++ b/crates/goose/src/providers/oauth.rs
@@ -298,7 +298,7 @@ impl OAuthFlow {
         // though it will ultimately only get used once
         let tx = Arc::new(tokio::sync::Mutex::new(Some(tx)));
 
-        // Setup a server that will recieve the redirect, capture the code, and display success/failure
+        // Setup a server that will receive the redirect, capture the code, and display success/failure
         let app = Router::new().route(
             "/",
             get(move |Query(params): Query<HashMap<String, String>>| {

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -184,7 +184,7 @@ impl Router for CounterRouter {
     fn list_prompts(&self) -> Vec<Prompt> {
         vec![Prompt::new(
             "example_prompt",
-            Some("This is an example prompt that takes one required agrument, message"),
+            Some("This is an example prompt that takes one required argument, message"),
             Some(vec![PromptArgument {
                 name: "message".to_string(),
                 description: Some("A message to put in the prompt".to_string()),


### PR DESCRIPTION
This PR corrects various spelling errors found throughout the codebase in error messages, documentation, and configuration files. 

## Changes Made

### Error Messages & Documentation: Fixed spelling errors in multiple Rust files:

- extension.rs: Fixed "accomodate" → "accommodate" in context limit error message
- router_tools.rs: Fixed "Imporant" → "Important" in tool selection instructions
- system_gpt_4.1.md: Fixed "CRITIAL" → "CRITICAL" in system prompt documentation
- oauth.rs: Fixed "recieve" → "receive" in OAuth flow comment
- main.rs (mcp-server): Fixed "agrument" → "argument" in example prompt description

### Configuration Files:
- kubernetes_swagger.json: Fixed "classses" → "classes" in DeviceClassSpec descriptions (2 instances)