### PR TITLE
fix: add maintainer, homepage and categories to DEB/RPM package config

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -27,7 +27,7 @@ let cfg = {
     CFBundleDocumentTypes: [
       {
         CFBundleTypeName: "Folders",
-        CFBundleTypeRole: "Viewer", 
+        CFBundleTypeRole: "Viewer",
         LSHandlerRank: "Alternate",
         LSItemContentTypes: ["public.directory", "public.folder"]
       }
@@ -85,6 +85,9 @@ module.exports = {
       config: {
         name: 'Goose',
         bin: 'Goose',
+        maintainer: 'Block, Inc.',
+        homepage: 'https://block.github.io/goose/',
+        categories: ['Development']
       },
     },
     {
@@ -92,6 +95,9 @@ module.exports = {
       config: {
         name: 'Goose',
         bin: 'Goose',
+        maintainer: 'Block, Inc.',
+        homepage: 'https://block.github.io/goose/',
+        categories: ['Development']
       },
     },
   ],


### PR DESCRIPTION
Add missing package metadata fields to Electron Forge configuration:
- maintainer: 'Block, Inc.'
- homepage: 'https://block.github.io/goose/'
- categories: ['Development']

This resolves the `dpkg` warning about missing 'Maintainer' field when installing packages with `apt`:
```
dpkg: warning: parsing file '/var/lib/dpkg/status' near line ####
package 'goose': missing 'Maintainer' field
```

There are plenty of additional options to bikeshed in [MakerRpmConfigOptions](https://github.com/electron/forge/blob/9f35bdea87fe0df5b2566b74ff909f2f037ef556/packages/maker/rpm/src/Config.ts#L1) and [MakerDebConfigOptions](https://github.com/electron/forge/blob/9f35bdea87fe0df5b2566b74ff909f2f037ef556/packages/maker/deb/src/Config.ts#L1), but this is more than sufficient to resolve the warning and put Goose in the _Development_ category in the menu rather than just in _All_.