### PR TITLE
add playwright-mcp server to extensions list

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -165,5 +165,17 @@
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []
+  },
+  {
+    "id": "playwright",
+    "name": "Playwright",
+    "description": "Interact with web pages through structured accessibility snapshots using Playwright",
+    "command": "npx @playwright/mcp@latest",
+    "link": "https://github.com/microsoft/playwright-mcp",
+    "installation_notes": "Install using npx package manager. Note: Default memory graph location may be hard to find where npx installs the module.",
+    "is_builtin": false,
+    "endorsed": true,
+    "githubStars": 12309,
+    "environmentVariables": []
   }
 ]


### PR DESCRIPTION
## Summary 

This updates the documentation to include the playwright-mcp server in the extensions list. You can learn more about playwright-mcp here: https://github.com/microsoft/playwright-mcp

## Testing

```
cd documentation
yarn start
# Navigate to http://localhost:3000/goose/extensions/
```