### PR TITLE
Fix: Allow native Cmd+Up/Down cursor movement when user has typed text

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -118,6 +118,7 @@ export default function ChatInput({
     // Reset history index when input is cleared
     setHistoryIndex(-1);
     setIsInGlobalHistory(false);
+    setHasUserTyped(false);
   }, [initialValue]); // Keep only initialValue as a dependency
 
   // State to track if the IME is composing (i.e., in the middle of Japanese IME input)
@@ -125,6 +126,7 @@ export default function ChatInput({
   const [historyIndex, setHistoryIndex] = useState(-1);
   const [savedInput, setSavedInput] = useState('');
   const [isInGlobalHistory, setIsInGlobalHistory] = useState(false);
+  const [hasUserTyped, setHasUserTyped] = useState(false);
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   const [processedFilePaths, setProcessedFilePaths] = useState<string[]>([]);
 
@@ -221,6 +223,9 @@ export default function ChatInput({
     const val = evt.target.value;
     setDisplayValue(val); // Update display immediately
     debouncedSetValue(val); // Debounce the actual state update
+
+    // Mark that the user has typed something
+    setHasUserTyped(true);
   };
 
   const handlePaste = async (evt: React.ClipboardEvent<HTMLTextAreaElement>) => {
@@ -332,6 +337,13 @@ export default function ChatInput({
       return;
     }
 
+    // Only prevent history navigation if the user has actively typed something
+    // This allows history navigation when text is populated from history or other sources
+    // but prevents it when the user is actively editing text
+    if (hasUserTyped && displayValue.trim() !== '') {
+      return;
+    }
+
     evt.preventDefault();
 
     // Get global history once to avoid multiple calls
@@ -389,6 +401,8 @@ export default function ChatInput({
         setDisplayValue(newValue || '');
         setValue(newValue || '');
       }
+      // Reset hasUserTyped when we populate from history
+      setHasUserTyped(false);
     }
   };
 
@@ -421,6 +435,7 @@ export default function ChatInput({
       setHistoryIndex(-1);
       setSavedInput('');
       setIsInGlobalHistory(false);
+      setHasUserTyped(false);
     }
   };
 


### PR DESCRIPTION
## Problem
Currently, when users type text in the chat input field and press `Cmd+Up` (or `Ctrl+Up`), the text gets replaced with the previous message from history instead of moving the cursor to the beginning of the text. This conflicts with native macOS behavior and user expectations, especially for users familiar with apps like Slack where `Cmd+Up` moves the cursor when there's text in the input.

## Solution
This PR implements a smart solution that distinguishes between text that comes from history navigation vs. text that the user has actively typed:

- **When input is empty**: `Cmd+Up/Down` continues to work for history navigation (preserves existing behavior)
- **When text comes from history**: Users can continue using `Cmd+Up/Down` to navigate through more history items  
- **When user types text**: `Cmd+Up/Down` switches to native cursor movement behavior
- **Smart reset**: The system resets when text is populated from history, message is submitted, or input is cleared

## Technical Implementation
- Added `hasUserTyped` state to track when user actively modifies the input field
- Updated history navigation logic to only prevent navigation when `hasUserTyped && displayValue.trim() !== ''`
- Reset tracking appropriately in `handleChange`, `performSubmit`, history navigation, and initialization

## Benefits
✅ **Preserves all existing functionality** - History navigation works exactly as before when input is empty  
✅ **Allows continued history navigation** - Users can navigate through multiple history items without interference  
✅ **Enables native text editing** - When users type, they get familiar macOS cursor movement behavior  
✅ **Smart and intuitive** - Behavior automatically adapts based on how text got into the field  
✅ **No breaking changes** - All existing tests should continue to pass  

## Testing
- [x] TypeScript compilation passes
- [x] ESLint checks pass
- [x] Existing history navigation functionality preserved
- [x] Native cursor movement works when user types text
- [x] Continued history navigation works when text comes from history

Fixes the UX friction mentioned in the team discussion where `Cmd+Up` would unexpectedly replace user-typed text.