### PR TITLE
fix: handled the missing keyring error gracefully with a user-friendly message

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -170,8 +170,19 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> Session {
 
     // Create the agent
     let agent: Agent = Agent::new();
-    let new_provider = create(&provider_name, model_config).unwrap();
-
+    let new_provider = match create(&provider_name, model_config) {
+        Ok(provider) => provider,
+        Err(e) => {
+            output::render_error(&format!(
+                "Error {}.\n\
+                Please check your system keychain and run 'goose configure' again.\n\
+                If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
+                For more info, see: https://block.github.io/goose/docs/troubleshooting/#keychainkeyring-errors",
+                e
+            ));
+            process::exit(1);
+        }
+    };
     // Keep a reference to the provider for display_session_info
     let provider_for_display = Arc::clone(&new_provider);
 


### PR DESCRIPTION
This pull request improves error handling in the `build_session` function of the `goose-cli` crate. Specifically, it replaces an `unwrap` call with a more robust error-handling mechanism to provide user-friendly error messages and guidance.

### Error handling improvements:
* Updated the `build_session` function in `crates/goose-cli/src/session/builder.rs` to replace the `unwrap` call with a `match` statement. This change ensures that errors during the creation of a provider are caught and handled gracefully. If an error occurs, a detailed error message is displayed, including troubleshooting steps and a link to relevant documentation, before the process exits with a non-zero status.

### Details:
The error message displayed when no keyring is found is different from what [the goose doc](https://block.github.io/goose/docs/troubleshooting/#keychainkeyring-errors) mentioned. It currently looked like this (Display `thread 'main' panicked....` is kinda off to users I think, since this message is intended for developers and exposes internal file paths and implementation details that are confusing or irrelevant to end users.)
![image](https://github.com/user-attachments/assets/ee67dd2e-ce8f-45b1-a8a8-ad12f1d4b4bf)
I made the system handle the error gracefully and display a user-friendly message with reference to the troubleshooting session to the goose doc.