### PR TITLE
feat: Recipe sets goose model, provider and temperature settings through gui

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -66,6 +66,14 @@ struct UpdateProviderRequest {
 #[derive(Deserialize)]
 struct SessionConfigRequest {
     response: Option<Response>,
+    settings: Option<SessionSettings>,
+}
+
+#[derive(Deserialize)]
+struct SessionSettings {
+    goose_provider: Option<String>,
+    goose_model: Option<String>,
+    temperature: Option<f32>,
 }
 
 #[derive(Deserialize)]
@@ -73,9 +81,74 @@ pub struct GetToolsQuery {
     extension_name: Option<String>,
 }
 
-#[derive(Serialize)]
+#[derive(Serialize, Debug)]
 struct ErrorResponse {
     error: String,
+}
+
+async fn authenticate_and_get_agent(
+    headers: &HeaderMap,
+    state: &Arc<AppState>,
+) -> Result<Arc<goose::agents::Agent>, Json<ErrorResponse>> {
+    verify_secret_key(headers, state).map_err(|_| {
+        Json(ErrorResponse {
+            error: "Unauthorized - Invalid or missing API key".to_string(),
+        })
+    })?;
+
+    state.get_agent().await.map_err(|e| {
+        tracing::error!("Failed to get agent: {}", e);
+        Json(ErrorResponse {
+            error: format!("Failed to get agent: {}", e),
+        })
+    })
+}
+
+fn create_model_config_from_settings(
+    settings: Option<SessionSettings>,
+) -> Result<Option<(String, ModelConfig)>, Json<ErrorResponse>> {
+    let Some(settings) = settings else {
+        return Ok(None);
+    };
+
+    let has_model = settings.goose_model.is_some();
+    let has_provider = settings.goose_provider.is_some();
+    if has_model != has_provider {
+        return Err(Json(ErrorResponse {
+            error: "Both goose_model and goose_provider must be specified together, or neither"
+                .to_string(),
+        }));
+    }
+
+    if settings.goose_provider.is_some()
+        || settings.goose_model.is_some()
+        || settings.temperature.is_some()
+    {
+        let config = Config::global();
+
+        let provider_name = settings
+            .goose_provider
+            .or_else(|| config.get_param("GOOSE_PROVIDER").ok())
+            .ok_or_else(|| {
+                Json(ErrorResponse {
+                    error: "No provider specified".to_string(),
+                })
+            })?;
+
+        let model_name = settings
+            .goose_model
+            .or_else(|| config.get_param("GOOSE_MODEL").ok())
+            .ok_or_else(|| {
+                Json(ErrorResponse {
+                    error: "No model specified".to_string(),
+                })
+            })?;
+
+        let model_config = ModelConfig::new(model_name).with_temperature(settings.temperature);
+        Ok(Some((provider_name, model_config)))
+    } else {
+        Ok(None)
+    }
 }
 
 async fn get_versions() -> Json<VersionsResponse> {
@@ -240,18 +313,7 @@ async fn update_router_tool_selector(
     State(state): State<Arc<AppState>>,
     headers: HeaderMap,
 ) -> Result<Json<String>, Json<ErrorResponse>> {
-    verify_secret_key(&headers, &state).map_err(|_| {
-        Json(ErrorResponse {
-            error: "Unauthorized - Invalid or missing API key".to_string(),
-        })
-    })?;
-
-    let agent = state.get_agent().await.map_err(|e| {
-        tracing::error!("Failed to get agent: {}", e);
-        Json(ErrorResponse {
-            error: format!("Failed to get agent: {}", e),
-        })
-    })?;
+    let agent = authenticate_and_get_agent(&headers, &state).await?;
 
     agent
         .update_router_tool_selector(None, Some(true))
@@ -281,29 +343,29 @@ async fn update_session_config(
     headers: HeaderMap,
     Json(payload): Json<SessionConfigRequest>,
 ) -> Result<Json<String>, Json<ErrorResponse>> {
-    verify_secret_key(&headers, &state).map_err(|_| {
-        Json(ErrorResponse {
-            error: "Unauthorized - Invalid or missing API key".to_string(),
-        })
-    })?;
-
-    let agent = state.get_agent().await.map_err(|e| {
-        tracing::error!("Failed to get agent: {}", e);
-        Json(ErrorResponse {
-            error: format!("Failed to get agent: {}", e),
-        })
-    })?;
+    let agent = authenticate_and_get_agent(&headers, &state).await?;
 
     if let Some(response) = payload.response {
         agent.add_final_output_tool(response).await;
-
-        tracing::info!("Added final output tool with response config");
-        Ok(Json(
-            "Session config updated with final output tool".to_string(),
-        ))
-    } else {
-        Ok(Json("Nothing provided to update.".to_string()))
     }
+
+    if let Some((provider_name, model_config)) =
+        create_model_config_from_settings(payload.settings)?
+    {
+        let new_provider = create(&provider_name, model_config).map_err(|e| {
+            Json(ErrorResponse {
+                error: format!("Failed to create provider: {}", e),
+            })
+        })?;
+
+        agent.update_provider(new_provider).await.map_err(|e| {
+            Json(ErrorResponse {
+                error: format!("Failed to update provider: {}", e),
+            })
+        })?;
+    }
+    let message = "Session config updated successfully".to_string();
+    Ok(Json(message))
 }
 
 pub fn routes(state: Arc<AppState>) -> Router {
@@ -319,4 +381,89 @@ pub fn routes(state: Arc<AppState>) -> Router {
         )
         .route("/agent/session_config", post(update_session_config))
         .with_state(state)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_create_model_config_from_settings_none() {
+        let result = create_model_config_from_settings(None);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_create_model_config_from_settings_model_without_provider() {
+        let settings = Some(SessionSettings {
+            goose_provider: None,
+            goose_model: Some("gpt-4".to_string()),
+            temperature: None,
+        });
+
+        let result = create_model_config_from_settings(settings);
+        assert!(result.is_err());
+
+        if let Err(Json(error)) = result {
+            assert!(error
+                .error
+                .contains("Both goose_model and goose_provider must be specified together"));
+        }
+    }
+
+    #[test]
+    fn test_create_model_config_from_settings_both_specified() {
+        let settings = Some(SessionSettings {
+            goose_provider: Some("openai".to_string()),
+            goose_model: Some("gpt-4".to_string()),
+            temperature: Some(0.7),
+        });
+
+        let result = create_model_config_from_settings(settings);
+        assert!(result.is_ok());
+
+        if let Ok(Some((provider_name, model_config))) = result {
+            assert_eq!(provider_name, "openai");
+            assert_eq!(model_config.model_name, "gpt-4");
+            assert_eq!(model_config.temperature, Some(0.7));
+        }
+    }
+
+    #[test]
+    fn test_create_model_config_from_settings_temperature_only() {
+        struct EnvGuard {
+            keys: Vec<&'static str>,
+        }
+
+        impl Drop for EnvGuard {
+            fn drop(&mut self) {
+                for key in &self.keys {
+                    std::env::remove_var(key);
+                }
+            }
+        }
+
+        let _guard = EnvGuard {
+            keys: vec!["GOOSE_PROVIDER", "GOOSE_MODEL"],
+        };
+
+        std::env::set_var("GOOSE_PROVIDER", "test_provider");
+        std::env::set_var("GOOSE_MODEL", "test_model");
+
+        let settings = Some(SessionSettings {
+            goose_provider: None,
+            goose_model: None,
+            temperature: Some(0.8),
+        });
+
+        let result = create_model_config_from_settings(settings);
+
+        assert!(result.is_ok());
+        if let Ok(Some((provider_name, model_config))) = result {
+            assert_eq!(provider_name, "test_provider");
+            assert_eq!(model_config.model_name, "test_model");
+            assert_eq!(model_config.temperature, Some(0.8));
+        }
+    }
 }

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -27,7 +27,10 @@ import { useChat } from './hooks/useChat';
 
 import 'react-toastify/dist/ReactToastify.css';
 import { useConfig, MalformedConfigError } from './components/ConfigContext';
-import { ModelAndProviderProvider } from './components/ModelAndProviderContext';
+import {
+  ModelAndProviderProvider,
+  useModelAndProvider,
+} from './components/ModelAndProviderContext';
 import { addExtensionFromDeepLink as addExtensionFromDeepLinkV2 } from './components/settings/extensions';
 import {
   backupConfig,
@@ -112,7 +115,7 @@ const getInitialView = (): ViewConfig => {
   };
 };
 
-export default function App() {
+function AppContent() {
   const [fatalError, setFatalError] = useState<string | null>(null);
   const [modalVisible, setModalVisible] = useState(false);
   const [pendingLink, setPendingLink] = useState<string | null>(null);
@@ -122,6 +125,7 @@ export default function App() {
   const [{ view, viewOptions }, setInternalView] = useState<ViewConfig>(getInitialView());
 
   const { getExtensions, addExtension, read } = useConfig();
+  const { changeModel } = useModelAndProvider();
   const initAttemptedRef = useRef(false);
 
   function extractCommand(link: string): string {
@@ -232,6 +236,7 @@ export default function App() {
             await initializeSystem(provider as string, model as string, {
               getExtensions,
               addExtension,
+              changeModel,
             });
           } catch (error) {
             console.error('Error in initialization:', error);
@@ -257,7 +262,7 @@ export default function App() {
       console.error('Unhandled error in initialization:', error);
       setFatalError(`${error instanceof Error ? error.message : 'Unknown error'}`);
     });
-  }, [read, getExtensions, addExtension]);
+  }, [read, getExtensions, addExtension, changeModel]);
 
   const [isGoosehintsModalOpen, setIsGoosehintsModalOpen] = useState(false);
   const [isLoadingSession, setIsLoadingSession] = useState(false);
@@ -509,7 +514,7 @@ export default function App() {
     );
 
   return (
-    <ModelAndProviderProvider>
+    <>
       <ToastContainer
         aria-label="Toast notifications"
         toastClassName={() =>
@@ -612,6 +617,14 @@ export default function App() {
         />
       )}
       <AnnouncementModal />
+    </>
+  );
+}
+
+export default function App() {
+  return (
+    <ModelAndProviderProvider>
+      <AppContent />
     </ModelAndProviderProvider>
   );
 }

--- a/ui/desktop/src/components/settings/providers/ProviderSettingsPage.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderSettingsPage.tsx
@@ -3,6 +3,7 @@ import { ScrollArea } from '../../ui/scroll-area';
 import BackButton from '../../ui/BackButton';
 import ProviderGrid from './ProviderGrid';
 import { useConfig } from '../../ConfigContext';
+import { useModelAndProvider } from '../../ModelAndProviderContext';
 import { ProviderDetails } from '../../../api/types.gen';
 import { initializeSystem } from '../../../utils/providerUtils';
 import WelcomeGooseLogo from '../../WelcomeGooseLogo';
@@ -16,6 +17,7 @@ interface ProviderSettingsProps {
 
 export default function ProviderSettings({ onClose, isOnboarding }: ProviderSettingsProps) {
   const { getProviders, upsert, getExtensions, addExtension } = useConfig();
+  const { changeModel } = useModelAndProvider();
   const [loading, setLoading] = useState(true);
   const [providers, setProviders] = useState<ProviderDetails[]>([]);
   const initialLoadDone = useRef(false);
@@ -73,6 +75,7 @@ export default function ProviderSettings({ onClose, isOnboarding }: ProviderSett
         await initializeSystem(provider.name, model, {
           getExtensions,
           addExtension,
+          changeModel,
         });
       } catch (error) {
         console.error(`Failed to initialize with provider ${provider_name}:`, error);
@@ -84,7 +87,7 @@ export default function ProviderSettings({ onClose, isOnboarding }: ProviderSett
       });
       onClose();
     },
-    [onClose, upsert, getExtensions, addExtension]
+    [onClose, upsert, getExtensions, addExtension, changeModel]
   );
 
   return (

--- a/ui/desktop/src/recipe/index.ts
+++ b/ui/desktop/src/recipe/index.ts
@@ -26,6 +26,11 @@ export interface Recipe {
   context?: string[];
   profile?: string;
   mcps?: number;
+  settings?: {
+    goose_provider?: string;
+    goose_model?: string;
+    temperature?: number;
+  };
   // Properties added for scheduled execution
   scheduledJobId?: string;
   isScheduledExecution?: boolean;


### PR DESCRIPTION
Updates the gui to support the usage of 'settings' property when running a recipe:
```
  settings?: {
    goose_provider?: string;
    goose_model?: string;
    temperature?: number;
  };
```

The settings are only updated for the recipes goose session, it does not update the client config and it does not update the config on disc. So if a recipe changes the model, we will see the updated model for that recipe session. But if a user then does Cmd+N the new session will be back to the model specified in config. 

This keeps recipe execution as an independent run rather than changing a users default settings.

**Tested:**
- Deeplinks with & without settings
- Recipe library load recipe with & without settings
