### PR TITLE
fix(docker): install protoc to fix lance-encoding build

### DIFF
--- a/documentation/docs/docker/Dockerfile
+++ b/documentation/docs/docker/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR /usr/src/goose
 # Copy the entire project
 COPY . .
 
+RUN apt-get update && apt-get install -y protobuf-compiler
+
 # Build the project
 RUN cargo build --release
 


### PR DESCRIPTION
This PR adds `protobuf-compiler` to the Dockerfile so that the `lance-encoding` crate can compile successfully during the `cargo build` step.

Without this change, the Docker build fails with the following error:
```
Error: Custom { kind: NotFound, error: "Could not find protoc. If protoc is installed, try setting the PROTOC environment variable..." }
```

This fix installs the required `protoc` binary using `apt-get`, allowing Goose to build in Docker without error.

Tested on Apple M4 MacBook Pro with `docker-compose up --build`.
