### PR TITLE
feat: add support for 'cu' command in extension installation

### DIFF
--- a/ui/desktop/src/components/settings/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings/extensions/deeplink.ts
@@ -14,7 +14,7 @@ function getStdioConfig(
   timeout: number
 ) {
   // Validate that the command is one of the allowed commands
-  const allowedCommands = ['docker', 'jbang', 'npx', 'uvx', 'goosed'];
+  const allowedCommands = ['cu', 'docker', 'jbang', 'npx', 'uvx', 'goosed'];
   if (!allowedCommands.includes(cmd)) {
     toastService.handleError(
       'Invalid Command',

--- a/ui/desktop/src/components/settings/extensions/utils.ts
+++ b/ui/desktop/src/components/settings/extensions/utils.ts
@@ -196,6 +196,7 @@ export function extractExtensionConfig(fixedEntry: FixedExtensionEntry): Extensi
 
 export async function replaceWithShims(cmd: string) {
   const binaryPathMap: Record<string, string> = {
+    cu: await window.electron.getBinaryPath('cu'),
     goosed: await window.electron.getBinaryPath('goosed'),
     jbang: await window.electron.getBinaryPath('jbang'),
     npx: await window.electron.getBinaryPath('npx'),
@@ -212,7 +213,7 @@ export async function replaceWithShims(cmd: string) {
 
 export function removeShims(cmd: string) {
   // Only remove shims if the path matches our known shim patterns
-  const shimPatterns = [/goosed$/, /docker$/, /jbang$/, /npx$/, /uvx$/];
+  const shimPatterns = [/cu$/, /goosed$/, /docker$/, /jbang$/, /npx$/, /uvx$/];
 
   // Check if the command matches any shim pattern
   const isShim = shimPatterns.some((pattern) => pattern.test(cmd));

--- a/ui/desktop/src/extensions.tsx
+++ b/ui/desktop/src/extensions.tsx
@@ -270,6 +270,7 @@ export async function loadAndAddStoredExtensions() {
 // Update the path to the binary based on the command
 export async function replaceWithShims(cmd: string) {
   const binaryPathMap: Record<string, string> = {
+    cu: await window.electron.getBinaryPath('cu'),
     goosed: await window.electron.getBinaryPath('goosed'),
     jbang: await window.electron.getBinaryPath('jbang'),
     npx: await window.electron.getBinaryPath('npx'),


### PR DESCRIPTION
Container Use (cu) is featured in our content and Dagger's documentation:
- We have a [blog post](https://block.github.io/goose/blog/2025/06/19/isolated-development-environments) about Container Use with Goose
- We have a [YouTube video](https://www.youtube.com/watch?v=pGce9T4E5Yw) demonstrating it
- Dagger includes [deeplink installation](https://container-use.com/quickstart#method-3%3A-goose-desktop) instructions in their documentation

However, when users try to install cu-based extensions via the documented deeplinks, they encounter this error:
`Failed to install extension: Invalid command: cu. Only docker, jbang, npx, uvx, goosed are allowed.`

This PR solves that by adding : 
- Add 'cu' to allowedCommands list in deeplink validation
- Include 'cu' in shimPatterns for path resolution
- Add 'cu' to binaryPathMap in both utils.ts and extensions.tsx
- Fixes error: 'Invalid command: cu. Only docker, jbang, npx, uvx, goosed are allowed'
 