### PR TITLE
docs: Show both remote options for extensions in CLI

### DIFF
--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -54,7 +54,8 @@ Here are the built-in extensions:
     3. Choose the type of extension you'd like to add:
         - `Built-In Extension`: Use an extension that comes pre-installed with Goose.
         - `Command-Line Extension`: Add a local command or script to run as an extension.
-        - `Remote Extension`: Connect to a remote system via SSE (Server-Sent Events).
+        - `Remote Extension (SSE)`: Connect to a remote system via SSE (Server-Sent Events).
+        - `Remote Extension (Streaming HTTP)`: Connect to a remote system via Streaming HTTP
     4. Follow the prompts based on the type of extension you selected.
 
     **Example: Adding Built-in Extension**
@@ -143,7 +144,8 @@ See available servers in the **[MCP Server Directory](https://www.pulsemcp.com/s
   3. Choose the type of extension you'd like to add:
       - `Built-In Extension`: Use an extension that comes pre-installed with Goose.
       - `Command-Line Extension`: Add a local command or script to run as an extension.
-      - `Remote Extension`: Connect to a remote system via SSE (Server-Sent Events).
+      - `Remote Extension (SSE)`: Connect to a remote system via SSE (Server-Sent Events).
+      - `Remote Extension (Streaming HTTP)`: Connect to a remote system via Streaming HTTP
 
   4. Follow the prompts based on the type of extension you selected.
 
@@ -590,7 +592,7 @@ To enable a remote extension over SSE while starting a session, run the followin
 goose session --with-remote-extension "{extension URL}" --with-remote-extension "{another extension URL}"
 ```
 
-For example, to start a session with a remote extension running on localhost on port 8080, you'd run:
+For example, to start a session with a remote extension over SSE running on localhost on port 8080, you'd run:
 
 ```bash
 goose session --with-remote-extension "http://localhost:8080/sse"

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -114,7 +114,7 @@ goose run --with-builtin "developer,computercontroller" -t "your instructions"
 goose run --with-extension "ENV1=value1 custom-extension-args" -t "your instructions"
 ```
 
-- Using remote extensions
+- Using remote SSE extensions
 
 ```bash
 goose run --with-remote-extension "url" -t "your instructions"

--- a/documentation/docs/mcp/agentql-mcp.md
+++ b/documentation/docs/mcp/agentql-mcp.md
@@ -61,7 +61,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/asana-mcp.md
+++ b/documentation/docs/mcp/asana-mcp.md
@@ -66,7 +66,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/blender-mcp.md
+++ b/documentation/docs/mcp/blender-mcp.md
@@ -74,7 +74,8 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/brave-mcp.md
+++ b/documentation/docs/mcp/brave-mcp.md
@@ -61,7 +61,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/browserbase-mcp.md
+++ b/documentation/docs/mcp/browserbase-mcp.md
@@ -56,7 +56,8 @@ This tutorial covers how to add the Browserbase MCP Server as a Goose extension 
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/cloudinary-asset-management-mcp.md
+++ b/documentation/docs/mcp/cloudinary-asset-management-mcp.md
@@ -59,7 +59,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/cognee-mcp.md
+++ b/documentation/docs/mcp/cognee-mcp.md
@@ -58,7 +58,8 @@ goose configure
   // highlight-start    
   │  ● Command-line Extension (Run a local command or script)
   // highlight-end    
-  │  ○ Remote Extension 
+  │  ○ Remote Extension (SSE) 
+  │  ○ Remote Extension (Streaming HTTP) 
   └ 
 ```
 

--- a/documentation/docs/mcp/computer-controller-mcp.md
+++ b/documentation/docs/mcp/computer-controller-mcp.md
@@ -46,7 +46,8 @@ Let Goose complete its tasks without interruption - avoid using your mouse or ke
   │  ● Built-in Extension (Use an extension that comes with Goose)
   // highlight-end  
   │  ○ Command-line Extension 
-  │  ○ Remote Extension 
+  │  ○ Remote Extension (SSE) 
+  │  ○ Remote Extension (Streaming HTTP) 
   └  
   ```
 

--- a/documentation/docs/mcp/elevenlabs-mcp.md
+++ b/documentation/docs/mcp/elevenlabs-mcp.md
@@ -62,7 +62,8 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/fetch-mcp.md
+++ b/documentation/docs/mcp/fetch-mcp.md
@@ -58,7 +58,8 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/figma-mcp.md
+++ b/documentation/docs/mcp/figma-mcp.md
@@ -62,7 +62,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/filesystem-mcp.md
+++ b/documentation/docs/mcp/filesystem-mcp.md
@@ -57,7 +57,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
         // highlight-start    
         │  ● Command-line Extension (Run a local command or script)
         // highlight-end    
-        │  ○ Remote Extension 
+        │  ○ Remote Extension (SSE) 
+        │  ○ Remote Extension (Streaming HTTP) 
         └ 
     ```
 

--- a/documentation/docs/mcp/google-drive-mcp.md
+++ b/documentation/docs/mcp/google-drive-mcp.md
@@ -129,7 +129,8 @@ You'll need to re-authenticate once a day when using the Google Drive extension.
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/google-maps-mcp.md
+++ b/documentation/docs/mcp/google-maps-mcp.md
@@ -60,7 +60,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/jetbrains-mcp.md
+++ b/documentation/docs/mcp/jetbrains-mcp.md
@@ -44,7 +44,8 @@ This tutorial covers how to enable and use the JetBrains MCP Server as a built-i
   │  ● Built-in Extension (Use an extension that comes with Goose)
   // highlight-end  
   │  ○ Command-line Extension 
-  │  ○ Remote Extension 
+  │  ○ Remote Extension (SSE) 
+  │  ○ Remote Extension (Streaming HTTP) 
   └  
   ```
 

--- a/documentation/docs/mcp/knowledge-graph-mcp.md
+++ b/documentation/docs/mcp/knowledge-graph-mcp.md
@@ -56,7 +56,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/mbot-mcp.md
+++ b/documentation/docs/mcp/mbot-mcp.md
@@ -59,7 +59,8 @@ This tutorial will get you started with [deemkeen's MQTT MCP server](https://git
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/memory-mcp.md
+++ b/documentation/docs/mcp/memory-mcp.md
@@ -43,7 +43,8 @@ This tutorial covers enabling and using the Memory MCP Server, which is a built-
   │  ● Built-in Extension (Use an extension that comes with Goose)
   // highlight-end  
   │  ○ Command-line Extension 
-  │  ○ Remote Extension 
+  │  ○ Remote Extension (SSE) 
+  │  ○ Remote Extension (Streaming HTTP)  
   └  
   ```
 

--- a/documentation/docs/mcp/netlify-mcp.md
+++ b/documentation/docs/mcp/netlify-mcp.md
@@ -62,7 +62,8 @@ netlify login
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/nostrbook-mcp.md
+++ b/documentation/docs/mcp/nostrbook-mcp.md
@@ -52,7 +52,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/pdf-mcp.md
+++ b/documentation/docs/mcp/pdf-mcp.md
@@ -57,7 +57,8 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 // highlight-start
 │  ● Command-line Extension (Run a local command or script)
 // highlight-end
-│  ○ Remote Extension
+│  ○ Remote Extension (SSE) 
+│  ○ Remote Extension (Streaming HTTP) 
 └
 ```
 

--- a/documentation/docs/mcp/pieces-mcp.md
+++ b/documentation/docs/mcp/pieces-mcp.md
@@ -56,10 +56,12 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
         │  ○ Built-in Extension 
         │  ○ Command-line Extension (Run a local command or script)
         // highlight-start    
-        │  ● Remote Extension 
-        // highlight-end    
+        │  ● Remote Extension (SSE)
+        // highlight-end
+        │  ○ Remote Extension (Streaming HTTP)     
         └ 
       ```
+    
 
   3. Give your extension a name
   
@@ -70,7 +72,7 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
         │  Add Extension (Connect to a new extension) 
         │
         ◇  What type of extension would you like to add?
-        │  Remote Extension 
+        │  Remote Extension (SSE)
         │
         // highlight-start
         ◆  What would you like to call this extension?
@@ -92,7 +94,7 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
         │  Add Extension (Connect to a new extension) 
         │
         ◇  What type of extension would you like to add?
-        │  Remote Extension 
+        │  Remote Extension (SSE)
         │
         ◇  What would you like to call this extension?
         │  Pieces
@@ -113,7 +115,7 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
         │  Add Extension (Connect to a new extension) 
         │
         ◇  What type of extension would you like to add?
-        │  Remote Extension 
+        │  Remote Extension (SSE)
         │
         ◇  What would you like to call this extension?
         │  Pieces
@@ -137,7 +139,7 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
         │  Add Extension (Connect to a new extension) 
         │
         ◇  What type of extension would you like to add?
-        │  Remote Extension 
+        │  Remote Extension (SSE)
         │
         ◇  What would you like to call this extension?
         │  Pieces
@@ -165,7 +167,7 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
         │  Add Extension (Connect to a new extension) 
         │
         ◇  What type of extension would you like to add?
-        │  Remote Extension 
+        │  Remote Extension (SSE)
         │
         ◇  What would you like to call this extension?
         │  Pieces

--- a/documentation/docs/mcp/playwright-mcp.md
+++ b/documentation/docs/mcp/playwright-mcp.md
@@ -52,8 +52,11 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     │
     ◆  What type of extension would you like to add?
     │  ○ Built-in Extension 
+    // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
-    │  ○ Remote Extension 
+    // highlight-end    
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/postgres-mcp.md
+++ b/documentation/docs/mcp/postgres-mcp.md
@@ -84,7 +84,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/puppeteer-mcp.md
+++ b/documentation/docs/mcp/puppeteer-mcp.md
@@ -56,7 +56,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/repomix-mcp.md
+++ b/documentation/docs/mcp/repomix-mcp.md
@@ -57,7 +57,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/selenium-mcp.md
+++ b/documentation/docs/mcp/selenium-mcp.md
@@ -58,7 +58,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/speech-mcp.md
+++ b/documentation/docs/mcp/speech-mcp.md
@@ -63,7 +63,8 @@ Before adding this extension, make sure [PortAudio](https://github.com/GoogleClo
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/square-mcp.md
+++ b/documentation/docs/mcp/square-mcp.md
@@ -58,142 +58,143 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
      4. It will ask you to login or reauthenticate to Square, and may ask you to confirm the permissions you want to allow.
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
-  1. Run the `configure` command:
-  ```sh
-  goose configure
+    1. Run the `configure` command:
+    ```sh
+    goose configure
+    ```
+
+    2. Choose to add a `Command-line Extension`
+    ```sh
+      ┌   goose-configure 
+      │
+      ◇  What would you like to configure?
+      │  Add Extension (Connect to a new extension) 
+      │
+      ◆  What type of extension would you like to add?
+      │  ○ Built-in Extension 
+      │  ○ Command-line Extension (Run a local command or script)
+      // highlight-start    
+      │  ● Remote Extension (SSE) 
+      // highlight-end    
+      │  ○ Remote Extension (Streaming HTTP)    
+      └ 
+    ```
+
+    3. Give your extension a name
+    ```sh
+      ┌   goose-configure 
+      │
+      ◇  What would you like to configure?
+      │  Add Extension (Connect to a new extension) 
+      │
+      ◇  What type of extension would you like to add?
+      │  Remote Extension (SSE) 
+      │
+      // highlight-start
+      ◆  What would you like to call this extension?
+      │  square-mcp-remote
+      // highlight-end
+      └ 
   ```
 
-  1. Choose to add a `Command-line Extension`
-  ```sh
-    ┌   goose-configure 
-    │
-    ◇  What would you like to configure?
-    │  Add Extension (Connect to a new extension) 
-    │
-    ◆  What type of extension would you like to add?
-    │  ○ Built-in Extension 
-    │  ○ Command-line Extension (Run a local command or script)
-    // highlight-start    
-    │  ● Remote Extension 
-    // highlight-end    
-    └ 
-  ```
+    4. Enter the SSE URI
+    ```sh
+      ┌   goose-configure 
+      │
+      ◇  What would you like to configure?
+      │  Add Extension (Connect to a new extension) 
+      │
+      ◇  What type of extension would you like to add?
+      │  Remote Extension (SSE) 
+      │
+      ◇  What would you like to call this extension?
+      │  square-mcp-remote
+      │
+      // highlight-start
+      ◆  What is the SSE endpoint URI?
+      │  https://mcp.squareup.com/sse
+      // highlight-end
+      └ 
+    ```  
 
-  1. Give your extension a name
-  ```sh
-    ┌   goose-configure 
-    │
-    ◇  What would you like to configure?
-    │  Add Extension (Connect to a new extension) 
-    │
-    ◇  What type of extension would you like to add?
-    │  Remote Extension 
-    │
-    // highlight-start
-    ◆  What would you like to call this extension?
-    │  square-mcp-remote
-    // highlight-end
-    └ 
-  ```
+    5. Enter the number of seconds Goose should wait for actions to complete before timing out. Default is 300s
+    ```sh
+      ┌   goose-configure 
+      │
+      ◇  What would you like to configure?
+      │  Add Extension (Connect to a new extension) 
+      │
+      ◇  What type of extension would you like to add?
+      │  Remote Extension (SSE) 
+      │
+      ◇  What would you like to call this extension?
+      │  square-mcp-remote
+      │
+      ◆  What is the SSE endpoint URI?
+      │  https://mcp.squareup.com/sse
+      │
+      // highlight-start
+      ◆  Please set the timeout for this tool (in secs):
+      │  300
+      // highlight-end
+      └ 
+    ```  
 
-  1. Enter the SSE URI
-  ```sh
-    ┌   goose-configure 
-    │
-    ◇  What would you like to configure?
-    │  Add Extension (Connect to a new extension) 
-    │
-    ◇  What type of extension would you like to add?
-    │  Remote Extension
-    │
-    ◇  What would you like to call this extension?
-    │  square-mcp-remote
-    │
-    // highlight-start
-    ◆  What is the SSE endpoint URI?
-    │  https://mcp.squareup.com/sse
-    // highlight-end
-    └ 
-  ```  
+    6. Choose to add a description. If you select "Yes" here, you will be prompted to enter a description for the extension.
+    ```sh
+      ┌   goose-configure 
+      │
+      ◇  What would you like to configure?
+      │  Add Extension (Connect to a new extension) 
+      │
+      ◇  What type of extension would you like to add?
+      │  Remote Extension (SSE) 
+      │
+      ◇  What would you like to call this extension?
+      │  square-mcp-remote
+      │
+      ◆  What is the SSE endpoint URI?
+      │  https://mcp.squareup.com/sse
+      │
+      ◆  Please set the timeout for this tool (in secs):
+      │  300
+      │
+      // highlight-start
+      ◇  Would you like to add a description?
+      │  No
+      // highlight-end
+      └ 
+    ```  
 
-  1. Enter the number of seconds Goose should wait for actions to complete before timing out. Default is 300s
-   ```sh
-    ┌   goose-configure 
-    │
-    ◇  What would you like to configure?
-    │  Add Extension (Connect to a new extension) 
-    │
-    ◇  What type of extension would you like to add?
-    │  Remote Extension
-    │
-    ◇  What would you like to call this extension?
-    │  square-mcp-remote
-    │
-    ◆  What is the SSE endpoint URI?
-    │  https://mcp.squareup.com/sse
-    │
-    // highlight-start
-    ◆  Please set the timeout for this tool (in secs):
-    │  300
-    // highlight-end
-    └ 
-  ```  
-
-  1. Choose to add a description. If you select "Yes" here, you will be prompted to enter a description for the extension.
-   ```sh
-    ┌   goose-configure 
-    │
-    ◇  What would you like to configure?
-    │  Add Extension (Connect to a new extension) 
-    │
-    ◇  What type of extension would you like to add?
-    │  Remote Extension
-    │
-    ◇  What would you like to call this extension?
-    │  square-mcp-remote
-    │
-    ◆  What is the SSE endpoint URI?
-    │  https://mcp.squareup.com/sse
-    │
-    ◆  Please set the timeout for this tool (in secs):
-    │  300
-    │
-    // highlight-start
-    ◇  Would you like to add a description?
-    │  No
-    // highlight-end
-    └ 
-  ```  
-
-  1. Obtain a [Square Access Token](https://developer.squareup.com/apps) and paste it in.
-   ```sh
-    ┌   goose-configure 
-    │
-    ◇  What would you like to configure?
-    │  Add Extension (Connect to a new extension) 
-    │
-    ◇  What type of extension would you like to add?
-    │  Remote Extension
-    │
-    ◇  What would you like to call this extension?
-    │  square-mcp-remote
-    │
-    ◆  What is the SSE endpoint URI?
-    │  https://mcp.squareup.com/sse
-    │
-    ◇  Please set the timeout for this tool (in secs):
-    │  300
-    │
-    ◇  Would you like to add a description?
-    │  No
-    │
-    // highlight-start
-    ◆  Would you like to add environment variables?
-    │  No
-    // highlight-end
-    │
-    └  Added square-mcp-remote extension
-  ```  
+    7. Obtain a [Square Access Token](https://developer.squareup.com/apps) and paste it in.
+    ```sh
+      ┌   goose-configure 
+      │
+      ◇  What would you like to configure?
+      │  Add Extension (Connect to a new extension) 
+      │
+      ◇  What type of extension would you like to add?
+      │  Remote Extension (SSE) 
+      │
+      ◇  What would you like to call this extension?
+      │  square-mcp-remote
+      │
+      ◆  What is the SSE endpoint URI?
+      │  https://mcp.squareup.com/sse
+      │
+      ◇  Please set the timeout for this tool (in secs):
+      │  300
+      │
+      ◇  Would you like to add a description?
+      │  No
+      │
+      // highlight-start
+      ◆  Would you like to add environment variables?
+      │  No
+      // highlight-end
+      │
+      └  Added square-mcp-remote extension
+    ```  
       </TabItem>
   </Tabs>
 
@@ -256,7 +257,8 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/tavily-mcp.md
+++ b/documentation/docs/mcp/tavily-mcp.md
@@ -61,7 +61,8 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 

--- a/documentation/docs/mcp/tutorial-mcp.md
+++ b/documentation/docs/mcp/tutorial-mcp.md
@@ -41,7 +41,8 @@ goose configure
 │  ● Built-in Extension (Use an extension that comes with Goose)
 // highlight-end  
 │  ○ Command-line Extension 
-│  ○ Remote Extension 
+│  ○ Remote Extension (SSE) 
+│  ○ Remote Extension (Streaming HTTP) 
 └  
 ```
 

--- a/documentation/docs/mcp/youtube-transcript-mcp.md
+++ b/documentation/docs/mcp/youtube-transcript-mcp.md
@@ -57,7 +57,8 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     // highlight-start    
     │  ● Command-line Extension (Run a local command or script)
     // highlight-end    
-    │  ○ Remote Extension 
+    │  ○ Remote Extension (SSE) 
+    │  ○ Remote Extension (Streaming HTTP) 
     └ 
   ```
 


### PR DESCRIPTION
Updated CLI options to show both remote options: SSE and Streaming HTTP