### PR TITLE
docs: move topics to tutorials section

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -341,7 +341,7 @@ goose run --max-turns 25 -i plan.md
 
 ### bench
 
-Used to evaluate system-configuration across a range of practical tasks. See the [detailed guide](/docs/guides/benchmarking) for more information.
+Used to evaluate system-configuration across a range of practical tasks. See the [detailed guide](/docs/tutorials/benchmarking) for more information.
 
 **Usage:**
 

--- a/documentation/docs/tutorials/benchmarking.md
+++ b/documentation/docs/tutorials/benchmarking.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 12
 title: Benchmarking with Goose
 sidebar_label: Benchmark with Goose
 ---

--- a/documentation/docs/tutorials/benchmarking.md
+++ b/documentation/docs/tutorials/benchmarking.md
@@ -194,5 +194,6 @@ RUST_LOG=debug goose bench bench-config.json
 ### Tool Shimming
 
 Tool shimming allows you to use a non-tool-capable models with Goose, provided Ollama is installed on the
-system.<br></br>
-See this guide for important details on [tool shimming](experimental-features).
+system.
+
+See this guide for important details on [tool shimming](/docs/guides/experimental-features).

--- a/documentation/docs/tutorials/goose-in-docker.md
+++ b/documentation/docs/tutorials/goose-in-docker.md
@@ -1,7 +1,6 @@
 ---
 title: Building Goose in Docker
 sidebar_label: Goose in Docker
-sidebar_position: 15
 ---
 
 :::info Tell Us What You Need


### PR DESCRIPTION
This PR moves the two topics to the Tutorials section:

Documentation updates:
- `documentation/docs/tutorials/benchmarking.md`: Moved from /guides section & fix link to experimental-features topic
- `documentation/docs/tutorials/goose-in-docker.md`: Moved from /guides section
- `documentation/docs/guides/goose-cli-commands.md`: Update link to goose-in-docker topic

