### PR TITLE
feat: add GitHub Actions workflows for automatic labeling of PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,58 @@
+# This file is used by GitHub Actions to automatically label pull requests based on the files changed.
+# See https://github.com/actions/labeler
+
+# Documentation changes
+documentation:
+  - changed-files:
+      - any-glob-to-any-file: 
+          - '**/*.md'
+          - 'documentation/**/*'
+
+# CLI-related changes
+cli:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'crates/goose-cli/**/*'
+
+# Rust backend changes
+rust:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'crates/**/*'
+          - '**/*.rs'
+
+# UI/Desktop application changes
+ui:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'ui/desktop/**/*'
+          - '**/*.tsx'
+          - '**/*.ts'
+          - '**/*.js'
+          - '**/*.jsx'
+
+# Windows-specific changes
+windows:
+  - changed-files:
+      - any-glob-to-any-file:
+          - 'ui/desktop/src/platform/windows/**/*'
+          - '**/*windows*'
+          - '**/*.bat'
+          - '**/*.ps1'
+
+# Dependency updates
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - '**/Cargo.toml'
+          - '**/Cargo.lock'
+          - '**/package.json'
+          - '**/package-lock.json'
+          - '**/yarn.lock'
+          - '**/pnpm-lock.yaml'
+
+
+# Demonstration of labeler for initial Pull Request commit
+labeler:
+  - changed-files:
+      - any-glob-to-any-file: '.github/labeler.yml'

--- a/.github/workflows/add-labels.yml
+++ b/.github/workflows/add-labels.yml
@@ -1,0 +1,20 @@
+name: Add Labels
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add_labels_on_opened:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Label PR (opened)
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          sync-labels: false

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,20 @@
+name: Sync Labels
+
+on:
+  pull_request:
+    types: [synchronize, reopened]
+
+jobs:
+  sync_labels_on_updated:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Label PR (updated)
+        uses: actions/labeler@v5
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          sync-labels: true


### PR DESCRIPTION
Github supports organizing issues/pull requests using [labels](https://github.com/block/goose/labels).

This pull request introduces automated labeling for pull requests based on file changes, using GitHub Actions. It includes configuration for label rules, workflows to add labels when a pull request is opened, and workflows to synchronize labels when a pull request is updated or reopened.

### Configuration for automated labeling:
* [`.github/labeler.yml`](diffhunk://#diff-a22c263686553013feaeb0677d26eeb0b8778a756c4311c1fce13384258026aaR1-R58): Added rules to assign labels based on file paths and patterns, covering areas like documentation, CLI, Rust backend, UI/Desktop application, Windows-specific changes, and dependency updates.

### Workflows for applying and synchronizing labels:
* [`.github/workflows/add-labels.yml`](diffhunk://#diff-86037dc13a579c94d5fc266ffcba76a1d72cac443d52ecf3174e378c93003e84R1-R20): Created a workflow to apply labels to pull requests when they are opened, using the `actions/labeler` GitHub Action.
* [`.github/workflows/sync-labels.yml`](diffhunk://#diff-a877ed9f27d115d95934fd904f2475dcec6ce4125da686dd5b3c75a696fff1c6R1-R20): Created a workflow to synchronize labels on pull requests when they are updated or reopened, ensuring labels stay consistent with changes.