### PR TITLE
Fix: Improve visibility of tool calls

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -166,6 +166,11 @@ function ToolCallView({
   // Only expand if there are actual results that need to be shown, not just for tool details
   const isShouldExpand = toolResults.some((v) => v.isExpandToolResults);
 
+  // Helper function to truncate long values
+  const truncate = (str: string, maxLength: number = 50): string => {
+    return str.length > maxLength ? str.substring(0, maxLength) + '...' : str;
+  };
+
   // Function to create a descriptive representation of what the tool is doing
   const getToolDescription = () => {
     const args = toolCall.arguments as Record<string, ToolCallArgumentValue>;
@@ -174,11 +179,6 @@ function ToolCallView({
     // Helper function to get string value safely
     const getStringValue = (value: ToolCallArgumentValue): string => {
       return typeof value === 'string' ? value : JSON.stringify(value);
-    };
-
-    // Helper function to truncate long values
-    const truncate = (str: string, maxLength: number = 50): string => {
-      return str.length > maxLength ? str.substring(0, maxLength) + '...' : str;
     };
 
     // Generate descriptive text based on tool type
@@ -313,8 +313,9 @@ function ToolCallView({
               if (description) {
                 return description;
               }
-              // Fallback to the original tool name formatting
-              return snakeToTitleCase(toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2));
+              // Fallback to formatted and truncated tool name using shared truncate function
+              const toolName = toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2);
+              return truncate(snakeToTitleCase(toolName));
             })()}
           </span>
         </>

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -292,20 +292,8 @@ function ToolCallView({
         return 'poking around...';
 
       default: {
-        // Fallback to showing key parameters for unknown tools
-        const entries = Object.entries(args);
-        if (entries.length === 0) return null;
-
-        // For a single parameter, show key and truncated value
-        if (entries.length === 1) {
-          const [key, value] = entries[0];
-          const stringValue = getStringValue(value);
-          const truncatedValue = truncate(stringValue, 30);
-          return `${key}: ${truncatedValue}`;
-        }
-
-        // For multiple parameters, just show the keys
-        return entries.map(([key]) => key).join(', ');
+        // For unknown tools, always return null to fall back to tool name
+        return null;
       }
     }
 


### PR DESCRIPTION
# 🐛 Fix Tool Call Display: Show Names Instead of Parameters

This PR fixes a UI bug where tool calls with parameters displayed confusing parameter information instead of clear tool names for unknown/unrecognized tools.

![image](https://github.com/user-attachments/assets/bbda346c-31ae-440d-a09c-edf559737631)

## 🚨 Problem Solved

**Confusing Tool Display**: Unknown tools with parameters showed parameter details instead of tool names, making it hard for users to understand what Goose was doing:


## ✨ What's Fixed

### 🔧 Clean Fallback Logic
- **Unknown tools now return `null`** → triggers proper tool name fallback
- **Consistent display** for all unrecognized tools
- **Parameter details still available** in expandable "Tool Details" section

### 🎨 Enhanced Tool Name Display
- **Truncation for long names** (50 character limit with ellipsis)
- **Consistent formatting** using existing `snakeToTitleCase` utility
- **Shared truncation logic** eliminates code duplication

## 🚀 Key Improvements

### ✅ Better User Experience
```typescript
// Before: Confusing parameter list
"support_type, start_date, end_date, category"

// After: Clear, descriptive tool name  
"Retrieve Support Tickets"
```

### ✅ Handles All Tool Types
- **Known tools**: Custom descriptions (unchanged)
- **Unknown tools**: Formatted tool names (fixed)
- **Long tool names**: Properly truncated (enhanced)

## 🎁 User Experience Enhancements

- **Clear tool identification** - Users can immediately see what tool is running
- **Consistent display format** - All tools follow same naming pattern
- **Parameter details preserved** - Still accessible via expandable sections
- **Cleaner UI** - No more confusing parameter lists in tool headers

## 🔧 Technical Implementation

### Core Changes
- **Simplified default case** - Returns `null` to trigger fallback
- **Extracted truncate helper** - Shared between functions for consistency
- **Enhanced fallback logic** - Formats and truncates tool names properly

// Enhanced fallback with shared truncation
const toolName = toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2);
return truncate(snakeToTitleCase(toolName));


## 🎨 Examples of Fixed Display

### MCP Extension Tools
```
❌ Before: "start_date, end_date, category"
✅ After:  "Retrieve Support Tickets"

❌ Before: "issueKey, summary, description"  
✅ After:  "Create Issue"

❌ Before: "environment, orderId, country"
✅ After:  "Get Order Transaction Details..."
```

## 📊 Impact

**Bug**: Tool names missing for unknown tools → **Fixed**: All tools show clear names
**Code Quality**: Duplicated truncation logic → **Improved**: Shared helper function  
**UX**: Confusing parameter lists → **Enhanced**: Clear, truncated tool names
**Maintainability**: Scattered logic → **Consolidated**: Single source of truth

## ✅ Testing

- ✅ TypeScript compilation passes
- ✅ ESLint checks pass  
- ✅ No breaking changes to existing functionality
- ✅ Known tools still show custom descriptions
- ✅ Unknown tools now show formatted names
- ✅ Long tool names properly truncated

## 🔧 Files Changed

- `src/components/ToolCallWithResponse.tsx` - Fixed fallback logic and added shared truncation



![tool name visible](https://github.com/user-attachments/assets/424491e9-0a46-4647-9d1b-5f7716857bc5)
![After_expanded](https://github.com/user-attachments/assets/54159167-13a5-454c-b7f8-ed77e947458d)
