### PR TITLE
fix invalid context length for claude models

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -21,8 +21,7 @@ static MODEL_SPECIFIC_LIMITS: Lazy<HashMap<&'static str, usize>> = Lazy::new(|| 
     map.insert("gpt-4-1", 1_000_000);
 
     // Anthropic models, https://docs.anthropic.com/en/docs/about-claude/models
-    map.insert("claude-3", 200_000);
-    map.insert("claude-4", 200_000);
+    map.insert("claude", 200_000);
 
     // Google models, https://ai.google/get-started/our-models/
     map.insert("gemini-2.5", 1_000_000);


### PR DESCRIPTION
fix #2871

All claude models has the same context length - 200k: https://docs.anthropic.com/en/docs/about-claude/models/overview#model-comparison-table