### PR TITLE
Enhancement: Extension name tooltips for tool banners

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -7,6 +7,7 @@ import { cn, snakeToTitleCase } from '../utils';
 import Dot, { LoadingStatus } from './ui/Dot';
 import { NotificationEvent } from '../hooks/useMessageStream';
 import { ChevronRight, LoaderCircle } from 'lucide-react';
+import { TooltipWrapper } from './settings/providers/subcomponents/buttons/TooltipWrapper';
 
 interface ToolCallWithResponseProps {
   isCancelledMessage: boolean;
@@ -120,6 +121,17 @@ const logToString = (logMessage: NotificationEvent) => {
 
 const notificationToProgress = (notification: NotificationEvent): Progress =>
   notification.message.params as unknown as Progress;
+
+// Helper function to extract extension name for tooltip
+const getExtensionTooltip = (toolCallName: string): string | null => {
+  const lastIndex = toolCallName.lastIndexOf('__');
+  if (lastIndex === -1) return null;
+  
+  const extensionName = toolCallName.substring(0, lastIndex);
+  if (!extensionName) return null;
+  
+  return `${extensionName} extension`;
+};
 
 function ToolCallView({
   isCancelledMessage,
@@ -387,6 +399,25 @@ function ToolCallView({
     return null;
   };
 
+  // Get extension tooltip for the current tool
+  const extensionTooltip = getExtensionTooltip(toolCall.name);
+
+  // Extract tool label content to avoid duplication
+  const getToolLabelContent = () => {
+    const description = getToolDescription();
+    if (description) {
+      return description;
+    }
+    // Fallback tool name formatting
+    return snakeToTitleCase(toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2));
+  };
+
+  const toolLabel = (
+    <span className={cn("ml-2", extensionTooltip && "cursor-pointer hover:opacity-80")}>
+      {getToolLabelContent()}
+    </span>
+  );
+
   return (
     <ToolCallExpandable
       isStartExpanded={isRenderingProgress}
@@ -400,16 +431,13 @@ function ToolCallView({
               <Dot size={2} loadingStatus={loadingStatus} />
             )}
           </div>
-          <span className="ml-2">
-            {(() => {
-              const description = getToolDescription();
-              if (description) {
-                return description;
-              }
-              // Fallback tool name formatting
-              return snakeToTitleCase(toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2));
-            })()}
-          </span>
+          {extensionTooltip ? (
+            <TooltipWrapper tooltipContent={extensionTooltip} side="top" align="start">
+              {toolLabel}
+            </TooltipWrapper>
+          ) : (
+            toolLabel
+          )}
         </>
       }
     >


### PR DESCRIPTION
# Add Extension Name Tooltips to Tool Banners

> **⚠️ DEPENDENCY**: This PR depends on #3231 being merged first. Please review and merge #3231 before this PR.

## Overview

Adds hover tooltips to tool banners showing extension names (e.g., "developer extension") without cluttering the UI. This builds on the clean tool descriptions from #3231 by providing extension information on demand through tooltips.

## Features

- **Extension Name Tooltips**: Hover over tool descriptions to see which extension provides that tool
- **Left-Aligned Positioning**: Tooltips align with text start for natural reading flow
- **Smart Detection**: Extracts extension names from tool patterns (`developer__shell` → "developer extension")
- **Graceful Fallback**: Tools without `__` separator show no tooltip

## Screenshot

![Screenshot 2025-07-03 at 4 54 53 PM](https://github.com/user-attachments/assets/48e4594a-947e-4df9-8161-52a2ff399cb6)

## Implementation

- Modified `ui/desktop/src/components/ToolCallWithResponse.tsx`
- Added `getExtensionTooltip()` helper function
- Uses existing `TooltipWrapper` component with `align="start"`
- Zero performance impact, fully backward compatible

## Testing

- ✅ TypeScript compilation passes
- ✅ ESLint checks pass
- ✅ All existing functionality preserved
- ✅ Accessibility maintained

---

Provides extension information on demand while maintaining a clean interface.