### PR TITLE
feat (cli): add an alias --id for --name param for goose session --resume command

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -43,7 +43,8 @@ struct Identifier {
         long,
         value_name = "NAME",
         help = "Name for the chat session (e.g., 'project-x')",
-        long_help = "Specify a name for your chat session. When used with --resume, will resume this specific session if it exists."
+        long_help = "Specify a name for your chat session. When used with --resume, will resume this specific session if it exists.",
+        alias = "id",
     )]
     name: Option<String>,
 


### PR DESCRIPTION
Since `id` and `name` are interchangeable to locate a stored goose session, this pull request introduces a minor enhancement to the `crates/goose-cli/src/cli.rs` file by adding an alias for the `name` argument in the command-line interface.

* **Command-line interface improvement**:
  - Added an alias (`id`) for the `name` argument in the `struct Identifier` definition to provide an alternative, shorter option for specifying the chat session name.

### Before
![image](https://github.com/user-attachments/assets/2c402f85-1da4-439a-b260-e21e0aa11e07)
### After
![image](https://github.com/user-attachments/assets/b479bd21-a00b-48c8-afa0-d95b645123c7)
