### PR TITLE
feat: allow users view and edit their non-secret config's

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -110,7 +110,8 @@ export default function App() {
   const [modalMessage, setModalMessage] = useState<string>('');
   const [extensionConfirmLabel, setExtensionConfirmLabel] = useState<string>('');
   const [extensionConfirmTitle, setExtensionConfirmTitle] = useState<string>('');
-  const [{ view, viewOptions }, setInternalView] = useState<ViewConfig>(getInitialView());
+  const [_history, setHistory] = useState<View[]>(['chat']);
+  const [{ view, viewOptions }, setCurrentView] = useState<ViewConfig>(getInitialView());
 
   const { getExtensions, addExtension, read } = useConfig();
   const initAttemptedRef = useRef(false);
@@ -129,7 +130,21 @@ export default function App() {
 
   const setView = (view: View, viewOptions: ViewOptions = {}) => {
     console.log(`Setting view to: ${view}`, viewOptions);
-    setInternalView({ view, viewOptions });
+    setHistory((prev) => [...prev, view]);
+    setCurrentView({ view, viewOptions });
+  };
+
+  const goBack = () => {
+    setHistory((prev) => {
+      if (prev.length <= 1) {
+        setCurrentView({ view: 'chat', viewOptions: {} });
+        return ['chat'];
+      }
+      const popped = prev.slice(0, -1);
+      const previousView = popped[popped.length - 1];
+      setCurrentView({ view: previousView, viewOptions: {} });
+      return popped;
+    });
   };
 
   useEffect(() => {
@@ -503,15 +518,13 @@ export default function App() {
           )}
           {view === 'settings' && (
             <SettingsView
-              onClose={() => {
-                setView('chat');
-              }}
+              onClose={goBack}
               setView={setView}
               viewOptions={viewOptions as SettingsViewOptions}
             />
           )}
           {view === 'ConfigureProviders' && (
-            <ProviderSettings onClose={() => setView('chat')} isOnboarding={false} />
+            <ProviderSettings onClose={goBack} isOnboarding={false} />
           )}
           {view === 'chat' && !isLoadingSession && (
             <ChatView
@@ -523,7 +536,7 @@ export default function App() {
             />
           )}
           {view === 'sessions' && <SessionsView setView={setView} />}
-          {view === 'schedules' && <SchedulesView onClose={() => setView('chat')} />}
+          {view === 'schedules' && <SchedulesView onClose={goBack} />}
           {view === 'sharedSession' && (
             <SharedSessionView
               session={

--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -8,6 +8,7 @@ import { ToolSelectionStrategySection } from './tool_selection_strategy/ToolSele
 import SessionSharingSection from './sessions/SessionSharingSection';
 import { ResponseStylesSection } from './response_styles/ResponseStylesSection';
 import AppSettingsSection from './app/AppSettingsSection';
+import ConfigSettings from './config/ConfigSettings';
 import { ExtensionConfig } from '../../api';
 import MoreMenuLayout from '../more_menu/MoreMenuLayout';
 
@@ -47,6 +48,8 @@ export default function SettingsView({
                 deepLinkConfig={viewOptions.deepLinkConfig}
                 showEnvVars={viewOptions.showEnvVars}
               />
+              {/* Config Settings */}
+              <ConfigSettings />
               {/* Goose Modes */}
               <ModeSection setView={setView} />
               {/*Session sharing*/}

--- a/ui/desktop/src/components/settings/config/ConfigSettings.tsx
+++ b/ui/desktop/src/components/settings/config/ConfigSettings.tsx
@@ -1,0 +1,146 @@
+import { useState, useEffect } from 'react';
+import { Input } from '../../ui/input';
+import { Button } from '../../ui/button';
+import { useConfig } from '../../ConfigContext';
+import { cn } from '../../../utils';
+import { Save, RotateCcw, FileText } from 'lucide-react';
+import { toastSuccess, toastError } from '../../../toasts';
+import { getUiNames, providerPrefixes } from '../../../utils/configUtils';
+import type { ConfigData, ConfigValue } from '../../../types/config';
+
+export default function ConfigSettings() {
+  const { config, upsert } = useConfig();
+  const typedConfig = config as ConfigData;
+  const [configValues, setConfigValues] = useState<ConfigData>({});
+  const [modified, setModified] = useState(false);
+  const [saving, setSaving] = useState<string | null>(null);
+
+  useEffect(() => {
+    setConfigValues(typedConfig);
+  }, [typedConfig]);
+
+  const handleChange = (key: string, value: string) => {
+    setConfigValues((prev: ConfigData) => ({
+      ...prev,
+      [key]: value,
+    }));
+    setModified(true);
+  };
+
+  const handleSave = async (key: string) => {
+    setSaving(key);
+    try {
+      await upsert(key, configValues[key], false);
+      toastSuccess({
+        title: 'Configuration Updated',
+        msg: `Successfully saved "${getUiNames(key)}"`,
+      });
+      setModified(false);
+    } catch (error) {
+      console.error('Failed to save config:', error);
+      toastError({
+        title: 'Save Failed',
+        msg: `Failed to save "${getUiNames(key)}"`,
+        traceback: error instanceof Error ? error.message : String(error),
+      });
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  const handleReset = () => {
+    setConfigValues(typedConfig);
+    setModified(false);
+    toastSuccess({
+      title: 'Configuration Reset',
+      msg: 'All changes have been reverted',
+    });
+  };
+
+  const currentProvider = typedConfig.GOOSE_PROVIDER || '';
+
+  const currentProviderPrefixes = providerPrefixes[currentProvider] || [];
+
+  const allProviderPrefixes = Object.values(providerPrefixes).flat();
+
+  const providerSpecificEntries: [string, ConfigValue][] = [];
+  const generalEntries: [string, ConfigValue][] = [];
+
+  Object.entries(configValues).forEach(([key, value]) => {
+    // skip secrets
+    if (key === 'extensions' || key.includes('_KEY') || key.includes('_TOKEN')) {
+      return;
+    }
+
+    const providerSpecific = allProviderPrefixes.some((prefix: string) => key.startsWith(prefix));
+
+    if (providerSpecific) {
+      if (currentProviderPrefixes.some((prefix: string) => key.startsWith(prefix))) {
+        providerSpecificEntries.push([key, value]);
+      }
+    } else {
+      generalEntries.push([key, value]);
+    }
+  });
+
+  const configEntries = [...providerSpecificEntries, ...generalEntries];
+
+  return (
+    <section id="configEditor" className="px-8">
+      <div className="flex justify-between items-center mb-2">
+        <div className="flex items-center gap-2">
+          <FileText className="text-iconStandard" size={20} />
+          <h2 className="text-xl font-medium text-textStandard">Configuration</h2>
+        </div>
+        {modified && (
+          <Button onClick={handleReset} variant="ghost" className="text-sm">
+            <RotateCcw className="h-4 w-4 mr-2" />
+            Reset
+          </Button>
+        )}
+      </div>
+      <div className="pb-8">
+        <p className="text-sm text-textSubtle mb-6">
+          Edit your goose config
+          {currentProvider && ` (current settings for ${currentProvider})`}
+        </p>
+
+        <div className="space-y-3">
+          {configEntries.length === 0 ? (
+            <p className="text-textSubtle">No configuration settings found.</p>
+          ) : (
+            configEntries.map(([key, _value]) => (
+              <div key={key} className="grid grid-cols-[200px_1fr_auto] gap-3 items-center">
+                <label className="text-sm font-medium text-textStandard" title={key}>
+                  {getUiNames(key)}
+                </label>
+                <Input
+                  value={String(configValues[key] || '')}
+                  onChange={(e) => handleChange(key, e.target.value)}
+                  className={cn(
+                    'text-textStandard border-borderSubtle hover:border-borderStandard',
+                    configValues[key] !== typedConfig[key] && 'border-blue-500'
+                  )}
+                  placeholder={`Enter ${getUiNames(key).toLowerCase()}`}
+                />
+                <Button
+                  onClick={() => handleSave(key)}
+                  disabled={configValues[key] === typedConfig[key] || saving === key}
+                  variant="ghost"
+                  size="sm"
+                  className="min-w-[60px]"
+                >
+                  {saving === key ? (
+                    <span className="text-xs">Saving...</span>
+                  ) : (
+                    <Save className="h-4 w-4" />
+                  )}
+                </Button>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/ui/desktop/src/components/settings/providers/ProviderSettingsPage.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderSettingsPage.tsx
@@ -98,10 +98,9 @@ export default function ProviderSettings({ onClose, isOnboarding }: ProviderSett
           </div>
         )}
         <div className="px-8 pt-6 pb-4">
-          {/* Only show back button if not in onboarding mode */}
-          {!isOnboarding && <BackButton onClick={onClose} />}
+          <BackButton onClick={onClose} />
           <h1
-            className="text-3xl font-medium text-textStandard mt-1"
+            className="text-3xl font-medium text-textStandard mt-4"
             data-testid="provider-selection-heading"
           >
             {isOnboarding ? 'Configure your providers' : 'Provider Configuration Settings'}

--- a/ui/desktop/src/types/config.ts
+++ b/ui/desktop/src/types/config.ts
@@ -1,0 +1,2 @@
+export type ConfigValue = string | number | null | undefined;
+export type ConfigData = Record<string, ConfigValue>;

--- a/ui/desktop/src/utils/configUtils.ts
+++ b/ui/desktop/src/utils/configUtils.ts
@@ -1,0 +1,64 @@
+export const configLabels: Record<string, string> = {
+  // goose settings
+  GOOSE_PROVIDER: 'Goose Provider',
+  GOOSE_MODEL: 'Goose Model',
+  GOOSE_TEMPERATURE: 'Goose Temperature',
+  GOOSE_MODE: 'Goose Execution Mode',
+  GOOSE_LEAD_PROVIDER: 'Goose Lead Provider',
+  GOOSE_LEAD_MODEL: 'Goose Lead Model',
+  GOOSE_PLANNER_PROVIDER: 'Goose Planner Provider',
+  GOOSE_PLANNER_MODEL: 'Goose Planner Model',
+  GOOSE_TOOLSHIM: 'Goose Tool Shim Enabled',
+  GOOSE_TOOLSHIM_OLLAMA_MODEL: 'Goose Tool Shim Model',
+  GOOSE_CLI_MIN_PRIORITY: 'Goose Minimum Priority',
+  GOOSE_ALLOWLIST: 'Goose Allowlist URL',
+  GOOSE_RECIPE_GITHUB_REPO: 'Goose Recipe Repository',
+
+  // openai
+  OPENAI_HOST: 'OpenAI API Host',
+  OPENAI_BASE_PATH: 'OpenAI Base Path',
+
+  // anthropic
+  ANTHROPIC_HOST: 'Anthropic API Host',
+
+  // databricks
+  DATABRICKS_HOST: 'Databricks Host URL',
+
+  // ollama
+  OLLAMA_HOST: 'Ollama Server Host',
+
+  // azure openai
+  AZURE_OPENAI_ENDPOINT: 'Azure OpenAI Endpoint',
+  AZURE_OPENAI_DEPLOYMENT_NAME: 'Azure OpenAI Deployment Name',
+  AZURE_OPENAI_API_VERSION: 'Azure OpenAI API Version',
+
+  // gcp vertex
+  GCP_PROJECT_ID: 'Project ID',
+  GCP_LOCATION: 'Location',
+
+  // snowflake
+  SNOWFLAKE_HOST: 'Snowflake Account Host',
+};
+
+export const providerPrefixes: Record<string, string[]> = {
+  openai: ['OPENAI_'],
+  anthropic: ['ANTHROPIC_'],
+  google: ['GOOGLE_'],
+  groq: ['GROQ_'],
+  databricks: ['DATABRICKS_'],
+  openrouter: ['OPENROUTER_'],
+  ollama: ['OLLAMA_'],
+  azure_openai: ['AZURE_'],
+  gcp_vertex_ai: ['GCP_'],
+  snowflake: ['SNOWFLAKE_'],
+};
+
+export const getUiNames = (key: string): string => {
+  if (configLabels[key]) {
+    return configLabels[key];
+  }
+  return key
+    .split('_')
+    .map((word) => word.charAt(0) + word.slice(1).toLowerCase())
+    .join(' ');
+};


### PR DESCRIPTION
Fixes: #1220

- Allow users view and edit their non-secret configs
- Fix pages navigation `goBack`

<img width="702" alt="image" src="https://github.com/user-attachments/assets/cb3de082-7f00-481a-b57e-f8ae7b6b22a4" />
