### PR TITLE
Add YouTube video to Netlify MCP documentation

### DIFF
--- a/documentation/docs/mcp/netlify-mcp.md
+++ b/documentation/docs/mcp/netlify-mcp.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
-<!-- <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/izoQatKtJ2I" /> -->
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/iSUNmxOf6gw" />
 
 This tutorial covers how to add the [Netlify MCP Server](https://github.com/netlify/netlify-mcp) as a Goose extension to build, deploy, and manage Netlify sites.
 
@@ -201,7 +201,7 @@ In this example, I’ll show you how to use Goose with the Netlify Extension to 
 :::note CLI
 
 <details>
-<summary>Tool Calls</summary>
+    <summary>Tool Calls</summary>
     I'll help you deploy your tic-tac-toe app to Netlify from your GitHub repository. Let me first check your Netlify account and then set up the deployment.
 
     ─── netlify-user-services | netlify ──────────────────────────


### PR DESCRIPTION
## Summary
This PR adds a YouTube video to the Netlify MCP documentation page to enhance the user experience and provide visual guidance.

## Changes
- Added YouTube Short video (https://www.youtube.com/shorts/iSUNmxOf6gw) to the netlify-mcp.md documentation page
- Video embedded using the YouTubeShortEmbed component following the same pattern as other MCP pages
- Video positioned at the top of the page after imports and before main content

## Testing
- Verified the video URL format matches the embed pattern used in other MCP documentation pages
- Confirmed the YouTubeShortEmbed component is properly imported and used

The video will help users better understand how to use the Netlify MCP extension with Goose.