### PR TITLE
theme bug

### DIFF
--- a/ui/desktop/src/components/GooseSidebar/ThemeSelector.tsx
+++ b/ui/desktop/src/components/GooseSidebar/ThemeSelector.tsx
@@ -23,11 +23,20 @@ const ThemeSelector: React.FC<ThemeSelectorProps> = ({
   });
 
   const [isDarkMode, setDarkMode] = useState(() => {
+    // Always check the actual DOM state first to ensure consistency
+    const currentlyDark = document.documentElement.classList.contains('dark');
+    if (currentlyDark !== undefined) {
+      return currentlyDark;
+    }
+
+    // Fallback to calculating from theme mode
     const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    if (themeMode === 'system') {
+    const savedUseSystemTheme = localStorage.getItem('use_system_theme') === 'true';
+    if (savedUseSystemTheme) {
       return systemPrefersDark;
     }
-    return themeMode === 'dark';
+    const savedTheme = localStorage.getItem('theme');
+    return savedTheme === 'dark';
   });
 
   useEffect(() => {


### PR DESCRIPTION

  ## Root Cause: State Initialization Race Condition

  The bug was caused by a state initialization race condition in the
  ThemeSelector component. Here's what was happening:

  The Original Problematic Code

```
  const [themeMode, setThemeMode] = useState<'light' | 'dark' |
  'system'>(() => {
    const savedUseSystemTheme = localStorage.getItem('use_system_theme')
  === 'true';
    if (savedUseSystemTheme) {
      return 'system';
    }
    const savedTheme = localStorage.getItem('theme');
    return savedTheme === 'dark' ? 'dark' : 'light';
  });

  const [isDarkMode, setDarkMode] = useState(() => {
    const systemPrefersDark = window.matchMedia('(prefers-color-scheme:
  dark)').matches;
    if (themeMode === 'system') {  // ❌ PROBLEM: themeMode is a closure
  variable
      return systemPrefersDark;
    }
    return themeMode === 'dark';    // ❌ PROBLEM: themeMode is a closure
   variable
  });
```

  ## The Problem Explained

  1. Closure Capture: In the `isDarkMode` initialization, `themeMode` is
  captured as a closure variable from the initial render, not the actual
  state value.
  2. Stale Reference: When the component re-mounts (like when navigating
  to Settings -> App), the themeMode variable inside the isDarkMode
  initializer refers to the initial value from when the function was
  first created, not the current state.
  3. Race Condition: The component has two different systems trying to
  determine the theme:
    - The initialization script in index.html
    - The React component's state initialization

  Step-by-Step Bug Flow

  Here's exactly what happened when you clicked Settings -> App:

  1. User is in dark mode ✅
    - DOM has class="dark"
    - localStorage has correct dark theme settings
  2. User navigates to Settings -> App 🔄
    - React router causes components to re-mount
    - ThemeSelector component initializes again
  3. State Initialization ❌
```
  // First, themeMode initializes correctly from localStorage
  themeMode = 'dark' // ✅ Correct

  // Then, isDarkMode tries to initialize
  // But themeMode here is the closure variable, which might be undefined
   or stale
  if (themeMode === 'system') {  // themeMode might be undefined
    return systemPrefersDark;
  }
  return themeMode === 'dark';   // themeMode might be undefined, so this
   returns false
  5. Result: isDarkMode gets set to false (light mode) ❌
  6. useEffect Triggers ❌
  useEffect(() => {
    if (isDarkMode) {  // false
      document.documentElement.classList.add('dark');
    } else {
      document.documentElement.classList.remove('dark');  // ❌ Removes
  dark class!
      document.documentElement.classList.add('light');
    }
  }, [isDarkMode]);
```
  7. UI switches to light mode ❌

  Why It Didn't Persist

  The theme didn't persist because:
  - The localStorage still had the correct dark theme settings
  - Only the React component's state was wrong
  - On the next navigation/refresh, the same bug would happen again

  ## The Fix
```
  const [isDarkMode, setDarkMode] = useState(() => {
    // ✅ SOLUTION: Check actual DOM state first
    const currentlyDark =
  document.documentElement.classList.contains('dark');
    if (currentlyDark !== undefined) {
      return currentlyDark;  // Use the real current state
    }

    // Fallback logic if DOM state is unclear
    const systemPrefersDark = window.matchMedia('(prefers-color-scheme:
  dark)').matches;
    const savedUseSystemTheme = localStorage.getItem('use_system_theme')
  === 'true';
    if (savedUseSystemTheme) {
      return systemPrefersDark;
    }
    const savedTheme = localStorage.getItem('theme');
    return savedTheme === 'dark';
  });
```
  ## Why The Fix Works

  1. DOM as Source of Truth: Instead of relying on potentially stale
  closure variables, we check the actual DOM state first
  2. Consistency: This ensures the React state matches the actual visual
  state
  3. Race Condition Eliminated: No matter when the component re-mounts,
  it reads the current reality
