### PR TITLE
docs: add goose-mobile

### DIFF
--- a/documentation/docs/experimental/_category_.json
+++ b/documentation/docs/experimental/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Experimental",
+  "position": 7,
+  "link": {
+    "type": "doc",
+    "id": "experimental/index"
+  }
+}

--- a/documentation/docs/experimental/goose-mobile.md
+++ b/documentation/docs/experimental/goose-mobile.md
@@ -1,0 +1,46 @@
+---
+title: Goose Mobile
+sidebar_position: 2
+sidebar_label: Goose Mobile
+---
+
+Goose Mobile is an experimental project inspired by the Goose application, designed to automate tasks on Android devices. It acts as an open agent that can run on your phone, providing maximal automation of everyday tasks.
+
+![Goose Mobile Screenshot](https://github.com/user-attachments/assets/af9d7d83-54f4-4ace-ad66-9e19f86c8fb9)
+
+## Overview
+
+Goose Mobile is an interpretation of [Goose](https://github.com/block/goose) for Android, allowing for end-to-end task automation. It can function as a home screen replacement or react to notifications, executing pre-defined rules on your behalf.
+
+:::caution
+Goose Mobile is an experimental project that requires deep access to your device. Use at your own risk.
+:::
+
+## Key Features
+
+- **Automation**: Automate multi-step tasks using installed apps.
+- **Notification Handling**: Respond to incoming notifications based on set rules.
+- **Extensibility**: Discover and use extensions from other apps to perform background tasks.
+
+## Getting Started
+
+Goose Mobile is a research project and not intended for production use. It's recommended to try it on a spare Android phone or an emulator.
+
+### Installation Options
+
+- **Pre-built APK**: Quickly install via [Firebase distribution link](https://appdistribution.firebase.google.com/pub/i/3f111ea732d5f7f6).
+- **Build from Source**: For developers, instructions are available in the [Goose Mobile repository](https://github.com/block/goose-mobile).
+
+## Extending Goose Mobile
+
+Goose Mobile supports extensions via the "mobile MCP" system, allowing it to use tools from other apps without switching contexts. For example, it can use a weather extension to quickly fetch weather information.
+
+Example extension code and setup can be found in the repository's [README](https://github.com/block/goose-mobile).
+
+## Contribution and Development
+
+We welcome contributions to Goose Mobile. For more information, see the [Contributing Guide](https://github.com/block/goose-mobile/blob/main/CONTRIBUTING.md).
+
+## Further Information
+
+For detailed instructions, scenarios, and development setup, please refer to the [Goose Mobile repository](https://github.com/block/goose-mobile).

--- a/documentation/docs/experimental/index.md
+++ b/documentation/docs/experimental/index.md
@@ -1,0 +1,19 @@
+---
+title: Experimental
+hide_title: true
+description: Experimental and radically unstable, but lot's of fun.
+---
+
+## Overview
+
+Goose is an open source project that is constantly being improved and expanded upon. This leads to new features and projects and some of these features / projects are considered experimental, meaning they are still in development and may not be fully stable or ready for production use. This area highlights some of our experimental features and projects we want to explore further.
+
+:::note
+The list of experimental features may change as Goose development progresses. Some features may be promoted to stable features, while others might be modified or removed.This section will be updated with specific experimental features as they become available
+:::
+
+
+
+## Feedback
+
+If you encounter any issues with these features, check if the issue is already reported in the [GitHub issues](https://github.com/goose/goose/issues) or join the [Discord community](https://discord.gg/block-opensource) to share.

--- a/documentation/docs/experimental/ollama.md
+++ b/documentation/docs/experimental/ollama.md
@@ -1,19 +1,8 @@
 ---
-title: Experimental Features
-sidebar_position: 16
-sidebar_label: Experimental Features
+title: Ollama Tool Shim
+sidebar_position: 1
+sidebar_label: Ollama Tool Shim
 ---
-
-Goose is an open source project that is constantly being improved, and new features are added regularly. Some of these features are considered experimental, meaning they are still in development and may not be fully stable or ready for production use. This guide covers how to enable and use experimental features in Goose, as well as how to provide feedback on them.
-
-
-## Available Experimental Features
-
-:::note
-The list of experimental features may change as Goose development progresses. Some features may be promoted to stable features, while others might be modified or removed.This section will be updated with specific experimental features as they become available
-:::
-
-### Ollama Tool Shim
 
 The Ollama tool shim is an experimental feature that enables tool calling capabilities for language models that don't natively support tool calling (like DeepSeek). It works by instructing the primary model to output json for intended tool usage, the interpretive model uses ollama structured outputs to translate the primary model's message into valid json, and then that json is translated into valid tool calls to be invoked.
 
@@ -53,8 +42,3 @@ Start a new Goose session with your tool shim preferences:
   ```bash
   GOOSE_TOOLSHIM=1 GOOSE_TOOLSHIM_OLLAMA_MODEL=llama3.2 cargo run --bin goose session
   ```
-
-
-## Feedback
-
-If you encounter any issues with these features, check if the issue is already reported in the [GitHub issues](https://github.com/goose/goose/issues) or join the [Discord community](https://discord.gg/block-opensource) to share.


### PR DESCRIPTION
This is a proof of concept to show how we could potentially fit goose mobile into the goose docs.

The old experimental section was a guide showing experimental features for goose. I have lifted that out of the guides section and created a new top level section just generally called experimental, and highlighted that this section is for both experimental projects and features surrounding goose.

Give it a look and let me know your thoughts. I don't have a great solution for where goose-mobile should live in the docs, but this is my first pass at a new idea. Hopefully we can find the best solution!

Thanks