### PR TITLE
fix(temporal-service): makes the search for possible temporal paths parallel.

### DIFF
--- a/temporal-service/main.go
+++ b/temporal-service/main.go
@@ -13,6 +13,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -199,22 +200,45 @@ func findTemporalCLI() (string, error) {
 
 	log.Printf("Checking %d possible paths for temporal CLI", len(possiblePaths))
 
-	// Test each possible path
+	// Check all possible paths in parallel, pick the first one that works.
+	pathFound := make(chan string)
+	var wg sync.WaitGroup
+	// This allows us to cancel whatever remaining work is done when we find a valid path.
+	psCtx, psCancel := context.WithCancel(context.Background())
 	for i, path := range possiblePaths {
-		log.Printf("Checking path %d/%d: %s", i+1, len(possiblePaths), path)
-		if _, err := os.Stat(path); err == nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			log.Printf("Checking path %d/%d: %s", i+1, len(possiblePaths), path)
+			if _, err := os.Stat(path); err != nil {
+				log.Printf("File does not exist at %s: %v", path, err)
+			}
 			log.Printf("File exists at: %s", path)
 			// File exists, test if it's executable and the right binary
-			cmd := exec.Command(path, "--version")
-			if err := cmd.Run(); err == nil {
-				log.Printf("Successfully verified temporal CLI at: %s", path)
-				return path, nil
-			} else {
+			cmd := exec.CommandContext(psCtx, path, "--version")
+			if err := cmd.Run(); err != nil {
 				log.Printf("Failed to verify temporal CLI at %s: %v", path, err)
 			}
-		} else {
-			log.Printf("File does not exist at %s: %v", path, err)
-		}
+			select {
+			case pathFound <- path:
+				log.Printf("Successfully verified temporal CLI at: %s", path)
+			case <-psCtx.Done():
+				// No need to report the path not chosen.
+			}
+		}()
+	}
+	// We transform the workgroup wait into a channel so we can wait for either this or pathFound
+	pathNotFound := make(chan bool)
+	go func() {
+		wg.Wait()
+		pathNotFound <- true
+	}()
+	select {
+	case path := <-pathFound:
+		psCancel() // Cancel the remaining search functions otherwise they'll just exist eternally.
+		return path, nil
+	case <-pathNotFound:
+		// No need to do anything, this just says that none of the functions were able to do it and there's nothing left to cleanup
 	}
 
 	return "", fmt.Errorf("temporal CLI not found in PATH or any of the expected locations: %v", possiblePaths)


### PR DESCRIPTION
The serialized nature of it meant that even a slightly larger than
expected delay could quickly add up to enough to trigger timeouts
consistently. Since these operations are highly IO bound there's no
reason not to run them all asynchronously.
