### PR TITLE
fix: Make the entire toolcall argument row clickable to expand

### DIFF
--- a/ui/desktop/src/components/ToolCallArguments.tsx
+++ b/ui/desktop/src/components/ToolCallArguments.tsx
@@ -39,20 +39,24 @@ export function ToolCallArguments({ args }: ToolCallArgumentsProps) {
 
       return (
         <div className="text-sm mb-2">
-          <div className="flex flex-row">
-            <span className="text-textSubtle min-w-[140px]">{key}</span>
+          <div className="flex flex-row items-start">
+            <button
+              onClick={() => toggleKey(key)}
+              className="text-left text-textSubtle min-w-[140px]"
+            >
+              {key}
+            </button>
             <div className="w-full flex justify-between items-start">
               {isExpanded ? (
                 <div className="">
                   <MarkdownContent content={value} className="text-sm text-textPlaceholder" />
                 </div>
               ) : (
-                <span className="text-textPlaceholder mr-2">{value.slice(0, 60)}...</span>
+                <button onClick={() => toggleKey(key)} className="text-textPlaceholder mr-2">
+                  {value.slice(0, 60)}...
+                </button>
               )}
-              <button
-                onClick={() => toggleKey(key)}
-                className="hover:opacity-75 text-textPlaceholder pr-2"
-              >
+              <button onClick={() => toggleKey(key)} className="text-textPlaceholder pr-2">
                 <Expand size={5} isExpanded={isExpanded} />
               </button>
             </div>

--- a/ui/desktop/src/components/ui/Expand.tsx
+++ b/ui/desktop/src/components/ui/Expand.tsx
@@ -3,7 +3,7 @@ import { ChevronUp } from 'lucide-react';
 export default function Expand({ size, isExpanded }: { size: number; isExpanded: boolean }) {
   return (
     <ChevronUp
-      className={`w-${size} h-${size} text-textPlaceholder transition-all origin-center ${isExpanded ? 'rotate-180' : 'rotate-90'}`}
+      className={`shrink-0 w-${size} h-${size} text-textPlaceholder transition-all origin-center ${isExpanded ? 'rotate-180' : 'rotate-90'}`}
     />
   );
 }


### PR DESCRIPTION
Make the entire ToolCallArgument row clickable to expand. This improves the UX and brings it inline with the other elements from ToolCallWithResponse.

### Enhancements to `ToolCallArguments` component:

* Updated the `ToolCallArguments` layout to make keys and truncated values clickable, enabling users to toggle expanded views directly by interacting with these elements.
* Adjusted the `flex` layout to ensure proper alignment of elements, improving visual consistency and usability.

### Refinements to `Expand` component:

* Added the `shrink-0` class to the `ChevronUp` icon to prevent resizing issues, ensuring the icon maintains its intended dimensions regardless of surrounding layout changes.