### PR TITLE
docs: typo - wrong extension id

### DIFF
--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -304,7 +304,7 @@ For advanced users, you can also directly edit the config file (`~/.config/goose
 
 ```yaml
 extensions:
-  fetch:
+  github:
     name: GitHub
     cmd: npx
     args: [-y @modelcontextprotocol/server-github]


### PR DESCRIPTION
This pull request updates the documentation to reflect a change in the configuration file for extensions, specifically replacing the `fetch` extension with a `github` extension.

* [`documentation/docs/getting-started/using-extensions.md`](diffhunk://#diff-51503ee9089502f4a3c4577a1ee0d5f4f09b616d6226c8eb076d358d5950c1caL307-R307): Updated the example configuration file to use the `github` extension instead of the `fetch` extension, with corresponding updates to the `name`, `cmd`, and `args` fields.