### PR TITLE
feat: add integration test coverage for tool use with enum argument

### DIFF
--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -172,10 +172,7 @@ impl ProviderTester {
             .expect("Expected successful tool_call");
 
         assert_eq!(tool_call.name, "get_weather");
-        assert_eq!(
-            tool_call.arguments.get("location").and_then(|v| v.as_str()),
-            Some("San Francisco, CA")
-        );
+        
         assert_eq!(
             tool_call.arguments.get("unit").and_then(|v| v.as_str()),
             Some("celsius")
@@ -183,9 +180,19 @@ impl ProviderTester {
 
         let id = &tool_request.id;
 
-        let weather_response_content = "The weather in San Francisco is 15 degrees celsius.";
-        let weather = Message::user()
-            .with_tool_response(id, Ok(vec![Content::text(weather_response_content)]));
+        let weather = Message::user().with_tool_response(
+            id,
+            Ok(vec![Content::text(
+                "
+                  50°F°C
+                  Precipitation: 0%
+                  Humidity: 84%
+                  Wind: 2 mph
+                  Weather
+                  Saturday 9:00 PM
+                  Clear",
+            )]),
+        );
 
         // Verify we construct a valid payload including the request/response pair for the next inference
         let (response2, _) = self
@@ -207,17 +214,6 @@ impl ProviderTester {
                 .iter()
                 .any(|content| matches!(content, MessageContent::Text(_))),
             "Expected text for final response"
-        );
-
-        let final_text = response2
-            .content
-            .iter()
-            .find_map(|content| content.as_text().map(String::from))
-            .unwrap_or_default();
-
-        assert!(
-            final_text.contains("15") && final_text.contains("celsius"),
-            "Final response should contain the weather information"
         );
 
         Ok(())


### PR DESCRIPTION
## Issue 

https://github.com/block/goose/issues/2983 

Cross-posting my[ comment](https://github.com/block/goose/issues/2983#issuecomment-3002942321) on that issue:

![Screenshot 2025-06-24 at 8 58 09 PM](https://github.com/user-attachments/assets/3ee34a13-bfb7-45e3-a4ba-24bd4747917a)

## Description

Add test coverage to demo that tool usage with enum arguments is already handled and prevent future regressions:

1. Add test case when `get_weather` tool requires both a "location" property of type string as well as an "unit" property of type enum
2. "What's the weather like in San Francisco in celsius?" prompt.
3. Tool call includes the "unit" property with value celsius. I.e. the application can invoke the use of the tool with a parameter matching one of the enum values.

## Test Plan

Run integration tests with LLM providers:

1) Google
```
danielzayas ~/Development/goose [zayas/enum-literal] $ cargo test --test providers test_google_provider -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.59s
     Running tests/providers.rs (target/debug/deps/providers-2e3075804c07fa08)

running 1 test
=== Google::reponse1 ===
[crates/goose/tests/providers.rs:151:9] &response1 = Message {
    role: Assistant,
    created: 1750826030,
    content: [
        ToolRequest(
            ToolRequest {
                id: "r16pTCH4",
                tool_call: Ok(
                    ToolCall {
                        name: "get_weather",
                        arguments: Object {
                            "location": String("San Francisco, CA"),
                            "unit": String("celsius"),
                        },
                    },
                ),
            },
        ),
    ],
}
===================
=== Google::reponse2 ===
[crates/goose/tests/providers.rs:201:9] &response2 = Message {
    role: Assistant,
    created: 1750826031,
    content: [
        Text(
            TextContent {
                text: "The weather in San Francisco is 15 degrees celsius.\n",
                annotations: None,
            },
        ),
    ],
}
===================
=== Google::context_length_exceeded_error ===
[crates/goose/tests/providers.rs:255:9] &result = Err(
    ContextLengthExceeded(
        "The input token count (1300117) exceeds the maximum number of tokens allowed (1048575).",
    ),
)
===================
test test_google_provider ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 8.36s


============== Providers ==============
✅ Google
=======================================
```

2) OpenAI
```
$ cargo test --test providers test_openai_provider -- --nocapture
   Compiling goose v1.0.29 (/Users/danielzayas/Development/goose/crates/goose)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1.85s
     Running tests/providers.rs (target/debug/deps/providers-2e3075804c07fa08)

running 1 test
=== OpenAI::reponse1 ===
[crates/goose/tests/providers.rs:151:9] &response1 = Message {
    role: Assistant,
    created: 1750826419,
    content: [
        ToolRequest(
            ToolRequest {
                id: "call_Ifm6p6JYo93MaxomI320pwy7",
                tool_call: Ok(
                    ToolCall {
                        name: "get_weather",
                        arguments: Object {
                            "location": String("San Francisco, CA"),
                            "unit": String("celsius"),
                        },
                    },
                ),
            },
        ),
    ],
}
===================
=== OpenAI::reponse2 ===
[crates/goose/tests/providers.rs:206:9] &response2 = Message {
    role: Assistant,
    created: 1750826420,
    content: [
        Text(
            TextContent {
                text: "The weather in San Francisco is currently 15 degrees Celsius.",
                annotations: None,
            },
        ),
    ],
}
===================
=== OpenAI::context_length_exceeded_error ===
[crates/goose/tests/providers.rs:260:9] &result = Err(
    ContextLengthExceeded(
        "This model's maximum context length is 128000 tokens. However, your messages resulted in 300102 tokens. Please reduce the length of the messages.",
    ),
)
===================
test test_openai_provider ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 12 filtered out; finished in 3.17s


============== Providers ==============
✅ OpenAI
=======================================
```

3) Databricks
```
$ cargo test --test providers test_databricks_provider -- --nocapture
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.56s
     Running tests/providers.rs (target/debug/deps/providers-2e3075804c07fa08)

running 2 tests
=== Databricks::reponse1 ===
[crates/goose/tests/providers.rs:151:9] &response1 = Message {
    role: Assistant,
    created: 1750826439,
    content: [
        Text(
            TextContent {
                text: "I'll check the current weather in San Francisco for you in Celsius.",
                annotations: None,
            },
        ),
        ToolRequest(
            ToolRequest {
                id: "toolu_bdrk_01JeGUGrhouwAe1kczmem3QQ",
                tool_call: Ok(
                    ToolCall {
                        name: "get_weather",
                        arguments: Object {
                            "location": String("San Francisco, CA"),
                            "unit": String("celsius"),
                        },
                    },
                ),
            },
        ),
    ],
}
===================
=== Databricks OAuth::reponse1 ===
[crates/goose/tests/providers.rs:151:9] &response1 = Message {
    role: Assistant,
    created: 1750826439,
    content: [
        Text(
            TextContent {
                text: "I'll check the current weather in San Francisco for you in Celsius.",
                annotations: None,
            },
        ),
        ToolRequest(
            ToolRequest {
                id: "toolu_bdrk_01S6NSXXVQrUcF9crFwnG9sm",
                tool_call: Ok(
                    ToolCall {
                        name: "get_weather",
                        arguments: Object {
                            "location": String("San Francisco, CA"),
                            "unit": String("celsius"),
                        },
                    },
                ),
            },
        ),
    ],
}
===================
=== Databricks::reponse2 ===
[crates/goose/tests/providers.rs:206:9] &response2 = Message {
    role: Assistant,
    created: 1750826440,
    content: [
        Text(
            TextContent {
                text: "The current weather in San Francisco is 15 degrees Celsius. Is there anything else about the weather you'd like to know?",
                annotations: None,
            },
        ),
    ],
}
===================
=== Databricks OAuth::reponse2 ===
[crates/goose/tests/providers.rs:206:9] &response2 = Message {
    role: Assistant,
    created: 1750826441,
    content: [
        Text(
            TextContent {
                text: "The current weather in San Francisco is 15 degrees Celsius. Let me know if you need any other weather information!",
                annotations: None,
            },
        ),
    ],
}
===================
=== Databricks::context_length_exceeded_error ===
[crates/goose/tests/providers.rs:260:9] &result = Err(
    ContextLengthExceeded(
        "{\"error_code\":\"bad_request\",\"message\":\"{\\\"message\\\":\\\"input is too long for requested model.\\\"}\"}",
    ),
)
===================
test test_databricks_provider ... ok
=== Databricks OAuth::context_length_exceeded_error ===
[crates/goose/tests/providers.rs:260:9] &result = Err(
    ContextLengthExceeded(
        "{\"error_code\":\"bad_request\",\"message\":\"{\\\"message\\\":\\\"input is too long for requested model.\\\"}\"}",
    ),
)
===================
test test_databricks_provider_oauth ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 11 filtered out; finished in 7.03s


============== Providers ==============
✅ Databricks
✅ Databricks OAuth
=======================================
```