### PR TITLE
docs: typo in guide description

### DIFF
--- a/documentation/docs/tutorials/lead-worker.md
+++ b/documentation/docs/tutorials/lead-worker.md
@@ -1,5 +1,5 @@
 ---
-description: Enable multi-modal functionality by pairing LLMs to complete your tasks
+description: Enable multi-model functionality by pairing LLMs to complete your tasks
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
modal → model