### PR TITLE
feat: Add lead-worker model selection and real-time model display in GUI

### DIFF
--- a/crates/goose-cli/src/commands/web.rs
+++ b/crates/goose-cli/src/commands/web.rs
@@ -589,6 +589,10 @@ async fn process_message_streaming(
                         // For now, we'll just log them
                         tracing::info!("Received MCP notification in web interface");
                     }
+                    Ok(AgentEvent::ModelChange { model, mode }) => {
+                        // Log model change
+                        tracing::info!("Model changed to {} in {} mode", model, mode);
+                    }
                     Err(e) => {
                         error!("Error in message stream: {}", e);
                         let mut sender = sender.lock().await;

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -928,6 +928,12 @@ impl Session {
                                 }
                             }
                         }
+                        Some(Ok(AgentEvent::ModelChange { model, mode })) => {
+                            // Log model change if in debug mode
+                            if self.debug {
+                                eprintln!("Model changed to {} in {} mode", model, mode);
+                            }
+                        }
                         Some(Err(e)) => {
                             eprintln!("Error: {}", e);
                             drop(stream);

--- a/crates/goose-ffi/src/lib.rs
+++ b/crates/goose-ffi/src/lib.rs
@@ -266,6 +266,9 @@ pub unsafe extern "C" fn goose_agent_send_message(
                 Ok(AgentEvent::McpNotification(_)) => {
                     // TODO: Handle MCP notifications.
                 }
+                Ok(AgentEvent::ModelChange { .. }) => {
+                    // Model change events are informational, just continue
+                }
                 Err(e) => {
                     full_response.push_str(&format!("\nError in message stream: {}", e));
                 }

--- a/crates/goose-scheduler-executor/src/main.rs
+++ b/crates/goose-scheduler-executor/src/main.rs
@@ -165,6 +165,9 @@ async fn execute_recipe(job_id: &str, recipe_path: &str) -> Result<String> {
             Ok(AgentEvent::McpNotification(_)) => {
                 // Handle notifications if needed
             }
+            Ok(AgentEvent::ModelChange { .. }) => {
+                // Model change events are informational, just continue
+            }
             Err(e) => {
                 return Err(anyhow!("Error receiving message from agent: {}", e));
             }

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -441,6 +441,26 @@ pub async fn backup_config(
     }
 }
 
+#[utoipa::path(
+    get,
+    path = "/config/current-model",
+    responses(
+        (status = 200, description = "Current model retrieved successfully", body = String),
+    )
+)]
+pub async fn get_current_model(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> Result<Json<Value>, StatusCode> {
+    verify_secret_key(&headers, &state)?;
+
+    let current_model = goose::providers::base::get_current_model();
+
+    Ok(Json(serde_json::json!({
+        "model": current_model
+    })))
+}
+
 pub fn routes(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/config", get(read_all_config))
@@ -454,6 +474,7 @@ pub fn routes(state: Arc<AppState>) -> Router {
         .route("/config/init", post(init_config))
         .route("/config/backup", post(backup_config))
         .route("/config/permissions", post(upsert_permissions))
+        .route("/config/current-model", get(get_current_model))
         .with_state(state)
 }
 

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -152,6 +152,9 @@ use async_trait::async_trait;
 pub trait LeadWorkerProviderTrait {
     /// Get information about the lead and worker models for logging
     fn get_model_info(&self) -> (String, String);
+
+    /// Get the currently active model name
+    fn get_active_model(&self) -> String;
 }
 
 /// Base trait for AI providers (OpenAI, Anthropic, etc)
@@ -206,6 +209,17 @@ pub trait Provider: Send + Sync {
     /// This is used for logging model information at startup
     fn as_lead_worker(&self) -> Option<&dyn LeadWorkerProviderTrait> {
         None
+    }
+
+    /// Get the currently active model name
+    /// For regular providers, this returns the configured model
+    /// For LeadWorkerProvider, this returns the currently active model (lead or worker)
+    fn get_active_model_name(&self) -> String {
+        if let Some(lead_worker) = self.as_lead_worker() {
+            lead_worker.get_active_model()
+        } else {
+            self.get_model_config().model_name
+        }
     }
 }
 

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1114,6 +1114,9 @@ async fn run_scheduled_job_internal(
                         Ok(AgentEvent::McpNotification(_)) => {
                             // Handle notifications if needed
                         }
+                        Ok(AgentEvent::ModelChange { .. }) => {
+                            // Model change events are informational, just continue
+                        }
                         Err(e) => {
                             tracing::error!(
                                 "[Job {}] Error receiving message from agent: {}",

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -136,6 +136,9 @@ async fn run_truncate_test(
             Ok(AgentEvent::McpNotification(n)) => {
                 println!("MCP Notification: {n:?}");
             }
+            Ok(AgentEvent::ModelChange { .. }) => {
+                // Model change events are informational, just continue
+            }
             Err(e) => {
                 println!("Error: {:?}", e);
                 return Err(e);

--- a/ui/desktop/src/components/ChatView.tsx
+++ b/ui/desktop/src/components/ChatView.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState, useMemo, useCallback } from 'react';
+import React, { useEffect, useRef, useState, useMemo, useCallback, createContext, useContext } from 'react';
 import { getApiUrl } from '../config';
 import FlappyGoose from './FlappyGoose';
 import GooseMessage from './GooseMessage';
@@ -36,6 +36,10 @@ import {
   getTextContent,
   TextContent,
 } from '../types/message';
+
+// Context for sharing current model info
+const CurrentModelContext = createContext<{ model: string; mode: string } | null>(null);
+export const useCurrentModelInfo = () => useContext(CurrentModelContext);
 
 export interface ChatType {
   id: string;
@@ -144,6 +148,7 @@ function ChatContent({
     handleSubmit: _submitMessage,
     updateMessageStreamBody,
     notifications,
+    currentModelInfo,
   } = useMessageStream({
     api: getApiUrl('/reply'),
     initialMessages: chat.messages,
@@ -504,7 +509,8 @@ function ChatContent({
   }, new Map());
 
   return (
-    <div className="flex flex-col w-full h-screen items-center justify-center">
+    <CurrentModelContext.Provider value={currentModelInfo}>
+      <div className="flex flex-col w-full h-screen items-center justify-center">
       {/* Loader when generating recipe */}
       {isGeneratingRecipe && <LayingEggLoader />}
       <MoreMenuLayout
@@ -647,5 +653,6 @@ function ChatContent({
         summaryContent={summaryContent}
       />
     </div>
+    </CurrentModelContext.Provider>
   );
 }

--- a/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.tsx
@@ -1,0 +1,262 @@
+import { useState, useEffect } from 'react';
+import { useConfig } from '../../../ConfigContext';
+import { useModelAndProvider } from '../../../ModelAndProviderContext';
+import { Button } from '../../../ui/button';
+import { Select } from '../../../ui/Select';
+import { Input } from '../../../ui/input';
+import { Info } from 'lucide-react';
+
+interface LeadWorkerSettingsProps {
+  onClose: () => void;
+}
+
+export function LeadWorkerSettings({ onClose }: LeadWorkerSettingsProps) {
+  const { read, upsert, getProviders, remove } = useConfig();
+  const { currentModel } = useModelAndProvider();
+  const [leadModel, setLeadModel] = useState<string>('');
+  const [workerModel, setWorkerModel] = useState<string>('');
+  const [leadProvider, setLeadProvider] = useState<string>('');
+  const [workerProvider, setWorkerProvider] = useState<string>('');
+  const [leadTurns, setLeadTurns] = useState<number>(3);
+  const [failureThreshold, setFailureThreshold] = useState<number>(2);
+  const [fallbackTurns, setFallbackTurns] = useState<number>(2);
+  const [isEnabled, setIsEnabled] = useState(false);
+  const [modelOptions, setModelOptions] = useState<{ value: string; label: string; provider: string }[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load current configuration
+  useEffect(() => {
+    const loadConfig = async () => {
+      try {
+        setIsLoading(true);
+        const [
+          leadModelConfig,
+          leadProviderConfig,
+          leadTurnsConfig,
+          failureThresholdConfig,
+          fallbackTurnsConfig,
+        ] = await Promise.all([
+          read('GOOSE_LEAD_MODEL', false),
+          read('GOOSE_LEAD_PROVIDER', false),
+          read('GOOSE_LEAD_TURNS', false),
+          read('GOOSE_LEAD_FAILURE_THRESHOLD', false),
+          read('GOOSE_LEAD_FALLBACK_TURNS', false),
+        ]);
+
+        if (leadModelConfig) {
+          setLeadModel(leadModelConfig as string);
+          setIsEnabled(true);
+        }
+        if (leadProviderConfig) setLeadProvider(leadProviderConfig as string);
+        if (leadTurnsConfig) setLeadTurns(Number(leadTurnsConfig));
+        if (failureThresholdConfig) setFailureThreshold(Number(failureThresholdConfig));
+        if (fallbackTurnsConfig) setFallbackTurns(Number(fallbackTurnsConfig));
+        
+        // Set worker model to current model or from config
+        const workerModelConfig = await read('GOOSE_MODEL', false);
+        if (workerModelConfig) {
+          setWorkerModel(workerModelConfig as string);
+        } else if (currentModel) {
+          setWorkerModel(currentModel as string);
+        }
+        
+        const workerProviderConfig = await read('GOOSE_PROVIDER', false);
+        if (workerProviderConfig) {
+          setWorkerProvider(workerProviderConfig as string);
+        }
+
+        // Load available models
+        const providers = await getProviders(false);
+        const activeProviders = providers.filter((p) => p.is_configured);
+        const options: { value: string; label: string; provider: string }[] = [];
+        
+        activeProviders.forEach(({ metadata, name }) => {
+          if (metadata.known_models) {
+            metadata.known_models.forEach((model) => {
+              options.push({
+                value: model.name,
+                label: `${model.name} (${metadata.display_name})`,
+                provider: name,
+              });
+            });
+          }
+        });
+        
+        setModelOptions(options);
+      } catch (error) {
+        console.error('Error loading configuration:', error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    loadConfig();
+  }, [read, getProviders, currentModel]);
+
+  const handleSave = async () => {
+    try {
+      if (isEnabled && leadModel && workerModel) {
+        // Save lead/worker configuration
+        await Promise.all([
+          upsert('GOOSE_LEAD_MODEL', leadModel, false),
+          leadProvider && upsert('GOOSE_LEAD_PROVIDER', leadProvider, false),
+          upsert('GOOSE_MODEL', workerModel, false),
+          workerProvider && upsert('GOOSE_PROVIDER', workerProvider, false),
+          upsert('GOOSE_LEAD_TURNS', leadTurns, false),
+          upsert('GOOSE_LEAD_FAILURE_THRESHOLD', failureThreshold, false),
+          upsert('GOOSE_LEAD_FALLBACK_TURNS', fallbackTurns, false),
+        ]);
+      } else {
+        // Remove lead/worker configuration
+        await Promise.all([
+          remove('GOOSE_LEAD_MODEL', false),
+          remove('GOOSE_LEAD_PROVIDER', false),
+          remove('GOOSE_LEAD_TURNS', false),
+          remove('GOOSE_LEAD_FAILURE_THRESHOLD', false),
+          remove('GOOSE_LEAD_FALLBACK_TURNS', false),
+        ]);
+      }
+      onClose();
+    } catch (error) {
+      console.error('Error saving configuration:', error);
+    }
+  };
+
+  if (isLoading) {
+    return <div className="p-4">Loading...</div>;
+  }
+
+  return (
+    <div className="p-4 space-y-4">
+      <div className="space-y-2">
+        <h3 className="text-lg font-medium text-textProminent">Lead/Worker Mode</h3>
+        <p className="text-sm text-textSubtle">
+          Configure a lead model for planning and a worker model for execution
+        </p>
+      </div>
+
+      <div className="flex items-center space-x-2">
+        <input
+          type="checkbox"
+          id="enable-lead-worker"
+          checked={isEnabled}
+          onChange={(e) => setIsEnabled(e.target.checked)}
+          className="rounded border-borderStandard"
+        />
+        <label htmlFor="enable-lead-worker" className="text-sm text-textStandard">
+          Enable lead/worker mode
+        </label>
+      </div>
+
+      <div className="space-y-4">
+        <div className="space-y-2">
+          <label className="text-sm text-textSubtle">Lead Model</label>
+          <Select
+            options={modelOptions}
+            value={modelOptions.find((opt) => opt.value === leadModel) || null}
+            onChange={(newValue: unknown) => {
+              const option = newValue as { value: string; provider: string } | null;
+              if (option) {
+                setLeadModel(option.value);
+                setLeadProvider(option.provider);
+              }
+            }}
+            placeholder="Select lead model..."
+            isDisabled={!isEnabled}
+          />
+          <p className="text-xs text-textSubtle">
+            Strong model for initial planning and fallback recovery
+          </p>
+        </div>
+
+        <div className="space-y-2">
+          <label className="text-sm text-textSubtle">Worker Model</label>
+          <Select
+            options={modelOptions}
+            value={modelOptions.find((opt) => opt.value === workerModel) || null}
+            onChange={(newValue: unknown) => {
+              const option = newValue as { value: string; provider: string } | null;
+              if (option) {
+                setWorkerModel(option.value);
+                setWorkerProvider(option.provider);
+              }
+            }}
+            placeholder="Select worker model..."
+            isDisabled={!isEnabled}
+          />
+          <p className="text-xs text-textSubtle">
+            Fast model for routine execution tasks
+          </p>
+        </div>
+
+        <div className="space-y-4 pt-4 border-t border-borderSubtle">
+          <div className="space-y-2">
+            <label className="text-sm text-textSubtle flex items-center gap-1">
+              Initial Lead Turns
+              <Info size={14} className="text-textSubtle" />
+            </label>
+            <Input
+              type="number"
+              min={1}
+              max={10}
+              value={leadTurns}
+              onChange={(e) => setLeadTurns(Number(e.target.value))}
+              className="w-20"
+              disabled={!isEnabled}
+            />
+            <p className="text-xs text-textSubtle">
+              Number of turns to use the lead model at the start
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm text-textSubtle flex items-center gap-1">
+              Failure Threshold
+              <Info size={14} className="text-textSubtle" />
+            </label>
+            <Input
+              type="number"
+              min={1}
+              max={5}
+              value={failureThreshold}
+              onChange={(e) => setFailureThreshold(Number(e.target.value))}
+              className="w-20"
+              disabled={!isEnabled}
+            />
+            <p className="text-xs text-textSubtle">
+              Consecutive failures before switching back to lead
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm text-textSubtle flex items-center gap-1">
+              Fallback Turns
+              <Info size={14} className="text-textSubtle" />
+            </label>
+            <Input
+              type="number"
+              min={1}
+              max={5}
+              value={fallbackTurns}
+              onChange={(e) => setFallbackTurns(Number(e.target.value))}
+              className="w-20"
+              disabled={!isEnabled}
+            />
+            <p className="text-xs text-textSubtle">
+              Turns to use lead model during fallback
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-end space-x-2 pt-4 border-t border-borderSubtle">
+        <Button variant="ghost" onClick={onClose}>
+          Cancel
+        </Button>
+        <Button onClick={handleSave} disabled={isEnabled && (!leadModel || !workerModel)}>
+          Save Settings
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/ui/desktop/src/hooks/useCurrentModel.ts
+++ b/ui/desktop/src/hooks/useCurrentModel.ts
@@ -1,0 +1,10 @@
+import { useCurrentModelInfo } from '../components/ChatView';
+
+export function useCurrentModel() {
+  const modelInfo = useCurrentModelInfo();
+  
+  return { 
+    currentModel: modelInfo?.model || null,
+    isLoading: false 
+  };
+}

--- a/ui/desktop/src/hooks/useMessageStream.ts
+++ b/ui/desktop/src/hooks/useMessageStream.ts
@@ -24,6 +24,7 @@ type MessageEvent =
   | { type: 'Message'; message: Message }
   | { type: 'Error'; error: string }
   | { type: 'Finish'; reason: string }
+  | { type: 'ModelChange'; model: string; mode: string }
   | NotificationEvent;
 
 export interface UseMessageStreamOptions {
@@ -140,6 +141,9 @@ export interface UseMessageStreamHelpers {
   updateMessageStreamBody?: (newBody: object) => void;
 
   notifications: NotificationEvent[];
+  
+  /** Current model info from the backend */
+  currentModelInfo: { model: string; mode: string } | null;
 }
 
 /**
@@ -168,6 +172,7 @@ export function useMessageStream({
   });
 
   const [notifications, setNotifications] = useState<NotificationEvent[]>([]);
+  const [currentModelInfo, setCurrentModelInfo] = useState<{ model: string; mode: string } | null>(null);
 
   // expose a way to update the body so we can update the session id when CLE occurs
   const updateMessageStreamBody = useCallback((newBody: object) => {
@@ -270,6 +275,16 @@ export function useMessageStream({
                       ...parsedEvent,
                     };
                     setNotifications((prev) => [...prev, newNotification]);
+                    break;
+                  }
+
+                  case 'ModelChange': {
+                    // Update the current model in the frontend
+                    const modelInfo = {
+                      model: parsedEvent.model,
+                      mode: parsedEvent.mode,
+                    };
+                    setCurrentModelInfo(modelInfo);
                     break;
                   }
 
@@ -543,5 +558,6 @@ export function useMessageStream({
     addToolResult,
     updateMessageStreamBody,
     notifications,
+    currentModelInfo,
   };
 }


### PR DESCRIPTION
## Summary

This PR implements a comprehensive feature for configuring and monitoring different AI models for planning (lead) and execution (worker) phases in the Goose GUI, with real-time display of the currently active model.

## Changes

### Backend Enhancements

- **Event System**: Added `AgentEvent::ModelChange` event type to track when the system switches between models
- **API Endpoint**: Implemented `/config/current-model` endpoint to retrieve the active model information
- **Provider Integration**: Enhanced LeadWorkerProvider with `get_active_model()` method for accurate model state tracking
- **Global State Management**: Fixed async runtime panic by implementing global state store for model information
- **Cross-Component Integration**: Integrated ModelChange events across all components (CLI, web, FFI, scheduler)

### Frontend Improvements

- **Configuration UI**: Created LeadWorkerSettings component with intuitive interface for model configuration
- **Real-time Display**: Shows currently active model with mode indicators (e.g., "claude-opus (lead)", "gpt-4o (worker)")
- **State Management**: Migrated from window.appConfig to React Context for better state management
- **Event-Driven Updates**: Implemented automatic UI updates when models switch, no polling required

### Configuration Options

Users can now configure:
- Lead model selection with provider choice
- Worker model selection with provider choice
- Lead turns (number of planning iterations)
- Failure thresholds for fallback behavior
- Toggle to enable/disable lead-worker mode entirely

## Technical Details

The main challenge was displaying the correct active model during execution. This was solved by:
1. Using the `usage.model` field from provider responses for accurate model identification
2. Creating a React Context (`ModelContext`) for shared model state across components
3. Implementing a priority system where active model from events takes precedence over configured model

## Testing

- All existing tests pass, including agent tests that were updated for the new event type
- Manual testing confirms real-time model display updates correctly
- Code has been formatted with `cargo fmt` and passes `cargo clippy -- -D warnings`
- Frontend code passes lint checks

## Screenshots

<img width="520" alt="Screenshot 2025-06-17 at 15 37 55" src="https://github.com/user-attachments/assets/62ef652c-7c76-4b08-bba8-3c009c656888" />

The new UI allows users to:
1. Enable/disable lead-worker mode
2. Select different models and providers for lead and worker roles
3. Configure advanced parameters
4. See real-time model usage in the chat interface

---

**Files changed**: 16  
**Insertions**: 475  
**Deletions**: 9