### PR TITLE
Drop temporal-service binary

### DIFF
--- a/temporal-service/.gitignore
+++ b/temporal-service/.gitignore
@@ -1,0 +1,1 @@
+temporal-service


### PR DESCRIPTION
I'm assuming this was accidentally committed. Remove it and add a .gitignore to prevent it from coming back.

I noticed this repository when cloning is now over 1G. This is surprising for a repository of this age and scope. For reference the Linux kernel repository's `.git` is now 3.4G.

There are a few causes to this (the large high resolution photos in `documentation/` are one) but in looking around, this binary executable is one that is almost certainly a mistake. If it's not a mistake it needs a good bit of justification I think.