### PR TITLE
fix: updated openrouter known models

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -21,10 +21,11 @@ pub const OPENROUTER_MODEL_PREFIX_ANTHROPIC: &str = "anthropic";
 
 // OpenRouter can run many models, we suggest the default
 pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
+    "anthropic/claude-3.5-sonnet",
+    "anthropic/claude-3.7-sonnet",
     "anthropic/claude-sonnet-4",
-    "google/gemini-2.5-pro-preview"
-    "google/gemini-2.0-flash-001",
-    "deepseek/deepseek-r1-0528:free",
+    "google/gemini-2.5-pro"
+    "deepseek/deepseek-r1-0528",
 ];
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -24,7 +24,7 @@ pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
     "anthropic/claude-3.5-sonnet",
     "anthropic/claude-3.7-sonnet",
     "anthropic/claude-sonnet-4",
-    "google/gemini-2.5-pro"
+    "google/gemini-2.5-pro",
     "deepseek/deepseek-r1-0528",
 ];
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -21,10 +21,10 @@ pub const OPENROUTER_MODEL_PREFIX_ANTHROPIC: &str = "anthropic";
 
 // OpenRouter can run many models, we suggest the default
 pub const OPENROUTER_KNOWN_MODELS: &[&str] = &[
-    "anthropic/claude-3.5-sonnet",
-    "anthropic/claude-3.7-sonnet",
-    "google/gemini-2.5-pro-exp-03-25:free",
-    "deepseek/deepseek-r1",
+    "anthropic/claude-sonnet-4",
+    "google/gemini-2.5-pro-preview"
+    "google/gemini-2.0-flash-001",
+    "deepseek/deepseek-r1-0528:free",
 ];
 pub const OPENROUTER_DOC_URL: &str = "https://openrouter.ai/models";
 


### PR DESCRIPTION
The OpenRouter known models are outdated. In the case of `google/gemini-2.5-pro-exp-03-25:free` it no longer exists on OpenRouter, so requests fail when users select this suggested model. In cases where the model still exists, there were most recent models available. 

No other changes are introduced beyond replacing the items in the model list.