### PR TITLE
Docs: Add Recipe video to landing page

### DIFF
--- a/documentation/docs/guides/recipes/index.md
+++ b/documentation/docs/guides/recipes/index.md
@@ -13,18 +13,18 @@ import styles from '@site/src/components/Card/styles.module.css';
 </p>
 
 
-<!-- will replace with Recipe video once live -->
-<!-- <div className="video-container margin-bottom--lg">
+will replace with Recipe video once live -->
+ <div className="video-container margin-bottom--lg">
   <iframe 
     width="100%"
     height="400"
-    src="https://www.youtube.com/embed/D-DpDunrbpo"
-    title="Vibe coding with Goose"
+    src="https://www.youtube.com/embed/8rTliYrQ6Iw"
+    title="Create Reusable AI Agents with Recipes"
     frameBorder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
     allowFullScreen
   ></iframe>
-</div> -->
+</div> 
 
 <div className={styles.categorySection}>
   <h2 className={styles.categoryTitle}>📚 Documentation & Guides</h2>


### PR DESCRIPTION
This pull request updates the `index.md` file in the documentation's guides section to replace a placeholder comment with an embedded YouTube video showcasing a new tutorial. 

Content updates:

* Replaced the placeholder comment in the `index.md` file with an embedded video titled "Create Reusable AI Agents with Recipes," updating the `src` attribute to point to the new video link (`https://www.youtube.com/embed/8rTliYrQ6Iw`).