### PR TITLE
feat(cli): Clear persisted session file with /clear command

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -544,6 +544,10 @@ impl Session {
                         &Message::assistant().with_text("Chat context cleared."),
                         self.debug,
                     );
+                    if self.session_file.exists() {
+                        std::fs::remove_file(&self.session_file)?;
+                        std::fs::File::create(&self.session_file)?;
+                    }
                     continue;
                 }
                 input::InputResult::PromptCommand(opts) => {


### PR DESCRIPTION
**feat(cli): Clear persisted session file with /clear command**

The  command in the CLI now not only clears the in-memory chat history but also deletes and recreates the associated session file. This ensures that the chat context is fully reset, including any previously persisted messages, providing a more complete clear operation.

Possibly fixes #3138

Screenshot of behavior **including** the changes within this pull request:
![image](https://github.com/user-attachments/assets/4b168550-0919-474c-846d-f2f89f84d1a1)

Although it should possibly be noted, **without** these changes the current behavior seems to be that the memory shows as cleared the next time you interact with Goose.  The session jsonl file remains until the next interaction with Goose.  If the session is `/quit` immediately after a `/clear` the session is **not** cleared.

Example screenshot **without** the changes in this pull request  (**existing** Goose behavior):
![image](https://github.com/user-attachments/assets/c11a9b15-96ef-4c3d-8e26-19622ed30003)


Thanks again for your work on this great project!