### PR TITLE
Docs: Session Export via CLI

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -185,6 +185,33 @@ Session removal is permanent and cannot be undone. Goose will show which session
 
 ---
 
+### session export [options]
+
+Export a session to Markdown format for sharing, documentation, or archival purposes.
+
+**Options:**
+- **`-n, --name <name>`**: Export a specific session by name
+- **`-p, --path <path>`**: Export a specific session by file path  
+- **`-o, --output <file>`**: Save exported content to a file (default: stdout)
+
+**Usage:**
+
+```bash
+# Export specific session to file
+goose session export --name my-session --output session.md
+
+# Export specific session to stdout
+goose session export --name my-session
+
+# Interactive export (prompts for session selection)
+goose session export
+
+# Export session by path
+goose session export --path ./my-session.jsonl --output exported.md
+```
+
+---
+
 ### info [options]
 
 Shows Goose information, including the version, configuration file location, session storage, and logs.

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -229,6 +229,35 @@ You can resume a CLI session in Desktop and vice versa.
 
 You can remove sessions using CLI commands. For detailed instructions on session removal, see the [CLI Commands documentation](/docs/guides/goose-cli-commands#session-remove-options).
 
+## Export Sessions
+
+Export sessions to Markdown to share with your team, create documentation, archive conversations, or review them in a readable format.
+
+<Tabs>
+    <TabItem value="ui" label="Goose Desktop" default>
+        Session export is currently only available through the CLI. You can export Desktop sessions via their session filename:
+
+        1. Click `⚙️` in the upper right corner
+        2. Click `Session History` 
+        3. Note the session filename (e.g., `20250305_113223.jsonl`)
+        4. In the CLI, run the command:
+        ```bash
+        goose session export --name 20250305_113223 --output my-session.md
+        ```
+    </TabItem>
+    <TabItem value="cli" label="Goose CLI">
+        Export sessions using the `export` subcommand:
+
+        ```bash
+        # Interactive export - prompts you to select a session
+        goose session export
+        ```
+        
+    </TabItem>
+</Tabs>
+
+For more details on export options, available flags, and output formats, see the [CLI commands documentation](/docs/guides/goose-cli-commands#session-export-options).
+
 ## Search Within Sessions
 
 Search allows you to find specific content within your current session. The search functionality is available in both CLI and Desktop interfaces.


### PR DESCRIPTION
This pull request introduces a new feature to Goose CLI: the ability to export sessions to Markdown format. It includes updates to the documentation to explain the feature, its usage, and its options. The changes aim to improve usability for sharing, documenting, and archiving sessions.

### New Feature: Session Export

* **Documentation update in `goose-cli-commands.md`:** Added a new section detailing the `session export` command, including options (`--name`, `--path`, `--output`) and example usage for exporting sessions to Markdown format.
* **Documentation update in `managing-goose-sessions.md`:** Added a section on exporting sessions, including instructions for Goose Desktop and Goose CLI, and links to further details on CLI export options.