### PR TITLE
Add `/extension` path for extension installation

### DIFF
--- a/documentation/src/pages/extension.tsx
+++ b/documentation/src/pages/extension.tsx
@@ -1,0 +1,17 @@
+import React, { useEffect } from 'react';
+import { useLocation } from '@docusaurus/router';
+
+export default function ExtensionRedirect(): JSX.Element {
+  const location = useLocation();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+    window.location.href = `goose://extension${params.toString() ? '?' + params.toString() : ''}`;
+  }, [location]);
+
+  return (
+    <div style={{ padding: '2rem', textAlign: 'center' }}>
+      Redirecting to Goose...
+    </div>
+  );
+}


### PR DESCRIPTION
## Context

I want to add Goose as a recommended MCP Client in https://github.com/microsoft/playwright-mcp/pull/575

## Problem

GitHub markdown does not allow me use a custom protocol in the rendered README, which means that our `goose://` link will not work.

## Solution

We can add a new `/goose/extension` path that will redirect to the application and forward the query string to install the extension. With this change, playwright-mcp is installable into Goose using this URL: 

```
https://block.github.io/goose/extension?cmd=npx&arg=%40playwright%2Fmcp%40latest&id=playwright&name=Playwright&description=Interact%20with%20web%20pages%20through%20structured%20accessibility%20snapshots%20using%20Playwright
```