### PR TITLE
refactor: streamline memory directory management

### DIFF
--- a/crates/goose-mcp/src/memory/mod.rs
+++ b/crates/goose-mcp/src/memory/mod.rs
@@ -630,7 +630,7 @@ mod tests {
     fn test_lazy_directory_creation() {
         let temp_dir = tempdir().unwrap();
         let memory_base = temp_dir.path().join("test_memory");
-        
+
         let router = MemoryRouter {
             tools: vec![],
             instructions: String::new(),
@@ -641,13 +641,29 @@ mod tests {
         assert!(!router.global_memory_dir.exists());
         assert!(!router.local_memory_dir.exists());
 
-        router.remember("test_context", "test_category", "test_data", &["tag1"], false).unwrap();
-        
+        router
+            .remember(
+                "test_context",
+                "test_category",
+                "test_data",
+                &["tag1"],
+                false,
+            )
+            .unwrap();
+
         assert!(router.local_memory_dir.exists());
         assert!(!router.global_memory_dir.exists());
 
-        router.remember("test_context", "global_category", "global_data", &["global_tag"], true).unwrap();
-        
+        router
+            .remember(
+                "test_context",
+                "global_category",
+                "global_data",
+                &["global_tag"],
+                true,
+            )
+            .unwrap();
+
         assert!(router.global_memory_dir.exists());
     }
 
@@ -655,7 +671,7 @@ mod tests {
     fn test_clear_nonexistent_directories() {
         let temp_dir = tempdir().unwrap();
         let memory_base = temp_dir.path().join("nonexistent_memory");
-        
+
         let router = MemoryRouter {
             tools: vec![],
             instructions: String::new(),
@@ -671,7 +687,7 @@ mod tests {
     fn test_remember_retrieve_clear_workflow() {
         let temp_dir = tempdir().unwrap();
         let memory_base = temp_dir.path().join("workflow_test");
-        
+
         let router = MemoryRouter {
             tools: vec![],
             instructions: String::new(),
@@ -679,16 +695,27 @@ mod tests {
             local_memory_dir: memory_base.join("local"),
         };
 
-        router.remember("context", "test_category", "test_data_content", &["test_tag"], false).unwrap();
+        router
+            .remember(
+                "context",
+                "test_category",
+                "test_data_content",
+                &["test_tag"],
+                false,
+            )
+            .unwrap();
 
         let memories = router.retrieve("test_category", false).unwrap();
         assert!(!memories.is_empty());
-        
-        let has_content = memories.values().any(|v| v.iter().any(|content| content.contains("test_data_content")));
+
+        let has_content = memories.values().any(|v| {
+            v.iter()
+                .any(|content| content.contains("test_data_content"))
+        });
         assert!(has_content);
 
         router.clear_memory("test_category", false).unwrap();
-        
+
         let memories_after_clear = router.retrieve("test_category", false).unwrap();
         assert!(memories_after_clear.is_empty());
     }
@@ -697,7 +724,7 @@ mod tests {
     fn test_directory_creation_on_write() {
         let temp_dir = tempdir().unwrap();
         let memory_base = temp_dir.path().join("write_test");
-        
+
         let router = MemoryRouter {
             tools: vec![],
             instructions: String::new(),
@@ -706,9 +733,11 @@ mod tests {
         };
 
         assert!(!router.local_memory_dir.exists());
-        
-        router.remember("context", "category", "data", &[], false).unwrap();
-        
+
+        router
+            .remember("context", "category", "data", &[], false)
+            .unwrap();
+
         assert!(router.local_memory_dir.exists());
         assert!(router.local_memory_dir.join("category.txt").exists());
     }
@@ -717,7 +746,7 @@ mod tests {
     fn test_remove_specific_memory() {
         let temp_dir = tempdir().unwrap();
         let memory_base = temp_dir.path().join("remove_test");
-        
+
         let router = MemoryRouter {
             tools: vec![],
             instructions: String::new(),
@@ -725,19 +754,29 @@ mod tests {
             local_memory_dir: memory_base.join("local"),
         };
 
-        router.remember("context", "category", "keep_this", &[], false).unwrap();
-        router.remember("context", "category", "remove_this", &[], false).unwrap();
-        
+        router
+            .remember("context", "category", "keep_this", &[], false)
+            .unwrap();
+        router
+            .remember("context", "category", "remove_this", &[], false)
+            .unwrap();
+
         let memories = router.retrieve("category", false).unwrap();
         assert_eq!(memories.len(), 1);
-        
-        router.remove_specific_memory("category", "remove_this", false).unwrap();
-        
+
+        router
+            .remove_specific_memory("category", "remove_this", false)
+            .unwrap();
+
         let memories_after = router.retrieve("category", false).unwrap();
-        let has_removed = memories_after.values().any(|v| v.iter().any(|content| content.contains("remove_this")));
+        let has_removed = memories_after
+            .values()
+            .any(|v| v.iter().any(|content| content.contains("remove_this")));
         assert!(!has_removed);
-        
-        let has_kept = memories_after.values().any(|v| v.iter().any(|content| content.contains("keep_this")));
+
+        let has_kept = memories_after
+            .values()
+            .any(|v| v.iter().any(|content| content.contains("keep_this")));
         assert!(has_kept);
     }
 }


### PR DESCRIPTION
Closes #3202 

These directories will now only be created if `remember` is called rather than upfront.

I added an extra check as well before clearing the memories to check the directory exists first, but this could be overly defensive.