### PR TITLE
fix router trait error

### DIFF
--- a/crates/goose/src/agents/router_tool_selector.rs
+++ b/crates/goose/src/agents/router_tool_selector.rs
@@ -282,7 +282,7 @@ impl RouterToolSelector for LLMToolSelector {
         }
     }
 
-    async fn index_tools(&self, tools: &[Tool]) -> Result<(), ToolError> {
+    async fn index_tools(&self, tools: &[Tool], _extension_name: &str) -> Result<(), ToolError> {
         let mut tool_strings = self.tool_strings.write().await;
 
         for tool in tools {


### PR DESCRIPTION
Fix the error:

```
error[E0050]: method `index_tools` has 2 parameters but the declaration in trait `RouterToolSelector::index_tools` has 3
   --> crates/goose/src/agents/router_tool_selector.rs:285:26
    |
28  |     async fn index_tools(&self, tools: &[Tool], extension_name: &str) -> Result<(), ToolError>;
    |                          ------------------------------------------- trait requires 3 parameters
...
285 |     async fn index_tools(&self, tools: &[Tool]) -> Result<(), ToolError> {
    |                          ^^^^^^^^^^^^^^^^^^^^^ expected 3 parameters, found 2

For more information about this error, try `rustc --explain E0050`.
```