### PR TITLE
Use `current_dir()` or fall back to `get_home_dir()` when writing default session metadata

### DIFF
--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -125,7 +125,7 @@ impl SessionMetadata {
 
 impl Default for SessionMetadata {
     fn default() -> Self {
-        Self::new(get_home_dir())
+        Self::new(std::env::current_dir().unwrap_or_else(|_| get_home_dir()))
     }
 }
 


### PR DESCRIPTION
When saving a session, `SessionMetadata::default()` uses `get_home_dir()`, regardless of the actual working directory. If you try and resume a session using a non-home working directory from the GUI, the model is confused doesn't know the correct working directory.

This PR changes the default to be the current working directory, which allows session resumption to work. If the current working directory is not available, it falls back to the home directory.

In the screenshot below you can see all the sessions (which actually took place with `/Users/jud/Projects/goose` as the working directory) showing `/Users/jud`, except the second entry, which was a debug build incorporating this fix.

<img width="862" alt="Screenshot 2025-06-29 at 12 11 04 AM" src="https://github.com/user-attachments/assets/c14dd203-335d-45e5-ad0c-35dbbde45770" />
