### PR TITLE
update styling of user messages

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -1342,6 +1342,12 @@
               "envs": {
                 "$ref": "#/components/schemas/Envs"
               },
+              "headers": {
+                "type": "object",
+                "additionalProperties": {
+                  "type": "string"
+                }
+              },
               "name": {
                 "type": "string",
                 "description": "The name used to identify this extension"

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -132,6 +132,9 @@ export type ExtensionConfig = {
     description?: string | null;
     env_keys?: Array<string>;
     envs?: Envs;
+    headers?: {
+        [key: string]: string;
+    };
     /**
      * The name used to identify this extension
      */

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -127,7 +127,6 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
           prose-ol:my-2
           prose-ul:mt-0 prose-ul:mb-3
           prose-li:m-0
-          ${className.includes('user-message') ? 'prose-headings:text-white prose-strong:text-white prose-em:text-white' : ''}
 
           ${className}`}
         components={{

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -127,6 +127,7 @@ export default function MarkdownContent({ content, className = '' }: MarkdownCon
           prose-ol:my-2
           prose-ul:mt-0 prose-ul:mb-3
           prose-li:m-0
+          ${className.includes('user-message') ? 'prose-headings:text-white prose-strong:text-white prose-em:text-white' : ''}
 
           ${className}`}
         components={{

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -38,7 +38,7 @@ export default function UserMessage({ message }: UserMessageProps) {
             <div ref={contentRef}>
               <MarkdownContent
                 content={displayText}
-                className="text-white prose-a:text-white user-message"
+                className="text-white prose-a:text-white prose-headings:text-white prose-strong:text-white prose-em:text-white user-message"
               />
             </div>
           </div>


### PR DESCRIPTION
Weird formatting of markdown styles (headers, bold) in light mode 

Before
![image](https://github.com/user-attachments/assets/fe0e406b-014e-4cf9-9ece-4a463ed48dec)


After

<img width="633" alt="Screenshot 2025-07-03 at 2 03 55 PM" src="https://github.com/user-attachments/assets/dcc8ef8d-4c10-4f13-a0a1-129e1b3d4f96" />

