### PR TITLE
Fix GitHub Copilot Provider Config

### DIFF
--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -17,6 +17,7 @@ use super::formats::openai::{create_request, get_usage, response_to_message};
 use super::utils::{emit_debug_trace, get_model, handle_response_openai_compat, ImageFormat};
 
 use crate::config::{Config, ConfigError};
+use crate::providers::base::ConfigKey;
 use crate::message::Message;
 use crate::model::ModelConfig;
 use mcp_core::tool::Tool;
@@ -389,7 +390,14 @@ impl Provider for GithubCopilotProvider {
             GITHUB_COPILOT_DEFAULT_MODEL,
             GITHUB_COPILOT_KNOWN_MODELS.to_vec(),
             GITHUB_COPILOT_DOC_URL,
-            vec![],
+            vec![
+                ConfigKey::new(
+                    "GITHUB_COPILOT_TOKEN",
+                    true,  // required
+                    true,  // secret
+                    None,  // no default value
+                ),
+            ],
         )
     }
 

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -393,9 +393,9 @@ impl Provider for GithubCopilotProvider {
             vec![
                 ConfigKey::new(
                     "GITHUB_COPILOT_TOKEN",
-                    true,  // required
-                    true,  // secret
-                    None,  // no default value
+                    true,  
+                    true, 
+                    None,  
                 ),
             ],
         )


### PR DESCRIPTION
This PR updates the `GithubCopilotProvider` to correctly return required configuration keys for activation. Specifically, it:

- Adds the `GITHUB_COPILOT_TOKEN` as a required `ConfigKey` in the provider definition.
- Ensures the provider exposes this token correctly to Goose and other MCP systems that rely on it.

This change enables proper setup and avoids silent failures when the token is missing.

---

🔧 Affected file:
- `crates/goose/src/providers/githubcopilot.rs`

