### PR TITLE
dynamic port selection for temporal

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.26"
+    "version": "1.0.27"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -26,7 +26,7 @@ export const findAvailablePort = (): Promise<number> => {
 // Check if goosed server is ready by polling the status endpoint
 const checkServerStatus = async (
   port: number,
-  maxAttempts: number = 60,
+  maxAttempts: number = 80,
   interval: number = 100
 ): Promise<boolean> => {
   const statusUrl = `http://127.0.0.1:${port}/status`;


### PR DESCRIPTION
This should fix the problem for temporal startup on just commands and on directly running of the Goosed server.