### PR TITLE
Temporarily Remove GH Copilot Provider 

### DIFF
--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -48,7 +48,7 @@ pub fn providers() -> Vec<ProviderMetadata> {
         DatabricksProvider::metadata(),
         GcpVertexAIProvider::metadata(),
         GeminiCliProvider::metadata(),
-        GithubCopilotProvider::metadata(),
+        // GithubCopilotProvider::metadata(),
         GoogleProvider::metadata(),
         GroqProvider::metadata(),
         OllamaProvider::metadata(),
@@ -135,7 +135,7 @@ fn create_provider(name: &str, model: ModelConfig) -> Result<Arc<dyn Provider>> 
         "sagemaker_tgi" => Ok(Arc::new(SageMakerTgiProvider::from_env(model)?)),
         "venice" => Ok(Arc::new(VeniceProvider::from_env(model)?)),
         "snowflake" => Ok(Arc::new(SnowflakeProvider::from_env(model)?)),
-        "github_copilot" => Ok(Arc::new(GithubCopilotProvider::from_env(model)?)),
+        // "github_copilot" => Ok(Arc::new(GithubCopilotProvider::from_env(model)?)),
         "xai" => Ok(Arc::new(XaiProvider::from_env(model)?)),
         _ => Err(anyhow::anyhow!("Unknown provider: {}", name)),
     }


### PR DESCRIPTION
This PR temporarily disables the GitHub Copilot provider by commenting out its registration in the provider factory. This is a temporary measure until issues with the GitHub Copilot integration can be resolved.

## Changes
- Commented out `GithubCopilotProvider::metadata()` in the `providers()` function to remove it from available providers list
- Commented out the `github_copilot` case in `create_provider()` to prevent provider instantiation
- Removed `gh copilot provider` from `docs/getting-started/providers` page

## Testing
The GitHub Copilot provider will no longer appear as an available option when:
- Listing available providers
- Attempting to configure GitHub Copilot as a provider

## Notes
- This is a temporary change until [GitHub Copilot integration issues](https://github.com/block/goose/issues/3187) are fixed
- The provider code remains in the codebase but is inactive
- Documentation updates will be handled separately when the provider is re-enabled