### PR TITLE
fix: Revert downgrade to version number

### DIFF
--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "goose-app",
-  "version": "1.0.20",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "goose-app",
-      "version": "1.0.20",
+      "version": "1.0.27",
       "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/openai": "^0.0.72",


### PR DESCRIPTION
Made this pr in case the [recent version downgrade](https://github.com/block/goose/pull/2852/files#diff-6b70a318d1ddd7ef0fc9132f732413f6282a0e411e233c05a2a4e60e83082cdfR2-R9) was unintentional.