### PR TITLE
feat: Add AZURE_OPENAI_API_KEY as a visible config parameter

### DIFF
--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -67,8 +67,10 @@ impl AzureProvider {
             .get_param("AZURE_OPENAI_API_VERSION")
             .unwrap_or_else(|_| AZURE_DEFAULT_API_VERSION.to_string());
 
-        // Try to get API key first, if not found use Azure credential chain
-        let api_key = config.get_secret("AZURE_OPENAI_API_KEY").ok();
+        let api_key = config
+            .get_secret("AZURE_OPENAI_API_KEY")
+            .ok()
+            .filter(|key: &String| !key.is_empty());
         let auth = AzureAuth::new(api_key)?;
 
         let client = Client::builder()
@@ -227,6 +229,7 @@ impl Provider for AzureProvider {
                 ConfigKey::new("AZURE_OPENAI_ENDPOINT", true, false, None),
                 ConfigKey::new("AZURE_OPENAI_DEPLOYMENT_NAME", true, false, None),
                 ConfigKey::new("AZURE_OPENAI_API_VERSION", true, false, Some("2024-10-21")),
+                ConfigKey::new("AZURE_OPENAI_API_KEY", true, true, Some("")),
             ],
         )
     }

--- a/ui/desktop/src/components/settings/providers/ProviderRegistry.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderRegistry.tsx
@@ -196,11 +196,6 @@ export const PROVIDER_REGISTRY: ProviderRegistry[] = [
         'Access Azure OpenAI models using API key or Azure credentials. If no API key is provided, Azure credential chain will be used.',
       parameters: [
         {
-          name: 'AZURE_OPENAI_API_KEY',
-          is_secret: true,
-          required: false,
-        },
-        {
           name: 'AZURE_OPENAI_ENDPOINT',
           is_secret: false,
         },
@@ -212,6 +207,11 @@ export const PROVIDER_REGISTRY: ProviderRegistry[] = [
           name: 'AZURE_OPENAI_API_VERSION',
           is_secret: false,
           default: '2024-10-21',
+        },
+        {
+          name: 'AZURE_OPENAI_API_KEY',
+          is_secret: true,
+          default: '',
         },
       ],
     },


### PR DESCRIPTION
AZURE_OPENAI_API_KEY was previously an optional parameter and since only required parameters are visible in the UI, it was not possible to configure it. Let's make it required with an empty string as the default value. See also #2582.

Example from the UI
<img width="516" alt="Screenshot 2025-07-06 at 17 10 53" src="https://github.com/user-attachments/assets/7b1f3b66-dc90-4345-818b-43b37b333d63" />

