### PR TITLE
Add support for escape key to dismiss settings menu

### DIFF
--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -12,6 +12,7 @@ import SchedulerSection from './scheduler/SchedulerSection';
 import DictationSection from './dictation/DictationSection';
 import { ExtensionConfig } from '../../api';
 import MoreMenuLayout from '../more_menu/MoreMenuLayout';
+import { useEffect } from 'react';
 
 export type SettingsViewOptions = {
   deepLinkConfig?: ExtensionConfig;
@@ -28,6 +29,20 @@ export default function SettingsView({
   setView: (view: View, viewOptions?: ViewOptions) => void;
   viewOptions: SettingsViewOptions;
 }) {
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [onClose]);
+
   return (
     <div className="h-screen w-full animate-[fadein_200ms_ease-in_forwards]">
       <MoreMenuLayout showMenu={false} />


### PR DESCRIPTION
I got stuck in the settings menu. If you scroll down in the settings menu, the back link stays up at the top. This PR supports pressing escape to dismiss the settings menu and return to the main screen. A follow up to pin the back link to the top may make sense as well

https://github.com/user-attachments/assets/f07db13e-b8d0-4fe4-9e9b-7c42359b9aa3

Botched a rebase of a [previous PR](https://github.com/block/goose/pull/3124) of the same change. It was easier to create a new PR.