### PR TITLE
Fix name of GPT-4.1 System Prompt (#3348)

### DIFF
--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -185,25 +185,25 @@ mod tests {
         // should match prompts based on contained normalized keys
         assert_eq!(
             PromptManager::model_prompt_map("gpt-4.1"),
-            "system_gpt_4_1.md"
+            "system_gpt_4.1.md"
         );
 
         assert_eq!(
             PromptManager::model_prompt_map("gpt-4.1-2025-04-14"),
-            "system_gpt_4_1.md"
+            "system_gpt_4.1.md"
         );
 
         assert_eq!(
             PromptManager::model_prompt_map("openai/gpt-4.1"),
-            "system_gpt_4_1.md"
+            "system_gpt_4.1.md"
         );
         assert_eq!(
             PromptManager::model_prompt_map("goose-gpt-4-1"),
-            "system_gpt_4_1.md"
+            "system_gpt_4.1.md"
         );
         assert_eq!(
             PromptManager::model_prompt_map("gpt-4-1-huge"),
-            "system_gpt_4_1.md"
+            "system_gpt_4.1.md"
         );
     }
 

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -48,7 +48,7 @@ impl PromptManager {
     /// Map model (normalized) to prompt filenames; returns filename if a key is contained in the normalized model
     fn model_prompt_map(model: &str) -> &'static str {
         let mut map = HashMap::new();
-        map.insert("gpt_4_1", "system_gpt_4_1.md");
+        map.insert("gpt_4_1", "system_gpt_4.1.md");
         // Add more mappings as needed
         let norm_model = Self::normalize_model_name(model);
         for (key, val) in &map {


### PR DESCRIPTION
Fixes the naming of the system prompt for OpenAI GPT 4.1, fixing #3348 