### PR TITLE
fix: added url encoding and decoding for goose recipe url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3514,6 +3514,7 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "urlencoding",
  "webbrowser 1.0.4",
  "winapi",
 ]

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -64,6 +64,7 @@ http = "1.0"
 webbrowser = "1.0"
 
 indicatif = "0.17.11"
+urlencoding = "2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose-cli/src/commands/recipe.rs
+++ b/crates/goose-cli/src/commands/recipe.rs
@@ -47,7 +47,8 @@ pub fn handle_deeplink(recipe_name: &str) -> Result<()> {
                     style("✓").green().bold(),
                     recipe.title
                 );
-                println!("goose://recipe?config={}", deeplink);
+                let url_safe = urlencoding::encode(&deeplink);
+                println!("goose://recipe?config={}", url_safe);
             }
             Ok(())
         }

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -254,9 +254,10 @@ app.on('open-url', async (_event, url) => {
     if (parsedUrl.hostname === 'bot' || parsedUrl.hostname === 'recipe') {
       let recipeConfig = null;
       const configParam = parsedUrl.searchParams.get('config');
+      const base64 = decodeURIComponent(configParam || '');
       if (configParam) {
         try {
-          recipeConfig = JSON.parse(Buffer.from(configParam, 'base64').toString('utf-8'));
+          recipeConfig = JSON.parse(Buffer.from(base64, 'base64').toString('utf-8'));
         } catch (e) {
           console.error('Failed to parse bot config:', e);
         }


### PR DESCRIPTION
**Why**
Without the encoding/decode uri, the deeplink generated for recipe containing "```" cannot be decoded on Desktop side. It will show error.  [Example recipe](https://github.com/squareup/goose-recipes/blob/main/weekly-updates/recipe.yaml)

**What**
Added the uri encoding on Rust side and uri decoding on Desktop side to handle the deeplink for recipe. 