### PR TITLE
fix: escape control characters in LLM tool call arguments JSON

### DIFF
--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -3,8 +3,8 @@ use crate::model::ModelConfig;
 use crate::providers::base::Usage;
 use crate::providers::errors::ProviderError;
 use crate::providers::utils::{
-    convert_image, detect_image_path, is_valid_function_name, load_image_file,
-    sanitize_function_name, ImageFormat,
+    convert_image, detect_image_path, is_valid_function_name, json_escape_control_chars_in_string,
+    load_image_file, sanitize_function_name, ImageFormat,
 };
 use anyhow::{anyhow, Error};
 use mcp_core::ToolError;
@@ -322,14 +322,24 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                     .as_str()
                     .unwrap_or_default()
                     .to_string();
-                let mut arguments = tool_call["function"]["arguments"]
+
+                // Get the raw arguments string from the LLM.
+                let arguments_str = tool_call["function"]["arguments"]
                     .as_str()
                     .unwrap_or_default()
                     .to_string();
-                // If arguments is empty, we will have invalid json parsing error later.
-                if arguments.is_empty() {
-                    arguments = "{}".to_string();
-                }
+
+                // If arguments_str is empty, default to an empty JSON object string.
+                let arguments_str = if arguments_str.is_empty() {
+                    "{}".to_string()
+                } else {
+                    arguments_str
+                };
+
+                // Escape literal control characters in the arguments string to make it valid JSON.
+                // This handles cases where the LLM might output raw newlines or other control
+                // characters within string values in the JSON arguments.
+                let escaped_arguments = json_escape_control_chars_in_string(&arguments_str);
 
                 if !is_valid_function_name(&function_name) {
                     let error = ToolError::NotFound(format!(
@@ -338,7 +348,7 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                     ));
                     content.push(MessageContent::tool_request(id, Err(error)));
                 } else {
-                    match serde_json::from_str::<Value>(&arguments) {
+                    match serde_json::from_str::<Value>(&escaped_arguments) {
                         Ok(params) => {
                             content.push(MessageContent::tool_request(
                                 id,
@@ -347,8 +357,8 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                         }
                         Err(e) => {
                             let error = ToolError::InvalidParameters(format!(
-                                "Could not interpret tool use parameters for id {}: {}",
-                                id, e
+                                "Could not interpret tool use parameters for id {}: {}. Raw arguments: '{}', Processed (escaped) arguments: '{}'",
+                                id, e, arguments_str, escaped_arguments
                             ));
                             content.push(MessageContent::tool_request(id, Err(error)));
                         }

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -3,8 +3,8 @@ use crate::model::ModelConfig;
 use crate::providers::base::Usage;
 use crate::providers::errors::ProviderError;
 use crate::providers::utils::{
-    convert_image, detect_image_path, is_valid_function_name, json_escape_control_chars_in_string,
-    load_image_file, sanitize_function_name, ImageFormat,
+    convert_image, detect_image_path, is_valid_function_name, load_image_file, safely_parse_json,
+    sanitize_function_name, ImageFormat,
 };
 use anyhow::{anyhow, Error};
 use mcp_core::ToolError;
@@ -336,11 +336,6 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                     arguments_str
                 };
 
-                // Escape literal control characters in the arguments string to make it valid JSON.
-                // This handles cases where the LLM might output raw newlines or other control
-                // characters within string values in the JSON arguments.
-                let escaped_arguments = json_escape_control_chars_in_string(&arguments_str);
-
                 if !is_valid_function_name(&function_name) {
                     let error = ToolError::NotFound(format!(
                         "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
@@ -348,7 +343,7 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                     ));
                     content.push(MessageContent::tool_request(id, Err(error)));
                 } else {
-                    match serde_json::from_str::<Value>(&escaped_arguments) {
+                    match safely_parse_json(&arguments_str) {
                         Ok(params) => {
                             content.push(MessageContent::tool_request(
                                 id,
@@ -357,8 +352,8 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                         }
                         Err(e) => {
                             let error = ToolError::InvalidParameters(format!(
-                                "Could not interpret tool use parameters for id {}: {}. Raw arguments: '{}', Processed (escaped) arguments: '{}'",
-                                id, e, arguments_str, escaped_arguments
+                                "Could not interpret tool use parameters for id {}: {}. Raw arguments: '{}'",
+                                id, e, arguments_str
                             ));
                             content.push(MessageContent::tool_request(id, Err(error)));
                         }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -3,8 +3,8 @@ use crate::model::ModelConfig;
 use crate::providers::base::Usage;
 use crate::providers::errors::ProviderError;
 use crate::providers::utils::{
-    convert_image, detect_image_path, is_valid_function_name, json_escape_control_chars_in_string,
-    load_image_file, sanitize_function_name, ImageFormat,
+    convert_image, detect_image_path, is_valid_function_name, load_image_file, safely_parse_json,
+    sanitize_function_name, ImageFormat,
 };
 use anyhow::{anyhow, Error};
 use mcp_core::ToolError;
@@ -252,11 +252,6 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                     arguments_str
                 };
 
-                // Escape literal control characters in the arguments string to make it valid JSON.
-                // This handles cases where the LLM might output raw newlines or other control
-                // characters within string values in the JSON arguments.
-                let escaped_arguments = json_escape_control_chars_in_string(&arguments_str);
-
                 if !is_valid_function_name(&function_name) {
                     let error = ToolError::NotFound(format!(
                         "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
@@ -264,7 +259,7 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                     ));
                     content.push(MessageContent::tool_request(id, Err(error)));
                 } else {
-                    match serde_json::from_str::<Value>(&escaped_arguments) {
+                    match safely_parse_json(&arguments_str) {
                         Ok(params) => {
                             content.push(MessageContent::tool_request(
                                 id,
@@ -273,8 +268,8 @@ pub fn response_to_message(response: Value) -> anyhow::Result<Message> {
                         }
                         Err(e) => {
                             let error = ToolError::InvalidParameters(format!(
-                                "Could not interpret tool use parameters for id {}: {}. Raw arguments: '{}', Processed (escaped) arguments: '{}'",
-                                id, e, arguments_str, escaped_arguments
+                                "Could not interpret tool use parameters for id {}: {}. Raw arguments: '{}'",
+                                id, e, arguments_str
                             ));
                             content.push(MessageContent::tool_request(id, Err(error)));
                         }

--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -335,6 +335,52 @@ pub fn emit_debug_trace(
     );
 }
 
+/// Helper to escape control characters in a string that is supposed to be a JSON document.
+/// This function iterates through the input string `s` and replaces any literal
+/// control characters (U+0000 to U+001F) with their JSON-escaped equivalents
+/// (e.g., '\n' becomes "\\n", '\u0001' becomes "\\u0001").
+///
+/// It does NOT escape quotes (") or backslashes (\) because it assumes `s` is a
+/// full JSON document, and these characters might be structural (e.g., object delimiters,
+/// existing valid escape sequences). The goal is to fix common LLM errors where
+/// control characters are emitted raw into what should be JSON string values,
+/// making the overall JSON structure unparsable.
+///
+/// If the input string `s` has other JSON syntax errors (e.g., an unescaped quote
+/// *within* a string value like `{"key": "string with " quote"}`), this function
+/// will not fix them. It specifically targets unescaped control characters.
+pub fn json_escape_control_chars_in_string(s: &str) -> String {
+    let mut r = String::with_capacity(s.len()); // Pre-allocate for efficiency
+    for c in s.chars() {
+        match c {
+            // ASCII Control characters (U+0000 to U+001F)
+            '\u{0000}'..='\u{001F}' => {
+                match c {
+                    '\u{0008}' => r.push_str("\\b"), // Backspace
+                    '\u{000C}' => r.push_str("\\f"), // Form feed
+                    '\n' => r.push_str("\\n"),       // Line feed
+                    '\r' => r.push_str("\\r"),       // Carriage return
+                    '\t' => r.push_str("\\t"),       // Tab
+                    // Other control characters (e.g., NUL, SOH, VT, etc.)
+                    // that don't have a specific short escape sequence.
+                    _ => {
+                        r.push_str(&format!("\\u{:04x}", c as u32));
+                    }
+                }
+            }
+            // Other characters are passed through.
+            // This includes quotes (") and backslashes (\). If these are part of the
+            // JSON structure (e.g. {"key": "value"}) or part of an already correctly
+            // escaped sequence within a string value (e.g. "string with \\\" quote"),
+            // they are preserved as is. This function does not attempt to fix
+            // malformed quote or backslash usage *within* string values if the LLM
+            // generates them incorrectly (e.g. {"key": "unescaped " quote in string"}).
+            _ => r.push(c),
+        }
+    }
+    r
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -559,5 +605,56 @@ mod tests {
             let result = get_google_final_status(status.unwrap_or(StatusCode::OK), Some(&payload));
             assert_eq!(result, expected_status);
         }
+    }
+
+    #[test]
+    fn test_json_escape_control_chars_in_string() {
+        // Test basic control character escaping
+        assert_eq!(
+            json_escape_control_chars_in_string("Hello\nWorld"),
+            "Hello\\nWorld"
+        );
+        assert_eq!(
+            json_escape_control_chars_in_string("Hello\tWorld"),
+            "Hello\\tWorld"
+        );
+        assert_eq!(
+            json_escape_control_chars_in_string("Hello\rWorld"),
+            "Hello\\rWorld"
+        );
+
+        // Test multiple control characters
+        assert_eq!(
+            json_escape_control_chars_in_string("Hello\n\tWorld\r"),
+            "Hello\\n\\tWorld\\r"
+        );
+
+        // Test that quotes and backslashes are preserved (not escaped)
+        assert_eq!(
+            json_escape_control_chars_in_string("Hello \"World\""),
+            "Hello \"World\""
+        );
+        assert_eq!(
+            json_escape_control_chars_in_string("Hello\\World"),
+            "Hello\\World"
+        );
+
+        // Test JSON-like string with control characters
+        assert_eq!(
+            json_escape_control_chars_in_string("{\"message\": \"Hello\nWorld\"}"),
+            "{\"message\": \"Hello\\nWorld\"}"
+        );
+
+        // Test no changes for normal strings
+        assert_eq!(
+            json_escape_control_chars_in_string("Hello World"),
+            "Hello World"
+        );
+
+        // Test other control characters get unicode escapes
+        assert_eq!(
+            json_escape_control_chars_in_string("Hello\u{0001}World"),
+            "Hello\\u0001World"
+        );
     }
 }


### PR DESCRIPTION
- Add json_escape_control_chars_in_string() utility function
- Apply fix to OpenAI and Databricks response parsers
- Enhance error messages with raw and processed arguments
- Add comprehensive test coverage for control character escaping

### Testing
- ✅ Added unit tests for the new utility function covering various control character scenarios
- ✅ Updated existing tests to verify empty argument handling
- ✅ Manual testing with both OpenAI providers
- ✅ Verified that valid JSON arguments are unchanged
- ✅ Confirmed that structural JSON elements (quotes, backslashes) are preserved

### Backwards Compatibility
This change is fully backwards compatible. It only affects the processing of malformed JSON arguments that would have previously failed to parse. Valid JSON arguments continue to work exactly as before.

### Related Issues
Fixes https://github.com/block/goose/issues/2892
