### PR TITLE
fix(devcontainer): install protoc to fix build

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,4 +7,5 @@ RUN apt-get update && apt-get install -y \
     libdbus-1-dev \
     gnome-keyring \
     libxcb1-dev \
+    protobuf-compiler \
     && apt-get clean


### PR DESCRIPTION
similar to #2995, need to install protoc in devcontainer or `cargo build` fails