### PR TITLE
Update linux instructions

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -90,8 +90,17 @@ import LinuxDesktopInstallButtons from '@site/src/components/LinuxDesktopInstall
         <LinuxDesktopInstallButtons/>
 
         <div style={{ marginTop: '1rem' }}>
-          1. Extract the downloaded tar.bz2 file.
-          2. Run the executable file to launch the Goose Desktop application.
+          **For Debian/Ubuntu-based distributions:**
+          1. Download the DEB file
+          2. Navigate to the directory where it is saved in a terminal
+          3. Run `sudo dpkg -i (filename).deb`
+          4. Launch Goose from the app menu
+
+          **For Red Hat/Fedora-based distributions:**
+          1. Download the RPM file
+          2. Navigate to the directory where it is saved in a terminal
+          3. Run `sudo dnf install (filename).rpm` or `sudo rpm -i (filename).rpm`
+          4. Launch Goose from the app menu
 
           :::tip Updating Goose
           It's best to keep Goose updated by periodically running the installation steps again.

--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -95,13 +95,7 @@ import LinuxDesktopInstallButtons from '@site/src/components/LinuxDesktopInstall
           2. Navigate to the directory where it is saved in a terminal
           3. Run `sudo dpkg -i (filename).deb`
           4. Launch Goose from the app menu
-
-          **For Red Hat/Fedora-based distributions:**
-          1. Download the RPM file
-          2. Navigate to the directory where it is saved in a terminal
-          3. Run `sudo dnf install (filename).rpm` or `sudo rpm -i (filename).rpm`
-          4. Launch Goose from the app menu
-
+          
           :::tip Updating Goose
           It's best to keep Goose updated by periodically running the installation steps again.
           :::

--- a/documentation/docs/guides/updating-goose.md
+++ b/documentation/docs/guides/updating-goose.md
@@ -74,11 +74,6 @@ The Goose CLI and desktop apps are under active and continuous development. To g
           4. Run `sudo dpkg -i (filename).deb`
           5. Launch Goose from the app menu
 
-          **For Red Hat/Fedora-based distributions:**
-          2. Download the RPM file
-          3. Navigate to the directory where it is saved in a terminal
-          4. Run `sudo dnf install (filename).rpm` or `sudo rpm -i (filename).rpm`
-          5. Launch Goose from the app menu
         </div>
       </TabItem>
       <TabItem value="cli" label="Goose CLI">

--- a/documentation/docs/guides/updating-goose.md
+++ b/documentation/docs/guides/updating-goose.md
@@ -67,10 +67,18 @@ The Goose CLI and desktop apps are under active and continuous development. To g
         :::
         <div style={{ marginTop: '1rem' }}>
           1. <LinuxDesktopInstallButtons/>
-          2. Extract the downloaded tar.bz2 file.
-          3. Run the executable file to launch the Goose Desktop application.
-          4. Overwrite the existing Goose application with the new version.
-          5. Run the executable file to launch the Goose Desktop application.
+          
+          **For Debian/Ubuntu-based distributions:**
+          2. Download the DEB file
+          3. Navigate to the directory where it is saved in a terminal
+          4. Run `sudo dpkg -i (filename).deb`
+          5. Launch Goose from the app menu
+
+          **For Red Hat/Fedora-based distributions:**
+          2. Download the RPM file
+          3. Navigate to the directory where it is saved in a terminal
+          4. Run `sudo dnf install (filename).rpm` or `sudo rpm -i (filename).rpm`
+          5. Launch Goose from the app menu
         </div>
       </TabItem>
       <TabItem value="cli" label="Goose CLI">

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -54,8 +54,17 @@ Let's begin 🚀
       <TabItem value="ui" label="Goose Desktop" default>
         <LinuxDesktopInstallButtons/>
         <div style={{ marginTop: '1rem' }}>
-          1. Extract the downloaded tar.bz2 file.
-          2. Run the executable file to launch the Goose Desktop application.
+          **For Debian/Ubuntu-based distributions:**
+          1. Download the DEB file
+          2. Navigate to the directory where it is saved in a terminal
+          3. Run `sudo dpkg -i (filename).deb`
+          4. Launch Goose from the app menu
+
+          **For Red Hat/Fedora-based distributions:**
+          1. Download the RPM file
+          2. Navigate to the directory where it is saved in a terminal
+          3. Run `sudo dnf install (filename).rpm` or `sudo rpm -i (filename).rpm`
+          4. Launch Goose from the app menu
         </div>
       </TabItem>
       <TabItem value="cli" label="Goose CLI">

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -60,11 +60,6 @@ Let's begin 🚀
           3. Run `sudo dpkg -i (filename).deb`
           4. Launch Goose from the app menu
 
-          **For Red Hat/Fedora-based distributions:**
-          1. Download the RPM file
-          2. Navigate to the directory where it is saved in a terminal
-          3. Run `sudo dnf install (filename).rpm` or `sudo rpm -i (filename).rpm`
-          4. Launch Goose from the app menu
         </div>
       </TabItem>
       <TabItem value="cli" label="Goose CLI">


### PR DESCRIPTION
This pull request updates the installation instructions for the Goose Desktop application across multiple documentation files to reflect a new installation process for Debian/Ubuntu-based distributions. The changes replace the previous tar.bz2 extraction method with steps for downloading and installing a DEB package.

### Installation Instructions Update:

* [`documentation/docs/getting-started/installation.md`](diffhunk://#diff-1da95befef448a968841697bffcbb8f9c53f1238842a36a63444ca5d4ea0499aL93-R97): Updated the installation steps for Debian/Ubuntu-based distributions to include downloading a DEB file, navigating to it in a terminal, running `sudo dpkg -i (filename).deb`, and launching Goose from the app menu.
* [`documentation/docs/guides/updating-goose.md`](diffhunk://#diff-73634242804f8cf84d6a17bd17773e3dbe74d393409f94c6e7a64b83d7842a9bL70-R76): Replaced the old tar.bz2 extraction and overwrite instructions with the new DEB package installation steps for Debian/Ubuntu-based distributions.
* [`documentation/docs/quickstart.md`](diffhunk://#diff-705849878fb66d2c4fd70c10e053e7d408dccc37915537db5da0102ad020e4d5L57-R62): Modified the quickstart guide to reflect the updated DEB package installation process for Debian/Ubuntu-based distributions.