### PR TITLE
docs: Remove Deeplink for Filesystem MCP Server

### DIFF
--- a/documentation/docs/mcp/filesystem-mcp.md
+++ b/documentation/docs/mcp/filesystem-mcp.md
@@ -12,17 +12,11 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 This tutorial covers how to add the [Filesystem MCP server](https://github.com/modelcontextprotocol/servers/tree/HEAD/src/filesystem) as a Goose extension, enabling powerful code analysis and file management. With this extension, Goose can analyze project structures, edit and organize files, detect unused dependencies, and generate documentation to improve software maintainability.
 
 :::tip TLDR
-<Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@modelcontextprotocol/server-filesystem&arg=/path/to/allowed/directory&id=filesystem-mcp&name=Filesystem%20MCP%20Server&description=Filesystem%20MCP%20Server)
-  </TabItem>
-  <TabItem value="cli" label="Goose CLI">
   **Command**
   ```sh
   npx -y @modelcontextprotocol/server-filesystem </path/to/allowed/directory>
   ```
-  </TabItem>
-</Tabs>
+
     You can specify multiple allowed directories by separating them with a space.
 :::
 
@@ -34,10 +28,15 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-    1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@modelcontextprotocol/server-filesystem&arg=/path/to/allowed/directory&id=filesystem-mcp&name=Filesystem%20MCP%20Server&description=Filesystem%20MCP%20Server)
-    2. Press `Yes` to confirm the installation
-    3. Add additional allowed directories if desired, separated by a space.
-    4. Click `Save Configuration`
+    1. Click `...` in the upper right corner
+    2. Click `Advanced Settings`
+    3. Under `Extensions`, click the `Add Custom Extensions` button
+    4. On the `Add Extension Manually` modal, enter the following:
+            * **Type**: `Standard IO`
+            * **Extension Name**: `filesystem` (_set this to whatever you want_)
+            * **Description**: `filesystem MCP Server` (_(optional) set this to whatever you want_)
+            * **Command**: `npx -y @modelcontextprotocol/server-filesystem </path/to/allowed/directory>` (_Add additional allowed directories if desired, separated by a space._)
+    5. Click `Add Extension` button
   </TabItem>
 
   <TabItem value="cli" label="Goose CLI">


### PR DESCRIPTION
This PR updates the **Filesystem MCP tutorial** to remove the non-functional deeplink for the Goose Desktop extension.

#### ❌ Removed
- The `goose://` URI deeplink under the TLDR section and setup instructions for Goose Desktop. Since the Filesystem MCP server requires a user-specified directory path at runtime, it cannot support deeplinks.

#### ✅ Added
- Clear manual setup instructions for adding the Filesystem MCP Server to Goose Desktop via `Advanced Settings`, including:
  - Extension Type: `Standard IO`
  - Command: `npx -y @modelcontextprotocol/server-filesystem </path/to/allowed/directory>`
