### PR TITLE
fix: Enable agent to see instruction to use final output tool when it wasn't called

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -821,10 +821,14 @@ impl Agent {
                             if let Some(final_output_tool) = self.final_output_tool.lock().await.as_ref() {
                                 if final_output_tool.final_output.is_none() {
                                     tracing::warn!("Final output tool has not been called yet. Continuing agent loop.");
-                                    yield AgentEvent::Message(Message::user().with_text(FINAL_OUTPUT_CONTINUATION_MESSAGE));
+                                    let message = Message::assistant().with_text(FINAL_OUTPUT_CONTINUATION_MESSAGE);
+                                    messages.push(message.clone());
+                                    yield AgentEvent::Message(message);
                                     continue;
                                 } else {
-                                    yield AgentEvent::Message(Message::assistant().with_text(final_output_tool.final_output.clone().unwrap()));
+                                    let message = Message::assistant().with_text(final_output_tool.final_output.clone().unwrap());
+                                    messages.push(message.clone());
+                                    yield AgentEvent::Message(message);
                                 }
                             }
                             break;

--- a/crates/goose/src/agents/final_output_tool.rs
+++ b/crates/goose/src/agents/final_output_tool.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 pub const FINAL_OUTPUT_TOOL_NAME: &str = "recipe__final_output";
 pub const FINAL_OUTPUT_CONTINUATION_MESSAGE: &str =
-    "You MUST call the `final_output` tool with your final output for the user.";
+    "I see I MUST call the `final_output` tool NOW with the final output for the user.";
 
 pub struct FinalOutputTool {
     pub response: Response,
@@ -76,7 +76,7 @@ impl FinalOutputTool {
 
     pub fn system_prompt(&self) -> String {
         formatdoc! {r#"
-            # Final Ouptut Instructions
+            # Final Output Instructions
 
             You MUST use the `final_output` tool to collect the final output for a user.
             The final output MUST be a valid JSON object that matches the following expected schema:


### PR DESCRIPTION
There was a bug that the final tool continuation message was not being added to the internal 'messages' variable so the llm never saw the message telling it to use the final tool (creating an infinite loop). This PR fixes that by adding the message to the 'messages' variable. As this is all internal to the reply loop I can't easily write a test for it but I have tested it locally.