### PR TITLE
fix: handle JsonRPC error variants as responses

### DIFF
--- a/crates/mcp-client/examples/integration_test.rs
+++ b/crates/mcp-client/examples/integration_test.rs
@@ -110,6 +110,12 @@ where
     let collected_events_after = events.lock().await.len();
     assert_eq!(collected_events_after - collected_eventes_before, n_steps);
 
+    let error_result = client
+        .call_tool("add", serde_json::json!({ "a": "foo", "b": "bar" }))
+        .await;
+    assert!(error_result.is_err());
+    println!("Error result: {error_result:#?}\n");
+
     // List resources
     let resources = client.list_resources(None).await?;
     println!("Resources: {resources:#?}\n");

--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -135,7 +135,8 @@ where
                     Ok(message) => {
                         tracing::info!("Received message: {:?}", message);
                         match message {
-                            JsonRpcMessage::Response(JsonRpcResponse { id: Some(id), .. }) => {
+                            JsonRpcMessage::Response(JsonRpcResponse { id: Some(id), .. })
+                            | JsonRpcMessage::Error(JsonRpcError { id: Some(id), .. }) => {
                                 service_ptr.respond(&id.to_string(), Ok(message)).await;
                             }
                             _ => {


### PR DESCRIPTION
Previously the message handling block treated only JsonRpcMessage::JsonRpcResponse types with ids as request responses, and all other messages were sent to the notification stream. But, servers may send back a JsonRpcError which is distinct from JsonRpcResponse. This should not be sent to the notification stream.

Also added this to the integration test.

Fixes #2884