### PR TITLE
fix: Check for stderr error in receive()

### DIFF
--- a/crates/mcp-client/examples/integration_test.rs
+++ b/crates/mcp-client/examples/integration_test.rs
@@ -22,6 +22,17 @@ async fn main() -> Result<()> {
     test_transport(sse_transport().await?).await?;
     test_transport(stdio_transport().await?).await?;
 
+    // Test broken transport
+    match test_transport(broken_stdio_transport().await?).await {
+        Ok(_) => assert!(false, "Expected an error but got success"),
+        Err(e) => {
+            assert!(e
+                .to_string()
+                .contains("error: package(s) `thispackagedoesnotexist` not found in workspace"));
+            println!("Expected error occurred: {e}");
+        }
+    }
+
     Ok(())
 }
 
@@ -45,6 +56,17 @@ async fn stdio_transport() -> Result<StdioTransport> {
     Ok(StdioTransport::new(
         "npx",
         vec!["@modelcontextprotocol/server-everything"]
+            .into_iter()
+            .map(|s| s.to_string())
+            .collect(),
+        HashMap::new(),
+    ))
+}
+
+async fn broken_stdio_transport() -> Result<StdioTransport> {
+    Ok(StdioTransport::new(
+        "cargo",
+        vec!["run", "-p", "thispackagedoesnotexist"]
             .into_iter()
             .map(|s| s.to_string())
             .collect(),

--- a/crates/mcp-client/src/client.rs
+++ b/crates/mcp-client/src/client.rs
@@ -145,8 +145,7 @@ where
                         }
                     }
                     Err(e) => {
-                        tracing::error!("transport error: {:?}", e);
-                        service_ptr.hangup().await;
+                        service_ptr.hangup(e).await;
                         subscribers_ptr.lock().await.clear();
                         break;
                     }

--- a/crates/mcp-client/src/transport/stdio.rs
+++ b/crates/mcp-client/src/transport/stdio.rs
@@ -168,7 +168,13 @@ impl TransportHandle for StdioTransportHandle {
 
     async fn receive(&self) -> Result<JsonRpcMessage, Error> {
         let mut receiver = self.receiver.lock().await;
-        receiver.recv().await.ok_or(Error::ChannelClosed)
+        match receiver.recv().await {
+            Some(message) => Ok(message),
+            None => {
+                self.check_for_errors().await?;
+                Err(Error::ChannelClosed)
+            }
+        }
     }
 }
 


### PR DESCRIPTION
There was a check in send(), but the new code path has the client shutting down before hitting another call to send(), so we need to check for stderr logs in receive() too.