### PR TITLE
docs: fix YouTube Transcript MCP package manager

### DIFF
--- a/documentation/docs/mcp/youtube-transcript-mcp.md
+++ b/documentation/docs/mcp/youtube-transcript-mcp.md
@@ -27,8 +27,9 @@ This tutorial covers how to add the [YouTube Transcript MCP Server](https://gith
 
 ## Configuration
 
+
 :::info
-Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
+Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on your system to run this command, as it uses `uvx`.
 :::
 
 <Tabs groupId="interface">

--- a/documentation/docs/mcp/youtube-transcript-mcp.md
+++ b/documentation/docs/mcp/youtube-transcript-mcp.md
@@ -14,7 +14,7 @@ This tutorial covers how to add the [YouTube Transcript MCP Server](https://gith
 :::tip TLDR
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40jkawamoto%2Fmcp-youtube-transcript&id=youtube-transcript&name=YouTube%20Transcript&description=Access%20YouTube%20video%20transcripts)
+  [Launch the installer](goose://extension?cmd=uvx&arg=--from&arg=git%2Bhttps%3A%2F%2Fgithub.com%2Fjkawamoto%2Fmcp-youtube-transcript&arg=mcp-youtube-transcript&id=youtube-transcript&name=YouTube%20Transcript&description=Access%20YouTube%20video%20transcripts)
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
   **Command**
@@ -34,7 +34,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40jkawamoto%2Fmcp-youtube-transcript&id=youtube-transcript&name=YouTube%20Transcript&description=Access%20YouTube%20video%20transcripts)
+  1. [Launch the installer](goose://extension?cmd=uvx&arg=--from&arg=git%2Bhttps%3A%2F%2Fgithub.com%2Fjkawamoto%2Fmcp-youtube-transcript&arg=mcp-youtube-transcript&id=youtube-transcript&name=YouTube%20Transcript&description=Access%20YouTube%20video%20transcripts)
   2. Press `Yes` to confirm the installation
   3. Click `Save Configuration`
   4. Scroll to the top and click `Exit` from the upper left corner
@@ -93,7 +93,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     │
     // highlight-start
     ◆  What command should be run?
-    │  npx -y @jkawamoto/mcp-youtube-transcript
+    │  uvx --from git+https://github.com/jkawamoto/mcp-youtube-transcript mcp-youtube-transcript
     // highlight-end
     └ 
   ```  
@@ -112,7 +112,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     │  youtube-transcript
     │
     ◇  What command should be run?
-    │  npx -y @jkawamoto/mcp-youtube-transcript
+    │  uvx --from git+https://github.com/jkawamoto/mcp-youtube-transcript mcp-youtube-transcript
     │
     // highlight-start
     ◆  Please set the timeout for this tool (in secs):
@@ -133,10 +133,10 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     │  Command-line Extension 
     │
     ◇  What would you like to call this extension?
-    │  knowledge graph memory
+    │  youtube-transcript
     │
     ◇  What command should be run?
-    │  npx -y @modelcontextprotocol/server-memory
+    │  uvx --from git+https://github.com/jkawamoto/mcp-youtube-transcript mcp-youtube-transcript
     │
     ◆  Please set the timeout for this tool (in secs):
     │  300
@@ -163,7 +163,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     │  youtube-transcript
     │
     ◇  What command should be run?
-    │  npx -y @jkawamoto/mcp-youtube-transcript
+    │  uvx --from git+https://github.com/jkawamoto/mcp-youtube-transcript mcp-youtube-transcript
     │
     ◇  Please set the timeout for this tool (in secs):
     │  300


### PR DESCRIPTION
YouTube Transcript MCP uses uv but we incorrectly listed Node