### PR TITLE
feat(ui): Source CashSans-Bold and improve overall text rendering

### DIFF
--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -249,6 +249,16 @@
 }
 
 @font-face {
+  font-family: 'Cash Sans';
+  src:
+    url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSans-Bold.woff2)
+      format('woff2'),
+    url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff/CashSans-Bold.woff) format('woff');
+  font-weight: 700;
+  font-style: normal;
+}
+
+@font-face {
   font-family: 'Cash Sans Mono';
   src:
     url(https://cash-f.squarecdn.com/static/fonts/cashsans/woff2/CashSansMono-Regular.woff2)
@@ -485,6 +495,8 @@
 
 body {
   background-color: var(--background-app);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
 }
 
 .word-break {


### PR DESCRIPTION
## Problem 

Previously, text (especially bolded text) could appear blurry. Goose told me that was likely due to a combination of default rendering settings and the potential for “faux bolding” when a true bold font weight was not available.

## Changes Implemented

1.  Added `@font-face` for Cash Sans Bold
    *   Using the `CashSans-Bold.woff` and `CashSans-Bold.woff2` font files. This makes a true bold variant of the Cash Sans font family available to Goose.app.

2.  Enhanced Global Text Rendering
    *   The following CSS properties have been applied globally to the `body` element in `main.css`:
        *   `-webkit-font-smoothing: antialiased;`: Improves font sharpness and clarity on macOS by enabling grayscale antialiasing.
        *   `text-rendering: optimizeLegibility;`: Instructs the browser to prioritize legibility, enabling features like kerning and ligatures for a more refined text appearance.

All text should now look crisper and easier to read, especially bold text.

## Open Question

**What combination of these settings do Goose designers prefer?** I’ve added both, but we could instead take either one (or neither and close the PR). See _Demos_ for combinations.

## Demos

_Click the images to open in a new tab, so you can zoom to 100% and not get resizing blurriness._

### Before
![Goose’s bold text is blurry](https://github.com/user-attachments/assets/ee5b9cb4-cc0e-40e4-9bfd-057fa7038ce4)

![Goose’s blurry bold text at 6x zoom](https://github.com/user-attachments/assets/00a72e09-01e1-4a84-973a-1fdfdf90e22e)

### Choices

original: no -Bold and NOT antialiased

![original (no -Bold and NOT antialiased)](https://github.com/user-attachments/assets/f5f0dbdb-beb3-4e73-be5b-af11e8942f1f)

CashSans-Bold antialiased 👈🏼 **This** is what I’m proposing.

![CashSans-Bold antialiased](https://github.com/user-attachments/assets/05e5f4a5-cc33-40bb-a92e-dc056911180e)

antialiased, no -Bold

![antialiased, no -Bold](https://github.com/user-attachments/assets/7fcc79a2-2bf6-4515-9aec-8bc7c488e108)

CashSans-Bold NOT antialiased

![CashSans-Bold NOT antialiased](https://github.com/user-attachments/assets/4b47a75a-9872-4c15-9f74-ef1f1a12bd41)
