### PR TITLE
feat: add ability to create new directory in working dir selection

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -678,7 +678,7 @@ const openDirectoryDialog = async (
   replaceWindow: boolean = false
 ): Promise<OpenDialogReturnValue> => {
   const result = (await dialog.showOpenDialog({
-    properties: ['openFile', 'openDirectory'],
+    properties: ['openFile', 'openDirectory', 'createDirectory'],
   })) as unknown as OpenDialogReturnValue;
 
   if (!result.canceled && result.filePaths.length > 0) {


### PR DESCRIPTION
It is annoying to have to manually create a new directory outside goose if you want to work on something new.