### PR TITLE
docs: update cli install instructions for windows

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -145,10 +145,7 @@ import LinuxDesktopInstallButtons from '@site/src/components/LinuxDesktopInstall
         </div>
       </TabItem>
       <TabItem value="cli" label="Goose CLI">
-        Install the Goose CLI directly from the browser using our download script, or use WSL for a Linux-like experience.
-
-        <h3 style={{ marginTop: '1rem' }}>Option 1: Native Windows CLI (Recommended)</h3>
-        Run the following command in **Git Bash**, **MSYS2**, or **PowerShell** to install the latest version of Goose natively on Windows:
+        Run the following command in **Git Bash**, **MSYS2**, or **PowerShell** to install the Goose CLI natively on Windows:
 
         ```bash
         curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
@@ -169,38 +166,42 @@ import LinuxDesktopInstallButtons from '@site/src/components/LinuxDesktopInstall
         The script requires `curl` and `unzip` to be available in your environment.
         :::
 
-        <h3>Option 2: Windows Subsystem for Linux (WSL)</h3>
-        If you prefer a Linux-like environment, you can run Goose using WSL:
+        <details>
+        <summary>Install via Windows Subsystem for Linux (WSL)</summary>
 
-        1. Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
+          We recommend running the Goose CLI natively on Windows, but you can use WSL if you prefer a Linux-like environment.
 
-        ```bash
-        wsl --install
-        ```
-
-        2. If prompted, restart your computer to complete the WSL installation. Once restarted, or if WSL is already installed, launch your Ubuntu shell by running:
-
-        ```bash
-        wsl -d Ubuntu
-        ```
-
-        3. Run the Goose installation script:
-        ```bash
-        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
-        ```
-        :::tip
-          If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file:
+          1. Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
 
           ```bash
-          sudo apt update && sudo apt install bzip2 -y
+          wsl --install
           ```
-        :::
 
-        If you'd like to install without interactive configuration, disable `CONFIGURE`:
+          2. If prompted, restart your computer to complete the WSL installation. Once restarted, or if WSL is already installed, launch your Ubuntu shell by running:
 
-        ```sh
-        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
-        ```  
+          ```bash
+          wsl -d Ubuntu
+          ```
+
+          3. Run the Goose installation script:
+          ```bash
+          curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
+          ```
+          :::tip
+            If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file:
+
+            ```bash
+            sudo apt update && sudo apt install bzip2 -y
+            ```
+          :::
+
+          If you'd like to install without interactive configuration, disable `CONFIGURE`:
+
+          ```sh
+          curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+          ```  
+
+        </details>
       </TabItem>
     </Tabs>
   </TabItem>

--- a/documentation/docs/guides/updating-goose.md
+++ b/documentation/docs/guides/updating-goose.md
@@ -123,35 +123,7 @@ The Goose CLI and desktop apps are under active and continuous development. To g
         </div>
       </TabItem>
       <TabItem value="cli" label="Goose CLI">
-        There isn't native CLI support for Windows. You can run Goose CLI using WSL (Windows Subsystem for Linux).
-
-        **If you haven't set up WSL yet:**
-
-        1. Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
-
-        ```bash
-        wsl --install
-        ```
-
-        2. If prompted, restart your computer to complete the WSL installation. Once restarted, or if WSL is already installed, launch your Ubuntu shell by running:
-
-        ```bash
-        wsl -d Ubuntu
-        ```
-
-        3. Run the Goose installation script:
-        ```bash
-        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
-        ```
-        :::tip
-          If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file:
-
-          ```bash
-          sudo apt update && sudo apt install bzip2 -y
-          ```
-        :::
-
-        **If you already have Goose CLI installed in WSL, you can update it:**
+        You can update Goose by running:
 
         ```sh
         goose update
@@ -167,17 +139,28 @@ The Goose CLI and desktop apps are under active and continuous development. To g
         goose update --reconfigure
         ```
 
-        Or you can run the [installation](/docs/getting-started/installation) script again within WSL:
+        Or you can run the [installation](/docs/getting-started/installation) script again in **Git Bash**, **MSYS2**, or **PowerShell** to update the Goose CLI natively on Windows:
+
+        ```bash
+        curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
+        ```
+        
+        To check your current Goose version, use the following command:
+
+        ```sh
+        goose --version
+        ```        
+
+        <details>
+        <summary>Update via Windows Subsystem for Linux (WSL)</summary>
+
+        To update your WSL installation, use `goose update` or run the installation script again via WSL:
 
         ```sh
         curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | CONFIGURE=false bash
         ```
 
-        To check your current Goose version within WSL, use:
-
-        ```sh
-        goose --version
-        ```
+       </details>
       </TabItem>
     </Tabs>
   </TabItem>

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -73,6 +73,8 @@ Let's begin 🚀
   </TabItem>
 
   <TabItem value="windows" label="Windows">
+    Choose to install Goose on CLI and/or Desktop:
+
     <Tabs groupId="interface">
       <TabItem value="ui" label="Goose Desktop" default>
         <WindowsDesktopInstallButtons/>
@@ -82,27 +84,15 @@ Let's begin 🚀
         </div>
       </TabItem>
       <TabItem value="cli" label="Goose CLI">
-        There isn't native installation support for Windows, however you can run Goose using WSL (Windows Subsystem for Linux).
+        
+        Run the following command in **Git Bash**, **MSYS2**, or **PowerShell** to install the Goose CLI natively on Windows:
 
-        1. Open [PowerShell](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell-on-windows) as Administrator and install WSL and the default Ubuntu distribution:
-
-        ```bash
-        wsl --install
-        ```
-
-        2. Restart your computer if prompted.
-
-        3. Run the Goose installation script:
         ```bash
         curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash
         ```
-        :::tip
-          If you encounter any issues on download, you might need to install `bzip2` to extract the downloaded file:
+        
+        Learn about prerequisites in the [installation guide](/docs/getting-started/installation).
 
-          ```bash
-          sudo apt update && sudo apt install bzip2 -y
-          ```
-        :::
       </TabItem>
     </Tabs>
   </TabItem>


### PR DESCRIPTION
This PR updates CLI install and update instructions on Windows.

Documentation updates:
- `documentation/docs/getting-started/installation.md`: Add native Windows CLI installation instructions and de-emphasize WSL instructions
- `documentation/docs/guides/updating-goose.md`: Add native Windows CLI installation instructions and de-emphasize WSL instructions
- `documentation/docs/quickstart.md`: Add native Windows CLI installation instructions and remove WSL instructions