### PR TITLE
[fix][small] Replaced goose prompt unicode quotations with ascii quotations

### DIFF
--- a/crates/goose-bench/src/assets/kubernetes_swagger.json
+++ b/crates/goose-bench/src/assets/kubernetes_swagger.json
@@ -5684,7 +5684,7 @@
           "type": "object"
         },
         "volumeHandle": {
-          "description": "volumeHandle is the unique volume name returned by the CSI volume plugin’s CreateVolume to refer to the volume on all subsequent calls. Required.",
+          "description": "volumeHandle is the unique volume name returned by the CSI volume plugin's CreateVolume to refer to the volume on all subsequent calls. Required.",
           "type": "string"
         }
       },

--- a/crates/goose-llm/src/extractors/session_name.rs
+++ b/crates/goose-llm/src/extractors/session_name.rs
@@ -38,7 +38,7 @@ fn build_system_prompt() -> String {
     You are an assistant that crafts a concise session title.
     Given the first couple user messages in the conversation so far, 
     reply with only a short name (up to 4 words) that best describes 
-    this session’s goal.
+    this session's goal.
 
     Examples:
     "#}

--- a/crates/goose-llm/tests/extract_session_name.rs
+++ b/crates/goose-llm/tests/extract_session_name.rs
@@ -35,8 +35,8 @@ async fn test_generate_session_name_success() {
     // Build a few messages with at least two user messages
     let messages = vec![
         Message::user().with_text("Hello, how are you?"),
-        Message::assistant().with_text("I’m fine, thanks!"),
-        Message::user().with_text("What’s the weather in New York tomorrow?"),
+        Message::assistant().with_text("I'm fine, thanks!"),
+        Message::user().with_text("What's the weather in New York tomorrow?"),
     ];
 
     let name = _generate_session_name(&messages)

--- a/crates/goose/src/prompts/plan.md
+++ b/crates/goose/src/prompts/plan.md
@@ -1,4 +1,4 @@
-You are a specialized "planner" AI. Your task is to analyze the user’s request from the chat messages and create either:
+You are a specialized "planner" AI. Your task is to analyze the user's request from the chat messages and create either:
 1. A detailed step-by-step plan (if you have enough information) on behalf of user that another "executor" AI agent can follow, or
 2. A list of clarifying questions (if you do not have enough information) prompting the user to reply with the needed clarifications
 
@@ -14,14 +14,14 @@ No tools are defined.
 {% endif %}
 ## Guidelines
 1. Check for clarity and feasibility
-  - If the user’s request is ambiguous, incomplete, or requires more information, respond only with all your clarifying questions in a concise list.
+  - If the user's request is ambiguous, incomplete, or requires more information, respond only with all your clarifying questions in a concise list.
   - If available tools are inadequate to complete the request, outline the gaps and suggest next steps or ask for additional tools or guidance.
 2. Create a detailed plan
   - Once you have sufficient clarity, produce a step-by-step plan that covers all actions the executor AI must take.
   - Number the steps, and explicitly note any dependencies between steps (e.g., “Use the output from Step 3 as input for Step 4”).
   - Include any conditional or branching logic needed (e.g., “If X occurs, do Y; otherwise, do Z”).
 3. Provide essential context
-  - The executor AI will see only your final plan (as a user message) or your questions (as an assistant message) and will not have access to this conversation’s full history.
+  - The executor AI will see only your final plan (as a user message) or your questions (as an assistant message) and will not have access to this conversation's full history.
   - Therefore, restate any relevant background, instructions, or prior conversation details needed to execute the plan successfully.
 4. One-time response
   - You can respond only once.

--- a/crates/goose/src/prompts/system_gpt_4.1.md
+++ b/crates/goose/src/prompts/system_gpt_4.1.md
@@ -2,9 +2,9 @@ You are a general-purpose AI agent called Goose, created by Block, the parent co
 
 IMPORTANT INSTRUCTIONS: 
 
-Please keep going until the user’s query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved.
+Please keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved.
 
-If you are not sure about file content or codebase structure, or other information pertaining to the user’s request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer. It is important you use tools that can assist with providing the right context.
+If you are not sure about file content or codebase structure, or other information pertaining to the user's request, use your tools to read files and gather the relevant information: do NOT guess or make up an answer. It is important you use tools that can assist with providing the right context.
 
 CRITICAL: The str_replace command in the text_editor tool (when available) should be used most of the time, with the write tool only for new files. ALWAYS check the content of the file before editing. NEVER overwrite the whole content of a file unless directed to, always edit carefully by adding and changing content. Never leave content unfinished with comments like "rest of the file here"
 


### PR DESCRIPTION
https://github.com/block/goose/issues/2812

Updating Goose default prompts to use standard ascii quotation marks instead of unicode quotation marks. It's a small change but every token counts.

| Before | After |
| --- | --- |
| ![Before](https://github.com/user-attachments/assets/a4306263-dee3-45d4-ba4a-a1dca32e3a3c) | ![After](https://github.com/user-attachments/assets/3e8f6d97-63de-4885-9ebc-0b3e94a8304c)

[open ai tokenizer ui](https://platform.openai.com/tokenizer)