### PR TITLE
Add support in goose configure for streaming http mcp tools

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -844,7 +844,7 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 }
             }
 
-            let add_env = cliclack::confirm("Would you like to add environment variables?").interact()?;
+            let add_env = false; // No env prompt for Streaming HTTP
 
             let mut envs = HashMap::new();
             let mut env_keys = Vec::new();

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -498,8 +498,13 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
         )
         .item(
             "sse",
-            "Remote Extension",
-            "Connect to a remote extension via SSE",
+            "Remote Extension (SSE)",
+            "Connect to a remote extension via Server-Sent Events",
+        )
+        .item(
+            "streamable_http",
+            "Remote Extension (Streaming HTTP)",
+            "Connect to a remote extension via MCP Streaming HTTP",
         )
         .interact()?;
 
@@ -759,6 +764,129 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     uri,
                     envs: Envs::new(envs),
                     env_keys,
+                    description,
+                    timeout: Some(timeout),
+                    bundled: None,
+                },
+            })?;
+
+            cliclack::outro(format!("Added {} extension", style(name).green()))?;
+        }
+        "streamable_http" => {
+            let extensions = ExtensionConfigManager::get_all_names()?;
+            let name: String = cliclack::input("What would you like to call this extension?")
+                .placeholder("my-remote-extension")
+                .validate(move |input: &String| {
+                    if input.is_empty() {
+                        Err("Please enter a name")
+                    } else if extensions.contains(input) {
+                        Err("An extension with this name already exists")
+                    } else {
+                        Ok(())
+                    }
+                })
+                .interact()?;
+
+            let uri: String = cliclack::input("What is the Streaming HTTP endpoint URI?")
+                .placeholder("http://localhost:8000/messages")
+                .validate(|input: &String| {
+                    if input.is_empty() {
+                        Err("Please enter a URI")
+                    } else if !input.starts_with("http") {
+                        Err("URI should start with http:// or https://")
+                    } else {
+                        Ok(())
+                    }
+                })
+                .interact()?;
+
+            let timeout: u64 = cliclack::input("Please set the timeout for this tool (in secs):")
+                .placeholder(&goose::config::DEFAULT_EXTENSION_TIMEOUT.to_string())
+                .validate(|input: &String| match input.parse::<u64>() {
+                    Ok(_) => Ok(()),
+                    Err(_) => Err("Please enter a valid timeout"),
+                })
+                .interact()?;
+
+            let add_desc = cliclack::confirm("Would you like to add a description?").interact()?;
+
+            let description = if add_desc {
+                let desc = cliclack::input("Enter a description for this extension:")
+                    .placeholder("Description")
+                    .validate(|input: &String| match input.parse::<String>() {
+                        Ok(_) => Ok(()),
+                        Err(_) => Err("Please enter a valid description"),
+                    })
+                    .interact()?;
+                Some(desc)
+            } else {
+                None
+            };
+
+            let add_headers = cliclack::confirm("Would you like to add custom headers?").interact()?;
+
+            let mut headers = HashMap::new();
+            if add_headers {
+                loop {
+                    let key: String = cliclack::input("Header name:")
+                        .placeholder("Authorization")
+                        .interact()?;
+
+                    let value: String = cliclack::input("Header value:")
+                        .placeholder("Bearer token123")
+                        .interact()?;
+
+                    headers.insert(key, value);
+
+                    if !cliclack::confirm("Add another header?").interact()? {
+                        break;
+                    }
+                }
+            }
+
+            let add_env = cliclack::confirm("Would you like to add environment variables?").interact()?;
+
+            let mut envs = HashMap::new();
+            let mut env_keys = Vec::new();
+            let config = Config::global();
+
+            if add_env {
+                loop {
+                    let key: String = cliclack::input("Environment variable name:")
+                        .placeholder("API_KEY")
+                        .interact()?;
+
+                    let value: String = cliclack::password("Environment variable value:")
+                        .mask('▪')
+                        .interact()?;
+
+                    // Try to store in keychain
+                    let keychain_key = key.to_string();
+                    match config.set_secret(&keychain_key, Value::String(value.clone())) {
+                        Ok(_) => {
+                            // Successfully stored in keychain, add to env_keys
+                            env_keys.push(keychain_key);
+                        }
+                        Err(_) => {
+                            // Failed to store in keychain, store directly in envs
+                            envs.insert(key, value);
+                        }
+                    }
+
+                    if !cliclack::confirm("Add another environment variable?").interact()? {
+                        break;
+                    }
+                }
+            }
+
+            ExtensionConfigManager::set(ExtensionEntry {
+                enabled: true,
+                config: ExtensionConfig::StreamableHttp {
+                    name: name.clone(),
+                    uri,
+                    envs: Envs::new(envs),
+                    env_keys,
+                    headers,
                     description,
                     timeout: Some(timeout),
                     bundled: None,

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -826,7 +826,8 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                 None
             };
 
-            let add_headers = cliclack::confirm("Would you like to add custom headers?").interact()?;
+            let add_headers =
+                cliclack::confirm("Would you like to add custom headers?").interact()?;
 
             let mut headers = HashMap::new();
             if add_headers {


### PR DESCRIPTION
Adds support for configuring streamable HTTP MCP Servers

### Addition of "Streaming HTTP" extension support:

* **Updated extension list**: Added "Streaming HTTP" as a new option in the extension configuration dialog, with a description explaining its purpose as connecting to a remote extension via MCP Streaming HTTP. (`crates/goose-cli/src/commands/configure.rs`, [crates/goose-cli/src/commands/configure.rsL501-R507](diffhunk://#diff-29570269be581343f6b3201b4f0aae99751428f3b6b64080b7e29e252c3c21c8L501-R507))

* **Configuration prompts for "Streaming HTTP"**: Implemented detailed user prompts for setting up the "Streaming HTTP" extension, including inputs for name, URI, timeout, optional description, and custom headers. Environment variable configuration is excluded for this extension type. (`crates/goose-cli/src/commands/configure.rs`, [crates/goose-cli/src/commands/configure.rsR775-R900](diffhunk://#diff-29570269be581343f6b3201b4f0aae99751428f3b6b64080b7e29e252c3c21c8R775-R900))