### PR TITLE
fix the claude model name

### DIFF
--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -20,9 +20,8 @@ pub const ANTHROPIC_KNOWN_MODELS: &[&str] = &[
     "claude-3-opus-latest",
     "claude-3-7-sonnet-20250219",
     "claude-3-7-sonnet-latest",
-    "claude-sonnet-4-latest",
     "claude-sonnet-4-20250514",
-    "claude-opus-4-latest",
+    "claude-opus-4-20250514",
 ];
 
 pub const ANTHROPIC_DOC_URL: &str = "https://docs.anthropic.com/en/docs/about-claude/models";


### PR DESCRIPTION
There are no latest label for claude 4 models: https://docs.anthropic.com/en/docs/about-claude/models/overview