### PR TITLE
fix: avoid pass encoded empty string to goose run --recipe

### DIFF
--- a/crates/goose-cli/src/recipes/extract_from_cli.rs
+++ b/crates/goose-cli/src/recipes/extract_from_cli.rs
@@ -47,7 +47,7 @@ pub fn extract_recipe_info_from_cli(
     }
     Ok((
         InputConfig {
-            contents: recipe.prompt,
+            contents: recipe.prompt.filter(|s| !s.trim().is_empty()),
             extensions_override: recipe.extensions,
             additional_system_prompt: recipe.instructions,
         },

--- a/crates/goose-cli/src/recipes/recipe.rs
+++ b/crates/goose-cli/src/recipes/recipe.rs
@@ -37,7 +37,6 @@ pub fn load_recipe_content_as_template(
             missing_parameters_command_line(missing_params)
         ));
     }
-
     render_recipe_content_with_params(&recipe_file_content, &params_for_template)
 }
 

--- a/crates/goose-cli/src/recipes/search_recipe.rs
+++ b/crates/goose-cli/src/recipes/search_recipe.rs
@@ -117,7 +117,6 @@ fn read_recipe_file<P: AsRef<Path>>(recipe_path: P) -> Result<RecipeFile> {
 
     let content = fs::read_to_string(&path)
         .map_err(|e| anyhow!("Failed to read recipe file {}: {}", path.display(), e))?;
-
     let canonical = path.canonicalize().map_err(|e| {
         anyhow!(
             "Failed to resolve absolute path for {}: {}",


### PR DESCRIPTION
**Why**

@dianed-square reported the issue:
If we set in goose recipe
```
prompt: ""
```
It will pass an empty message to agent, and get a 404 error 
```
  2025-07-10T23:21:27.753310Z ERROR goose::agents::agent: Error: Request failed: Request failed with status: 400 Bad Request. Message: {"external_model_provider":"databricks-model-serving","external_model_error":{"error_code":"BAD_REQUEST","message":"{\"message\":\"messages: at least one message is required\"}"}}
    at crates/goose/src/agents/agent.rs:1006
```

**What**
- Avoid `""` escape when rendering the recipe file as a template
- If the parsed recipe has empty `prompt`, don't send the empty string as a message

**With fix**
- If user run the recipe in `non-interactive` mode,  it will return error "Error: no text provided for prompt in headless mode" (expected behaviour)
- If user run the recipe in `interactive` mode, user can start the session without seeing any error message