### PR TITLE
Update download_cli.sh to support arbitrary Goose versions

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -15,6 +15,7 @@ set -eu
 #
 # Environment variables:
 #   GOOSE_BIN_DIR  - Directory to which Goose will be installed (default: $HOME/.local/bin)
+#   GOOSE_VERSION  - Optional: specific version to install (e.g., "v1.0.25"). Overrides CANARY. Can be in the format vX.Y.Z, vX.Y.Z-suffix, or X.Y.Z
 #   GOOSE_PROVIDER - Optional: provider for goose
 #   GOOSE_MODEL    - Optional: model for goose
 #   CANARY         - Optional: if set to "true", downloads from canary release instead of stable
@@ -41,8 +42,20 @@ REPO="block/goose"
 OUT_FILE="goose"
 GOOSE_BIN_DIR="${GOOSE_BIN_DIR:-"$HOME/.local/bin"}"
 RELEASE="${CANARY:-false}"
-RELEASE_TAG="$([[ "$RELEASE" == "true" ]] && echo "canary" || echo "stable")"
 CONFIGURE="${CONFIGURE:-true}"
+if [ -n "${GOOSE_VERSION:-}" ]; then
+  # Validate the version format
+  if [[ ! "$GOOSE_VERSION" =~ ^v?[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+    echo "[error]: invalid version '$GOOSE_VERSION'."
+    echo "  expected: semver format vX.Y.Z, vX.Y.Z-suffix, or X.Y.Z"
+    exit 1
+  fi
+  GOOSE_VERSION=$(echo "$GOOSE_VERSION" | sed 's/^v\{0,1\}/v/') # Ensure the version string is prefixed with 'v' if not already present
+  RELEASE_TAG="$GOOSE_VERSION"
+else
+  # If GOOSE_VERSION is not set, fall back to existing behavior for backwards compatibility
+  RELEASE_TAG="$([[ "$RELEASE" == "true" ]] && echo "canary" || echo "stable")"
+fi
 
 # --- 3) Detect OS/Architecture ---
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')


### PR DESCRIPTION
Add a `GOOSE_VERSION` environment variable to the `download_cli.sh` install script to support installing arbitrary versions of Goose

This is a convenience to allow for integration testing of specific Goose versions to validate backwards compatibility. We verify the input version string is valid semver and prefix with `v` if not already present

`GOOSE_VERSION` is used with/without quotes, and the `v` prefix is auto added:
```bash
🐚 ~/Development/goose-fork wpfleger/support-install-versions GOOSE_VERSION=1.0.27 bash download_cli.sh 
Downloading v1.0.27 release: goose-aarch64-apple-darwin.tar.bz2...
Extracting goose-aarch64-apple-darwin.tar.bz2 to temporary directory...
```
```bash
🐚 ~/Development/goose-fork wpfleger/support-install-versions GOOSE_VERSION="1.0.27" bash download_cli.sh
Downloading v1.0.27 release: goose-aarch64-apple-darwin.tar.bz2...
Extracting goose-aarch64-apple-darwin.tar.bz2 to temporary directory...
```
```bash
🐚 ~/Development/goose-fork wpfleger/support-install-versions GOOSE_VERSION=v1.0.27 bash download_cli.sh 
Downloading v1.0.27 release: goose-aarch64-apple-darwin.tar.bz2...
Extracting goose-aarch64-apple-darwin.tar.bz2 to temporary directory...
Moving goose to /Users/wpfleger/.local/bin/goose
```
```bash
🐚 ~/Development/goose-fork wpfleger/support-install-versions GOOSE_VERSION="v1.0.27" bash download_cli.sh
Downloading v1.0.27 release: goose-aarch64-apple-darwin.tar.bz2...
Extracting goose-aarch64-apple-darwin.tar.bz2 to temporary directory...
```

Omitting `GOOSE_VERSION` still defaults to the latest stable release:
```bash
🐚 ~/Development/goose-fork wpfleger/support-install-versions bash download_cli.sh 
Downloading stable release: goose-aarch64-apple-darwin.tar.bz2...
Extracting goose-aarch64-apple-darwin.tar.bz2 to temporary directory...
```

And `CANARY` takes precedence:
```bash
🐚 ~/Development/goose-fork wpfleger/support-install-versions CANARY=true bash download_cli.sh 
Downloading canary release: goose-aarch64-apple-darwin.tar.bz2...
Extracting goose-aarch64-apple-darwin.tar.bz2 to temporary directory...
```