### PR TITLE
Docs linux desktop

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -3,15 +3,13 @@ sidebar_position: 1
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import SupportedEnvironments from '@site/src/components/SupportedEnvironments';
 import RateLimits from '@site/src/components/RateLimits';
 import MacDesktopInstallButtons from '@site/src/components/MacDesktopInstallButtons';
 import WindowsDesktopInstallButtons from '@site/src/components/WindowsDesktopInstallButtons';
+import LinuxDesktopInstallButtons from '@site/src/components/LinuxDesktopInstallButtons';
 
 
 # Install Goose
-
-<SupportedEnvironments /> 
 
 <Tabs>
   <TabItem value="mac" label="macOS" default>
@@ -82,18 +80,46 @@ import WindowsDesktopInstallButtons from '@site/src/components/WindowsDesktopIns
   </TabItem>
 
   <TabItem value="linux" label="Linux" default>
-    Run the following command to install the Goose CLI on Linux:
+    Choose to install Goose on CLI and/or Desktop:
 
-    ```sh
-    curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
-    ```
-    This script will fetch the latest version of Goose and set it up on your system.
+    <Tabs groupId="interface">
+      <TabItem value="ui" label="Goose Desktop" default>
+        Install Goose Desktop directly from the browser.
+        
+        <h3 style={{ marginTop: '1rem' }}>Install via Download</h3>
+        <LinuxDesktopInstallButtons/>
 
-    If you'd like to install without interactive configuration, disable `CONFIGURE`:
+        <div style={{ marginTop: '1rem' }}>
+          1. Extract the downloaded tar.bz2 file.
+          2. Run the executable file to launch the Goose Desktop application.
 
-    ```sh
-    curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
-    ```   
+          :::tip Updating Goose
+          It's best to keep Goose updated by periodically running the installation steps again.
+          :::
+        </div>
+      </TabItem>
+      <TabItem value="cli" label="Goose CLI">
+        Run the following command to install the Goose CLI on Linux:
+
+        ```sh
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+        ```
+        This script will fetch the latest version of Goose and set it up on your system.
+
+        If you'd like to install without interactive configuration, disable `CONFIGURE`:
+
+        ```sh
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+        ```
+
+        :::tip Updating Goose
+        It's best to keep Goose updated. To update Goose, run:
+        ```sh
+        goose update
+        ```
+        :::
+      </TabItem>
+    </Tabs>
   </TabItem>
 
   <TabItem value="windows" label="Windows">

--- a/documentation/docs/guides/updating-goose.md
+++ b/documentation/docs/guides/updating-goose.md
@@ -8,6 +8,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import MacDesktopInstallButtons from '@site/src/components/MacDesktopInstallButtons';
 import WindowsDesktopInstallButtons from '@site/src/components/WindowsDesktopInstallButtons';
+import LinuxDesktopInstallButtons from '@site/src/components/LinuxDesktopInstallButtons';
 
 The Goose CLI and desktop apps are under active and continuous development. To get the newest features and fixes, you should periodically update your Goose client using the following instructions.
 
@@ -58,6 +59,52 @@ The Goose CLI and desktop apps are under active and continuous development. To g
     </Tabs>
   </TabItem>
 
+  <TabItem value="linux" label="Linux">
+    <Tabs groupId="interface">
+      <TabItem value="ui" label="Goose Desktop" default>
+        :::info
+        To update Goose to the latest stable version, reinstall using the instructions below
+        :::
+        <div style={{ marginTop: '1rem' }}>
+          1. <LinuxDesktopInstallButtons/>
+          2. Extract the downloaded tar.bz2 file.
+          3. Run the executable file to launch the Goose Desktop application.
+          4. Overwrite the existing Goose application with the new version.
+          5. Run the executable file to launch the Goose Desktop application.
+        </div>
+      </TabItem>
+      <TabItem value="cli" label="Goose CLI">
+        You can update Goose by running:
+
+        ```sh
+        goose update
+        ```
+
+        Additional [options](/docs/guides/goose-cli-commands#update-options):
+        
+        ```sh
+        # Update to latest canary (development) version
+        goose update --canary
+
+        # Update and reconfigure settings
+        goose update --reconfigure
+        ```
+
+        Or you can run the [installation](/docs/getting-started/installation) script again:
+
+        ```sh
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+        ```
+
+        To check your current Goose version, use the following command:
+
+        ```sh
+        goose --version
+        ```
+      </TabItem>
+    </Tabs>
+  </TabItem>
+
   <TabItem value="windows" label="Windows">
     <Tabs groupId="interface">
       <TabItem value="ui" label="Goose Desktop" default>
@@ -71,6 +118,63 @@ The Goose CLI and desktop apps are under active and continuous development. To g
           4. Overwrite the existing Goose application with the new version.
           5. Run the executable file to launch the Goose Desktop application.
         </div>
+      </TabItem>
+      <TabItem value="cli" label="Goose CLI">
+        There isn't native CLI support for Windows. You can run Goose CLI using WSL (Windows Subsystem for Linux).
+
+        **If you haven't set up WSL yet:**
+
+        1. Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
+
+        ```bash
+        wsl --install
+        ```
+
+        2. If prompted, restart your computer to complete the WSL installation. Once restarted, or if WSL is already installed, launch your Ubuntu shell by running:
+
+        ```bash
+        wsl -d Ubuntu
+        ```
+
+        3. Run the Goose installation script:
+        ```bash
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+        ```
+        :::tip
+          If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file:
+
+          ```bash
+          sudo apt update && sudo apt install bzip2 -y
+          ```
+        :::
+
+        **If you already have Goose CLI installed in WSL, you can update it:**
+
+        ```sh
+        goose update
+        ```
+
+        Additional [options](/docs/guides/goose-cli-commands#update-options):
+        
+        ```sh
+        # Update to latest canary (development) version
+        goose update --canary
+
+        # Update and reconfigure settings
+        goose update --reconfigure
+        ```
+
+        Or you can run the [installation](/docs/getting-started/installation) script again within WSL:
+
+        ```sh
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+        ```
+
+        To check your current Goose version within WSL, use:
+
+        ```sh
+        goose --version
+        ```
       </TabItem>
     </Tabs>
   </TabItem>

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -6,16 +6,13 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import Link from "@docusaurus/Link";
 import { IconDownload } from "@site/src/components/icons/download";
-import SupportedEnvironments from '@site/src/components/SupportedEnvironments';
 import RateLimits from '@site/src/components/RateLimits';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import MacDesktopInstallButtons from '@site/src/components/MacDesktopInstallButtons';
 import WindowsDesktopInstallButtons from '@site/src/components/WindowsDesktopInstallButtons';
+import LinuxDesktopInstallButtons from '@site/src/components/LinuxDesktopInstallButtons';
 
 # Goose in 5 minutes
-
-<SupportedEnvironments />
-
 
 Goose is an open source AI agent that supercharges your software development by automating coding tasks. This quick tutorial will guide you through getting started with Goose!
 
@@ -47,7 +44,11 @@ Goose is an open source AI agent that supercharges your software development by 
   <TabItem value="linux" label="Linux">
     <Tabs groupId="interface">
       <TabItem value="ui" label="Goose Desktop" default>
-        Desktop version is currently unavailable for Linux.
+        <LinuxDesktopInstallButtons/>
+        <div style={{ marginTop: '1rem' }}>
+          1. Extract the downloaded tar.bz2 file.
+          2. Run the executable file to launch the Goose Desktop application.
+        </div>
       </TabItem>
       <TabItem value="cli" label="Goose CLI">
         Run the following command to install the Goose CLI on Linux:

--- a/documentation/src/components/LinuxDesktopInstallButtons.js
+++ b/documentation/src/components/LinuxDesktopInstallButtons.js
@@ -1,0 +1,20 @@
+import Link from "@docusaurus/Link";
+import { IconDownload } from "@site/src/components/icons/download";
+
+const LinuxDesktopInstallButtons = () => {
+  return (
+    <div>
+      <p>To download Goose Desktop for Linux, click the button below:</p>
+      <div className="pill-button">
+        <Link
+          className="button button--primary button--lg"
+          to="https://github.com/block/goose/releases/download/v1.0.29/goose-aarch64-unknown-linux-gnu.tar.bz2"
+        >
+          <IconDownload /> Linux
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default LinuxDesktopInstallButtons;

--- a/documentation/src/components/LinuxDesktopInstallButtons.js
+++ b/documentation/src/components/LinuxDesktopInstallButtons.js
@@ -4,13 +4,25 @@ import { IconDownload } from "@site/src/components/icons/download";
 const LinuxDesktopInstallButtons = () => {
   return (
     <div>
-      <p>To download Goose Desktop for Linux, click the button below:</p>
-      <div className="pill-button">
+      <p>To download Goose Desktop for Linux, choose the buttons below:</p>
+      <div className="pill-button" style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+        <Link
+          className="button button--primary button--lg"
+          to="https://github.com/block/goose/releases/download/v1.0.29/goose-x86_64-unknown-linux-gnu.tar.bz2"
+        >
+          <IconDownload /> Linux x86_64
+        </Link>
         <Link
           className="button button--primary button--lg"
           to="https://github.com/block/goose/releases/download/v1.0.29/goose-aarch64-unknown-linux-gnu.tar.bz2"
         >
-          <IconDownload /> Linux
+          <IconDownload /> Linux ARM64
+        </Link>
+        <Link
+          className="button button--secondary button--lg"
+          to="https://github.com/block/goose/releases/download/v1.0.29/Goose-1.0.29-1.x86_64.rpm"
+        >
+          <IconDownload /> RPM Package
         </Link>
       </div>
     </div>


### PR DESCRIPTION
This pull request introduces support for Linux installations of Goose Desktop and updates the documentation to reflect these changes. The most important updates include the addition of a new component for Linux installation buttons, updates to installation instructions across multiple documentation files, and enhancements to the update process for Goose CLI and Desktop on Linux and Windows.

### Updates to Linux installation support:

* [`documentation/src/components/LinuxDesktopInstallButtons.js`](diffhunk://#diff-6442dbb0af7be033dc433df0ec23196ce16d0d820ed6189831764be54837c354R1-R32): Added a new component, `LinuxDesktopInstallButtons`, that provides download links for Goose Desktop on Linux, including x86_64, ARM64, and RPM packages.
* [`documentation/docs/getting-started/installation.md`](diffhunk://#diff-1da95befef448a968841697bffcbb8f9c53f1238842a36a63444ca5d4ea0499aL6-L15): Updated the installation guide to include instructions for installing Goose Desktop and CLI on Linux. This includes steps for extracting the tar.bz2 file and running the executable. [[1]](diffhunk://#diff-1da95befef448a968841697bffcbb8f9c53f1238842a36a63444ca5d4ea0499aL6-L15) [[2]](diffhunk://#diff-1da95befef448a968841697bffcbb8f9c53f1238842a36a63444ca5d4ea0499aR83-R101) [[3]](diffhunk://#diff-1da95befef448a968841697bffcbb8f9c53f1238842a36a63444ca5d4ea0499aR114-R122)

### Updates to Goose update process:

* [`documentation/docs/guides/updating-goose.md`](diffhunk://#diff-73634242804f8cf84d6a17bd17773e3dbe74d393409f94c6e7a64b83d7842a9bR62-R107): Enhanced the update guide with detailed instructions for updating Goose Desktop and CLI on Linux, including commands for stable and development versions. Added instructions for using Goose CLI on Windows via WSL (Windows Subsystem for Linux). [[1]](diffhunk://#diff-73634242804f8cf84d6a17bd17773e3dbe74d393409f94c6e7a64b83d7842a9bR62-R107) [[2]](diffhunk://#diff-73634242804f8cf84d6a17bd17773e3dbe74d393409f94c6e7a64b83d7842a9bR122-R178)

### General documentation improvements:

* [`documentation/docs/quickstart.md`](diffhunk://#diff-705849878fb66d2c4fd70c10e053e7d408dccc37915537db5da0102ad020e4d5L9-L19): Updated the quickstart guide to include Linux installation instructions, replacing the previous note about the unavailability of Goose Desktop for Linux. [[1]](diffhunk://#diff-705849878fb66d2c4fd70c10e053e7d408dccc37915537db5da0102ad020e4d5L9-L19) [[2]](diffhunk://#diff-705849878fb66d2c4fd70c10e053e7d408dccc37915537db5da0102ad020e4d5L50-R51)