### PR TITLE
feat: change naming of recipe creation in more menu links

### DIFF
--- a/.github/ISSUE_TEMPLATE/submit-recipe.yml
+++ b/.github/ISSUE_TEMPLATE/submit-recipe.yml
@@ -10,7 +10,7 @@ body:
         Recipes are reusable sessions created in Goose Desktop or CLI and shared with the community to help others vibe code faster.
 
         📌 **How to Submit**
-        - Create your recipe using Goose ("Make Agent from this session")
+        - Create your recipe using Goose ("Make recipe from this session")
         - Fill out the YAML below using the format provided
         - Paste it into the field and submit the issue — we'll review and add it to the Cookbook!
 

--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -16,11 +16,11 @@ You can turn your current Goose session into a reusable recipe that includes the
 <Tabs>
   <TabItem value="ui" label="Goose Desktop" default>
    :::warning
-   You cannot create a recipe from an existing recipe session - the "Make Agent from this session" option will be disabled.
+   You cannot create a recipe from an existing recipe session - the "Make recipe from this session" option will be disabled.
    :::
 
    1. While in the session you want to save as a recipe, click the menu icon **⋮** in the top right corner  
-   2. Select **Make Agent from this session**  
+   2. Select **Make recipe from this session**
    3. In the dialog that appears:
       - Name the recipe
       - Provide a description

--- a/ui/desktop/src/components/more_menu/MoreMenu.tsx
+++ b/ui/desktop/src/components/more_menu/MoreMenu.tsx
@@ -341,13 +341,13 @@ export default function MoreMenu({
                   onClick={() => {
                     setOpen(false);
                     // Signal to ChatView that we want to make an agent from the current chat
-                    window.electron.logInfo('Make Agent button clicked');
+                    window.electron.logInfo('Make recipe button clicked');
                     window.dispatchEvent(new CustomEvent('make-agent-from-chat'));
                   }}
-                  subtitle="Make a custom agent you can share or reuse with a link"
+                  subtitle="Make a custom agent recipe you can share or reuse with a link"
                   icon={<Send className="w-4 h-4" />}
                 >
-                  Make Agent from this session
+                  Make recipe from this session
                 </MenuButton>
               )}
               <MenuButton


### PR DESCRIPTION
Uses consistent naming/branding when surfacing the recipe editor/creator in the more menu links. Right now it's confusing to users why the button says to make "an agent", and the page it goes to is all about making a "recipe"