### PR TITLE
fix: Improves reliability of flaky log tests

### DIFF
--- a/crates/goose-cli/src/logging.rs
+++ b/crates/goose-cli/src/logging.rs
@@ -180,9 +180,9 @@ fn setup_logging_internal(
 mod tests {
     use super::*;
     use chrono::TimeZone;
+    use rand;
     use std::env;
     use tempfile::TempDir;
-    use test_case::test_case;
 
     fn setup_temp_home() -> TempDir {
         let temp_dir = TempDir::new().unwrap();
@@ -209,16 +209,24 @@ mod tests {
     }
 
     #[tokio::test]
-    #[test_case(Some("test_session"), true ; "with session name and error capture")]
-    #[test_case(Some("test_session"), false ; "with session name without error capture")]
-    #[test_case(None, false ; "without session name")]
-    async fn test_log_file_name(session_name: Option<&str>, _with_error_capture: bool) {
+    async fn test_log_file_name_session_with_error_capture() {
+        do_test_log_file_name(Some("test_session_with_error"), true).await;
+    }
+
+    #[tokio::test]
+    async fn test_log_file_name_session_without_error_capture() {
+        do_test_log_file_name(Some("test_session_without_error"), false).await;
+    }
+
+    #[tokio::test]
+    async fn test_log_file_name_no_session() {
+        do_test_log_file_name(None, false).await;
+    }
+
+    async fn do_test_log_file_name(session_name: Option<&str>, _with_error_capture: bool) {
         // Create a unique test directory for each test
         let test_name = session_name.unwrap_or("no_session");
-        let random_suffix = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .subsec_nanos();
+        let random_suffix = rand::random::<u32>() % 100000000;
         let test_dir = PathBuf::from(format!(
             "/tmp/goose_test_home_{}_{}",
             test_name, random_suffix


### PR DESCRIPTION
The `logging::tests::test_log_file_name` often fail flakily. Run `cargo test logging::tests::test_log_file_name` to see.

I found 3 issues:
- The combination of [tokio::test] and [test_case] seemed to be causing each test to be running twice with the same parameters increase the chances of folder/file collisions
- Two of the test cases used the same session name
- The test directory suffix was based on nano seconds which is less likely than random numbers to be unique

This PR changes each of those issues so now tests only run once, use unique session names and a suffix based on random numbers. I'm not sure I got all the sources of flakiness but it seems to be much more reliable.