### PR TITLE
docs: cli theme persistence

### DIFF
--- a/documentation/docs/guides/config-file.md
+++ b/documentation/docs/guides/config-file.md
@@ -31,6 +31,7 @@ The following settings can be configured at the root level of your config.yaml f
 | `GOOSE_TOOLSHIM` | Enable tool interpretation | true/false | false | No |
 | `GOOSE_TOOLSHIM_OLLAMA_MODEL` | Model for tool interpretation | Model name (e.g., "llama3.2") | System default | No |
 | `GOOSE_CLI_MIN_PRIORITY` | Tool output verbosity | Float between 0.0 and 1.0 | 0.0 | No |
+| `GOOSE_CLI_THEME` | [Theme](/docs/guides/goose-cli-commands#themes) for CLI response  markdown | "light", "dark", "ansi" | "dark" | No |
 | `GOOSE_ALLOWLIST` | URL for allowed extensions | Valid URL | None | No |
 | `GOOSE_RECIPE_GITHUB_REPO` | GitHub repository for recipes | Format: "org/repo" | None | No |
 

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -107,6 +107,7 @@ These variables control how Goose manages conversation sessions and context.
 |----------|---------|---------|---------|
 | `GOOSE_CONTEXT_STRATEGY` | Controls how Goose handles context limit exceeded situations | "summarize", "truncate", "clear", "prompt" | "prompt" (interactive), "summarize" (headless) |
 | `GOOSE_MAX_TURNS` | [Maximum number of turns](/docs/guides/smart-context-management#maximum-turns) allowed without user input | Integer (e.g., 10, 50, 100) | 1000 |
+| `GOOSE_CLI_THEME` | [Theme](/docs/guides/goose-cli-commands#themes) for CLI response  markdown | "light", "dark", "ansi" | "dark" |
 
 **Examples**
 
@@ -125,6 +126,9 @@ export GOOSE_MAX_TURNS=25
 
 # Set a reasonable limit for production
 export GOOSE_MAX_TURNS=100
+
+# Set the ANSI theme for the session
+export GOOSE_CLI_THEME=ansi
 ```
 
 ### Context Limit Configuration

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -538,7 +538,8 @@ The CLI provides a set of slash commands that can be accessed during a session. 
 - `/prompts [--extension <n>]` - List all available prompts, optionally filtered by extension
 - `/recipe <recipe file name>` - Generate and save a session recipe to `recipe.yaml` or the filename specified by the command parameter.
 - `/summarize` - Summarize the current session to reduce context length while preserving key information
-- `/t` - Toggle between Light/Dark/Ansi themes
+- `/t` - Toggle between `light`, `dark`, and `ansi` themes
+- `/t <theme>` - Set the `light`, `dark`, or `ansi` theme
 
 All commands support tab completion. Press `<Tab>` after a slash (/) to cycle through available commands or to complete partial commands. 
 
@@ -568,6 +569,40 @@ Goose CLI supports several shortcuts and built-in commands for easier navigation
 
 ### Slash Commands
 - **`/exit` or `/quit`** - Exit the session
-- **`/t`** - Toggle between Light/Dark/Ansi themes
-- **`/t <theme>`** - Set theme directly (`/t light`, `/t dark`, or `/t ansi`)
+- **`/t`** - Toggle between `light`, `dark`, and `ansi` themes
+- **`/t <theme>`** - Set the `light`, `dark`, or `ansi` theme
 - **`/?` or `/help`** - Display the help menu
+
+### Themes
+
+The `/t` command controls the syntax highlighting theme for markdown content in Goose CLI responses. This affects the styles used for headers, code blocks, bold/italic text, and other markdown elements in the response output.
+
+**Commands:**
+- `/t` - Cycles through themes: `light` → `dark` → `ansi` → `light`
+- `/t light` - Sets `light` theme (subtle light colors)
+- `/t dark` - Sets `dark` theme (subtle darker colors)
+- `/t ansi` - Sets `ansi` theme (most visually distinct option with brighter colors)
+
+**Configuration:**
+- The default theme is `dark`
+- The theme setting is saved to the [configuration file](/docs/guides/config-file) as `GOOSE_CLI_THEME` and persists between sessions
+- The saved configuration can be overridden for the session using the `GOOSE_CLI_THEME` [environment variable](/docs/guides/environment-variables#session-management)
+
+:::info
+Syntax highlighting styles only affect the font, not the overall terminal interface. The `light` and `dark` themes have subtle differences in font color and weight.
+
+The Goose CLI theme is independent from the Goose Desktop theme.
+:::
+
+**Examples:**
+```bash
+# Set ANSI theme for the session via environment variable
+export GOOSE_CLI_THEME=ansi
+goose session --name use-custom-theme
+
+# Toggle theme during a session
+/t
+
+# Set the light theme during a session
+/t light
+```


### PR DESCRIPTION
This PR extends the documentation about the CLI syntax highlighting theme.

Documentation updates:
- `documentation/docs/guides/config-file.md` and  `documentation/docs/guides/environment-variables.md`: Add `GOOSE_CLI_THEME`
- `documentation/docs/guides/goose-cli-commands.md`: Add "Themes" section with usage, configuration, and examples