### PR TITLE
Improve Claude Code provider error message for missing CLI

### DIFF
--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -275,7 +275,7 @@ impl ClaudeCodeProvider {
             .spawn()
             .map_err(|e| ProviderError::RequestFailed(format!(
                 "Failed to spawn Claude CLI command '{}': {}. \
-                Make sure the Claude CLI is installed and in your PATH, or set CLAUDE_CODE_COMMAND in your config to the correct path.",
+                Make sure the Claude Code CLI is installed and in your PATH, or set CLAUDE_CODE_COMMAND in your config to the correct path.",
                 self.command, e
             )))?;
 

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -273,7 +273,11 @@ impl ClaudeCodeProvider {
 
         let mut child = cmd
             .spawn()
-            .map_err(|e| ProviderError::RequestFailed(format!("Failed to spawn command: {}", e)))?;
+            .map_err(|e| ProviderError::RequestFailed(format!(
+                "Failed to spawn Claude CLI command '{}': {}. \
+                Make sure the Claude CLI is installed and in your PATH, or set CLAUDE_CODE_COMMAND in your config to the correct path.",
+                self.command, e
+            )))?;
 
         let stdout = child
             .stdout


### PR DESCRIPTION
## Problem
The previous error "Failed to spawn command: No such file or directory" was unclear for users when the Claude CLI wasn't installed or in PATH.

<img width="733" height="344" alt="Screenshot 2025-07-11 at 5 23 03 PM" src="https://github.com/user-attachments/assets/18388105-dcd0-403b-a202-50e9e1641508" />

## Solution
The new error message shows the exact command that failed and provides clear guidance on how to fix the issue, including mentioning the CLAUDE_CODE_COMMAND config option.


