### PR TITLE
docs: cross reference recipe docs

### DIFF
--- a/documentation/docs/guides/recipes/index.md
+++ b/documentation/docs/guides/recipes/index.md
@@ -39,6 +39,11 @@ import styles from '@site/src/components/Card/styles.module.css';
       description="Complete technical reference for creating and customizing recipes in Goose via the CLI."
       link="/docs/guides/recipes/recipe-reference"
     />
+    <Card 
+      title="Goose Recipes Tutorial"
+      description="Learn how to create and use Goose recipes with prompts, parameters, MCP servers, and more."
+      link="/docs/tutorials/recipes-tutorial"
+    />
   </div>
 </div>
 

--- a/documentation/docs/tutorials/recipes-tutorial.md
+++ b/documentation/docs/tutorials/recipes-tutorial.md
@@ -1,5 +1,5 @@
 ---
-description: Learn how to create and use Goose recipes with this comprehensive tutorial covering prompts, parameters, MCP servers, and distribution
+description: Learn how to create and use Goose recipes with this comprehensive tutorial covering prompts, parameters, and MCP servers
 ---
 
 # Goose Recipes
@@ -126,9 +126,9 @@ Based on the UNESCO World Heritage site information and the current weather fore
 
 This itinerary takes you through three of Europe's most beautiful and culturally rich countries: France, Italy, and the Czech Republic. You'll experience world-class museums, UNESCO World Heritage sites, delicious cuisine, and vibrant local culture.
 
-## Day 1-3: Paris, France 🇫🇷
+#### Day 1-3: Paris, France 🇫🇷
 
-### Day 1: Arrival in Paris
+**Day 1: Arrival in Paris**
 - **Morning**: Arrive at Charles de Gaulle Airport, transfer to hotel
 - **Afternoon**: Leisurely walk along the Seine River, visit Notre-Dame Cathedral (exterior view due to reconstruction)
 - **Evening**: Dinner in the Latin Quarter (Budget: €30-40)
@@ -136,7 +136,7 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Pleasant temperatures around 27°C (81°F), partly cloudy
 
-### Day 2: Paris Highlights
+**Day 2: Paris Highlights**
 - **Morning**: Visit the Louvre Museum (Budget: €17)
 - **Afternoon**: Explore Tuileries Garden and Champs-Élysées
 - **Evening**: Eiffel Tower visit for sunset views (Budget: €26.80 for summit access)
@@ -145,7 +145,7 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Warm at 31°C (88°F), clear skies
 
-### Day 3: Versailles Day Trip
+**Day 3: Versailles Day Trip**
 - **Morning**: Day trip to Palace of Versailles, UNESCO World Heritage Site (Budget: €21 for palace access)
 - **Afternoon**: Explore the magnificent gardens
 - **Evening**: Return to Paris, dinner in Montmartre (Budget: €30-40)
@@ -153,9 +153,9 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Warm at 30°C (86°F), slight chance of rain
 
-## Day 4-6: Rome, Italy 🇮🇹
+#### Day 4-6: Rome, Italy 🇮🇹
 
-### Day 4: Travel to Rome
+**Day 4: Travel to Rome**
 - **Morning**: Flight from Paris to Rome (Budget: €100-150)
 - **Afternoon**: Check in to hotel, explore the Spanish Steps and Trevi Fountain
 - **Evening**: Dinner in Trastevere neighborhood (Budget: €25-35)
@@ -163,7 +163,7 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Hot at 35°C (95°F), clear skies
 
-### Day 5: Ancient Rome
+**Day 5: Ancient Rome**
 - **Morning**: Visit the Colosseum and Roman Forum (Budget: €16 combined ticket)
 - **Afternoon**: Palatine Hill and Circus Maximus
 - **Evening**: Dinner near Campo de' Fiori (Budget: €30-40)
@@ -171,7 +171,7 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Hot at 35°C (95°F), mostly sunny
 
-### Day 6: Vatican City
+**Day 6: Vatican City**
 - **Morning**: Vatican Museums and Sistine Chapel (Budget: €17)
 - **Afternoon**: St. Peter's Basilica and Square (UNESCO World Heritage Site)
 - **Evening**: Dinner in Prati district (Budget: €30-40)
@@ -179,9 +179,9 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Hot at 34°C (93°F), partly cloudy
 
-## Day 7-10: Prague, Czech Republic 🇨🇿
+#### Day 7-10: Prague, Czech Republic 🇨🇿
 
-### Day 7: Travel to Prague
+**Day 7: Travel to Prague**
 - **Morning**: Flight from Rome to Prague (Budget: €100-150)
 - **Afternoon**: Check in to hotel, explore Old Town Square
 - **Evening**: Dinner in Old Town (Budget: €20-30)
@@ -189,7 +189,7 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Pleasant at 29°C (84°F), partly cloudy
 
-### Day 8: Prague Castle and Lesser Town
+**Day 8: Prague Castle and Lesser Town**
 - **Morning**: Visit Prague Castle complex (UNESCO World Heritage Site) (Budget: 250 CZK/€10)
 - **Afternoon**: Explore Lesser Town and Charles Bridge
 - **Evening**: Dinner with views of the Vltava River (Budget: €25-35)
@@ -197,7 +197,7 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Cooler at 22°C (72°F), chance of thunderstorms
 
-### Day 9: Jewish Quarter and Cultural Sites
+**Day 9: Jewish Quarter and Cultural Sites**
 - **Morning**: Visit the Jewish Quarter (Josefov) and synagogues
 - **Afternoon**: Municipal House and Powder Tower
 - **Evening**: Traditional Czech folklore dinner with performance (Budget: €35-45)
@@ -205,56 +205,56 @@ This itinerary takes you through three of Europe's most beautiful and culturally
 
 **Weather forecast**: Pleasant at 24°C (75°F), mostly sunny
 
-### Day 10: Departure
+**Day 10: Departure**
 - **Morning**: Last-minute shopping in Prague's boutiques
 - **Afternoon**: Transfer to airport for departure flight
 
 **Weather forecast**: Pleasant at 24°C (75°F), mostly sunny
 
-## Budget Breakdown (Per Person)
+#### Budget Breakdown (Per Person)
 
-### Accommodation (9 nights)
+**Accommodation (9 nights)**
 - Paris: €120/night × 3 nights = €360
 - Rome: €100/night × 3 nights = €300
 - Prague: €80/night × 3 nights = €240
 - **Total accommodation**: €900
 
-### Transportation
+**Transportation**
 - International flights to/from Europe: €600-800 (varies by origin)
 - Paris to Rome flight: €100-150
 - Rome to Prague flight: €100-150
 - Local transportation (metro, bus, tram): €15/day × 10 days = €150
 - **Total transportation**: €950-1,250
 
-### Attractions & Activities
+**Attractions & Activities**
 - Paris museums and attractions: €100
 - Rome museums and attractions: €80
 - Prague museums and attractions: €70
 - **Total attractions**: €250
 
-### Food & Dining
+**Food & Dining**
 - Breakfast: €10/day × 10 days = €100
 - Lunch: €15/day × 10 days = €150
 - Dinner: €35/day × 10 days = €350
 - Snacks and drinks: €10/day × 10 days = €100
 - **Total food**: €700
 
-### Miscellaneous
+**Miscellaneous**
 - Travel insurance: €50
 - Souvenirs and shopping: €200
 - Contingency fund: €150
 - **Total miscellaneous**: €400
 
-### Grand Total
+**Grand Total**
 - **€3,200-3,500** per person (excluding international flights to/from Europe)
 
-## UNESCO World Heritage Sites Included
+#### UNESCO World Heritage Sites Included
 - Palace and Park of Versailles (France)
 - Historic Centre of Rome (Italy)
 - Vatican City (Italy)
 - Historic Centre of Prague (Czech Republic)
 
-## Travel Tips
+#### Travel Tips
 1. **Weather**: Based on forecasts, pack for warm weather in all destinations, with temperatures ranging from 20-35°C (68-95°F). Bring a light jacket for cooler evenings in Prague.
 2. **Currency**: Euros (€) for France and Italy, Czech Koruna (CZK) for the Czech Republic.
 3. **Transportation**: Purchase metro/public transport passes in each city to save money.
@@ -267,3 +267,6 @@ This itinerary offers a perfect blend of history, culture, and cuisine across th
 </details>
 
 :::
+
+## See Also
+- [Goose Recipes](/docs/guides/recipes) - Your source for finding docs, tools, and blog posts about Goose recipes.


### PR DESCRIPTION
PR to add cross-links to recipe docs

Documentation updates:
- `documentation/docs/guides/recipes/index.md`: Add card for tutorial
- `documentation/docs/tutorials/recipes-tutorial.md`: 
   - Update example output headings to get them out of the on-page nav
   - Add link to landing page
- 