### PR TITLE
build: Check in Cargo.lock changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4560,7 +4560,7 @@ dependencies = [
  "base64 0.22.1",
  "bytecount",
  "email_address",
- "fancy-regex",
+ "fancy-regex 0.14.0",
  "fraction",
  "idna",
  "itoa",


### PR DESCRIPTION
Whenever I build, `fancy-regex` Cargo.lock changes.

To test it out, run the CLI from a clean `main` branch.

```shell
cargo run --bin goose
```