### PR TITLE
docs: add CLI token usage

### DIFF
--- a/documentation/docs/guides/smart-context-management.md
+++ b/documentation/docs/guides/smart-context-management.md
@@ -158,7 +158,7 @@ After sending your first message, Goose Desktop and Goose CLI display token usag
         
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
-    The CLI displays a Context label above each command prompt, showing:
+    The CLI displays a context label above each command prompt, showing:
       - A visual indicator using dots (●○) and colors to represent your token usage:
         - **Green**: Below 50% usage
         - **Yellow**: Between 50-85% usage

--- a/documentation/docs/guides/smart-context-management.md
+++ b/documentation/docs/guides/smart-context-management.md
@@ -141,22 +141,30 @@ Key information has been preserved while reducing context length.
 </Tabs>
 
 ### Token usage
+After sending your first message, Goose Desktop and Goose CLI display token usage.
+
 <Tabs>
     <TabItem value="ui" label="Goose Desktop" default>
-    After sending your first message to Goose, a colored circle appears next to the model name at the bottom of the session window. The color provides a visual indicator of your token usage for the session. 
+    The Desktop displays a colored circle next to the model name at the bottom of the session window. The color provides a visual indicator of your token usage for the session. 
       - **Green**: Normal usage - Plenty of context space available
       - **Orange**: Warning state - Approaching limit (80% of capacity)
       - **Red**: Error state - Context limit reached
     
     Hover over this circle to display:
-      - the number of tokens used
-      - the percentage of available tokens used
-      - the total available tokens
+      - The number of tokens used
+      - The percentage of available tokens used
+      - The total available tokens
       - A progress bar showing your current token usage
         
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
-        This functionality is not available in the Goose CLI. 
+    The CLI displays a Context label above each command prompt, showing:
+      - A visual indicator using dots (●○) and colors to represent your token usage:
+        - **Green**: Below 50% usage
+        - **Yellow**: Between 50-85% usage
+        - **Red**: Above 85% usage
+      - Usage percentage
+      - Current token count and context limit
 
     </TabItem>
 </Tabs>


### PR DESCRIPTION
This PR documents the new token usage display features in the Goose CLI in the [Smart Context Management](https://block.github.io/goose/docs/guides/smart-context-management) topic.

Documentation updates:
- `documentation/docs/guides/smart-context-management.md`: 
  - Move intro out from Desktop tab 
  - Describe CLI usage info