### PR TITLE
fix: Prevent modal from closing on text select.

### DIFF
--- a/ui/desktop/src/components/Modal.tsx
+++ b/ui/desktop/src/components/Modal.tsx
@@ -28,7 +28,8 @@ export default function Modal({
     if (
       modalRef.current &&
       !modalRef.current.contains(e.target as Node) &&
-      !(e.target as HTMLElement).closest('.select__menu')
+      !(e.target as HTMLElement).closest('.select__menu') &&
+      window.getSelection()?.toString().length === 0 // Ensure no text is selected
     ) {
       onClose();
     }


### PR DESCRIPTION
This fixes a small UI issue where an open modal closes when selecting text for editing. To illustrate, here is the current behavior for when you select text and move your cursor off the open modal

https://github.com/user-attachments/assets/8d5954e3-60bf-40af-a238-e3ed040d11b3


The modal gets closed even though I'm just trying to select text to edit the value. I don't think the modal should close in this scenario. This fix adds a check to see if text is currently selected to prevent closing the modal. Here is the new behavior


https://github.com/user-attachments/assets/23acf8f9-1c71-4f92-9692-1f3e73f8b899