### PR TITLE
Clean up session file optionality for --no-session

### DIFF
--- a/crates/goose-bench/src/bench_session.rs
+++ b/crates/goose-bench/src/bench_session.rs
@@ -18,7 +18,7 @@ pub struct BenchAgentError {
 #[async_trait]
 pub trait BenchBaseSession: Send + Sync {
     async fn headless(&mut self, message: String) -> anyhow::Result<()>;
-    fn session_file(&self) -> PathBuf;
+    fn session_file(&self) -> Option<PathBuf>;
     fn message_history(&self) -> Vec<Message>;
     fn get_total_token_usage(&self) -> anyhow::Result<Option<i32>>;
 }
@@ -52,7 +52,7 @@ impl BenchAgent {
     pub(crate) async fn get_token_usage(&self) -> Option<i32> {
         self.session.get_total_token_usage().ok().flatten()
     }
-    pub(crate) fn session_file(&self) -> PathBuf {
+    pub(crate) fn session_file(&self) -> Option<PathBuf> {
         self.session.session_file()
     }
 }

--- a/crates/goose-bench/src/runners/eval_runner.rs
+++ b/crates/goose-bench/src/runners/eval_runner.rs
@@ -155,8 +155,15 @@ impl EvalRunner {
                 .canonicalize()
                 .context("Failed to canonicalize current directory path")?;
 
-            BenchmarkWorkDir::deep_copy(agent.session_file().as_path(), here.as_path(), false)
-                .context("Failed to copy session file to evaluation directory")?;
+            BenchmarkWorkDir::deep_copy(
+                agent
+                    .session_file()
+                    .expect("Failed to get session file")
+                    .as_path(),
+                here.as_path(),
+                false,
+            )
+            .context("Failed to copy session file to evaluation directory")?;
 
             tracing::info!("Evaluation completed successfully");
         } else {

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -691,7 +691,11 @@ pub async fn cli() -> Result<()> {
                     })
                     .await;
                     setup_logging(
-                        session.session_file().file_stem().and_then(|s| s.to_str()),
+                        session
+                            .session_file()
+                            .as_ref()
+                            .and_then(|p| p.file_stem())
+                            .and_then(|s| s.to_str()),
                         None,
                     )?;
 
@@ -831,7 +835,11 @@ pub async fn cli() -> Result<()> {
             .await;
 
             setup_logging(
-                session.session_file().file_stem().and_then(|s| s.to_str()),
+                session
+                    .session_file()
+                    .as_ref()
+                    .and_then(|p| p.file_stem())
+                    .and_then(|s| s.to_str()),
                 None,
             )?;
 
@@ -950,7 +958,11 @@ pub async fn cli() -> Result<()> {
                 })
                 .await;
                 setup_logging(
-                    session.session_file().file_stem().and_then(|s| s.to_str()),
+                    session
+                        .session_file()
+                        .as_ref()
+                        .and_then(|p| p.file_stem())
+                        .and_then(|s| s.to_str()),
                     None,
                 )?;
                 if let Err(e) = session.interactive(None).await {

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -15,7 +15,7 @@ impl BenchBaseSession for Session {
     async fn headless(&mut self, message: String) -> anyhow::Result<()> {
         self.headless(message).await
     }
-    fn session_file(&self) -> PathBuf {
+    fn session_file(&self) -> Option<PathBuf> {
         self.session_file()
     }
     fn message_history(&self) -> Vec<Message> {

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -115,7 +115,7 @@ impl Session {
         scheduled_job_id: Option<String>,
     ) -> Self {
         let messages = if let Some(session_file) = &session_file {
-            match session::read_messages(&session_file) {
+            match session::read_messages(session_file) {
                 Ok(msgs) => msgs,
                 Err(e) => {
                     eprintln!("Warning: Failed to load message history: {}", e);
@@ -321,7 +321,7 @@ impl Session {
         // Persist messages with provider for automatic description generation
         if let Some(session_file) = &self.session_file {
             session::persist_messages_with_schedule_id(
-                &session_file,
+                session_file,
                 &self.messages,
                 Some(provider),
                 self.scheduled_job_id.clone(),
@@ -437,7 +437,7 @@ impl Session {
                             // Persist messages with provider for automatic description generation
                             if let Some(session_file) = &self.session_file {
                                 session::persist_messages_with_schedule_id(
-                                    &session_file,
+                                    session_file,
                                     &self.messages,
                                     Some(provider),
                                     self.scheduled_job_id.clone(),
@@ -659,8 +659,7 @@ impl Session {
         println!(
             "\nClosing session.{}",
             self.session_file
-                .as_ref()
-                .and_then(|p| Some(format!(" Recorded to {}", p.display())))
+                .as_ref().map(|p| format!(" Recorded to {}", p.display()))
                 .unwrap_or_default()
         );
         Ok(())
@@ -1133,7 +1132,7 @@ impl Session {
             // No need for description update here
             if let Some(session_file) = &self.session_file {
                 session::persist_messages_with_schedule_id(
-                    &session_file,
+                    session_file,
                     &self.messages,
                     None,
                     self.scheduled_job_id.clone(),
@@ -1155,7 +1154,7 @@ impl Session {
                             // No need for description update here
                             if let Some(session_file) = &self.session_file {
                                 session::persist_messages_with_schedule_id(
-                                    &session_file,
+                                    session_file,
                                     &self.messages,
                                     None,
                                     self.scheduled_job_id.clone(),
@@ -1265,7 +1264,7 @@ impl Session {
             return Err(anyhow::anyhow!("Session file does not exist"));
         }
 
-        session::read_metadata(&self.session_file.as_ref().unwrap())
+        session::read_metadata(self.session_file.as_ref().unwrap())
     }
 
     // Get the session's total token usage

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -46,13 +46,12 @@ pub enum RunMode {
 pub struct Session {
     agent: Agent,
     messages: Vec<Message>,
-    session_file: PathBuf,
+    session_file: Option<PathBuf>,
     // Cache for completion data - using std::sync for thread safety without async
     completion_cache: Arc<std::sync::RwLock<CompletionCache>>,
     debug: bool, // New field for debug mode
     run_mode: RunMode,
     scheduled_job_id: Option<String>, // ID of the scheduled job that triggered this session
-    save_session: bool,               // Whether to save session to file
 }
 
 // Cache structure for completion data
@@ -111,12 +110,11 @@ pub async fn classify_planner_response(
 impl Session {
     pub fn new(
         agent: Agent,
-        session_file: PathBuf,
+        session_file: Option<PathBuf>,
         debug: bool,
         scheduled_job_id: Option<String>,
-        save_session: bool,
     ) -> Self {
-        let messages = if save_session {
+        let messages = if let Some(session_file) = &session_file {
             match session::read_messages(&session_file) {
                 Ok(msgs) => msgs,
                 Err(e) => {
@@ -137,7 +135,6 @@ impl Session {
             debug,
             run_mode: RunMode::Normal,
             scheduled_job_id,
-            save_session,
         }
     }
 
@@ -322,19 +319,21 @@ impl Session {
         let provider = self.agent.provider().await?;
 
         // Persist messages with provider for automatic description generation
-        session::persist_messages_with_schedule_id(
-            &self.session_file,
-            &self.messages,
-            Some(provider),
-            self.scheduled_job_id.clone(),
-            self.save_session,
-        )
-        .await?;
+        if let Some(session_file) = &self.session_file {
+            session::persist_messages_with_schedule_id(
+                &session_file,
+                &self.messages,
+                Some(provider),
+                self.scheduled_job_id.clone(),
+            )
+            .await?;
+        }
 
         // Track the current directory and last instruction in projects.json
         let session_id = self
             .session_file
-            .file_stem()
+            .as_ref()
+            .and_then(|p| p.file_stem())
             .and_then(|s| s.to_str())
             .map(|s| s.to_string());
 
@@ -420,7 +419,8 @@ impl Session {
                             // Track the current directory and last instruction in projects.json
                             let session_id = self
                                 .session_file
-                                .file_stem()
+                                .as_ref()
+                                .and_then(|p| p.file_stem())
                                 .and_then(|s| s.to_str())
                                 .map(|s| s.to_string());
 
@@ -435,14 +435,15 @@ impl Session {
                             let provider = self.agent.provider().await?;
 
                             // Persist messages with provider for automatic description generation
-                            session::persist_messages_with_schedule_id(
-                                &self.session_file,
-                                &self.messages,
-                                Some(provider),
-                                self.scheduled_job_id.clone(),
-                                self.save_session,
-                            )
-                            .await?;
+                            if let Some(session_file) = &self.session_file {
+                                session::persist_messages_with_schedule_id(
+                                    &session_file,
+                                    &self.messages,
+                                    Some(provider),
+                                    self.scheduled_job_id.clone(),
+                                )
+                                .await?;
+                            }
 
                             output::show_thinking();
                             self.process_agent_response(true).await?;
@@ -624,14 +625,15 @@ impl Session {
                         self.messages = summarized_messages;
 
                         // Persist the summarized messages
-                        session::persist_messages_with_schedule_id(
-                            &self.session_file,
-                            &self.messages,
-                            Some(provider),
-                            self.scheduled_job_id.clone(),
-                            self.save_session,
-                        )
-                        .await?;
+                        if let Some(session_file) = &self.session_file {
+                            session::persist_messages_with_schedule_id(
+                                session_file,
+                                &self.messages,
+                                Some(provider),
+                                self.scheduled_job_id.clone(),
+                            )
+                            .await?;
+                        }
 
                         output::hide_thinking();
                         println!(
@@ -655,8 +657,11 @@ impl Session {
         }
 
         println!(
-            "\nClosing session. Recorded to {}",
-            self.session_file.display()
+            "\nClosing session.{}",
+            self.session_file
+                .as_ref()
+                .and_then(|p| Some(format!(" Recorded to {}", p.display())))
+                .unwrap_or_default()
         );
         Ok(())
     }
@@ -744,19 +749,19 @@ impl Session {
     }
 
     async fn process_agent_response(&mut self, interactive: bool) -> Result<()> {
-        let session_id = session::Identifier::Path(self.session_file.clone());
+        let session_config = self.session_file.as_ref().map(|s| {
+            let session_id = session::Identifier::Path(s.clone());
+            SessionConfig {
+                id: session_id.clone(),
+                working_dir: std::env::current_dir()
+                    .expect("failed to get current session working directory"),
+                schedule_id: self.scheduled_job_id.clone(),
+                execution_mode: None,
+            }
+        });
         let mut stream = self
             .agent
-            .reply(
-                &self.messages,
-                Some(SessionConfig {
-                    id: session_id.clone(),
-                    working_dir: std::env::current_dir()
-                        .expect("failed to get current session working directory"),
-                    schedule_id: self.scheduled_job_id.clone(),
-                    execution_mode: None,
-                }),
-            )
+            .reply(&self.messages, session_config.clone())
             .await?;
 
         let mut progress_bars = output::McpSpinners::new();
@@ -803,7 +808,15 @@ impl Session {
                                         Err(ToolError::ExecutionError("Tool call cancelled by user".to_string()))
                                     ));
                                     self.messages.push(response_message);
-                                    session::persist_messages_with_schedule_id(&self.session_file, &self.messages, None, self.scheduled_job_id.clone(), self.save_session).await?;
+                                    if let Some(session_file) = &self.session_file {
+                                        session::persist_messages_with_schedule_id(
+                                            session_file,
+                                            &self.messages,
+                                            None,
+                                            self.scheduled_job_id.clone(),
+                                        )
+                                        .await?;
+                                    }
 
                                     drop(stream);
                                     break;
@@ -885,13 +898,7 @@ impl Session {
                                     .agent
                                     .reply(
                                         &self.messages,
-                                        Some(SessionConfig {
-                                            id: session_id.clone(),
-                                            working_dir: std::env::current_dir()
-                                                .expect("failed to get current session working directory"),
-                                            schedule_id: self.scheduled_job_id.clone(),
-                                            execution_mode: None,
-                                        }),
+                                        session_config.clone(),
                                     )
                                     .await?;
                             }
@@ -900,7 +907,15 @@ impl Session {
                                 self.messages.push(message.clone());
 
                                 // No need to update description on assistant messages
-                                session::persist_messages_with_schedule_id(&self.session_file, &self.messages, None, self.scheduled_job_id.clone(), self.save_session).await?;
+                                if let Some(session_file) = &self.session_file {
+                                    session::persist_messages_with_schedule_id(
+                                        session_file,
+                                        &self.messages,
+                                        None,
+                                        self.scheduled_job_id.clone(),
+                                    )
+                                    .await?;
+                                }
 
                                 if interactive {output::hide_thinking()};
                                 let _ = progress_bars.hide();
@@ -1099,14 +1114,15 @@ impl Session {
             self.messages.push(response_message);
 
             // No need for description update here
-            session::persist_messages_with_schedule_id(
-                &self.session_file,
-                &self.messages,
-                None,
-                self.scheduled_job_id.clone(),
-                self.save_session,
-            )
-            .await?;
+            if let Some(session_file) = &self.session_file {
+                session::persist_messages_with_schedule_id(
+                    session_file,
+                    &self.messages,
+                    None,
+                    self.scheduled_job_id.clone(),
+                )
+                .await?;
+            }
 
             let prompt = format!(
                 "The existing call to {} was interrupted. How would you like to proceed?",
@@ -1115,14 +1131,15 @@ impl Session {
             self.messages.push(Message::assistant().with_text(&prompt));
 
             // No need for description update here
-            session::persist_messages_with_schedule_id(
-                &self.session_file,
-                &self.messages,
-                None,
-                self.scheduled_job_id.clone(),
-                self.save_session,
-            )
-            .await?;
+            if let Some(session_file) = &self.session_file {
+                session::persist_messages_with_schedule_id(
+                    &session_file,
+                    &self.messages,
+                    None,
+                    self.scheduled_job_id.clone(),
+                )
+                .await?;
+            }
 
             output::render_message(&Message::assistant().with_text(&prompt), self.debug);
         } else {
@@ -1136,14 +1153,15 @@ impl Session {
                             self.messages.push(Message::assistant().with_text(prompt));
 
                             // No need for description update here
-                            session::persist_messages_with_schedule_id(
-                                &self.session_file,
-                                &self.messages,
-                                None,
-                                self.scheduled_job_id.clone(),
-                                self.save_session,
-                            )
-                            .await?;
+                            if let Some(session_file) = &self.session_file {
+                                session::persist_messages_with_schedule_id(
+                                    &session_file,
+                                    &self.messages,
+                                    None,
+                                    self.scheduled_job_id.clone(),
+                                )
+                                .await?;
+                            }
 
                             output::render_message(
                                 &Message::assistant().with_text(prompt),
@@ -1167,7 +1185,7 @@ impl Session {
         Ok(())
     }
 
-    pub fn session_file(&self) -> PathBuf {
+    pub fn session_file(&self) -> Option<PathBuf> {
         self.session_file.clone()
     }
 
@@ -1243,11 +1261,11 @@ impl Session {
 
     /// Get the session metadata
     pub fn get_metadata(&self) -> Result<session::SessionMetadata> {
-        if !self.session_file.exists() {
+        if !self.session_file.as_ref().is_some_and(|f| f.exists()) {
             return Err(anyhow::anyhow!("Session file does not exist"));
         }
 
-        session::read_metadata(&self.session_file)
+        session::read_metadata(&self.session_file.as_ref().unwrap())
     }
 
     // Get the session's total token usage

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -659,7 +659,8 @@ impl Session {
         println!(
             "\nClosing session.{}",
             self.session_file
-                .as_ref().map(|p| format!(" Recorded to {}", p.display()))
+                .as_ref()
+                .map(|p| format!(" Recorded to {}", p.display()))
                 .unwrap_or_default()
         );
         Ok(())

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::Error;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -550,12 +550,12 @@ pub fn display_session_info(
     resume: bool,
     provider: &str,
     model: &str,
-    session_file: &Path,
+    session_file: &Option<PathBuf>,
     provider_instance: Option<&Arc<dyn goose::providers::base::Provider>>,
 ) {
     let start_session_msg = if resume {
         "resuming session |"
-    } else if session_file.to_str() == Some("/dev/null") || session_file.to_str() == Some("NUL") {
+    } else if session_file.is_none() {
         "running without session |"
     } else {
         "starting session |"
@@ -597,7 +597,7 @@ pub fn display_session_info(
         );
     }
 
-    if session_file.to_str() != Some("/dev/null") && session_file.to_str() != Some("NUL") {
+    if let Some(session_file) = session_file {
         println!(
             "    {} {}",
             style("logging to").dim(),

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -1248,7 +1248,6 @@ async fn run_scheduled_job_internal(
                             &session_file_path,
                             &updated_metadata,
                             &all_session_messages,
-                            true,
                         ) {
                             tracing::error!(
                                 "[Job {}] Failed to persist final messages: {}",
@@ -1279,7 +1278,6 @@ async fn run_scheduled_job_internal(
                             &session_file_path,
                             &fallback_metadata,
                             &all_session_messages,
-                            true,
                         ) {
                             tracing::error!("[Job {}] Failed to persist final messages with fallback metadata: {}", job.id, e_fb);
                         }
@@ -1306,12 +1304,9 @@ async fn run_scheduled_job_internal(
             message_count: 0,
             ..Default::default()
         };
-        if let Err(e) = crate::session::storage::save_messages_with_metadata(
-            &session_file_path,
-            &metadata,
-            &[],
-            true,
-        ) {
+        if let Err(e) =
+            crate::session::storage::save_messages_with_metadata(&session_file_path, &metadata, &[])
+        {
             tracing::error!(
                 "[Job {}] Failed to persist metadata for empty job: {}",
                 job.id,

--- a/crates/goose/tests/private_tests.rs
+++ b/crates/goose/tests/private_tests.rs
@@ -788,7 +788,7 @@ async fn test_schedule_tool_session_content_action_with_real_session() {
     ];
 
     // Save the session file
-    goose::session::storage::save_messages_with_metadata(&session_path, &metadata, &messages, true)
+    goose::session::storage::save_messages_with_metadata(&session_path, &metadata, &messages)
         .unwrap();
 
     // Test the session_content action


### PR DESCRIPTION
Instead of using /dev/null or flags, make the session file optional on the agent and only try to save when we have one.

Closes #3228