### PR TITLE
Enable running sub-recipes from GitHub

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -522,9 +522,9 @@ enum Command {
         /// Additional sub-recipe file paths
         #[arg(
             long = "sub-recipe",
-            value_name = "FILE",
-            help = "Path to a sub-recipe YAML file (can be specified multiple times)",
-            long_help = "Specify paths to sub-recipe YAML files that contain additional recipe configuration or instructions to be used alongside the main recipe. Can be specified multiple times to include multiple sub-recipes.",
+            value_name = "RECIPE",
+            help = "Sub-recipe name or file path (can be specified multiple times)",
+            long_help = "Specify sub-recipes to include alongside the main recipe. Can be:\n  - Recipe names from GitHub (if GOOSE_RECIPE_GITHUB_REPO is configured)\n  - Local file paths to YAML files\nCan be specified multiple times to include multiple sub-recipes.",
             action = clap::ArgAction::Append
         )]
         additional_sub_recipes: Vec<String>,


### PR DESCRIPTION
Instead of processing `additional_sub_recipes` as only local file paths, we can process them using the existing `retrieve_recipe_file`. This will allow users to run sub recipes from GitHub (via `GOOSE_RECIPE_GITHUB_REPO`) instead of just local files, similar to how "main" (non sub) recipes currently work

this means I can pass sub recipes from GitHub into my "main" local recipe where I can prompt Goose to run them by name
```bash
~/Development/oncall-buddy main ~/Development/goose-fork/target/debug/goose run --recipe ./recipes/oncall-buddy-recipe.yaml --sub-recipe weekly-updates
Loading recipe: Oncall Buddy
Description: Oncall Buddy is an AI assistant specialized in helping engineers quickly diagnose and resolve incidents by providing relevant context and analysis across multiple systems


📦 Looking for recipe "weekly-updates" in github repo: squareup/goose-recipes
github.com
  ✓ Logged in to github.com account wpfleger96 (keyring)
  - Active account: true
  - Git operations protocol: ssh
  - Token: gho_************************************
  - Token scopes: 'admin:public_key', 'gist', 'read:org', 'repo'
Files downloaded from github:
  - /var/folders/fz/0gzt0czj7c74d0qyhv2r08300000gn/T/weekly-updates/recipe.yaml
⬇️  Retrieved recipe file: recipe.yaml

( O)> weekly-updates
I'll run the weekly-updates sub-recipe for you. This will generate team status reports by collecting data from Jira and other systems.
....
◓  Zooming through zettabytes...                                                                                                    
[sub-recipe weekly-updates] Loading recipe: Weekly Updates Assistant
[sub-recipe weekly-updates] Description: Automated workflow for generating and posting team weekly updates
[sub-recipe weekly-updates] Parameters used to load this recipe:
[sub-recipe weekly-updates]    slack_channel: team-updates
[sub-recipe weekly-updates]    collection_end_date: 2025-07-01
[sub-recipe weekly-updates]    collection_start_date: 2025-06-24
[sub-recipe weekly-updates]    slack_bot_id: bot-weekly-updates
[sub-recipe weekly-updates]    jira_project_key: TEAM
[sub-recipe weekly-updates]
```
I also updated the `retrieve_recipe_file` function to intelligently detect if a string looks like a file path (contains `/`, `\`, or starts with `~`) instead of only checking if the file's extension is `.yaml` or `.json`. This catches an edge case where if a local recipe is input as absolute/relative path, and has a typo (e.g. `/Users/wpfleger/Development/oncall-buddy/test-recipe.yam`), Goose will erroneously search for a GitHub recipe named `/Users/wpfleger/Development/oncall-buddy/test-recipe.yam` then because we call `env::temp_dir().join(recipe_name)` on the absolute path name, Goose will create an actual empty directory at `/Users/wpfleger/Development/oncall-buddy/test-recipe.yam` instead of failing out since it didn't find a valid recipe