### PR TITLE
only run google analytics in prod

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -65,10 +65,10 @@ const config: Config = {
             "./src/css/tailwind.css",
           ],
         },
-        gtag: {
+        gtag: process.env.NODE_ENV === 'production' ? {
           trackingID: 'G-ZS5D6SB4ZJ',
           anonymizeIP: true,
-        },
+        } : undefined,
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
This error keeps popping up in development, and I get distracted from it/it's slowing me down 🤣 so here's a PR to make do the analytics for prod but not run in dev mode. 

<img width="1698" height="424" alt="Screenshot 2025-07-13 at 2 53 03 PM" src="https://github.com/user-attachments/assets/00299e36-e94d-412a-bdd9-5bf46538800a" />
