### PR TITLE
feat (cli): list Groq-supported models

### DIFF
--- a/crates/goose/src/providers/groq.rs
+++ b/crates/goose/src/providers/groq.rs
@@ -190,8 +190,8 @@ impl Provider for GroqProvider {
                 .get("data")
                 .and_then(|v| v.as_array())
                 .ok_or_else(|| {
-                ProviderError::UsageError("Missing or invalid `data` field in response".into())
-            })?;
+                    ProviderError::UsageError("Missing or invalid `data` field in response".into())
+                })?;
 
             let mut model_names: Vec<String> = data
                 .iter()


### PR DESCRIPTION
Inspired by #3039, this pull request introduces a new asynchronous method to fetch supported models from the Groq API in the `GroqProvider` implementation. The method handles request construction, error responses, and extracts model names from the API response. Now user can choose Groq provider models interactively! [Related docs](https://console.groq.com/docs/models)


### New functionality for fetching supported models:

* [`crates/goose/src/providers/groq.rs`](diffhunk://#diff-32279a141d1b425b76ff7bbad62f02bf94a4315f0735e86d2eaf7f7977989e61R154-R203): Added the `fetch_supported_models_async` method to the `GroqProvider` implementation. This method constructs a request to the Groq API's models endpoint, handles authentication and error responses, and extracts and returns a sorted list of model names if the request is successful.

### After
![Screenshot 2025-06-24 002207](https://github.com/user-attachments/assets/bd272351-d532-4017-a420-b412c965cc63)