### PR TITLE
Fixes : Workflow error on issue comment

### DIFF
--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -12,15 +12,16 @@ on:
         required: false
         type: boolean
         default: false
+      ref:
+        type: string
+        required: false
+        default: 'refs/heads/main'
     secrets:
       WINDOWS_CERTIFICATE:
         required: false
       WINDOWS_CERTIFICATE_PASSWORD:
         required: false
-    ref:
-      type: string
-      required: false
-      default: 'refs/heads/main'
+    
 
 jobs:
   build-desktop-windows:


### PR DESCRIPTION
3 Workflow run failed after my comment on Issue #1388

### Failed workflows 
1. Bundle Intel Desktop App - [run](https://github.com/block/goose/actions/runs/15695847494)
2. Bundle Windows Desktop App - [run](https://github.com/block/goose/actions/runs/15695847497)
3. Build CLI - [run](https://github.com/block/goose/actions/runs/15695847496)

### Reason
1. Invalid .**bundle-desktop-windows.yml** file due to `ref`.
4. Workflow can't differentiate between issue and pr comment.