### PR TITLE
Docs: Fix Nav Bar and wrong command in docs

### DIFF
--- a/documentation/docs/guides/smart-context-management.md
+++ b/documentation/docs/guides/smart-context-management.md
@@ -70,11 +70,6 @@ export GOOSE_CONTEXT_STRATEGY=clear      # Automatically clear session
 export GOOSE_CONTEXT_STRATEGY=prompt     # Always prompt user (default)
 ```
 
-Or configure it permanently:
-```bash
-goose configure set GOOSE_CONTEXT_STRATEGY summarize
-```
-
 **Default behavior:**
 - **Interactive mode**: Prompts user to choose (equivalent to `prompt`)
 - **Headless mode** (`goose run`): Automatically summarizes (equivalent to `summarize`)

--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -301,9 +301,17 @@ html[data-theme="light"] .hide-in-light {
   border-bottom: 1px solid var(--border-divider);
 }
 
+/* Smooth transitions for navbar items */
 .navbar__item {
   display: flex;
   align-items: center;
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.navbar__toggle {
+  transition: opacity 0.3s ease, transform 0.3s ease;
+  opacity: 0;
+  transform: scale(0.8);
 }
 
 /* Dropdown styles */
@@ -327,6 +335,42 @@ html[data-theme="light"] .hide-in-light {
 
 .iconExternalLink_nPIU {
   margin-left: 8px !important;
+}
+
+/* Force hamburger menu to appear earlier to prevent navbar overlap with smooth transitions */
+@media (max-width: 1350px) {
+  .navbar__item {
+    opacity: 0;
+    transform: translateX(-10px);
+    pointer-events: none;
+    /* Use visibility instead of display for smoother transitions */
+    visibility: hidden;
+  }
+  
+  .navbar__toggle {
+    opacity: 1 !important;
+    transform: scale(1) !important;
+    display: inherit !important;
+  }
+  
+  .navbar-sidebar {
+    display: block;
+  }
+}
+
+/* Ensure navbar items are visible above the breakpoint */
+@media (min-width: 1351px) {
+  .navbar__item {
+    opacity: 1;
+    transform: translateX(0);
+    pointer-events: auto;
+    visibility: visible;
+  }
+  
+  .navbar__toggle {
+    opacity: 0;
+    transform: scale(0.8);
+  }
 }
 
 .carousel-image {


### PR DESCRIPTION
fix #2788
fix #2883 
- Removed `goose configure set GOOSE_CONTEXT_STRATEGY summarize` as that's not a current command.
- Fixed navbar breakpoints, so it shows hamburger menu earlier rather than having overlapping menu items.  

https://github.com/user-attachments/assets/f1ff755b-6e95-42c6-87d5-b4402fbbd36b

