### PR TITLE
docs: fix tab navigation

### DIFF
--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -12,7 +12,7 @@ A session is a single, continuous interaction between you and Goose, providing a
 
 ## Start Session 
 
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
         After choosing an LLM provider, you'll see the session interface ready for use. Type your questions, tasks, or instructions directly into the input field, and Goose will immediately get to work. 
 
@@ -53,7 +53,7 @@ If this is your first session, Goose will prompt you for an API key to access an
 :::
 
 ## Name Session
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
         Within the Desktop app, sessions are automatically named using the current timestamp in the format `YYYYMMDD_HHMMSS`. Goose also provides a description of the session based on context.
     </TabItem>
@@ -75,7 +75,7 @@ If this is your first session, Goose will prompt you for an API key to access an
 
 ## Exit Session
 Note that sessions are automatically saved when you exit.
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
     To exit a session, simply close the application.
     </TabItem>    
@@ -88,7 +88,7 @@ Note that sessions are automatically saved when you exit.
 
 ## Resume Session
 
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
     1. Click `⚙️` in the upper right corner
     2. Click `Session history`
@@ -125,7 +125,7 @@ Note that sessions are automatically saved when you exit.
 
 ### Search Session History
 
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
         In Goose Desktop, you can search session metadata including the description, filename, and working directory path. The search is text-based and supports case-sensitive matching, but doesn't search session content or support regex patterns.
 
@@ -177,7 +177,7 @@ Note that sessions are automatically saved when you exit.
 
 You can resume a CLI session in Desktop and vice versa.
 
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
     All saved sessions are listed in the Desktop app, even CLI sessions. To resume a CLI session within the Desktop:
 
@@ -242,7 +242,7 @@ You can remove sessions using CLI commands. For detailed instructions on session
 
 Export sessions to Markdown to share with your team, create documentation, archive conversations, or review them in a readable format.
 
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
         Session export is currently only available through the CLI. You can export Desktop sessions via their session filename:
 
@@ -271,7 +271,7 @@ For more details on export options, available flags, and output formats, see the
 
 Search allows you to find specific content within your current session. The search functionality is available in both CLI and Desktop interfaces.
 
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
         Trigger search using keyboard shortcuts or the search icon:
 
@@ -303,7 +303,7 @@ Search allows you to find specific content within your current session. The sear
 
 ## Share Files in Session
 
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
         Share files with Goose in three ways:
 

--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -13,11 +13,8 @@ You can turn your current Goose session into a reusable recipe that includes the
 
 ## Create Recipe
 
-<Tabs>
+<Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-   :::warning
-   You cannot create a recipe from an existing recipe session, but you can view or [edit the recipe](#edit-recipe).
-   :::
 
    1. While in the session you want to save as a recipe, click the gear icon `⚙️` in the top right corner  
    2. Select **Make recipe from this session**
@@ -29,15 +26,13 @@ You can turn your current Goose session into a reusable recipe that includes the
       - Some **activities** will be automatically generated. Add or remove as needed. 
    4. Copy the recipe URL and use it however you like (e.g., share it with teammates, drop it in documentation, or keep it for yourself)
 
+   :::warning
+   You cannot create a recipe from an existing recipe session, but you can view or [edit the recipe](#edit-recipe).
+   :::
+
   </TabItem>
 
   <TabItem value="cli" label="Goose CLI">
-   :::warning
-   You cannot create a recipe from an existing recipe session - the `/recipe` command will not work.
-   :::
-
-   ### Create a Recipe File
-
    Recipe files can be either JSON (.json) or YAML (.yaml) files. While in a [session](/docs/guides/managing-goose-sessions#start-session), run this command to generate a recipe.yaml file in your current directory:
 
    ```sh
@@ -73,7 +68,15 @@ You can turn your current Goose session into a reusable recipe that includes the
    ```
    </details>
 
-   ### Optional Parameters
+   :::warning
+   You cannot create a recipe from an existing recipe session - the `/recipe` command will not work.
+   :::
+
+   :::tip Validate Your Recipe
+   You should [validate your recipe](#validate-recipe) to verify that it's complete and properly formatted.
+   :::
+
+   #### Optional Parameters
 
    You may add parameters to a recipe, which will require users to fill in data when running the recipe. Parameters can be added to any part of the recipe (instructions, prompt, activities, etc).
 
@@ -131,28 +134,6 @@ You can turn your current Goose session into a reusable recipe that includes the
 
    See the [Recipe Reference Guide](/docs/guides/recipes/recipe-reference) for more information about recipe fields. 
 
-   ### Validate Recipe
-
-   [Exit the session](/docs/guides/managing-goose-sessions#exit-session) and run:
-
-   ```sh
-   goose recipe validate recipe.yaml
-   ```
-
-Validation ensures that:
-   - All required fields are present
-   - Parameters are properly formatted
-   - Referenced extensions exist and are valid
-   - The YAML/JSON syntax is correct
-
-   ### Share Your Recipe
-
-   Now that your recipe is created, you can share it with CLI users by directly sending them the recipe file or converting it to a shareable deep link for Desktop users:
-
-   ```sh
-   goose recipe deeplink recipe.yaml
-   ```
-
    </TabItem> 
 
 
@@ -166,17 +147,17 @@ Validation ensures that:
       - A **title** for the recipe
       - A **description**
       - A set of **instructions** for the recipe.
-      - An optional inital **prompt**:
+      - An optional initial **prompt**:
         - In the Desktop app, the prompt displays in the chat box.
         - In the CLI app, the prompt provides the initial message to run. Note that a prompt is required to run the recipe in headless (non-interactive) mode.
       - A set of optional **activities** to display in the Desktop app.
-      - YAML format only: Optional **author** contact information and **extensions** the recipe usess.
+      - YAML format only: Optional **author** contact information and **extensions** the recipe uses.
 
   </TabItem>
 </Tabs>
 
 ## Edit Recipe
-<Tabs>
+<Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
 
    1. While in the session created from a recipe, click the gear icon `⚙️` in the top right corner  
@@ -200,7 +181,7 @@ Validation ensures that:
 
 ## Use Recipe
 
-<Tabs>
+<Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
 
    There are two ways to use a recipe in Goose Desktop:
@@ -224,7 +205,12 @@ Validation ensures that:
 
   <TabItem value="cli" label="Goose CLI">
 
-   ### Configure Recipe Location
+  Using a recipe with the Goose CLI might involve the following tasks:
+  - [Configuring your recipe location](#configure-recipe-location)
+  - [Running a recipe](#run-a-recipe)
+  - [Scheduling a recipe](#schedule-a-recipe)
+
+   #### Configure Recipe Location
 
   Recipes can be stored locally on your device or in a GitHub repository. Configure your recipe repository using either the `goose configure` command or [config file](/docs/guides/config-file#global-settings).
 
@@ -295,9 +281,9 @@ Validation ensures that:
      </TabItem>
    </Tabs>
 
-   ### Run a Recipe
+   #### Run a Recipe
 
-   <Tabs>
+   <Tabs groupId="interface">
      <TabItem value="local" label="Local Recipe" default>
 
        **Basic Usage** - Run once and exit (see [run options](/docs/guides/goose-cli-commands#run-options) and [recipe commands](/docs/guides/goose-cli-commands#recipe) for more):
@@ -382,7 +368,7 @@ Validation ensures that:
   - Your session won't affect the original recipe creator's session
   :::
 
-  ### Schedule a Recipe
+  #### Schedule a Recipe
   Automate Goose recipes by running them on a schedule.
 
   **Create a schedule** - Create a scheduled cron job that runs the recipe on the specified cadence. 
@@ -396,6 +382,52 @@ Validation ensures that:
   See the [`schedule` command documentation](/docs/guides/goose-cli-commands#schedule) for detailed examples and options.
 
    </TabItem>
+</Tabs>
+
+## Validate Recipe
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="Goose Desktop" default>
+    Recipe validation is only available through the CLI.
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
+    Validate your recipe file to ensure it's properly configured. Validation ensures that:
+    - All required fields are present
+    - Parameters are properly formatted
+    - Referenced extensions exist and are valid
+    - The YAML/JSON syntax is correct
+
+   ```sh
+   goose recipe validate recipe.yaml
+   ```
+
+   :::info
+   If you want to validate a recipe you just created, you need to [exit the session](/docs/guides/managing-goose-sessions#exit-session) before running the `validate` subcommand.
+   :::
+
+   Recipe validation can be useful for:
+    - Troubleshooting recipes that aren't working as expected
+    - Verifying recipes after manual edits
+    - Automated testing in CI/CD pipelines
+
+  </TabItem>
+</Tabs>
+
+## Share Recipe
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="Goose Desktop" default>
+    Share your recipe with Desktop users by copying the recipe URL from the recipe creation dialog. When someone clicks the URL, it will open Goose Desktop with your recipe configuration.
+
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
+    Share your recipe with CLI users by directly sending them the recipe file or converting it to a shareable deep link for Desktop users:
+
+    ```sh
+    goose recipe deeplink recipe.yaml
+    ```
+
+  </TabItem>
 </Tabs>
 
 ## Core Components


### PR DESCRIPTION
This PR fixes some display issues in the Managing Goose Sessions and Shareable Recipes topics.

Documentation updates:
- `documentation/docs/guides/managing-goose-sessions.md`: Added `groupId` to sync all tabs with selection
- `documentation/docs/guides/recipes/session-recipes.md`:
   - Added `groupId` to sync all tabs with selection
   - Removed h3s in tabs to work around issue with on-page navigation links not working unless parent tab is active:
     - Promoted Validate and Share to h2
     - Demoted Configure Recipe Location, Run Recipe, and Schedule Recipe to h4 and added intro with links
   - Moved warnings down and fixed typos
