### PR TITLE
feat(ui): Add persistent draft state for chat input

### DIFF
--- a/ui/desktop/src/hooks/useChatDraft.ts
+++ b/ui/desktop/src/hooks/useChatDraft.ts
@@ -15,7 +15,7 @@ export function useChatDraft(initialValue: string = '') {
     () =>
       debounce((text: string) => {
         LocalMessageStorage.saveDraft(text);
-      }, 500), // Save draft 500ms after user stops typing
+      }, 300), // Reduced from 500ms to 300ms for better responsiveness
     []
   );
 

--- a/ui/desktop/src/utils/localMessageStorage.ts
+++ b/ui/desktop/src/utils/localMessageStorage.ts
@@ -55,8 +55,13 @@ export class LocalMessageStorage {
     const messages = this.getStoredMessages();
     const now = Date.now();
 
-    // Don't add duplicate of last message
-    if (messages.length > 0 && messages[messages.length - 1].content === content) {
+    // Duplicate prevention - check last few messages to avoid accidental rapid submissions
+    const isDuplicate = messages.some((msg, index) => {
+      // Check if it's the same content and within the last 5 messages
+      return msg.content === content && index >= messages.length - 5;
+    });
+
+    if (isDuplicate) {
       return;
     }
 


### PR DESCRIPTION
This came out of me having to re-type messages after going into settings to make sure that I had the correct set of MCP's setup for my request, we now keep a draft of that text so that when we return it uses the draft text and prevents us from having to retype our prompts.

https://github.com/user-attachments/assets/cbfd02ed-91c1-4d4a-9063-8385c57a50e8

