### PR TITLE
fix: fix desktop recipe url generation

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.0.30"
+    "version": "1.0.31"
   },
   "paths": {
     "/agent/tools": {

--- a/ui/desktop/src/components/RecipeEditor.tsx
+++ b/ui/desktop/src/components/RecipeEditor.tsx
@@ -19,7 +19,8 @@ interface RecipeEditorProps {
 // Function to generate a deep link from a recipe
 function generateDeepLink(recipe: Recipe): string {
   const configBase64 = Buffer.from(JSON.stringify(recipe)).toString('base64');
-  return `goose://recipe?config=${configBase64}`;
+  const urlSafe = encodeURIComponent(configBase64);
+  return `goose://recipe?config=${urlSafe}`;
 }
 
 export default function RecipeEditor({ config }: RecipeEditorProps) {

--- a/ui/desktop/src/components/schedule/CreateScheduleModal.tsx
+++ b/ui/desktop/src/components/schedule/CreateScheduleModal.tsx
@@ -119,7 +119,7 @@ function parseDeepLink(deepLink: string): Recipe | null {
       return null;
     }
 
-    const configJson = Buffer.from(configParam, 'base64').toString('utf-8');
+    const configJson = Buffer.from(decodeURIComponent(configParam), 'base64').toString('utf-8');
     return JSON.parse(configJson) as Recipe;
   } catch (error) {
     console.error('Failed to parse deep link:', error);

--- a/ui/desktop/src/components/ui/DeepLinkModal.tsx
+++ b/ui/desktop/src/components/ui/DeepLinkModal.tsx
@@ -17,7 +17,8 @@ interface DeepLinkModalProps {
 // Function to generate a deep link from a bot config
 export function generateDeepLink(recipeConfig: RecipeConfig): string {
   const configBase64 = Buffer.from(JSON.stringify(recipeConfig)).toString('base64');
-  return `goose://bot?config=${configBase64}`;
+  const urlSafe = encodeURIComponent(configBase64);
+  return `goose://bot?config=${urlSafe}`;
 }
 
 export function DeepLinkModal({ recipeConfig: initialRecipeConfig, onClose }: DeepLinkModalProps) {

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -157,7 +157,9 @@ if (process.platform === 'win32') {
             const configParam = parsedUrl.searchParams.get('config');
             if (configParam) {
               try {
-                recipeConfig = JSON.parse(Buffer.from(configParam, 'base64').toString('utf-8'));
+                recipeConfig = JSON.parse(
+                  Buffer.from(decodeURIComponent(configParam), 'base64').toString('utf-8')
+                );
 
                 // Check if this is a scheduled job
                 const scheduledJobId = parsedUrl.searchParams.get('scheduledJob');
@@ -260,7 +262,9 @@ function processProtocolUrl(parsedUrl: URL, window: BrowserWindow) {
     const configParam = parsedUrl.searchParams.get('config');
     if (configParam) {
       try {
-        recipeConfig = JSON.parse(Buffer.from(configParam, 'base64').toString('utf-8'));
+        recipeConfig = JSON.parse(
+          Buffer.from(decodeURIComponent(configParam), 'base64').toString('utf-8')
+        );
 
         // Check if this is a scheduled job
         const scheduledJobId = parsedUrl.searchParams.get('scheduledJob');


### PR DESCRIPTION
Some users are reporting issues with desktop recipe creation, where they create the recipe and are unable to open the deeplink. I believe the issue is that the base64 deeplink is not being encoded. In the CLI, the base64 config is encoded with `let url_safe = urlencoding::encode(&deeplink);` when creating the deeplink. But in the UI, the deeplink is not url encoded. This PR urlencodes the base64 config in UI recipe creation.