### PR TITLE
[cli] Add --provider and --model CLI options to run command

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -546,6 +546,24 @@ enum Command {
             action = clap::ArgAction::Append
         )]
         additional_sub_recipes: Vec<String>,
+
+        /// Provider to use for this run (overrides environment variable)
+        #[arg(
+            long = "provider",
+            value_name = "PROVIDER",
+            help = "Specify the LLM provider to use (e.g., 'openai', 'anthropic')",
+            long_help = "Override the GOOSE_PROVIDER environment variable for this run. Available providers include openai, anthropic, ollama, databricks, gemini-cli, claude-code, and others."
+        )]
+        provider: Option<String>,
+
+        /// Model to use for this run (overrides environment variable)
+        #[arg(
+            long = "model",
+            value_name = "MODEL",
+            help = "Specify the model to use (e.g., 'gpt-4o', 'claude-3.5-sonnet')",
+            long_help = "Override the GOOSE_MODEL environment variable for this run. The model must be supported by the specified provider."
+        )]
+        model: Option<String>,
     },
 
     /// Recipe utilities for validation and deeplinking
@@ -700,6 +718,8 @@ pub async fn cli() -> Result<()> {
                         extensions_override: None,
                         additional_system_prompt: None,
                         settings: None,
+                        provider: None,
+                        model: None,
                         debug,
                         max_tool_repetitions,
                         max_turns,
@@ -761,6 +781,8 @@ pub async fn cli() -> Result<()> {
             scheduled_job_id,
             quiet,
             additional_sub_recipes,
+            provider,
+            model,
         }) => {
             let (input_config, session_settings, sub_recipes, final_output_response) = match (
                 instructions,
@@ -845,6 +867,8 @@ pub async fn cli() -> Result<()> {
                 extensions_override: input_config.extensions_override,
                 additional_system_prompt: input_config.additional_system_prompt,
                 settings: session_settings,
+                provider,
+                model,
                 debug,
                 max_tool_repetitions,
                 max_turns,
@@ -970,6 +994,8 @@ pub async fn cli() -> Result<()> {
                     extensions_override: None,
                     additional_system_prompt: None,
                     settings: None::<SessionSettings>,
+                    provider: None,
+                    model: None,
                     debug: false,
                     max_tool_repetitions: None,
                     max_turns: None,

--- a/crates/goose-cli/src/commands/bench.rs
+++ b/crates/goose-cli/src/commands/bench.rs
@@ -41,6 +41,8 @@ pub async fn agent_generator(
         extensions_override: None,
         additional_system_prompt: None,
         settings: None,
+        provider: None,
+        model: None,
         debug: false,
         max_tool_repetitions: None,
         interactive: false, // Benchmarking is non-interactive

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -37,6 +37,10 @@ pub struct SessionBuilderConfig {
     pub additional_system_prompt: Option<String>,
     /// Settings to override the global Goose settings
     pub settings: Option<SessionSettings>,
+    /// Provider override from CLI arguments
+    pub provider: Option<String>,
+    /// Model override from CLI arguments
+    pub model: Option<String>,
     /// Enable debug printing
     pub debug: bool,
     /// Maximum number of consecutive identical tool calls allowed
@@ -167,16 +171,24 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> Session {
     let config = Config::global();
 
     let provider_name = session_config
-        .settings
-        .as_ref()
-        .and_then(|s| s.goose_provider.clone())
+        .provider
+        .or_else(|| {
+            session_config
+                .settings
+                .as_ref()
+                .and_then(|s| s.goose_provider.clone())
+        })
         .or_else(|| config.get_param("GOOSE_PROVIDER").ok())
         .expect("No provider configured. Run 'goose configure' first");
 
     let model_name = session_config
-        .settings
-        .as_ref()
-        .and_then(|s| s.goose_model.clone())
+        .model
+        .or_else(|| {
+            session_config
+                .settings
+                .as_ref()
+                .and_then(|s| s.goose_model.clone())
+        })
         .or_else(|| config.get_param("GOOSE_MODEL").ok())
         .expect("No model configured. Run 'goose configure' first");
 
@@ -523,6 +535,8 @@ mod tests {
             extensions_override: None,
             additional_system_prompt: Some("Test prompt".to_string()),
             settings: None,
+            provider: None,
+            model: None,
             debug: true,
             max_tool_repetitions: Some(5),
             max_turns: None,


### PR DESCRIPTION
- Add --provider and --model CLI arguments to run command for LLM selection
- Thread provider and model options through SessionBuilderConfig structure
- Implement priority order: CLI args > settings > environment variables
- Update bench command and session builder to support new options
- Update all relevant struct initializations with new fields

Solves #2435