### PR TITLE
fix: use the correct `contains` syntax on create-recipe-pr.yml

### DIFF
--- a/.github/workflows/create-recipe-pr.yml
+++ b/.github/workflows/create-recipe-pr.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   create-recipe-pr:
-    if: github.event.label.name == 'recipe submission' || github.event.issue.labels.*.name contains 'recipe submission'
+    if: ${{ github.event.label.name == 'recipe submission' || contains(github.event.issue.labels.*.name, 'recipe submission') }}
     runs-on: ubuntu-latest
 
     env:


### PR DESCRIPTION
I believe this should do the trick.
https://docs.github.com/en/actions/reference/evaluate-expressions-in-workflows-and-actions#contains

Related to https://github.com/block/goose/pull/3064
cc @EbonyLouis