### PR TITLE
Add support for setting `goose_lead_model` from a recipe

### DIFF
--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -60,6 +60,37 @@ pub fn providers() -> Vec<ProviderMetadata> {
     ]
 }
 
+pub enum ProviderType {
+    Default {
+        provider_name: String,
+        model_config: ModelConfig,
+    },
+    LeadWorker {
+        lead_model_name: String,
+        default_model_config: ModelConfig,
+    },
+}
+
+pub fn create_by_type(provider_type: ProviderType) -> Result<Arc<dyn Provider>> {
+    match provider_type {
+        ProviderType::Default {
+            provider_name,
+            model_config,} => {
+            create_provider(&provider_name, model_config)
+        }
+        ProviderType::LeadWorker {
+            lead_model_name,
+            default_model_config,
+        } => {
+            create_lead_worker_from_env(
+                &lead_model_name,
+                &default_model_config,
+                &lead_model_name,
+            )
+        }
+    }
+}
+
 pub fn create(name: &str, model: ModelConfig) -> Result<Arc<dyn Provider>> {
     let config = crate::config::Config::global();
 

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -29,4 +29,4 @@ pub mod utils_universal_openai_stream;
 pub mod venice;
 pub mod xai;
 
-pub use factory::{create, providers};
+pub use factory::{create, create_by_type, providers, ProviderType};


### PR DESCRIPTION
This builds on https://github.com/block/goose/pull/3296 to support passing a lead model from a recipe to allow recipes to override default model configs and use the LeadWorkerProvider.

The existing code for creating a LeadWorkerProvider pulls env vars in the factory method, which makes it hard to override the values for a specific recipe's session. To address this limitation, I added a new factory method that allows providing construction dependencies for the specific provider type based on what that provider needs.

This is my first time writing Rust, so I'm not sure if my changes are idiomatic/proper, but I made a best effort there. Shout out  to Goose for helping me understand the codebase and Rust syntax.