### PR TITLE
feat(ui): Add drag and drop support for opening sessions from finder.

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -21,6 +21,18 @@ let cfg = {
       schemes: ["goose"]
     }
   ],
+  // macOS Info.plist extensions for drag-and-drop support
+  extendInfo: {
+    // Document types for drag-and-drop support onto dock icon
+    CFBundleDocumentTypes: [
+      {
+        CFBundleTypeName: "Folders",
+        CFBundleTypeRole: "Viewer", 
+        LSHandlerRank: "Alternate",
+        LSItemContentTypes: ["public.directory", "public.folder"]
+      }
+    ]
+  },
   // macOS specific configuration
   osxSign: {
     entitlements: 'entitlements.plist',


### PR DESCRIPTION
introduces drag-and-drop support for macOS, this will allow us to drag a folder over the app icon in the doc and open a new window setup with the location of the folder.

### Drag-and-Drop Support for macOS:
* Added `CFBundleDocumentTypes` to `extendInfo` in `forge.config.ts` to define document types for drag-and-drop onto the dock icon, supporting folders and directories (`ui/desktop/forge.config.ts`).
* Implemented event listeners in `main.ts` to handle drag-and-drop actions, including `open-file` and `open-files` events for opening files or folders dropped onto the dock icon. Added a helper function `handleFileOpen` to manage these interactions (`ui/desktop/src/main.ts`).


https://github.com/user-attachments/assets/a4bdcd05-8cf3-4938-b8db-78970077d0af

