### PR TITLE
feat: fetch openrouter supported models in `goose configure`

### DIFF
--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -427,4 +427,42 @@ impl Provider for GithubCopilotProvider {
         emit_debug_trace(&self.model, &payload, &response, &usage);
         Ok((message, ProviderUsage::new(model, usage)))
     }
+
+    /// Fetch supported models from GitHub Copilot API
+    async fn fetch_supported_models_async(&self) -> Result<Option<Vec<String>>, ProviderError> {
+        let (endpoint, token) = self.get_api_info().await?;
+        let url = url::Url::parse(&format!("{}/models", endpoint))
+            .map_err(|e| ProviderError::RequestFailed(format!("Invalid models URL: {e}")))?;
+
+        let response = self
+            .client
+            .get(url)
+            .headers(self.get_github_headers())
+            .header("Authorization", format!("Bearer {}", token))
+            .send()
+            .await?;
+
+        let json: serde_json::Value = response.json().await?;
+
+        // Check for error in response
+        if let Some(err_obj) = json.get("error") {
+            let msg = err_obj
+                .get("message")
+                .and_then(|v| v.as_str())
+                .unwrap_or("unknown error");
+            return Err(ProviderError::Authentication(msg.to_string()));
+        }
+
+        // GitHub Copilot API returns models in a "data" array, similar to OpenAI
+        let data = json.get("data").and_then(|v| v.as_array()).ok_or_else(|| {
+            ProviderError::UsageError("Missing data field in JSON response".into())
+        })?;
+
+        let mut models: Vec<String> = data
+            .iter()
+            .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(str::to_string))
+            .collect();
+        models.sort();
+        Ok(Some(models))
+    }
 }

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -320,7 +320,8 @@ impl Provider for OpenRouterProvider {
                 .get("message")
                 .and_then(|v| v.as_str())
                 .unwrap_or("unknown error");
-            return Err(ProviderError::Authentication(msg.to_string()));
+            tracing::warn!("OpenRouter API returned an error: {}", msg);
+            return Ok(None);
         }
 
         let data = json.get("data").and_then(|v| v.as_array()).ok_or_else(|| {


### PR DESCRIPTION
## Before:

You have to type out a model manually.

```bash
┌   goose-configure
│
◇  What would you like to configure?
│  Configure Providers
│
◇  Which model provider should we use?
│  OpenRouter
│
●  OPENROUTER_API_KEY is already configured
│
◇  Would you like to update this value?
│  Yes
│
◇  Enter new value for OPENROUTER_API_KEY
│  [REDACTED]
│
◇  Model fetch complete
│
◆  Enter a model from that provider:
│  anthropic/claude-3.5-sonnet (default)
└
```

## After:

Goose CLI will automatically fetch the list of models that support tool use from OpenRouter when you configure it as a provider:

```bash
┌   goose-configure
│
◇  What would you like to configure?
│  Configure Providers
│
◇  Which model provider should we use?
│  OpenRouter
│
●  OPENROUTER_API_KEY is already configured
│
◇  Would you like to update this value?
│  Yes
│
◇  Enter new value for OPENROUTER_API_KEY
│  [REDACTED]
│
◇  Model fetch complete
│
◆  Select a model:
│
│  ● ai21/jamba-1.6-large
│  ○ ai21/jamba-1.6-mini
│  ○ amazon/nova-lite-v1
│  ○ amazon/nova-micro-v1
│  ○ amazon/nova-pro-v1
│  ○ anthropic/claude-3-haiku
...
```