### PR TITLE
feat(desktop): Prioritize suffix when truncating path in header

### DIFF
--- a/ui/desktop/src/components/more_menu/MoreMenuLayout.tsx
+++ b/ui/desktop/src/components/more_menu/MoreMenuLayout.tsx
@@ -41,11 +41,21 @@ export default function MoreMenuLayout({
                       window.electron.directoryChooser(true);
                     }
                   }}
+                  style={{ minWidth: 0 }}
                 >
                   <Document className="mr-1" />
-                  <div className="max-w-[200px] truncate [direction:rtl]">
+                  <span
+                    className="flex-grow block text-ellipsis overflow-hidden"
+                    style={{
+                      direction: 'rtl',
+                      textAlign: 'left',
+                      unicodeBidi: 'plaintext',
+                      minWidth: 0,
+                      maxWidth: '100%',
+                    }}
+                  >
                     {String(window.appConfig.get('GOOSE_WORKING_DIR'))}
-                  </div>
+                  </span>
                 </button>
               </TooltipTrigger>
               <TooltipContent className="max-w-96 overflow-auto scrollbar-thin" side="top">


### PR DESCRIPTION
## Summary
For long file paths, the last segments (e.g. the current directory) are typically the most relevant.  
We now truncate from the **start** of the path instead of the end, so users see the meaningful suffix rather than a generic unchanging prefix like `/Users/foo/`.


## Old Behavior
- Path Field was a fixed size
- If the path did not fit, Truncated the most useful information from the end of the string


## New Behavior
- Path field grows to fit the path if there is room to do so
- If the path still does not fit, Truncate from the beginning of the string


## Changes
- **RTL truncation** (`direction: rtl`)  
  - Makes text truncate from the left, keeping the rightmost (suffix) part visible.
- **`unicode-bidi: plaintext`**
  - Prevents path segments from rendering out of order when using RTL.
- **Switched `<div>` to `<span>`**
  - Inline behavior avoids unnecessary layout constraints.
- **Added `flex-grow` + `min-width: 0`**
  - Ensures the path container shrinks and grows properly in flex layouts.
- **Applied `overflow-hidden` + `text-ellipsis`**
  - Enables clean truncation without layout overflow.
