### PR TITLE
refactor: abstract keyring logic to better enable DI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3629,6 +3629,7 @@ dependencies = [
  "google-docs1",
  "google-drive3",
  "google-sheets4",
+ "goose",
  "http-body-util",
  "hyper 1.6.0",
  "ignore",

--- a/Justfile
+++ b/Justfile
@@ -185,6 +185,11 @@ test:
 # Run linting checks across all crates
 lint:
     @echo "Running linting checks..."
+    cargo clippy --workspace --all-features -- -D warnings
+
+# Run comprehensive linting checks (includes tests, examples, benchmarks)
+lint-all:
+    @echo "Running comprehensive linting checks..."
     cargo clippy --workspace --all-targets --all-features -- -D warnings
 
 # Format code across all crates
@@ -377,16 +382,16 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 ### Build the core code
 ### profile = --release or "" for debug
 ### allparam = OR/AND/ANY/NONE --workspace --all-features --all-targets
-win-bld profile allparam: 
+win-bld profile allparam:
   cargo run {{profile}} -p goose-server --bin  generate_schema
   cargo build {{profile}} {{allparam}}
 
 ### Build just debug
-win-bld-dbg: 
+win-bld-dbg:
   just win-bld " " " "
 
 ### Build debug and test, examples,...
-win-bld-dbg-all: 
+win-bld-dbg-all:
   just win-bld " " "--workspace --all-targets --all-features"
 
 ### Build just release
@@ -449,8 +454,8 @@ win-total-rls *allparam:
   just win-bld-rls{{allparam}}
   just win-run-rls
 
-### Build and run the Kotlin example with 
-### auto-generated bindings for goose-llm 
+### Build and run the Kotlin example with
+### auto-generated bindings for goose-llm
 kotlin-example:
     # Build Rust dylib and generate Kotlin bindings
     cargo build -p goose-llm

--- a/Justfile
+++ b/Justfile
@@ -177,6 +177,28 @@ run-server:
     @echo "Running server..."
     cargo run -p goose-server
 
+# Run tests across all crates with keyring disabled
+test:
+    @echo "Running tests with keyring disabled..."
+    GOOSE_DISABLE_KEYRING=1 cargo test --workspace
+
+# Run linting checks across all crates
+lint:
+    @echo "Running linting checks..."
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+# Format code across all crates
+format:
+    @echo "Formatting code..."
+    cargo fmt --all
+
+# Quality assurance: format, lint, and test everything
+qa:
+    @echo "Running quality assurance: format, lint, and test..."
+    @just format
+    @just lint
+    @just test
+
 # make GUI with latest binary
 lint-ui:
     cd ui/desktop && npm run lint:check

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 mcp-core = { path = "../mcp-core" }
 mcp-server = { path = "../mcp-server" }
+goose = { path = "../goose" }
 anyhow = "1.0.94"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -161,12 +161,21 @@ impl GoogleDriveRouter {
             Err(_) => false,
         };
 
+        // Create the appropriate keyring backend based on environment
+        let keyring: Arc<dyn goose::keyring::KeyringBackend> =
+            if std::env::var("GOOSE_DISABLE_KEYRING").is_ok() {
+                Arc::new(goose::keyring::MockKeyringBackend::new())
+            } else {
+                Arc::new(goose::keyring::SystemKeyringBackend)
+            };
+
         // Create a credentials manager for storing tokens securely
         let credentials_manager = Arc::new(CredentialsManager::new(
             credentials_path.clone(),
             fallback_to_disk,
             KEYCHAIN_SERVICE.to_string(),
             KEYCHAIN_USERNAME.to_string(),
+            keyring,
         ));
 
         // Read the OAuth credentials from the keyfile

--- a/crates/goose-mcp/src/google_drive/mod.rs
+++ b/crates/goose-mcp/src/google_drive/mod.rs
@@ -161,13 +161,8 @@ impl GoogleDriveRouter {
             Err(_) => false,
         };
 
-        // Create the appropriate keyring backend based on environment
-        let keyring: Arc<dyn goose::keyring::KeyringBackend> =
-            if std::env::var("GOOSE_DISABLE_KEYRING").is_ok() {
-                Arc::new(goose::keyring::MockKeyringBackend::new())
-            } else {
-                Arc::new(goose::keyring::SystemKeyringBackend)
-            };
+        // Use factory to create keyring backend consistently
+        let keyring = goose::keyring::create_default_keyring();
 
         // Create a credentials manager for storing tokens securely
         let credentials_manager = Arc::new(CredentialsManager::new(

--- a/crates/goose-mcp/src/google_drive/oauth_pkce.rs
+++ b/crates/goose-mcp/src/google_drive/oauth_pkce.rs
@@ -193,11 +193,7 @@ impl PkceOAuth2Client {
             };
 
             // Store updated token data
-            match self
-                .credentials_manager
-                .write_credentials(&token_data)
-                .await
-            {
+            match self.credentials_manager.write_credentials(&token_data) {
                 Ok(_) => debug!("Successfully stored token data"),
                 Err(e) => error!("Failed to store token data: {}", e),
             }
@@ -252,11 +248,7 @@ impl PkceOAuth2Client {
         };
 
         // Store updated token data
-        match self
-            .credentials_manager
-            .write_credentials(&token_data)
-            .await
-        {
+        match self.credentials_manager.write_credentials(&token_data) {
             Ok(_) => debug!("Successfully stored token data"),
             Err(e) => error!("Failed to store token data: {}", e),
         }
@@ -326,11 +318,7 @@ impl GetToken for PkceOAuth2Client {
     > {
         Box::pin(async move {
             // Try to read token data from storage to check if we have a valid token
-            if let Ok(token_data) = self
-                .credentials_manager
-                .read_credentials::<TokenData>()
-                .await
-            {
+            if let Ok(token_data) = self.credentials_manager.read_credentials::<TokenData>() {
                 // Verify the project_id matches
                 if token_data.project_id == self.project_id {
                     // Convert stored scopes to &str slices for comparison

--- a/crates/goose-mcp/src/google_drive/oauth_pkce.rs
+++ b/crates/goose-mcp/src/google_drive/oauth_pkce.rs
@@ -193,10 +193,14 @@ impl PkceOAuth2Client {
             };
 
             // Store updated token data
-            self.credentials_manager
+            match self
+                .credentials_manager
                 .write_credentials(&token_data)
-                .map(|_| debug!("Successfully stored token data"))
-                .unwrap_or_else(|e| error!("Failed to store token data: {}", e));
+                .await
+            {
+                Ok(_) => debug!("Successfully stored token data"),
+                Err(e) => error!("Failed to store token data: {}", e),
+            }
         } else {
             debug!("No refresh token provided in OAuth flow response");
         }
@@ -248,10 +252,14 @@ impl PkceOAuth2Client {
         };
 
         // Store updated token data
-        self.credentials_manager
+        match self
+            .credentials_manager
             .write_credentials(&token_data)
-            .map(|_| debug!("Successfully stored token data"))
-            .unwrap_or_else(|e| error!("Failed to store token data: {}", e));
+            .await
+        {
+            Ok(_) => debug!("Successfully stored token data"),
+            Err(e) => error!("Failed to store token data: {}", e),
+        }
 
         Ok(access_token)
     }
@@ -318,7 +326,11 @@ impl GetToken for PkceOAuth2Client {
     > {
         Box::pin(async move {
             // Try to read token data from storage to check if we have a valid token
-            if let Ok(token_data) = self.credentials_manager.read_credentials::<TokenData>() {
+            if let Ok(token_data) = self
+                .credentials_manager
+                .read_credentials::<TokenData>()
+                .await
+            {
                 // Verify the project_id matches
                 if token_data.project_id == self.project_id {
                     // Convert stored scopes to &str slices for comparison

--- a/crates/goose-mcp/src/google_drive/storage.rs
+++ b/crates/goose-mcp/src/google_drive/storage.rs
@@ -89,7 +89,7 @@ impl CredentialsManager {
     /// }
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let keyring = Arc::new(SystemKeyringBackend::new());
+    /// let keyring = Arc::new(SystemKeyringBackend);
     /// let manager = CredentialsManager::new(
     ///     String::from("/path/to/credentials.json"),
     ///     true,  // fallback to disk if keychain fails
@@ -194,7 +194,7 @@ impl CredentialsManager {
     ///     expiry: 1672531200, // Unix timestamp
     /// };
     ///
-    /// let keyring = Arc::new(SystemKeyringBackend::new());
+    /// let keyring = Arc::new(SystemKeyringBackend);
     /// let manager = CredentialsManager::new(
     ///     String::from("/path/to/credentials.json"),
     ///     true,  // fallback to disk if keychain fails

--- a/crates/goose-mcp/src/google_drive/storage.rs
+++ b/crates/goose-mcp/src/google_drive/storage.rs
@@ -1,16 +1,17 @@
 use anyhow::Result;
-use keyring::Entry;
+use goose::keyring::{KeyringBackend, KeyringError};
 use serde::{de::DeserializeOwned, Serialize};
 use std::fs;
 use std::path::Path;
+use std::sync::Arc;
 use thiserror::Error;
 use tracing::{debug, error, warn};
 
 #[allow(dead_code)]
 #[derive(Error, Debug)]
 pub enum StorageError {
-    #[error("Failed to access keychain: {0}")]
-    KeyringError(#[from] keyring::Error),
+    #[error("Failed to access keyring: {0}")]
+    KeyringError(String),
     #[error("Failed to access file system: {0}")]
     FileSystemError(#[from] std::io::Error),
     #[error("No credentials found")]
@@ -21,6 +22,15 @@ pub enum StorageError {
     SerializationError(#[from] serde_json::Error),
 }
 
+impl From<KeyringError> for StorageError {
+    fn from(err: KeyringError) -> Self {
+        match err {
+            KeyringError::NotFound { .. } => StorageError::NotFound,
+            _ => StorageError::KeyringError(err.to_string()),
+        }
+    }
+}
+
 /// CredentialsManager handles secure storage of OAuth credentials.
 /// It attempts to store credentials in the system keychain first,
 /// with fallback to file system storage if keychain access fails and fallback is enabled.
@@ -29,6 +39,7 @@ pub struct CredentialsManager {
     fallback_to_disk: bool,
     keychain_service: String,
     keychain_username: String,
+    keyring: Arc<dyn KeyringBackend>,
 }
 
 impl CredentialsManager {
@@ -37,12 +48,14 @@ impl CredentialsManager {
         fallback_to_disk: bool,
         keychain_service: String,
         keychain_username: String,
+        keyring: Arc<dyn KeyringBackend>,
     ) -> Self {
         Self {
             credentials_path,
             fallback_to_disk,
             keychain_service,
             keychain_username,
+            keyring,
         }
     }
 
@@ -53,17 +66,19 @@ impl CredentialsManager {
     ///
     /// # Type Parameters
     ///
-    /// * `T` - The type to deserialize the credentials into. Must implement `serde::de::DeserializeOwned`.
+    /// * `T` - The type to deserialize to. Must implement `serde::DeserializeOwned`.
     ///
     /// # Returns
     ///
-    /// * `Ok(T)` - The deserialized credentials
+    /// * `Ok(T)` - The deserialized data
     /// * `Err(StorageError)` - If reading or deserialization fails
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # use goose_mcp::google_drive::storage::CredentialsManager;
+    /// # use goose::keyring::SystemKeyringBackend;
+    /// # use std::sync::Arc;
     /// use serde::{Serialize, Deserialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -73,34 +88,46 @@ impl CredentialsManager {
     ///     expiry: u64,
     /// }
     ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let keyring = Arc::new(SystemKeyringBackend::new());
     /// let manager = CredentialsManager::new(
     ///     String::from("/path/to/credentials.json"),
     ///     true,  // fallback to disk if keychain fails
     ///     String::from("test_service"),
-    ///     String::from("test_user")
+    ///     String::from("test_user"),
+    ///     keyring
     /// );
-    /// match manager.read_credentials::<OAuthToken>() {
-    ///     Ok(token) => println!("Token expires at: {}", token.expiry),
+    /// match manager.read_credentials::<OAuthToken>().await {
+    ///     Ok(token) => println!("Access token: {}", token.access_token),
     ///     Err(e) => eprintln!("Failed to read token: {}", e),
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
-    pub fn read_credentials<T>(&self) -> Result<T, StorageError>
+    pub async fn read_credentials<T>(&self) -> Result<T, StorageError>
     where
         T: DeserializeOwned,
     {
-        let json_str = Entry::new(&self.keychain_service, &self.keychain_username)
-            .and_then(|entry| entry.get_password())
+        let json_str = self
+            .keyring
+            .get_password(&self.keychain_service, &self.keychain_username)
+            .await
             .inspect(|_| {
                 debug!("Successfully read credentials from keychain");
             })
             .or_else(|e| {
                 if self.fallback_to_disk {
-                    debug!("Falling back to file system due to keyring error: {}", e);
+                    warn!("Falling back to file system due to keyring error: {}", e);
                     self.read_from_file()
                 } else {
-                    match e {
-                        keyring::Error::NoEntry => Err(StorageError::NotFound),
-                        _ => Err(StorageError::KeyringError(e)),
+                    // Convert anyhow::Error back to our error type
+                    if let Some(keyring_err) = e.downcast_ref::<KeyringError>() {
+                        match keyring_err {
+                            KeyringError::NotFound { .. } => Err(StorageError::NotFound),
+                            _ => Err(StorageError::KeyringError(e.to_string())),
+                        }
+                    } else {
+                        Err(StorageError::KeyringError(e.to_string()))
                     }
                 }
             })?;
@@ -149,6 +176,8 @@ impl CredentialsManager {
     ///
     /// ```no_run
     /// # use goose_mcp::google_drive::storage::CredentialsManager;
+    /// # use goose::keyring::SystemKeyringBackend;
+    /// # use std::sync::Arc;
     /// use serde::{Serialize, Deserialize};
     ///
     /// #[derive(Serialize, Deserialize)]
@@ -158,30 +187,36 @@ impl CredentialsManager {
     ///     expiry: u64,
     /// }
     ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
     /// let token = OAuthToken {
     ///     access_token: String::from("access_token_value"),
     ///     refresh_token: String::from("refresh_token_value"),
     ///     expiry: 1672531200, // Unix timestamp
     /// };
     ///
+    /// let keyring = Arc::new(SystemKeyringBackend::new());
     /// let manager = CredentialsManager::new(
     ///     String::from("/path/to/credentials.json"),
     ///     true,  // fallback to disk if keychain fails
     ///     String::from("test_service"),
-    ///     String::from("test_user")
+    ///     String::from("test_user"),
+    ///     keyring
     /// );
-    /// if let Err(e) = manager.write_credentials(&token) {
+    /// if let Err(e) = manager.write_credentials(&token).await {
     ///     eprintln!("Failed to write token: {}", e);
     /// }
+    /// # Ok(())
+    /// # }
     /// ```
-    pub fn write_credentials<T>(&self, content: &T) -> Result<(), StorageError>
+    pub async fn write_credentials<T>(&self, content: &T) -> Result<(), StorageError>
     where
         T: Serialize,
     {
         let json_str = serde_json::to_string(content).map_err(StorageError::SerializationError)?;
 
-        Entry::new(&self.keychain_service, &self.keychain_username)
-            .and_then(|entry| entry.set_password(&json_str))
+        self.keyring
+            .set_password(&self.keychain_service, &self.keychain_username, &json_str)
+            .await
             .inspect(|_| {
                 debug!("Successfully wrote credentials to keychain");
             })
@@ -190,13 +225,14 @@ impl CredentialsManager {
                     warn!("Falling back to file system due to keyring error: {}", e);
                     self.write_to_file(&json_str)
                 } else {
-                    Err(StorageError::KeyringError(e))
+                    Err(StorageError::KeyringError(e.to_string()))
                 }
             })
     }
 
     fn write_to_file(&self, content: &str) -> Result<(), StorageError> {
         let path = Path::new(&self.credentials_path);
+
         if let Some(parent) = path.parent() {
             if !parent.exists() {
                 match fs::create_dir_all(parent) {
@@ -229,6 +265,7 @@ impl Clone for CredentialsManager {
             fallback_to_disk: self.fallback_to_disk,
             keychain_service: self.keychain_service.clone(),
             keychain_username: self.keychain_username.clone(),
+            keyring: self.keyring.clone(),
         }
     }
 }
@@ -236,6 +273,7 @@ impl Clone for CredentialsManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use goose::keyring::MockKeyringBackend;
     use serde::{Deserialize, Serialize};
     use tempfile::tempdir;
 
@@ -256,32 +294,38 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_read_write_from_keychain() {
+    #[tokio::test]
+    async fn test_read_write_from_keychain() {
         // Create a temporary directory for test files
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let cred_path = temp_dir.path().join("test_credentials.json");
         let cred_path_str = cred_path.to_str().unwrap().to_string();
 
+        // Create a mock keyring backend
+        let keyring = Arc::new(MockKeyringBackend::new());
+
         // Create a credentials manager with fallback enabled
-        // Using a unique service name to ensure keychain operation fails
         let manager = CredentialsManager::new(
             cred_path_str,
             true, // fallback to disk
             "test_service".to_string(),
             "test_user".to_string(),
+            keyring,
         );
 
         // Test credentials to store
         let creds = TestCredentials::new();
 
-        // Write should write to keychain
-        let write_result = manager.write_credentials(&creds);
-        assert!(write_result.is_ok(), "Write should succeed with fallback");
+        // Write should succeed with mock keyring
+        let write_result = manager.write_credentials(&creds).await;
+        assert!(
+            write_result.is_ok(),
+            "Write should succeed with mock keyring"
+        );
 
-        // Read should read from keychain
-        let read_result = manager.read_credentials::<TestCredentials>();
-        assert!(read_result.is_ok(), "Read should succeed with fallback");
+        // Read should succeed with mock keyring
+        let read_result = manager.read_credentials::<TestCredentials>().await;
+        assert!(read_result.is_ok(), "Read should succeed with mock keyring");
 
         // Verify the read credentials match what we wrote
         assert_eq!(
@@ -291,12 +335,15 @@ mod tests {
         );
     }
 
-    #[test]
-    fn test_no_fallback_not_found() {
+    #[tokio::test]
+    async fn test_no_fallback_not_found() {
         // Create a temporary directory for test files
         let temp_dir = tempdir().expect("Failed to create temp dir");
         let cred_path = temp_dir.path().join("nonexistent_credentials.json");
         let cred_path_str = cred_path.to_str().unwrap().to_string();
+
+        // Create a mock keyring backend (empty by default)
+        let keyring = Arc::new(MockKeyringBackend::new());
 
         // Create a credentials manager with fallback disabled
         let manager = CredentialsManager::new(
@@ -304,14 +351,19 @@ mod tests {
             false, // no fallback to disk
             "test_service_that_should_not_exist".to_string(),
             "test_user_no_fallback".to_string(),
+            keyring,
         );
 
-        // Read should fail with NotFound or KeyringError depending on the system
-        let read_result = manager.read_credentials::<TestCredentials>();
+        // Read should fail with NotFound since mock keyring is empty and no fallback
+        let read_result = manager.read_credentials::<TestCredentials>().await;
         println!("{:?}", read_result);
         assert!(
             read_result.is_err(),
             "Read should fail when credentials don't exist"
+        );
+        assert!(
+            matches!(read_result.unwrap_err(), StorageError::NotFound),
+            "Should return NotFound error"
         );
     }
 
@@ -323,15 +375,17 @@ mod tests {
         assert!(matches!(storage_error, StorageError::SerializationError(_)));
     }
 
-    #[test]
-    fn test_file_system_error_handling() {
+    #[tokio::test]
+    async fn test_file_system_error_handling() {
         // Test handling of file system errors by using an invalid path
         let invalid_path = String::from("/nonexistent_directory/credentials.json");
+        let keyring = Arc::new(MockKeyringBackend::new());
         let manager = CredentialsManager::new(
             invalid_path,
             true,
             "test_service".to_string(),
             "test_user".to_string(),
+            keyring,
         );
 
         // Create test credentials

--- a/crates/goose-mcp/src/google_drive/storage.rs
+++ b/crates/goose-mcp/src/google_drive/storage.rs
@@ -108,7 +108,9 @@ impl CredentialsManager {
     where
         T: DeserializeOwned,
     {
-        let json_str = self.keyring.get_password(&self.keychain_service, &self.keychain_username)
+        let json_str = self
+            .keyring
+            .get_password(&self.keychain_service, &self.keychain_username)
             .inspect(|_| {
                 debug!("Successfully read credentials from keychain");
             })
@@ -211,7 +213,8 @@ impl CredentialsManager {
     {
         let json_str = serde_json::to_string(content).map_err(StorageError::SerializationError)?;
 
-        self.keyring.set_password(&self.keychain_service, &self.keychain_username, &json_str)
+        self.keyring
+            .set_password(&self.keychain_service, &self.keychain_username, &json_str)
             .inspect(|_| {
                 debug!("Successfully wrote credentials to keychain");
             })

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -26,9 +26,8 @@ const KEYRING_USERNAME: &str = "secrets";
 const TEST_KEYRING_SERVICE: &str = "goose-test";
 
 // Shared runtime for sync wrapper operations
-static ASYNC_RUNTIME: Lazy<Runtime> = Lazy::new(|| {
-    Runtime::new().expect("Failed to create tokio runtime for config operations")
-});
+static ASYNC_RUNTIME: Lazy<Runtime> =
+    Lazy::new(|| Runtime::new().expect("Failed to create tokio runtime for config operations"));
 
 #[derive(Error, Debug)]
 pub enum ConfigError {
@@ -523,7 +522,8 @@ impl Config {
                     }
                     Err(e) => {
                         // Check if it's a "not found" error
-                        if let Some(keyring_err) = e.downcast_ref::<crate::keyring::KeyringError>() {
+                        if let Some(keyring_err) = e.downcast_ref::<crate::keyring::KeyringError>()
+                        {
                             match keyring_err {
                                 crate::keyring::KeyringError::NotFound { .. } => Ok(HashMap::new()),
                                 _ => Err(ConfigError::KeyringError(e.to_string())),
@@ -1075,7 +1075,7 @@ mod tests {
 
         // Create a failing keyring that returns backend errors
         struct FailingKeyring;
-        
+
         #[async_trait]
         impl KeyringBackend for FailingKeyring {
             async fn get_password(&self, _: &str, _: &str) -> anyhow::Result<String> {
@@ -1099,7 +1099,10 @@ mod tests {
         // This should return an error, not an empty HashMap
         let result = config.load_secrets();
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Keyring service unavailable"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("Keyring service unavailable"));
 
         // Restore GOOSE_DISABLE_KEYRING
         match saved_disable {
@@ -1117,14 +1120,15 @@ mod tests {
 
         // Create a keyring that always returns NotFound
         struct NotFoundKeyring;
-        
+
         #[async_trait]
         impl KeyringBackend for NotFoundKeyring {
             async fn get_password(&self, service: &str, username: &str) -> anyhow::Result<String> {
                 Err(KeyringError::NotFound {
                     service: service.to_string(),
                     username: username.to_string(),
-                }.into())
+                }
+                .into())
             }
             async fn set_password(&self, _: &str, _: &str, _: &str) -> anyhow::Result<()> {
                 Ok(())

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -20,6 +20,7 @@ pub static APP_STRATEGY: Lazy<AppStrategyArgs> = Lazy::new(|| AppStrategyArgs {
 
 const KEYRING_SERVICE: &str = "goose";
 const KEYRING_USERNAME: &str = "secrets";
+const SECRETS_FILE_NAME: &str = "secrets.yaml";
 
 #[cfg(test)]
 const TEST_KEYRING_SERVICE: &str = "goose-test";
@@ -133,7 +134,7 @@ impl Default for Config {
             .config_dir();
 
         let keyring: Arc<dyn KeyringBackend> = if is_env_var_truthy("GOOSE_DISABLE_KEYRING") {
-            Arc::new(FileKeyringBackend::new(config_dir.join("secrets.yaml")))
+            Arc::new(FileKeyringBackend::new(config_dir.join(SECRETS_FILE_NAME)))
         } else {
             Arc::new(SystemKeyringBackend)
         };
@@ -1089,20 +1090,35 @@ mod tests {
     #[test]
     fn test_env_var_truthy_values() {
         // Test truthy values
-        for value in ["1", "true", "TRUE", "yes", "YES", "on", "ON", " true ", "True"] {
+        for value in [
+            "1", "true", "TRUE", "yes", "YES", "on", "ON", " true ", "True",
+        ] {
             env::set_var("TEST_TRUTHY_VAR", value);
-            assert!(is_env_var_truthy("TEST_TRUTHY_VAR"), "Value '{}' should be truthy", value);
+            assert!(
+                is_env_var_truthy("TEST_TRUTHY_VAR"),
+                "Value '{}' should be truthy",
+                value
+            );
         }
 
         // Test falsy values
-        for value in ["0", "false", "FALSE", "no", "NO", "off", "OFF", "", " ", "random"] {
+        for value in [
+            "0", "false", "FALSE", "no", "NO", "off", "OFF", "", " ", "random",
+        ] {
             env::set_var("TEST_TRUTHY_VAR", value);
-            assert!(!is_env_var_truthy("TEST_TRUTHY_VAR"), "Value '{}' should be falsy", value);
+            assert!(
+                !is_env_var_truthy("TEST_TRUTHY_VAR"),
+                "Value '{}' should be falsy",
+                value
+            );
         }
 
         // Test unset variable
         env::remove_var("TEST_TRUTHY_VAR");
-        assert!(!is_env_var_truthy("TEST_TRUTHY_VAR"), "Unset variable should be falsy");
+        assert!(
+            !is_env_var_truthy("TEST_TRUTHY_VAR"),
+            "Unset variable should be falsy"
+        );
 
         // Clean up
         env::remove_var("TEST_TRUTHY_VAR");

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -24,7 +24,6 @@ const KEYRING_USERNAME: &str = "secrets";
 #[cfg(test)]
 const TEST_KEYRING_SERVICE: &str = "goose-test";
 
-
 #[derive(Error, Debug)]
 pub enum ConfigError {
     #[error("Configuration value not found: {0}")]
@@ -119,7 +118,7 @@ impl Default for Config {
         let config_dir = choose_app_strategy(APP_STRATEGY.clone())
             .expect("goose requires a home dir")
             .config_dir();
-        
+
         let keyring: Arc<dyn KeyringBackend> = if env::var("GOOSE_DISABLE_KEYRING").is_ok() {
             Arc::new(FileKeyringBackend::new(config_dir.join("secrets.yaml")))
         } else {
@@ -480,7 +479,10 @@ impl Config {
     }
 
     pub fn load_secrets(&self) -> Result<HashMap<String, Value>, ConfigError> {
-        match self.keyring.get_password(&self.keyring_service, KEYRING_USERNAME) {
+        match self
+            .keyring
+            .get_password(&self.keyring_service, KEYRING_USERNAME)
+        {
             Ok(content) => {
                 let values: HashMap<String, Value> = serde_json::from_str(&content)?;
                 Ok(values)
@@ -497,8 +499,6 @@ impl Config {
             }
         }
     }
-    
-
 
     // check all possible places for a parameter
     pub fn get(&self, key: &str, is_secret: bool) -> Result<Value, ConfigError> {
@@ -652,8 +652,6 @@ impl Config {
             .map_err(|e| ConfigError::KeyringError(e.to_string()))?;
         Ok(())
     }
-    
-
 
     /// Delete a secret from the system keyring.
     ///
@@ -674,8 +672,6 @@ impl Config {
             .map_err(|e| ConfigError::KeyringError(e.to_string()))?;
         Ok(())
     }
-    
-
 }
 
 /// Load init-config.yaml from workspace root if it exists.

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -497,13 +497,8 @@ impl Config {
     where
         F: std::future::Future<Output = Result<T, ConfigError>>,
     {
-        // Try to use current runtime first (for better performance in async contexts)
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            handle.block_on(future)
-        } else {
-            // Use shared runtime for sync contexts
-            ASYNC_RUNTIME.block_on(future)
-        }
+        // Always use shared runtime to avoid nested runtime issues
+        ASYNC_RUNTIME.block_on(future)
     }
 
     // Load current secrets from the keyring

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1,4 +1,6 @@
-use crate::keyring::{FileKeyringBackend, KeyringBackend, SystemKeyringBackend};
+use crate::keyring::{
+    create_default_keyring, create_keyring_with_file_path, FileKeyringBackend, KeyringBackend,
+};
 use etcetera::{choose_app_strategy, AppStrategy, AppStrategyArgs};
 use fs2::FileExt;
 use once_cell::sync::{Lazy, OnceCell};
@@ -24,19 +26,6 @@ const SECRETS_FILE_NAME: &str = "secrets.yaml";
 
 #[cfg(test)]
 const TEST_KEYRING_SERVICE: &str = "goose-test";
-
-/// Check if an environment variable is set to a truthy value
-/// Truthy values: "1", "true", "yes", "on" (case insensitive)
-/// Falsy values: "0", "false", "no", "off", "" or unset
-fn is_env_var_truthy(var_name: &str) -> bool {
-    match env::var(var_name) {
-        Ok(value) => {
-            let normalized = value.trim().to_lowercase();
-            matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
-        }
-        Err(_) => false,
-    }
-}
 
 #[derive(Error, Debug)]
 pub enum ConfigError {
@@ -133,11 +122,8 @@ impl Default for Config {
             .expect("goose requires a home dir")
             .config_dir();
 
-        let keyring: Arc<dyn KeyringBackend> = if is_env_var_truthy("GOOSE_DISABLE_KEYRING") {
-            Arc::new(FileKeyringBackend::new(config_dir.join(SECRETS_FILE_NAME)))
-        } else {
-            Arc::new(SystemKeyringBackend)
-        };
+        // Use factory with custom file path to maintain same behavior
+        let keyring = create_keyring_with_file_path(config_dir.join(SECRETS_FILE_NAME));
         Self::with_keyring(keyring)
     }
 }
@@ -178,7 +164,7 @@ impl Config {
     pub fn new<P: AsRef<Path>>(config_path: P, service: &str) -> Result<Self, ConfigError> {
         Ok(Config {
             config_path: config_path.as_ref().to_path_buf(),
-            keyring: Arc::new(SystemKeyringBackend),
+            keyring: create_default_keyring(),
             keyring_service: service.to_string(),
         })
     }
@@ -745,17 +731,7 @@ pub fn load_init_config_from_workspace() -> Result<HashMap<String, Value>, Confi
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use tempfile::NamedTempFile;
-
-    fn cleanup_keyring() -> Result<(), ConfigError> {
-        let entry = keyring::Entry::new(TEST_KEYRING_SERVICE, KEYRING_USERNAME)?;
-        match entry.delete_credential() {
-            Ok(_) => Ok(()),
-            Err(keyring::Error::NoEntry) => Ok(()),
-            Err(e) => Err(ConfigError::KeyringError(e.to_string())),
-        }
-    }
 
     #[test]
     fn test_basic_config() -> Result<(), ConfigError> {
@@ -867,11 +843,12 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_secret_management() -> Result<(), ConfigError> {
-        cleanup_keyring()?;
-        let temp_file = NamedTempFile::new().unwrap();
-        let config = Config::new(temp_file.path(), TEST_KEYRING_SERVICE)?;
+        use crate::keyring::MockKeyringBackend;
+
+        let _temp_file = NamedTempFile::new().unwrap();
+        let mock_keyring = Arc::new(MockKeyringBackend::new());
+        let config = Config::with_keyring(mock_keyring);
 
         // Test setting and getting a simple secret
         config.set_secret("api_key", Value::String("secret123".to_string()))?;
@@ -889,7 +866,6 @@ mod tests {
         let result: Result<String, ConfigError> = config.get_secret("api_key");
         assert!(matches!(result, Err(ConfigError::NotFound(_))));
 
-        cleanup_keyring()?;
         Ok(())
     }
 
@@ -933,11 +909,12 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn test_multiple_secrets() -> Result<(), ConfigError> {
-        cleanup_keyring()?;
-        let temp_file = NamedTempFile::new().unwrap();
-        let config = Config::new(temp_file.path(), TEST_KEYRING_SERVICE)?;
+        use crate::keyring::MockKeyringBackend;
+
+        let _temp_file = NamedTempFile::new().unwrap();
+        let mock_keyring = Arc::new(MockKeyringBackend::new());
+        let config = Config::with_keyring(mock_keyring);
 
         // Set multiple secrets
         config.set_secret("key1", Value::String("secret1".to_string()))?;
@@ -958,7 +935,6 @@ mod tests {
         assert!(matches!(result1, Err(ConfigError::NotFound(_))));
         assert_eq!(value2, "secret2");
 
-        cleanup_keyring()?;
         Ok(())
     }
 
@@ -1085,43 +1061,6 @@ mod tests {
         }
 
         Ok(())
-    }
-
-    #[test]
-    fn test_env_var_truthy_values() {
-        // Test truthy values
-        for value in [
-            "1", "true", "TRUE", "yes", "YES", "on", "ON", " true ", "True",
-        ] {
-            env::set_var("TEST_TRUTHY_VAR", value);
-            assert!(
-                is_env_var_truthy("TEST_TRUTHY_VAR"),
-                "Value '{}' should be truthy",
-                value
-            );
-        }
-
-        // Test falsy values
-        for value in [
-            "0", "false", "FALSE", "no", "NO", "off", "OFF", "", " ", "random",
-        ] {
-            env::set_var("TEST_TRUTHY_VAR", value);
-            assert!(
-                !is_env_var_truthy("TEST_TRUTHY_VAR"),
-                "Value '{}' should be falsy",
-                value
-            );
-        }
-
-        // Test unset variable
-        env::remove_var("TEST_TRUTHY_VAR");
-        assert!(
-            !is_env_var_truthy("TEST_TRUTHY_VAR"),
-            "Unset variable should be falsy"
-        );
-
-        // Clean up
-        env::remove_var("TEST_TRUTHY_VAR");
     }
 
     #[test]

--- a/crates/goose/src/keyring/factory.rs
+++ b/crates/goose/src/keyring/factory.rs
@@ -1,0 +1,345 @@
+#[cfg(test)]
+use super::KeyringError;
+use super::{FileKeyringBackend, KeyringBackend, MockKeyringBackend, SystemKeyringBackend};
+use etcetera::AppStrategy;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::{env, path::Path};
+
+/// Factory for creating keyring backends with environment-based defaults.
+///
+/// This factory provides a consistent way to create keyring backends across
+/// the entire codebase, handling environment variable detection and providing
+/// sensible defaults based on the execution context.
+///
+/// # Environment Variable Priority
+///
+/// The factory checks environment variables in this order:
+/// 1. `GOOSE_USE_MOCK_KEYRING` (highest priority) - Forces mock backend for testing
+/// 2. `GOOSE_DISABLE_KEYRING` - Forces file-based backend for production without OS keyring
+/// 3. Default behavior - Uses system keyring for production
+pub struct KeyringFactory;
+
+impl KeyringFactory {
+    /// Create a keyring backend using environment-based defaults.
+    ///
+    /// This is the most common use case - let the factory decide which backend
+    /// to use based on environment variables and execution context.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use goose::keyring::KeyringFactory;
+    ///
+    /// let keyring = KeyringFactory::create_default();
+    /// keyring.set_password("service", "user", "password").unwrap();
+    /// ```
+    pub fn create_default() -> Arc<dyn KeyringBackend> {
+        Self::create_with_config(DefaultKeyringConfig::new())
+    }
+
+    /// Create a keyring backend with custom configuration.
+    ///
+    /// This allows overriding default behavior such as specifying a custom
+    /// file path for the file-based backend.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use goose::keyring::{KeyringFactory, DefaultKeyringConfig};
+    /// use std::path::PathBuf;
+    ///
+    /// let config = DefaultKeyringConfig::new()
+    ///     .with_file_path(PathBuf::from("/custom/path/secrets.yaml"));
+    /// let keyring = KeyringFactory::create_with_config(config);
+    /// ```
+    pub fn create_with_config(config: DefaultKeyringConfig) -> Arc<dyn KeyringBackend> {
+        // Priority 1: Mock keyring for testing
+        if Self::is_env_var_truthy("GOOSE_USE_MOCK_KEYRING") {
+            return Arc::new(MockKeyringBackend::new());
+        }
+
+        // Priority 2: File-based keyring when system keyring disabled
+        if Self::is_env_var_truthy("GOOSE_DISABLE_KEYRING") {
+            let file_path = config
+                .file_path
+                .unwrap_or_else(|| Self::default_config_dir().join("secrets.yaml"));
+            return Arc::new(FileKeyringBackend::new(file_path));
+        }
+
+        // Priority 3: System keyring (default)
+        Arc::new(SystemKeyringBackend)
+    }
+
+    /// Check if an environment variable is set to a truthy value.
+    ///
+    /// This matches the same logic used throughout the goose codebase for
+    /// consistency in environment variable interpretation.
+    ///
+    /// Truthy values: "1", "true", "yes", "on" (case insensitive)
+    /// Falsy values: "0", "false", "no", "off", "" or unset
+    fn is_env_var_truthy(var_name: &str) -> bool {
+        match env::var(var_name) {
+            Ok(value) => {
+                let normalized = value.trim().to_lowercase();
+                matches!(normalized.as_str(), "1" | "true" | "yes" | "on")
+            }
+            Err(_) => false,
+        }
+    }
+
+    /// Get the default configuration directory using the same logic as Config.
+    ///
+    /// This ensures consistency with the rest of the goose configuration system.
+    fn default_config_dir() -> PathBuf {
+        use etcetera::{choose_app_strategy, AppStrategyArgs};
+
+        let strategy = AppStrategyArgs {
+            top_level_domain: "Block".to_string(),
+            author: "Block".to_string(),
+            app_name: "goose".to_string(),
+        };
+
+        choose_app_strategy(strategy)
+            .expect("goose requires a home dir")
+            .config_dir()
+    }
+}
+
+/// Configuration options for keyring factory creation.
+///
+/// This struct allows customizing the behavior of the keyring factory
+/// without breaking the simple default use case.
+#[derive(Default)]
+pub struct DefaultKeyringConfig {
+    /// Optional custom file path for FileKeyringBackend.
+    ///
+    /// If not provided, defaults to `{config_dir}/secrets.yaml`
+    pub file_path: Option<PathBuf>,
+}
+
+impl DefaultKeyringConfig {
+    /// Create a new configuration with default values.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set a custom file path for the file-based keyring backend.
+    ///
+    /// This path will be used when `GOOSE_DISABLE_KEYRING` is set but
+    /// `GOOSE_USE_MOCK_KEYRING` is not set.
+    pub fn with_file_path<P: AsRef<Path>>(mut self, path: P) -> Self {
+        self.file_path = Some(path.as_ref().to_path_buf());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::env;
+    use tempfile::tempdir;
+
+    /// Test utility for managing environment variables in tests.
+    ///
+    /// This ensures that environment variables are properly restored
+    /// after each test, preventing test interference.
+    struct EnvGuard {
+        key: String,
+        original_value: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &str, value: &str) -> Self {
+            let original_value = env::var(key).ok();
+            env::set_var(key, value);
+            EnvGuard {
+                key: key.to_string(),
+                original_value,
+            }
+        }
+
+        fn remove(key: &str) -> Self {
+            let original_value = env::var(key).ok();
+            env::remove_var(key);
+            EnvGuard {
+                key: key.to_string(),
+                original_value,
+            }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original_value {
+                Some(value) => env::set_var(&self.key, value),
+                None => env::remove_var(&self.key),
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_mock_keyring_priority() {
+        let _guard1 = EnvGuard::set("GOOSE_USE_MOCK_KEYRING", "true");
+        let _guard2 = EnvGuard::set("GOOSE_DISABLE_KEYRING", "true");
+
+        let keyring = KeyringFactory::create_default();
+
+        // Should use MockKeyringBackend despite GOOSE_DISABLE_KEYRING being set
+        // We can verify this by checking that a non-existent key returns NotFound
+        match keyring.get_password("test_service", "test_user") {
+            Err(e) => {
+                if let Some(keyring_err) = e.downcast_ref::<KeyringError>() {
+                    assert!(matches!(keyring_err, KeyringError::NotFound { .. }));
+                }
+            }
+            Ok(_) => panic!("Mock keyring should return NotFound for non-existent keys"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_file_keyring_when_disabled() {
+        let _guard1 = EnvGuard::remove("GOOSE_USE_MOCK_KEYRING");
+        let _guard2 = EnvGuard::set("GOOSE_DISABLE_KEYRING", "true");
+
+        let temp_dir = tempdir().unwrap();
+        let keyring = KeyringFactory::create_with_config(
+            DefaultKeyringConfig::new().with_file_path(temp_dir.path().join("test_secrets.yaml")),
+        );
+
+        // Use unique service/user names to avoid conflicts
+        let service = format!("service_{}", std::process::id());
+        let user = format!("user_{}", std::process::id());
+
+        // Verify it creates a FileKeyringBackend by testing file operations
+        keyring.set_password(&service, &user, "password").unwrap();
+        assert_eq!(keyring.get_password(&service, &user).unwrap(), "password");
+
+        // Verify the file was actually created
+        assert!(temp_dir.path().join("test_secrets.yaml").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn test_system_keyring_default() {
+        // For this test, we'll use mock keyring to avoid OS keyring popups
+        // but verify the logic by ensuring that when neither override is set,
+        // the factory doesn't choose the file backend
+        let _guard1 = EnvGuard::set("GOOSE_USE_MOCK_KEYRING", "true");
+        let _guard2 = EnvGuard::remove("GOOSE_DISABLE_KEYRING");
+
+        let keyring = KeyringFactory::create_default();
+
+        // Verify it creates a MockKeyringBackend (since we forced it for testing)
+        // The main thing we're testing is that the logic flow is correct
+        match keyring.get_password("non_existent_service", "non_existent_user") {
+            Err(e) => {
+                if let Some(keyring_err) = e.downcast_ref::<KeyringError>() {
+                    assert!(matches!(keyring_err, KeyringError::NotFound { .. }));
+                }
+            }
+            Ok(_) => panic!("Mock keyring should return NotFound for non-existent keys"),
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn test_default_config_with_custom_path() {
+        let _guard1 = EnvGuard::remove("GOOSE_USE_MOCK_KEYRING");
+        let _guard2 = EnvGuard::set("GOOSE_DISABLE_KEYRING", "true");
+
+        let temp_dir = tempdir().unwrap();
+        let custom_path = temp_dir.path().join("custom_secrets.yaml");
+
+        let config = DefaultKeyringConfig::new().with_file_path(&custom_path);
+        let keyring = KeyringFactory::create_with_config(config);
+
+        // Use unique service/user names to avoid conflicts
+        let service = format!("test_service_{}", std::process::id());
+        let user = format!("test_user_{}", std::process::id());
+
+        // Test that the custom path is used
+        keyring
+            .set_password(&service, &user, "test_password")
+            .unwrap();
+
+        // Verify the custom file was created
+        assert!(custom_path.exists());
+
+        // Verify we can retrieve the password
+        assert_eq!(
+            keyring.get_password(&service, &user).unwrap(),
+            "test_password"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_env_var_truthy_values() {
+        // Test truthy values
+        for value in [
+            "1", "true", "TRUE", "yes", "YES", "on", "ON", " true ", "True",
+        ] {
+            let _guard = EnvGuard::set("TEST_TRUTHY_VAR", value);
+            assert!(
+                KeyringFactory::is_env_var_truthy("TEST_TRUTHY_VAR"),
+                "Value '{}' should be truthy",
+                value
+            );
+        }
+
+        // Test falsy values
+        for value in [
+            "0", "false", "FALSE", "no", "NO", "off", "OFF", "", " ", "random",
+        ] {
+            let _guard = EnvGuard::set("TEST_TRUTHY_VAR", value);
+            assert!(
+                !KeyringFactory::is_env_var_truthy("TEST_TRUTHY_VAR"),
+                "Value '{}' should be falsy",
+                value
+            );
+        }
+
+        // Test unset variable
+        let _guard = EnvGuard::remove("TEST_TRUTHY_VAR");
+        assert!(
+            !KeyringFactory::is_env_var_truthy("TEST_TRUTHY_VAR"),
+            "Unset variable should be falsy"
+        );
+    }
+
+    #[test]
+    #[serial]
+    fn test_factory_consistency_with_existing_is_env_var_truthy() {
+        // This test ensures our factory's is_env_var_truthy matches the existing implementation
+        // We'll test a few key values to ensure consistency
+
+        let test_cases = [
+            ("1", true),
+            ("true", true),
+            ("TRUE", true),
+            ("yes", true),
+            ("on", true),
+            ("0", false),
+            ("false", false),
+            ("no", false),
+            ("off", false),
+            ("", false),
+            ("random", false),
+        ];
+
+        for (value, expected) in test_cases {
+            let _guard = EnvGuard::set("TEST_CONSISTENCY_VAR", value);
+            assert_eq!(
+                KeyringFactory::is_env_var_truthy("TEST_CONSISTENCY_VAR"),
+                expected,
+                "Value '{}' should be {}",
+                value,
+                if expected { "truthy" } else { "falsy" }
+            );
+        }
+    }
+}

--- a/crates/goose/src/keyring/file.rs
+++ b/crates/goose/src/keyring/file.rs
@@ -1,0 +1,252 @@
+use super::{KeyringBackend, KeyringError};
+use anyhow::Result;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+pub struct FileKeyringBackend {
+    secrets_path: PathBuf,
+}
+
+impl FileKeyringBackend {
+    pub fn new(secrets_path: PathBuf) -> Self {
+        Self { secrets_path }
+    }
+
+    fn load_all_secrets(&self) -> Result<HashMap<String, String>> {
+        if self.secrets_path.exists() {
+            let file_content = std::fs::read_to_string(&self.secrets_path)?;
+            let yaml_value: serde_yaml::Value = serde_yaml::from_str(&file_content)?;
+            let json_value: Value = serde_json::to_value(yaml_value)?;
+            match json_value {
+                Value::Object(map) => {
+                    let mut result = HashMap::new();
+                    for (key, value) in map {
+                        if let Some(string_value) = value.as_str() {
+                            result.insert(key, string_value.to_string());
+                        } else {
+                            // Convert non-string values to JSON strings
+                            result.insert(key, serde_json::to_string(&value)?);
+                        }
+                    }
+                    Ok(result)
+                }
+                _ => Ok(HashMap::new()),
+            }
+        } else {
+            Ok(HashMap::new())
+        }
+    }
+
+    fn save_all_secrets(&self, secrets: &HashMap<String, String>) -> Result<()> {
+        // Convert strings back to appropriate JSON values
+        let mut json_map = serde_json::Map::new();
+        for (key, value) in secrets {
+            // Try to parse as JSON first, fall back to string
+            let json_value = serde_json::from_str(value).unwrap_or_else(|_| Value::String(value.clone()));
+            json_map.insert(key.clone(), json_value);
+        }
+        
+        let yaml_value = serde_yaml::to_string(&json_map)?;
+        
+        // Ensure parent directory exists
+        if let Some(parent) = self.secrets_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        
+        std::fs::write(&self.secrets_path, yaml_value)?;
+        Ok(())
+    }
+
+    fn make_key(service: &str, username: &str) -> String {
+        format!("{}:{}", service, username)
+    }
+}
+
+impl KeyringBackend for FileKeyringBackend {
+    fn get_password(&self, service: &str, username: &str) -> Result<String> {
+        let key = Self::make_key(service, username);
+        let secrets = self.load_all_secrets()?;
+        
+        secrets.get(&key).cloned().ok_or_else(|| {
+            KeyringError::NotFound {
+                service: service.to_string(),
+                username: username.to_string(),
+            }
+            .into()
+        })
+    }
+
+    fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()> {
+        let key = Self::make_key(service, username);
+        let mut secrets = self.load_all_secrets()?;
+        secrets.insert(key, password.to_string());
+        self.save_all_secrets(&secrets)?;
+        Ok(())
+    }
+
+    fn delete_password(&self, service: &str, username: &str) -> Result<()> {
+        let key = Self::make_key(service, username);
+        let mut secrets = self.load_all_secrets()?;
+        secrets.remove(&key);
+        self.save_all_secrets(&secrets)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_basic_operations() -> Result<()> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let backend = FileKeyringBackend::new(temp_file.path().to_path_buf());
+
+        // Test setting a password
+        backend.set_password("test_service", "test_user", "test_password")?;
+
+        // Test getting the password
+        let password = backend.get_password("test_service", "test_user")?;
+        assert_eq!(password, "test_password");
+
+        // Test deleting the password
+        backend.delete_password("test_service", "test_user")?;
+
+        // Test that getting deleted password returns NotFound error
+        let result = backend.get_password("test_service", "test_user");
+        assert!(result.is_err());
+        if let Err(e) = result {
+            if let Some(keyring_err) = e.downcast_ref::<KeyringError>() {
+                assert!(matches!(keyring_err, KeyringError::NotFound { .. }));
+            } else {
+                panic!("Expected KeyringError::NotFound, got: {:?}", e);
+            }
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_services() -> Result<()> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let backend = FileKeyringBackend::new(temp_file.path().to_path_buf());
+
+        // Set passwords for different services
+        backend.set_password("service1", "user1", "password1")?;
+        backend.set_password("service2", "user2", "password2")?;
+        backend.set_password("service1", "user2", "password3")?;
+
+        // Verify all passwords can be retrieved correctly
+        assert_eq!(backend.get_password("service1", "user1")?, "password1");
+        assert_eq!(backend.get_password("service2", "user2")?, "password2");
+        assert_eq!(backend.get_password("service1", "user2")?, "password3");
+
+        // Delete one password and verify others remain
+        backend.delete_password("service1", "user1")?;
+        assert!(backend.get_password("service1", "user1").is_err());
+        assert_eq!(backend.get_password("service2", "user2")?, "password2");
+        assert_eq!(backend.get_password("service1", "user2")?, "password3");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_password_update() -> Result<()> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let backend = FileKeyringBackend::new(temp_file.path().to_path_buf());
+
+        // Set initial password
+        backend.set_password("service", "user", "old_password")?;
+        assert_eq!(backend.get_password("service", "user")?, "old_password");
+
+        // Update password
+        backend.set_password("service", "user", "new_password")?;
+        assert_eq!(backend.get_password("service", "user")?, "new_password");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_nonexistent_file() -> Result<()> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let file_path = temp_file.path().to_path_buf();
+        drop(temp_file); // Delete the file
+
+        let backend = FileKeyringBackend::new(file_path);
+
+        // Getting from non-existent file should return NotFound
+        let result = backend.get_password("service", "user");
+        assert!(result.is_err());
+        if let Err(e) = result {
+            if let Some(keyring_err) = e.downcast_ref::<KeyringError>() {
+                assert!(matches!(keyring_err, KeyringError::NotFound { .. }));
+            }
+        }
+
+        // Setting should create the file
+        backend.set_password("service", "user", "password")?;
+        assert_eq!(backend.get_password("service", "user")?, "password");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_empty_password() -> Result<()> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let backend = FileKeyringBackend::new(temp_file.path().to_path_buf());
+
+        // Test setting and getting empty password
+        backend.set_password("service", "user", "")?;
+        assert_eq!(backend.get_password("service", "user")?, "");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_special_characters_in_credentials() -> Result<()> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let backend = FileKeyringBackend::new(temp_file.path().to_path_buf());
+
+        // Test with special characters in service, user, and password
+        let service = "service-with-dashes_and_underscores.and.dots";
+        let user = "user@domain.com";
+        let password = "password with spaces & special chars: !@#$%^&*()";
+
+        backend.set_password(service, user, password)?;
+        assert_eq!(backend.get_password(service, user)?, password);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_json_content_in_password() -> Result<()> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let backend = FileKeyringBackend::new(temp_file.path().to_path_buf());
+
+        // Test storing JSON content as password
+        let json_password = r#"{"access_token":"abc123","refresh_token":"def456","expires_in":3600}"#;
+        backend.set_password("oauth_service", "user", json_password)?;
+        
+        let retrieved = backend.get_password("oauth_service", "user")?;
+        
+        // Parse both as JSON to compare content regardless of key order
+        let original: serde_json::Value = serde_json::from_str(json_password).unwrap();
+        let retrieved_parsed: serde_json::Value = serde_json::from_str(&retrieved).unwrap();
+        assert_eq!(original, retrieved_parsed);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_delete_nonexistent_password() -> Result<()> {
+        let temp_file = NamedTempFile::new().unwrap();
+        let backend = FileKeyringBackend::new(temp_file.path().to_path_buf());
+
+        // Deleting non-existent password should not error (idempotent)
+        backend.delete_password("nonexistent_service", "nonexistent_user")?;
+
+        Ok(())
+    }
+}

--- a/crates/goose/src/keyring/mock.rs
+++ b/crates/goose/src/keyring/mock.rs
@@ -38,7 +38,8 @@ impl MockKeyringBackend {
 impl KeyringBackend for MockKeyringBackend {
     async fn get_password(&self, service: &str, username: &str) -> Result<String> {
         let key = Self::make_key(service, username);
-        let storage = self.storage
+        let storage = self
+            .storage
             .read()
             .map_err(|e| KeyringError::Backend(format!("Mock keyring lock poisoned: {}", e)))?;
 

--- a/crates/goose/src/keyring/mock.rs
+++ b/crates/goose/src/keyring/mock.rs
@@ -1,0 +1,72 @@
+use super::{KeyringBackend, KeyringError};
+use anyhow::Result;
+use async_trait::async_trait;
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+#[derive(Clone, Default)]
+pub struct MockKeyringBackend {
+    storage: Arc<RwLock<HashMap<String, String>>>,
+}
+
+impl MockKeyringBackend {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn clear(&self) {
+        self.storage
+            .write()
+            .expect("Mock keyring lock poisoned")
+            .clear();
+    }
+
+    pub fn contains(&self, service: &str, username: &str) -> bool {
+        let key = format!("{}:{}", service, username);
+        self.storage
+            .read()
+            .expect("Mock keyring lock poisoned")
+            .contains_key(&key)
+    }
+
+    fn make_key(service: &str, username: &str) -> String {
+        format!("{}:{}", service, username)
+    }
+}
+
+#[async_trait]
+impl KeyringBackend for MockKeyringBackend {
+    async fn get_password(&self, service: &str, username: &str) -> Result<String> {
+        let key = Self::make_key(service, username);
+        let storage = self.storage
+            .read()
+            .map_err(|e| KeyringError::Backend(format!("Mock keyring lock poisoned: {}", e)))?;
+
+        storage
+            .get(&key)
+            .cloned()
+            .ok_or_else(|| KeyringError::NotFound {
+                service: service.to_string(),
+                username: username.to_string(),
+            })
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()> {
+        let key = Self::make_key(service, username);
+        self.storage
+            .write()
+            .map_err(|e| KeyringError::Backend(format!("Mock keyring lock poisoned: {}", e)))?
+            .insert(key, password.to_string());
+        Ok(())
+    }
+
+    async fn delete_password(&self, service: &str, username: &str) -> Result<()> {
+        let key = Self::make_key(service, username);
+        self.storage
+            .write()
+            .map_err(|e| KeyringError::Backend(format!("Mock keyring lock poisoned: {}", e)))?
+            .remove(&key);
+        Ok(())
+    }
+}

--- a/crates/goose/src/keyring/mock.rs
+++ b/crates/goose/src/keyring/mock.rs
@@ -1,6 +1,5 @@
 use super::{KeyringBackend, KeyringError};
 use anyhow::Result;
-use async_trait::async_trait;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
@@ -34,9 +33,8 @@ impl MockKeyringBackend {
     }
 }
 
-#[async_trait]
 impl KeyringBackend for MockKeyringBackend {
-    async fn get_password(&self, service: &str, username: &str) -> Result<String> {
+    fn get_password(&self, service: &str, username: &str) -> Result<String> {
         let key = Self::make_key(service, username);
         let storage = self
             .storage
@@ -53,7 +51,7 @@ impl KeyringBackend for MockKeyringBackend {
             .map_err(anyhow::Error::from)
     }
 
-    async fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()> {
+    fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()> {
         let key = Self::make_key(service, username);
         self.storage
             .write()
@@ -62,7 +60,7 @@ impl KeyringBackend for MockKeyringBackend {
         Ok(())
     }
 
-    async fn delete_password(&self, service: &str, username: &str) -> Result<()> {
+    fn delete_password(&self, service: &str, username: &str) -> Result<()> {
         let key = Self::make_key(service, username);
         self.storage
             .write()

--- a/crates/goose/src/keyring/mod.rs
+++ b/crates/goose/src/keyring/mod.rs
@@ -1,0 +1,25 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+#[async_trait]
+pub trait KeyringBackend: Send + Sync {
+    async fn get_password(&self, service: &str, username: &str) -> Result<String>;
+    async fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()>;
+    async fn delete_password(&self, service: &str, username: &str) -> Result<()>;
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeyringError {
+    #[error("No entry found for service '{service}' user '{username}'")]
+    NotFound { service: String, username: String },
+    #[error("Access denied to keyring")]
+    AccessDenied,
+    #[error("Keyring backend error: {0}")]
+    Backend(String),
+}
+
+pub mod mock;
+pub mod system;
+
+pub use mock::MockKeyringBackend;
+pub use system::SystemKeyringBackend;

--- a/crates/goose/src/keyring/mod.rs
+++ b/crates/goose/src/keyring/mod.rs
@@ -6,7 +6,6 @@ pub trait KeyringBackend: Send + Sync {
     fn delete_password(&self, service: &str, username: &str) -> Result<()>;
 }
 
-
 #[derive(Debug, thiserror::Error)]
 pub enum KeyringError {
     #[error("No entry found for service '{service}' user '{username}'")]

--- a/crates/goose/src/keyring/mod.rs
+++ b/crates/goose/src/keyring/mod.rs
@@ -1,12 +1,11 @@
 use anyhow::Result;
-use async_trait::async_trait;
 
-#[async_trait]
 pub trait KeyringBackend: Send + Sync {
-    async fn get_password(&self, service: &str, username: &str) -> Result<String>;
-    async fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()>;
-    async fn delete_password(&self, service: &str, username: &str) -> Result<()>;
+    fn get_password(&self, service: &str, username: &str) -> Result<String>;
+    fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()>;
+    fn delete_password(&self, service: &str, username: &str) -> Result<()>;
 }
+
 
 #[derive(Debug, thiserror::Error)]
 pub enum KeyringError {
@@ -18,8 +17,10 @@ pub enum KeyringError {
     Backend(String),
 }
 
+pub mod file;
 pub mod mock;
 pub mod system;
 
+pub use file::FileKeyringBackend;
 pub use mock::MockKeyringBackend;
 pub use system::SystemKeyringBackend;

--- a/crates/goose/src/keyring/mod.rs
+++ b/crates/goose/src/keyring/mod.rs
@@ -16,10 +16,51 @@ pub enum KeyringError {
     Backend(String),
 }
 
+pub mod factory;
 pub mod file;
 pub mod mock;
 pub mod system;
 
+pub use factory::{DefaultKeyringConfig, KeyringFactory};
 pub use file::FileKeyringBackend;
 pub use mock::MockKeyringBackend;
 pub use system::SystemKeyringBackend;
+
+/// Convenience function for creating a keyring backend with environment-based defaults.
+///
+/// This is the most common use case - it automatically selects the appropriate
+/// keyring backend based on environment variables:
+/// - `GOOSE_USE_MOCK_KEYRING=true` → MockKeyringBackend (for testing)
+/// - `GOOSE_DISABLE_KEYRING=true` → FileKeyringBackend (for systems without keyring)
+/// - Default → SystemKeyringBackend (for normal operation)
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use goose::keyring::create_default_keyring;
+///
+/// let keyring = create_default_keyring();
+/// keyring.set_password("service", "user", "password").unwrap();
+/// ```
+pub fn create_default_keyring() -> std::sync::Arc<dyn KeyringBackend> {
+    KeyringFactory::create_default()
+}
+
+/// Convenience function for creating a keyring backend with a custom file path.
+///
+/// This is useful when you need to store secrets in a specific location
+/// while still respecting the environment variable hierarchy.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// use goose::keyring::create_keyring_with_file_path;
+/// use std::path::PathBuf;
+///
+/// let keyring = create_keyring_with_file_path(PathBuf::from("/custom/secrets.yaml"));
+/// ```
+pub fn create_keyring_with_file_path(
+    file_path: std::path::PathBuf,
+) -> std::sync::Arc<dyn KeyringBackend> {
+    KeyringFactory::create_with_config(DefaultKeyringConfig::new().with_file_path(file_path))
+}

--- a/crates/goose/src/keyring/system.rs
+++ b/crates/goose/src/keyring/system.rs
@@ -1,0 +1,46 @@
+use super::{KeyringBackend, KeyringError};
+use anyhow::Result;
+use async_trait::async_trait;
+use keyring::Entry;
+
+pub struct SystemKeyringBackend;
+
+#[async_trait]
+impl KeyringBackend for SystemKeyringBackend {
+    async fn get_password(&self, service: &str, username: &str) -> Result<String> {
+        let entry =
+            Entry::new(service, username).map_err(|e| KeyringError::Backend(e.to_string()))?;
+
+        entry
+            .get_password()
+            .map_err(|e| match e {
+                keyring::Error::NoEntry => KeyringError::NotFound {
+                    service: service.to_string(),
+                    username: username.to_string(),
+                },
+                _ => KeyringError::Backend(e.to_string()),
+            })
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()> {
+        let entry =
+            Entry::new(service, username).map_err(|e| KeyringError::Backend(e.to_string()))?;
+
+        entry
+            .set_password(password)
+            .map_err(|e| KeyringError::Backend(e.to_string()))
+            .map_err(anyhow::Error::from)
+    }
+
+    async fn delete_password(&self, service: &str, username: &str) -> Result<()> {
+        let entry =
+            Entry::new(service, username).map_err(|e| KeyringError::Backend(e.to_string()))?;
+
+        match entry.delete_credential() {
+            Ok(()) => Ok(()),
+            Err(keyring::Error::NoEntry) => Ok(()), // Already deleted is fine
+            Err(e) => Err(anyhow::Error::from(KeyringError::Backend(e.to_string()))),
+        }
+    }
+}

--- a/crates/goose/src/keyring/system.rs
+++ b/crates/goose/src/keyring/system.rs
@@ -1,13 +1,11 @@
 use super::{KeyringBackend, KeyringError};
 use anyhow::Result;
-use async_trait::async_trait;
 use keyring::Entry;
 
 pub struct SystemKeyringBackend;
 
-#[async_trait]
 impl KeyringBackend for SystemKeyringBackend {
-    async fn get_password(&self, service: &str, username: &str) -> Result<String> {
+    fn get_password(&self, service: &str, username: &str) -> Result<String> {
         let entry =
             Entry::new(service, username).map_err(|e| KeyringError::Backend(e.to_string()))?;
 
@@ -23,7 +21,7 @@ impl KeyringBackend for SystemKeyringBackend {
             .map_err(anyhow::Error::from)
     }
 
-    async fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()> {
+    fn set_password(&self, service: &str, username: &str, password: &str) -> Result<()> {
         let entry =
             Entry::new(service, username).map_err(|e| KeyringError::Backend(e.to_string()))?;
 
@@ -33,7 +31,7 @@ impl KeyringBackend for SystemKeyringBackend {
             .map_err(anyhow::Error::from)
     }
 
-    async fn delete_password(&self, service: &str, username: &str) -> Result<()> {
+    fn delete_password(&self, service: &str, username: &str) -> Result<()> {
         let entry =
             Entry::new(service, username).map_err(|e| KeyringError::Backend(e.to_string()))?;
 

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agents;
 pub mod config;
 pub mod context_mgmt;
+pub mod keyring;
 pub mod message;
 pub mod model;
 pub mod permission;

--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -237,7 +237,10 @@ mod tests {
             ("GOOSE_LEAD_TURNS", env::var("GOOSE_LEAD_TURNS").ok()),
             ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
             ("ANTHROPIC_API_KEY", env::var("ANTHROPIC_API_KEY").ok()),
-            ("GOOSE_DISABLE_KEYRING", env::var("GOOSE_DISABLE_KEYRING").ok()),
+            (
+                "GOOSE_DISABLE_KEYRING",
+                env::var("GOOSE_DISABLE_KEYRING").ok(),
+            ),
         ];
 
         // Disable keyring to avoid keychain popups during tests
@@ -266,7 +269,7 @@ mod tests {
                 assert!(
                     !error_msg.contains("not found") || // Configuration not found
                     error_msg.contains("invalid") ||    // Invalid API key format
-                    error_msg.contains("unauthorized")  // API validation failed
+                    error_msg.contains("unauthorized") // API validation failed
                 );
             }
         }
@@ -303,7 +306,10 @@ mod tests {
                 env::var("GOOSE_LEAD_FALLBACK_TURNS").ok(),
             ),
             ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
-            ("GOOSE_DISABLE_KEYRING", env::var("GOOSE_DISABLE_KEYRING").ok()),
+            (
+                "GOOSE_DISABLE_KEYRING",
+                env::var("GOOSE_DISABLE_KEYRING").ok(),
+            ),
         ];
 
         // Disable keyring to avoid keychain popups during tests
@@ -333,10 +339,10 @@ mod tests {
                 let error_msg = error.to_string().to_lowercase();
                 // Allow various provider-level failures but not keychain issues
                 assert!(
-                    error_msg.contains("invalid") ||
-                    error_msg.contains("unauthorized") ||
-                    error_msg.contains("model") ||
-                    !error_msg.contains("not found")
+                    error_msg.contains("invalid")
+                        || error_msg.contains("unauthorized")
+                        || error_msg.contains("model")
+                        || !error_msg.contains("not found")
                 );
             }
         }
@@ -365,10 +371,19 @@ mod tests {
             ("GOOSE_LEAD_MODEL", env::var("GOOSE_LEAD_MODEL").ok()),
             ("GOOSE_LEAD_PROVIDER", env::var("GOOSE_LEAD_PROVIDER").ok()),
             ("GOOSE_LEAD_TURNS", env::var("GOOSE_LEAD_TURNS").ok()),
-            ("GOOSE_LEAD_FAILURE_THRESHOLD", env::var("GOOSE_LEAD_FAILURE_THRESHOLD").ok()),
-            ("GOOSE_LEAD_FALLBACK_TURNS", env::var("GOOSE_LEAD_FALLBACK_TURNS").ok()),
+            (
+                "GOOSE_LEAD_FAILURE_THRESHOLD",
+                env::var("GOOSE_LEAD_FAILURE_THRESHOLD").ok(),
+            ),
+            (
+                "GOOSE_LEAD_FALLBACK_TURNS",
+                env::var("GOOSE_LEAD_FALLBACK_TURNS").ok(),
+            ),
             ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
-            ("GOOSE_DISABLE_KEYRING", env::var("GOOSE_DISABLE_KEYRING").ok()),
+            (
+                "GOOSE_DISABLE_KEYRING",
+                env::var("GOOSE_DISABLE_KEYRING").ok(),
+            ),
         ];
 
         // Disable keyring to avoid keychain popups during tests
@@ -380,7 +395,7 @@ mod tests {
         env::remove_var("GOOSE_LEAD_TURNS");
         env::remove_var("GOOSE_LEAD_FAILURE_THRESHOLD");
         env::remove_var("GOOSE_LEAD_FALLBACK_TURNS");
-        
+
         // Set fake API key to avoid keychain access
         env::set_var("OPENAI_API_KEY", "fake-test-key");
 
@@ -397,9 +412,9 @@ mod tests {
                 let error_msg = error.to_string().to_lowercase();
                 // Allow provider-level failures but not keychain issues
                 assert!(
-                    error_msg.contains("invalid") ||
-                    error_msg.contains("unauthorized") ||
-                    !error_msg.contains("not found")
+                    error_msg.contains("invalid")
+                        || error_msg.contains("unauthorized")
+                        || !error_msg.contains("not found")
                 );
             }
         }

--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -180,6 +180,39 @@ mod tests {
     use mcp_core::{content::TextContent, Role};
     use std::env;
 
+    /// Helper to save and restore environment variables for testing
+    struct EnvVarGuard {
+        saved_vars: Vec<(&'static str, Option<String>)>,
+    }
+
+    impl EnvVarGuard {
+        fn new(var_names: &[&'static str]) -> Self {
+            let saved_vars = var_names
+                .iter()
+                .map(|&name| (name, env::var(name).ok()))
+                .collect();
+            Self { saved_vars }
+        }
+
+        fn clear_all(&self) {
+            for (key, _) in &self.saved_vars {
+                env::remove_var(key);
+            }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            // Restore all env vars
+            for (key, value) in &self.saved_vars {
+                match value {
+                    Some(val) => env::set_var(key, val),
+                    None => env::remove_var(key),
+                }
+            }
+        }
+    }
+
     #[allow(dead_code)]
     #[derive(Clone)]
     struct MockTestProvider {
@@ -230,15 +263,13 @@ mod tests {
 
     #[test]
     fn test_create_lead_worker_provider() {
-        // Save current env vars
-        let saved_vars = [
-            ("GOOSE_LEAD_MODEL", env::var("GOOSE_LEAD_MODEL").ok()),
-            ("GOOSE_LEAD_PROVIDER", env::var("GOOSE_LEAD_PROVIDER").ok()),
-            ("GOOSE_LEAD_TURNS", env::var("GOOSE_LEAD_TURNS").ok()),
-            ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
-            ("ANTHROPIC_API_KEY", env::var("ANTHROPIC_API_KEY").ok()),
-        ];
-
+        let _guard = EnvVarGuard::new(&[
+            "GOOSE_LEAD_MODEL",
+            "GOOSE_LEAD_PROVIDER",
+            "GOOSE_LEAD_TURNS",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
+        ]);
 
         // Set fake API keys to avoid keychain access
         env::set_var("OPENAI_API_KEY", "fake-test-key");
@@ -275,37 +306,22 @@ mod tests {
         let _result = create("openai", ModelConfig::new("gpt-4o-mini".to_string()));
         // Similar validation as above - confirms the logic path
 
-        // Restore all env vars
-        for (key, value) in saved_vars {
-            match value {
-                Some(val) => env::set_var(key, val),
-                None => env::remove_var(key),
-            }
-        }
+        // EnvVarGuard will automatically restore all env vars when dropped
     }
 
     #[test]
     fn test_lead_model_env_vars_with_defaults() {
-        // Save current env vars including API keys
-        let saved_vars = [
-            ("GOOSE_LEAD_MODEL", env::var("GOOSE_LEAD_MODEL").ok()),
-            ("GOOSE_LEAD_PROVIDER", env::var("GOOSE_LEAD_PROVIDER").ok()),
-            ("GOOSE_LEAD_TURNS", env::var("GOOSE_LEAD_TURNS").ok()),
-            (
-                "GOOSE_LEAD_FAILURE_THRESHOLD",
-                env::var("GOOSE_LEAD_FAILURE_THRESHOLD").ok(),
-            ),
-            (
-                "GOOSE_LEAD_FALLBACK_TURNS",
-                env::var("GOOSE_LEAD_FALLBACK_TURNS").ok(),
-            ),
-            ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
-        ];
+        let guard = EnvVarGuard::new(&[
+            "GOOSE_LEAD_MODEL",
+            "GOOSE_LEAD_PROVIDER",
+            "GOOSE_LEAD_TURNS",
+            "GOOSE_LEAD_FAILURE_THRESHOLD",
+            "GOOSE_LEAD_FALLBACK_TURNS",
+            "OPENAI_API_KEY",
+        ]);
 
         // Clear all lead env vars
-        for (key, _) in &saved_vars {
-            env::remove_var(key);
-        }
+        guard.clear_all();
 
         // Set fake API key to avoid keychain access
         env::set_var("OPENAI_API_KEY", "fake-test-key");
@@ -342,39 +358,22 @@ mod tests {
         let _result = create("openai", ModelConfig::new("gpt-4o-mini".to_string()));
         // Should still attempt to create lead/worker provider with custom settings
 
-        // Restore all env vars
-        for (key, value) in saved_vars {
-            match value {
-                Some(val) => env::set_var(key, val),
-                None => env::remove_var(key),
-            }
-        }
+        // EnvVarGuard will automatically restore all env vars when dropped
     }
 
     #[test]
     fn test_create_regular_provider_without_lead_config() {
-        // Save current env vars including API key
-        let saved_vars = [
-            ("GOOSE_LEAD_MODEL", env::var("GOOSE_LEAD_MODEL").ok()),
-            ("GOOSE_LEAD_PROVIDER", env::var("GOOSE_LEAD_PROVIDER").ok()),
-            ("GOOSE_LEAD_TURNS", env::var("GOOSE_LEAD_TURNS").ok()),
-            (
-                "GOOSE_LEAD_FAILURE_THRESHOLD",
-                env::var("GOOSE_LEAD_FAILURE_THRESHOLD").ok(),
-            ),
-            (
-                "GOOSE_LEAD_FALLBACK_TURNS",
-                env::var("GOOSE_LEAD_FALLBACK_TURNS").ok(),
-            ),
-            ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
-        ];
+        let guard = EnvVarGuard::new(&[
+            "GOOSE_LEAD_MODEL",
+            "GOOSE_LEAD_PROVIDER",
+            "GOOSE_LEAD_TURNS",
+            "GOOSE_LEAD_FAILURE_THRESHOLD",
+            "GOOSE_LEAD_FALLBACK_TURNS",
+            "OPENAI_API_KEY",
+        ]);
 
         // Ensure all GOOSE_LEAD_* variables are not set
-        env::remove_var("GOOSE_LEAD_MODEL");
-        env::remove_var("GOOSE_LEAD_PROVIDER");
-        env::remove_var("GOOSE_LEAD_TURNS");
-        env::remove_var("GOOSE_LEAD_FAILURE_THRESHOLD");
-        env::remove_var("GOOSE_LEAD_FALLBACK_TURNS");
+        guard.clear_all();
 
         // Set fake API key to avoid keychain access
         env::set_var("OPENAI_API_KEY", "fake-test-key");
@@ -399,13 +398,7 @@ mod tests {
             }
         }
 
-        // Restore all env vars
-        for (key, value) in saved_vars {
-            match value {
-                Some(val) => env::set_var(key, val),
-                None => env::remove_var(key),
-            }
-        }
+        // EnvVarGuard will automatically restore all env vars when dropped
     }
 
     #[test]

--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -231,9 +231,21 @@ mod tests {
     #[test]
     fn test_create_lead_worker_provider() {
         // Save current env vars
-        let saved_lead = env::var("GOOSE_LEAD_MODEL").ok();
-        let saved_provider = env::var("GOOSE_LEAD_PROVIDER").ok();
-        let saved_turns = env::var("GOOSE_LEAD_TURNS").ok();
+        let saved_vars = [
+            ("GOOSE_LEAD_MODEL", env::var("GOOSE_LEAD_MODEL").ok()),
+            ("GOOSE_LEAD_PROVIDER", env::var("GOOSE_LEAD_PROVIDER").ok()),
+            ("GOOSE_LEAD_TURNS", env::var("GOOSE_LEAD_TURNS").ok()),
+            ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
+            ("ANTHROPIC_API_KEY", env::var("ANTHROPIC_API_KEY").ok()),
+            ("GOOSE_DISABLE_KEYRING", env::var("GOOSE_DISABLE_KEYRING").ok()),
+        ];
+
+        // Disable keyring to avoid keychain popups during tests
+        env::set_var("GOOSE_DISABLE_KEYRING", "1");
+
+        // Set fake API keys to avoid keychain access
+        env::set_var("OPENAI_API_KEY", "fake-test-key");
+        env::set_var("ANTHROPIC_API_KEY", "fake-test-key");
 
         // Test with basic lead model configuration
         env::set_var("GOOSE_LEAD_MODEL", "gpt-4o");
@@ -241,16 +253,21 @@ mod tests {
         // This will try to create a lead/worker provider
         let result = create("openai", ModelConfig::new("gpt-4o-mini".to_string()));
 
-        // The creation might succeed or fail depending on API keys, but we can verify the logic path
+        // Since we provided fake API keys, the creation should proceed to the provider instantiation
+        // It may still fail at the provider level, but we should not get keychain-related errors
         match result {
             Ok(_) => {
-                // If it succeeds, it means we created a lead/worker provider successfully
-                // This would happen if API keys are available in the test environment
+                // If it succeeds with fake keys, the logic worked
             }
             Err(error) => {
-                // If it fails, it should be due to missing API keys, confirming we tried to create providers
-                let error_msg = error.to_string();
-                assert!(error_msg.contains("OPENAI_API_KEY") || error_msg.contains("secret"));
+                // Should not fail due to missing secrets, but may fail due to invalid fake keys
+                let error_msg = error.to_string().to_lowercase();
+                // Ensure it's not a keychain/secret-related error
+                assert!(
+                    !error_msg.contains("not found") || // Configuration not found
+                    error_msg.contains("invalid") ||    // Invalid API key format
+                    error_msg.contains("unauthorized")  // API validation failed
+                );
             }
         }
 
@@ -259,26 +276,20 @@ mod tests {
         env::set_var("GOOSE_LEAD_TURNS", "5");
 
         let _result = create("openai", ModelConfig::new("gpt-4o-mini".to_string()));
-        // Similar validation as above - will fail due to missing API keys but confirms the logic
+        // Similar validation as above - confirms the logic path
 
-        // Restore env vars
-        match saved_lead {
-            Some(val) => env::set_var("GOOSE_LEAD_MODEL", val),
-            None => env::remove_var("GOOSE_LEAD_MODEL"),
-        }
-        match saved_provider {
-            Some(val) => env::set_var("GOOSE_LEAD_PROVIDER", val),
-            None => env::remove_var("GOOSE_LEAD_PROVIDER"),
-        }
-        match saved_turns {
-            Some(val) => env::set_var("GOOSE_LEAD_TURNS", val),
-            None => env::remove_var("GOOSE_LEAD_TURNS"),
+        // Restore all env vars
+        for (key, value) in saved_vars {
+            match value {
+                Some(val) => env::set_var(key, val),
+                None => env::remove_var(key),
+            }
         }
     }
 
     #[test]
     fn test_lead_model_env_vars_with_defaults() {
-        // Save current env vars
+        // Save current env vars including API keys
         let saved_vars = [
             ("GOOSE_LEAD_MODEL", env::var("GOOSE_LEAD_MODEL").ok()),
             ("GOOSE_LEAD_PROVIDER", env::var("GOOSE_LEAD_PROVIDER").ok()),
@@ -291,12 +302,20 @@ mod tests {
                 "GOOSE_LEAD_FALLBACK_TURNS",
                 env::var("GOOSE_LEAD_FALLBACK_TURNS").ok(),
             ),
+            ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
+            ("GOOSE_DISABLE_KEYRING", env::var("GOOSE_DISABLE_KEYRING").ok()),
         ];
+
+        // Disable keyring to avoid keychain popups during tests
+        env::set_var("GOOSE_DISABLE_KEYRING", "1");
 
         // Clear all lead env vars
         for (key, _) in &saved_vars {
             env::remove_var(key);
         }
+
+        // Set fake API key to avoid keychain access
+        env::set_var("OPENAI_API_KEY", "fake-test-key");
 
         // Set only the required lead model
         env::set_var("GOOSE_LEAD_MODEL", "grok-3");
@@ -304,15 +323,21 @@ mod tests {
         // This should use defaults for all other values
         let result = create("openai", ModelConfig::new("gpt-4o-mini".to_string()));
 
-        // Should attempt to create lead/worker provider (will fail due to missing API keys but confirms logic)
+        // Should attempt to create lead/worker provider with fake keys
         match result {
             Ok(_) => {
-                // Success means we have API keys and created the provider
+                // Success means the logic path worked
             }
             Err(error) => {
-                // Should fail due to missing API keys, confirming we tried to create providers
-                let error_msg = error.to_string();
-                assert!(error_msg.contains("OPENAI_API_KEY") || error_msg.contains("secret"));
+                // Should not fail due to missing secrets since we provided fake keys
+                let error_msg = error.to_string().to_lowercase();
+                // Allow various provider-level failures but not keychain issues
+                assert!(
+                    error_msg.contains("invalid") ||
+                    error_msg.contains("unauthorized") ||
+                    error_msg.contains("model") ||
+                    !error_msg.contains("not found")
+                );
             }
         }
 
@@ -335,12 +360,19 @@ mod tests {
 
     #[test]
     fn test_create_regular_provider_without_lead_config() {
-        // Save current env vars
-        let saved_lead = env::var("GOOSE_LEAD_MODEL").ok();
-        let saved_provider = env::var("GOOSE_LEAD_PROVIDER").ok();
-        let saved_turns = env::var("GOOSE_LEAD_TURNS").ok();
-        let saved_threshold = env::var("GOOSE_LEAD_FAILURE_THRESHOLD").ok();
-        let saved_fallback = env::var("GOOSE_LEAD_FALLBACK_TURNS").ok();
+        // Save current env vars including API key
+        let saved_vars = [
+            ("GOOSE_LEAD_MODEL", env::var("GOOSE_LEAD_MODEL").ok()),
+            ("GOOSE_LEAD_PROVIDER", env::var("GOOSE_LEAD_PROVIDER").ok()),
+            ("GOOSE_LEAD_TURNS", env::var("GOOSE_LEAD_TURNS").ok()),
+            ("GOOSE_LEAD_FAILURE_THRESHOLD", env::var("GOOSE_LEAD_FAILURE_THRESHOLD").ok()),
+            ("GOOSE_LEAD_FALLBACK_TURNS", env::var("GOOSE_LEAD_FALLBACK_TURNS").ok()),
+            ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
+            ("GOOSE_DISABLE_KEYRING", env::var("GOOSE_DISABLE_KEYRING").ok()),
+        ];
+
+        // Disable keyring to avoid keychain popups during tests
+        env::set_var("GOOSE_DISABLE_KEYRING", "1");
 
         // Ensure all GOOSE_LEAD_* variables are not set
         env::remove_var("GOOSE_LEAD_MODEL");
@@ -348,38 +380,36 @@ mod tests {
         env::remove_var("GOOSE_LEAD_TURNS");
         env::remove_var("GOOSE_LEAD_FAILURE_THRESHOLD");
         env::remove_var("GOOSE_LEAD_FALLBACK_TURNS");
+        
+        // Set fake API key to avoid keychain access
+        env::set_var("OPENAI_API_KEY", "fake-test-key");
 
         // This should try to create a regular provider
         let result = create("openai", ModelConfig::new("gpt-4o-mini".to_string()));
 
-        // The creation might succeed or fail depending on API keys
+        // The creation should proceed with fake API key
         match result {
             Ok(_) => {
                 // If it succeeds, it means we created a regular provider successfully
-                // This would happen if API keys are available in the test environment
             }
             Err(error) => {
-                // If it fails, it should be due to missing API keys
-                let error_msg = error.to_string();
-                assert!(error_msg.contains("OPENAI_API_KEY") || error_msg.contains("secret"));
+                // Should not fail due to missing secrets since we provided fake key
+                let error_msg = error.to_string().to_lowercase();
+                // Allow provider-level failures but not keychain issues
+                assert!(
+                    error_msg.contains("invalid") ||
+                    error_msg.contains("unauthorized") ||
+                    !error_msg.contains("not found")
+                );
             }
         }
 
-        // Restore env vars
-        if let Some(val) = saved_lead {
-            env::set_var("GOOSE_LEAD_MODEL", val);
-        }
-        if let Some(val) = saved_provider {
-            env::set_var("GOOSE_LEAD_PROVIDER", val);
-        }
-        if let Some(val) = saved_turns {
-            env::set_var("GOOSE_LEAD_TURNS", val);
-        }
-        if let Some(val) = saved_threshold {
-            env::set_var("GOOSE_LEAD_FAILURE_THRESHOLD", val);
-        }
-        if let Some(val) = saved_fallback {
-            env::set_var("GOOSE_LEAD_FALLBACK_TURNS", val);
+        // Restore all env vars
+        for (key, value) in saved_vars {
+            match value {
+                Some(val) => env::set_var(key, val),
+                None => env::remove_var(key),
+            }
         }
     }
 

--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -237,14 +237,8 @@ mod tests {
             ("GOOSE_LEAD_TURNS", env::var("GOOSE_LEAD_TURNS").ok()),
             ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
             ("ANTHROPIC_API_KEY", env::var("ANTHROPIC_API_KEY").ok()),
-            (
-                "GOOSE_DISABLE_KEYRING",
-                env::var("GOOSE_DISABLE_KEYRING").ok(),
-            ),
         ];
 
-        // Disable keyring to avoid keychain popups during tests
-        env::set_var("GOOSE_DISABLE_KEYRING", "1");
 
         // Set fake API keys to avoid keychain access
         env::set_var("OPENAI_API_KEY", "fake-test-key");
@@ -306,14 +300,7 @@ mod tests {
                 env::var("GOOSE_LEAD_FALLBACK_TURNS").ok(),
             ),
             ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
-            (
-                "GOOSE_DISABLE_KEYRING",
-                env::var("GOOSE_DISABLE_KEYRING").ok(),
-            ),
         ];
-
-        // Disable keyring to avoid keychain popups during tests
-        env::set_var("GOOSE_DISABLE_KEYRING", "1");
 
         // Clear all lead env vars
         for (key, _) in &saved_vars {
@@ -380,14 +367,7 @@ mod tests {
                 env::var("GOOSE_LEAD_FALLBACK_TURNS").ok(),
             ),
             ("OPENAI_API_KEY", env::var("OPENAI_API_KEY").ok()),
-            (
-                "GOOSE_DISABLE_KEYRING",
-                env::var("GOOSE_DISABLE_KEYRING").ok(),
-            ),
         ];
-
-        // Disable keyring to avoid keychain popups during tests
-        env::set_var("GOOSE_DISABLE_KEYRING", "1");
 
         // Ensure all GOOSE_LEAD_* variables are not set
         env::remove_var("GOOSE_LEAD_MODEL");


### PR DESCRIPTION
This change introduces a clean keyring abstraction layer to replace global keyring state with dependency injection, addressing critical runtime errors and improving testability. 

The implementation creates a KeyringBackend trait with concrete implementations for system keyring (SystemKeyringBackend) and file-based storage (FileKeyringBackend), allowing the configuration system to use different keyring backends based on the GOOSE_DISABLE_KEYRING environment variable. 

This architectural improvement eliminates the need to touch the user's real OS keyring and thus enables comprehensive unit testing without keychain popups. The refactoring maintains full backward compatibility while establishing a foundation for reliable testing and development workflows

---

- **feat: introduce a keyring abstraction to help with dep injection**
- **feat: use dep injection for keyring ops**
- **fix: lints and fmts**
- **feat: more just recipes for qol**
- **refactor: reuse keyring abstraction from goose crate**
- **chore: add a lint-all just directive**
- **fix: fix nested runtime issues by using shared future rt**
- **refactor: move file based keyring logic to own module**
- **refactor(tests): use a guard pattern to restore env vars**
