### PR TITLE
feat: Adds max_turns for the agent without user input

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -312,6 +312,15 @@ enum Command {
         )]
         max_tool_repetitions: Option<u32>,
 
+        /// Maximum number of turns (iterations) allowed in a single response
+        #[arg(
+            long = "max-turns",
+            value_name = "NUMBER",
+            help = "Maximum number of turns allowed without user input (default: 1000)",
+            long_help = "Set a limit on how many turns (iterations) the agent can take without asking for user input to continue."
+        )]
+        max_turns: Option<u32>,
+
         /// Add stdio extensions with environment variables and commands
         #[arg(
             long = "with-extension",
@@ -448,6 +457,15 @@ enum Command {
             long_help = "Set a limit on how many times the same tool can be called consecutively with identical parameters. Helps prevent infinite loops."
         )]
         max_tool_repetitions: Option<u32>,
+
+        /// Maximum number of turns (iterations) allowed in a single response
+        #[arg(
+            long = "max-turns",
+            value_name = "NUMBER",
+            help = "Maximum number of turns allowed without user input (default: 1000)",
+            long_help = "Set a limit on how many turns (iterations) the agent can take without asking for user input to continue."
+        )]
+        max_turns: Option<u32>,
 
         /// Identifier for this run session
         #[command(flatten)]
@@ -635,6 +653,7 @@ pub async fn cli() -> Result<()> {
             history,
             debug,
             max_tool_repetitions,
+            max_turns,
             extensions,
             remote_extensions,
             builtins,
@@ -683,6 +702,7 @@ pub async fn cli() -> Result<()> {
                         settings: None,
                         debug,
                         max_tool_repetitions,
+                        max_turns,
                         scheduled_job_id: None,
                         interactive: true,
                         quiet: false,
@@ -726,6 +746,7 @@ pub async fn cli() -> Result<()> {
             no_session,
             debug,
             max_tool_repetitions,
+            max_turns,
             extensions,
             remote_extensions,
             builtins,
@@ -818,6 +839,7 @@ pub async fn cli() -> Result<()> {
                 settings: session_settings,
                 debug,
                 max_tool_repetitions,
+                max_turns,
                 scheduled_job_id,
                 interactive, // Use the interactive flag from the Run command
                 quiet,
@@ -937,6 +959,7 @@ pub async fn cli() -> Result<()> {
                     settings: None::<SessionSettings>,
                     debug: false,
                     max_tool_repetitions: None,
+                    max_turns: None,
                     scheduled_job_id: None,
                     interactive: true, // Default case is always interactive
                     quiet: false,

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -45,6 +45,7 @@ pub async fn agent_generator(
         max_tool_repetitions: None,
         interactive: false, // Benchmarking is non-interactive
         scheduled_job_id: None,
+        max_turns: None,
         quiet: false,
         sub_recipes: None,
     })

--- a/crates/goose-cli/src/commands/web.rs
+++ b/crates/goose-cli/src/commands/web.rs
@@ -479,6 +479,7 @@ async fn process_message_streaming(
         working_dir: std::env::current_dir()?,
         schedule_id: None,
         execution_mode: None,
+        max_turns: None,
     };
 
     // Get response from agent

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -53,6 +53,7 @@ pub struct Session {
     run_mode: RunMode,
     scheduled_job_id: Option<String>, // ID of the scheduled job that triggered this session
     save_session: bool,               // Whether to save session to file
+    max_turns: Option<u32>,
 }
 
 // Cache structure for completion data
@@ -115,6 +116,7 @@ impl Session {
         debug: bool,
         scheduled_job_id: Option<String>,
         save_session: bool,
+        max_turns: Option<u32>,
     ) -> Self {
         let messages = if save_session {
             match session::read_messages(&session_file) {
@@ -138,6 +140,7 @@ impl Session {
             run_mode: RunMode::Normal,
             scheduled_job_id,
             save_session,
+            max_turns,
         }
     }
 
@@ -755,6 +758,7 @@ impl Session {
                         .expect("failed to get current session working directory"),
                     schedule_id: self.scheduled_job_id.clone(),
                     execution_mode: None,
+                    max_turns: self.max_turns,
                 }),
             )
             .await?;
@@ -891,6 +895,7 @@ impl Session {
                                                 .expect("failed to get current session working directory"),
                                             schedule_id: self.scheduled_job_id.clone(),
                                             execution_mode: None,
+                                            max_turns: self.max_turns,
                                         }),
                                     )
                                     .await?;

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -184,6 +184,7 @@ async fn handler(
                     working_dir: PathBuf::from(session_working_dir),
                     schedule_id: request.scheduled_job_id.clone(),
                     execution_mode: None,
+                    max_turns: None,
                 }),
             )
             .await
@@ -358,6 +359,7 @@ async fn ask_handler(
                 working_dir: PathBuf::from(session_working_dir),
                 schedule_id: request.scheduled_job_id.clone(),
                 execution_mode: None,
+                max_turns: None,
             }),
         )
         .await

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -53,6 +53,8 @@ use super::subagent_manager::SubAgentManager;
 use super::subagent_tools;
 use super::tool_execution::{ToolCallResult, CHAT_MODE_TOOL_SKIPPED_RESPONSE, DECLINED_RESPONSE};
 
+const DEFAULT_MAX_TURNS: u32 = 1000;
+
 /// The main goose Agent
 pub struct Agent {
     pub(super) provider: Mutex<Option<Arc<dyn Provider>>>,
@@ -677,7 +679,21 @@ impl Agent {
 
         Ok(Box::pin(async_stream::try_stream! {
             let _ = reply_span.enter();
+            let mut turns_taken = 0u32;
+            let max_turns = session
+                .as_ref()
+                .and_then(|s| s.max_turns)
+                .unwrap_or(DEFAULT_MAX_TURNS);
+
             loop {
+                turns_taken += 1;
+                if turns_taken > max_turns {
+                    yield AgentEvent::Message(Message::assistant().with_text(
+                        "I've reached the maximum number of actions I can do without user input. Would you like me to continue?"
+                    ));
+                    break;
+                }
+
                 // Check for MCP notifications from subagents
                 let mcp_notifications = self.get_mcp_notifications().await;
                 for notification in mcp_notifications {

--- a/crates/goose/src/agents/types.rs
+++ b/crates/goose/src/agents/types.rs
@@ -26,4 +26,6 @@ pub struct SessionConfig {
     pub schedule_id: Option<String>,
     /// Execution mode for scheduled jobs: "foreground" or "background"
     pub execution_mode: Option<String>,
+    /// Maximum number of turns (iterations) allowed without user input
+    pub max_turns: Option<u32>,
 }

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1203,6 +1203,7 @@ async fn run_scheduled_job_internal(
             working_dir: current_dir.clone(),
             schedule_id: Some(job.id.clone()),
             execution_mode: job.execution_mode.clone(),
+            max_turns: None,
         };
 
         match agent

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -132,6 +132,18 @@ goose configure
     goose session --name my-session --debug
     ```
 
+- Limit the maximum number of turns the agent can take before asking for user input to continue
+
+    **Options:**
+
+    **`--max-turns <NUMBER>`**
+
+    **Usage:**
+
+    ```bash
+    goose session --max-turns 50
+    ```
+
 ---
 ### session list [options]
 
@@ -293,6 +305,7 @@ Execute commands from an instruction file or stdin. Check out the [full guide](/
 - **`--debug`**: Output complete tool responses, detailed parameter values, and full file paths
 - **`--explain`**: Show a recipe's title, description, and parameters
 - **`--no-session`**: Run goose commands without creating or storing a session file
+- **`--max-turns <NUMBER>`**: Limit the maximum number of turns the agent can take before asking for user input to continue (default: 1000)
 
 **Usage:**
 
@@ -319,6 +332,9 @@ goose run --recipe recipe.yaml --explain
 
 #Run instructions from a file without session storage
 goose run --no-session -i instructions.txt
+
+#Run with a limit of 25 turns before asking for user input
+goose run --max-turns 25 -i plan.md
 ```
 
 ---


### PR DESCRIPTION
This pull request introduces a cli option `--max-turns`, allowing users to set a maximum number of turns (`max_turns`) that the agent can take without user input (the default is 1000 to maintain current functionality). If the agent reply loop exceeds max-turns it stops the loop and asks the user if they want to continue.

This functionality is useful to limit agents going off the rails and looping endlessly on a task.