### PR TITLE
Fix: Adding dark mode support for recipe modal

### DIFF
--- a/ui/desktop/src/components/RecipeExpandableInfo.tsx
+++ b/ui/desktop/src/components/RecipeExpandableInfo.tsx
@@ -38,7 +38,7 @@ export default function RecipeExpandableInfo({
         </label>
       </div>
 
-      <div className="relative rounded-lg bg-white text-textStandard">
+      <div className="relative rounded-lg bg-bgApp text-textStandard">
         {infoValue && (
           <>
             <div
@@ -78,7 +78,7 @@ export default function RecipeExpandableInfo({
               onClick={() => setValueExpanded(!isValueExpanded)}
               aria-label={isValueExpanded ? 'Collapse content' : 'Expand content'}
               title={isValueExpanded ? 'Collapse' : 'Expand'}
-              className="bg-gray-100 hover:bg-gray-200 p-2 rounded text-black hover:text-blue-800 transition-colors"
+              className="bg-bgSubtle hover:bg-bgStandard p-2 rounded text-textStandard hover:text-textProminent transition-colors"
             >
               <ChevronDown
                 className={`w-6 h-6 transition-transform duration-300 ${

--- a/ui/desktop/src/components/RecipeInfoModal.tsx
+++ b/ui/desktop/src/components/RecipeInfoModal.tsx
@@ -41,7 +41,7 @@ export default function RecipeInfoModal({
         <div className="flex flex-col flex-grow overflow-y-auto space-y-8">
           <textarea
             ref={textareaRef}
-            className="w-full flex-grow resize-none min-h-[300px] max-h-[calc(100vh-300px)] border border-borderSubtle rounded-lg p-3 text-textStandard focus:outline-none focus:ring-2 focus:border-borderSubtle"
+            className="w-full flex-grow resize-none min-h-[300px] max-h-[calc(100vh-300px)] border border-borderSubtle rounded-lg p-3 text-textStandard bg-bgApp focus:outline-none focus:ring-1 focus:ring-borderProminent focus:border-borderProminent"
             value={value}
             onChange={(e) => setValue(e.target.value)}
             placeholder={`Enter ${infoLabel.toLowerCase()}...`}


### PR DESCRIPTION
Dark mode themes weren't applied to some parts of the recipe view. 

## BEFORE

<img width="734" alt="Screenshot 2025-06-10 at 6 20 15 PM" src="https://github.com/user-attachments/assets/fbec2c1d-6fed-4466-ab76-789cfdeb8f93" />
<img width="727" alt="Screenshot 2025-06-10 at 6 20 22 PM" src="https://github.com/user-attachments/assets/1ce72ab5-d21f-402f-9a50-eae5d1a0786b" />

## AFTER
<img width="749" alt="Screenshot 2025-06-10 at 6 20 49 PM" src="https://github.com/user-attachments/assets/b4cd1c41-b02a-4ffe-982c-43cdff26366b" />
<img width="739" alt="Screenshot 2025-06-10 at 6 20 55 PM" src="https://github.com/user-attachments/assets/52122ddf-01b5-4b9f-80cc-1c1b3d2e1dbf" />
