### PR TITLE
Docs: Fetch MCP doesnt work with Gemini

### DIFF
--- a/documentation/docs/tutorials/fetch-mcp.md
+++ b/documentation/docs/tutorials/fetch-mcp.md
@@ -9,6 +9,10 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/_WMm4kDYMog" />
 
+:::warning Known Limitation
+The Fetch extension [does not work](https://github.com/block/goose/issues/1184) with Google models (e.g. gemini-2.0-flash) because this extension uses `format: uri` in its JSON schema which Google doesn't support.
+:::
+
 This tutorial covers how to add the [Fetch MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) as a Goose extension to retrieve and process content from the web.
 
 :::tip TLDR


### PR DESCRIPTION
Fetch MCP still doesn't work with Gemini models. We removed this warning thinking the issue was resolved, but the issue still persists. 