### PR TITLE
feat/fix: don't stop cli starting if MCPs don't load

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn test_session_builder_config_default() {
         let config = SessionBuilderConfig::default();
-        
+
         assert!(config.identifier.is_none());
         assert!(!config.resume);
         assert!(!config.no_session);


### PR DESCRIPTION
this allows CLI to continue on if MCPs won't load 
it also will offer to try to fix the problem for you if you want: 

![image](https://github.com/user-attachments/assets/b296d68c-8da0-4175-9ae6-3875260f0c75)
