### PR TITLE
Add wakelock feature to prevent system sleep while Goose is working

### DIFF
--- a/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/app/AppSettingsSection.tsx
@@ -19,6 +19,7 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
   const [menuBarIconEnabled, setMenuBarIconEnabled] = useState(true);
   const [dockIconEnabled, setDockIconEnabled] = useState(true);
   const [quitConfirmationEnabled, setQuitConfirmationEnabled] = useState(true);
+  const [wakelockEnabled, setWakelockEnabled] = useState(true);
   const [isMacOS, setIsMacOS] = useState(false);
   const [isDockSwitchDisabled, setIsDockSwitchDisabled] = useState(false);
   const [showNotificationModal, setShowNotificationModal] = useState(false);
@@ -147,6 +148,10 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
       setQuitConfirmationEnabled(enabled);
     });
 
+    window.electron.getWakelockState().then((enabled) => {
+      setWakelockEnabled(enabled);
+    });
+
     if (isMacOS) {
       window.electron.getDockIconState().then((enabled) => {
         setDockIconEnabled(enabled);
@@ -199,6 +204,14 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
     const success = await window.electron.setQuitConfirmation(newState);
     if (success) {
       setQuitConfirmationEnabled(newState);
+    }
+  };
+
+  const handleWakelockToggle = async () => {
+    const newState = !wakelockEnabled;
+    const success = await window.electron.setWakelock(newState);
+    if (success) {
+      setWakelockEnabled(newState);
     }
   };
 
@@ -294,6 +307,23 @@ export default function AppSettingsSection({ scrollToSection }: AppSettingsSecti
               <Switch
                 checked={quitConfirmationEnabled}
                 onCheckedChange={handleQuitConfirmationToggle}
+                variant="mono"
+              />
+            </div>
+          </div>
+
+          {/* Prevent Sleep */}
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-text-default text-xs">Prevent Sleep</h3>
+              <p className="text-xs text-text-muted max-w-md mt-[2px]">
+                Keep your computer awake while Goose is running a task (screen can still lock)
+              </p>
+            </div>
+            <div className="flex items-center">
+              <Switch
+                checked={wakelockEnabled}
+                onCheckedChange={handleWakelockToggle}
                 variant="mono"
               />
             </div>

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -494,6 +494,9 @@ let appConfig = {
 let windowCounter = 0;
 const windowMap = new Map<number, BrowserWindow>();
 
+// Track power save blocker ID globally
+let powerSaveBlockerId: number | null = null;
+
 interface RecipeConfig {
   id: string;
   title: string;
@@ -1057,6 +1060,36 @@ ipcMain.handle('get-quit-confirmation-state', () => {
   } catch (error) {
     console.error('Error getting quit confirmation state:', error);
     return true;
+  }
+});
+
+// Handle wakelock setting
+ipcMain.handle('set-wakelock', async (_event, enable: boolean) => {
+  try {
+    const settings = loadSettings();
+    settings.enableWakelock = enable;
+    saveSettings(settings);
+
+    // Stop any existing power save blocker when disabling the setting
+    if (!enable && powerSaveBlockerId !== null) {
+      powerSaveBlocker.stop(powerSaveBlockerId);
+      powerSaveBlockerId = null;
+    }
+
+    return true;
+  } catch (error) {
+    console.error('Error setting wakelock:', error);
+    return false;
+  }
+});
+
+ipcMain.handle('get-wakelock-state', () => {
+  try {
+    const settings = loadSettings();
+    return settings.enableWakelock ?? false;
+  } catch (error) {
+    console.error('Error getting wakelock state:', error);
+    return false;
   }
 });
 
@@ -1859,24 +1892,19 @@ app.whenReady().then(async () => {
     }
   });
 
-  let powerSaveBlockerId: number | null = null;
-
   ipcMain.handle('start-power-save-blocker', () => {
-    log.info('Starting power save blocker...');
     if (powerSaveBlockerId === null) {
-      powerSaveBlockerId = powerSaveBlocker.start('prevent-display-sleep');
-      log.info('Started power save blocker');
+      powerSaveBlockerId = powerSaveBlocker.start('prevent-app-suspension');
       return true;
     }
+
     return false;
   });
 
   ipcMain.handle('stop-power-save-blocker', () => {
-    log.info('Stopping power save blocker...');
     if (powerSaveBlockerId !== null) {
       powerSaveBlocker.stop(powerSaveBlockerId);
       powerSaveBlockerId = null;
-      log.info('Stopped power save blocker');
       return true;
     }
     return false;

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -83,6 +83,8 @@ type ElectronAPI = {
   setSchedulingEngine: (engine: string) => Promise<boolean>;
   setQuitConfirmation: (show: boolean) => Promise<boolean>;
   getQuitConfirmationState: () => Promise<boolean>;
+  setWakelock: (enable: boolean) => Promise<boolean>;
+  getWakelockState: () => Promise<boolean>;
   openNotificationsSettings: () => Promise<boolean>;
   on: (
     channel: string,
@@ -163,6 +165,8 @@ const electronAPI: ElectronAPI = {
   setSchedulingEngine: (engine: string) => ipcRenderer.invoke('set-scheduling-engine', engine),
   setQuitConfirmation: (show: boolean) => ipcRenderer.invoke('set-quit-confirmation', show),
   getQuitConfirmationState: () => ipcRenderer.invoke('get-quit-confirmation-state'),
+  setWakelock: (enable: boolean) => ipcRenderer.invoke('set-wakelock', enable),
+  getWakelockState: () => ipcRenderer.invoke('get-wakelock-state'),
   openNotificationsSettings: () => ipcRenderer.invoke('open-notifications-settings'),
   on: (
     channel: string,

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -16,6 +16,7 @@ export interface Settings {
   showDockIcon: boolean;
   schedulingEngine: SchedulingEngine;
   showQuitConfirmation: boolean;
+  enableWakelock: boolean;
 }
 
 // Constants
@@ -30,6 +31,7 @@ const defaultSettings: Settings = {
   showDockIcon: true,
   schedulingEngine: 'builtin-cron',
   showQuitConfirmation: true,
+  enableWakelock: false,
 };
 
 // Settings management


### PR DESCRIPTION
- Add wakelock toggle UI in App Settings, default to false
- Hooks into the messaging infra to know when goose is working
- Releases wakelock when Goose is done with work to prevent killing your battery
- Use Electron's powerSaveBlocker with 'prevent-app-suspension' to allow the screen to still lock for security

<img width="725" alt="Screenshot 2025-07-09 at 1 54 43 PM" src="https://github.com/user-attachments/assets/4a6a0583-8cbd-4497-bbc4-d72450e36f00" />
