### PR TITLE
pipe the argument to storage

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -120,7 +120,7 @@ async fn offer_extension_debugging_help(
         std::env::temp_dir().join(format!("goose_debug_extension_{}.jsonl", extension_name));
 
     // Create the debugging session
-    let mut debug_session = Session::new(debug_agent, temp_session_file.clone(), false, None);
+    let mut debug_session = Session::new(debug_agent, temp_session_file.clone(), false, None, true);
 
     // Process the debugging request
     println!("{}", style("Analyzing the extension failure...").yellow());
@@ -366,6 +366,7 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> Session {
         session_file.clone(),
         session_config.debug,
         session_config.scheduled_job_id.clone(),
+        !session_config.no_session, // save_session is the inverse of no_session
     );
 
     // Add extensions if provided

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -52,7 +52,7 @@ pub struct Session {
     debug: bool, // New field for debug mode
     run_mode: RunMode,
     scheduled_job_id: Option<String>, // ID of the scheduled job that triggered this session
-    save_session: bool, // Whether to save session to file
+    save_session: bool,               // Whether to save session to file
 }
 
 // Cache structure for completion data

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -52,6 +52,7 @@ pub struct Session {
     debug: bool, // New field for debug mode
     run_mode: RunMode,
     scheduled_job_id: Option<String>, // ID of the scheduled job that triggered this session
+    save_session: bool, // Whether to save session to file
 }
 
 // Cache structure for completion data
@@ -113,13 +114,19 @@ impl Session {
         session_file: PathBuf,
         debug: bool,
         scheduled_job_id: Option<String>,
+        save_session: bool,
     ) -> Self {
-        let messages = match session::read_messages(&session_file) {
-            Ok(msgs) => msgs,
-            Err(e) => {
-                eprintln!("Warning: Failed to load message history: {}", e);
-                Vec::new()
+        let messages = if save_session {
+            match session::read_messages(&session_file) {
+                Ok(msgs) => msgs,
+                Err(e) => {
+                    eprintln!("Warning: Failed to load message history: {}", e);
+                    Vec::new()
+                }
             }
+        } else {
+            // Don't try to read messages if we're not saving sessions
+            Vec::new()
         };
 
         Session {
@@ -130,6 +137,7 @@ impl Session {
             debug,
             run_mode: RunMode::Normal,
             scheduled_job_id,
+            save_session,
         }
     }
 
@@ -319,6 +327,7 @@ impl Session {
             &self.messages,
             Some(provider),
             self.scheduled_job_id.clone(),
+            self.save_session,
         )
         .await?;
 
@@ -431,6 +440,7 @@ impl Session {
                                 &self.messages,
                                 Some(provider),
                                 self.scheduled_job_id.clone(),
+                                self.save_session,
                             )
                             .await?;
 
@@ -619,6 +629,7 @@ impl Session {
                             &self.messages,
                             Some(provider),
                             self.scheduled_job_id.clone(),
+                            self.save_session,
                         )
                         .await?;
 
@@ -792,7 +803,7 @@ impl Session {
                                         Err(ToolError::ExecutionError("Tool call cancelled by user".to_string()))
                                     ));
                                     self.messages.push(response_message);
-                                    session::persist_messages_with_schedule_id(&self.session_file, &self.messages, None, self.scheduled_job_id.clone()).await?;
+                                    session::persist_messages_with_schedule_id(&self.session_file, &self.messages, None, self.scheduled_job_id.clone(), self.save_session).await?;
 
                                     drop(stream);
                                     break;
@@ -889,7 +900,7 @@ impl Session {
                                 self.messages.push(message.clone());
 
                                 // No need to update description on assistant messages
-                                session::persist_messages_with_schedule_id(&self.session_file, &self.messages, None, self.scheduled_job_id.clone()).await?;
+                                session::persist_messages_with_schedule_id(&self.session_file, &self.messages, None, self.scheduled_job_id.clone(), self.save_session).await?;
 
                                 if interactive {output::hide_thinking()};
                                 let _ = progress_bars.hide();
@@ -1093,6 +1104,7 @@ impl Session {
                 &self.messages,
                 None,
                 self.scheduled_job_id.clone(),
+                self.save_session,
             )
             .await?;
 
@@ -1108,6 +1120,7 @@ impl Session {
                 &self.messages,
                 None,
                 self.scheduled_job_id.clone(),
+                self.save_session,
             )
             .await?;
 
@@ -1128,6 +1141,7 @@ impl Session {
                                 &self.messages,
                                 None,
                                 self.scheduled_job_id.clone(),
+                                self.save_session,
                             )
                             .await?;
 

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1248,6 +1248,7 @@ async fn run_scheduled_job_internal(
                             &session_file_path,
                             &updated_metadata,
                             &all_session_messages,
+                            true,
                         ) {
                             tracing::error!(
                                 "[Job {}] Failed to persist final messages: {}",
@@ -1278,6 +1279,7 @@ async fn run_scheduled_job_internal(
                             &session_file_path,
                             &fallback_metadata,
                             &all_session_messages,
+                            true,
                         ) {
                             tracing::error!("[Job {}] Failed to persist final messages with fallback metadata: {}", job.id, e_fb);
                         }
@@ -1305,7 +1307,7 @@ async fn run_scheduled_job_internal(
             ..Default::default()
         };
         if let Err(e) =
-            crate::session::storage::save_messages_with_metadata(&session_file_path, &metadata, &[])
+            crate::session::storage::save_messages_with_metadata(&session_file_path, &metadata, &[], true)
         {
             tracing::error!(
                 "[Job {}] Failed to persist metadata for empty job: {}",

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1306,9 +1306,12 @@ async fn run_scheduled_job_internal(
             message_count: 0,
             ..Default::default()
         };
-        if let Err(e) =
-            crate::session::storage::save_messages_with_metadata(&session_file_path, &metadata, &[], true)
-        {
+        if let Err(e) = crate::session::storage::save_messages_with_metadata(
+            &session_file_path,
+            &metadata,
+            &[],
+            true,
+        ) {
             tracing::error!(
                 "[Job {}] Failed to persist metadata for empty job: {}",
                 job.id,

--- a/crates/goose/tests/private_tests.rs
+++ b/crates/goose/tests/private_tests.rs
@@ -788,7 +788,7 @@ async fn test_schedule_tool_session_content_action_with_real_session() {
     ];
 
     // Save the session file
-    goose::session::storage::save_messages_with_metadata(&session_path, &metadata, &messages)
+    goose::session::storage::save_messages_with_metadata(&session_path, &metadata, &messages, true)
         .unwrap();
 
     // Test the session_content action


### PR DESCRIPTION
this is a more robust way to implement the `no-session` argument which does not rely on paths. 