### PR TITLE
feat: list Databricks-supported models and enable fuzzy search during model configuration

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -351,6 +351,7 @@ pub async fn configure_provider_dialog() -> Result<bool, Box<dyn Error>> {
                     .map(|m| (m, m.as_str(), ""))
                     .collect::<Vec<_>>(),
             )
+            .filter_mode() // enable "fuzzy search" filtering for the list of models
             .interact()?
             .to_string(),
         Ok(None) => {


### PR DESCRIPTION
This PR adds the following changes:

- implement the `fetch_supported_models_async` function for the Databricks provider. this allows users to interactively select their model during configuration, instead of needing to know the model name ahead of time and typing it in manually. This aligns with how most of the other provider interfaces are implemented (e.g. [openai.rs](https://github.com/block/goose/blob/main/crates/goose/src/providers/openai.rs#L183), [anthropic.rs](https://github.com/block/goose/blob/main/crates/goose/src/providers/anthropic.rs#L191)). In case of error we return `None` so the prompt can still fall back to manual input 
- enable "fuzzy search" filtering on the `cliclack` prompt. this allows users to type a fuzzy match query against the list of provider models that will dynamically filter the results, making it easier to find the model they're looking for since the lists of supported models can be quite long (e.g. OpenAI provider has 587 supported models, Databricks has 104 supported models)

Before this change, Databricks provider model names must be manually input:
```bash
┌   goose-configure
│
◇  What would you like to configure?
│  Configure Providers
│
◇  Which model provider should we use?
│  Databricks
│
●  DATABRICKS_HOST is already configured
│
◇  Would you like to update this value?
│  No
│
◇  Model fetch complete
│
◆  Enter a model from that provider:
│  databricks-claude-3-7-sonnet (default)
``` 

After this change, Databricks provider model can be chosen interactively:
```bash
   goose-configure
│
◇  What would you like to configure?
│  Configure Providers
│
◇  Which model provider should we use?
│  Databricks
│
●  DATABRICKS_HOST is already configured
│
◇  Would you like to update this value?
│  No
│
◇  Model fetch complete
│
◆  Select a model:
│
│  ● baxen-migration-demo
│  ○ big-hack
│  ○ case_history_hackweek
│  ○ case-history-checker
│  ○ claude-3-5-haiku
│  ○ claude-3-5-sonnet
│  ○ claude-3-5-sonnet-2
│  ○ claude-3-7-sonnet
.......
```

And can also be fuzzy searched (e.g. `databricks-`):
```bash
┌   goose-configure
│
◇  What would you like to configure?
│  Configure Providers
│
◇  Which model provider should we use?
│  Databricks
│
●  DATABRICKS_HOST is already configured
│
◇  Would you like to update this value?
│  No
│
◇  Model fetch complete
│
◆  Select a model:
│  databricks-
│  ● databricks-gte-large-en
│  ○ databricks-bge-large-en
│  ○ databricks-claude-sonnet-4
│  ○ databricks-llama-4-maverick
│  ○ databricks-claude-3-7-sonnet
```