### PR TITLE
docs: update github mcp config

### DIFF
--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -10,66 +10,302 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/TbmQDv3SQOE" />
 
-This tutorial covers how to add the [GitHub MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/github) as a Goose extension to enable file operations, repository management, search functionality, and more.
+This tutorial covers how to add the [GitHub MCP Server](https://github.com/github/github-mcp-server) as a Goose extension to enable file operations, repository management, search functionality, and more.
+
+:::warning Migration Notice
+The GitHub MCP Server has moved from the deprecated NPM package `@modelcontextprotocol/server-github` to GitHub's official repository. The server is now available as a remote hosted service (recommended) with no local installation required.
+:::
 
 :::tip TLDR
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-github&id=github&name=GitHub&description=GitHub%20API&env=GITHUB_PERSONAL_ACCESS_TOKEN%3DGitHub%20Personal%20Access%20Token)
+  Use `Add custom extension` in Settings → Extensions to add a `Streamable HTTP` extension type with:
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
-  **Command**
-  ```sh
-  npx -y @modelcontextprotocol/server-github
-  ```
+  Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
   </TabItem>
 </Tabs>
 
-  **Environment Variable**
+  **Endpoint URL**
   ```
-  GITHUB_PERSONAL_ACCESS_TOKEN: <YOUR_TOKEN>
+  https://api.githubcopilot.com/mcp/
+  ```
+  **Custom Request Header**
+  ```
+  Authorization: Bearer <YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>
   ```
 :::
 
 ## Configuration
-
-:::info
-Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
-:::
+These steps configure the Remote MCP Server. For other deployment options, see the [official GitHub MCP Server documentation](https://github.com/github/github-mcp-server).
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-  1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-github&id=github&name=GitHub&description=GitHub%20API&env=GITHUB_PERSONAL_ACCESS_TOKEN%3DGitHub%20Personal%20Access%20Token)
-  2. Press `Yes` to confirm the installation
-  3. Obtain a [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens) and paste it in
-  4. Click `Save Configuration`
-  5. Scroll to the top and click `Exit` from the upper left corner
+    1. Click the gear icon `⚙️` in the top right corner
+    2. Under `Extensions`, click `Add custom extension`
+    3. On the `Add custom extension` modal, enter the following:
+       - **Extension Name**: GitHub
+       - **Type**: Streamable HTTP
+       - **Endpoint**: `https://api.githubcopilot.com/mcp/`
+       - **Request Headers**: 
+         - **Header name**: `Authorization`
+         - **Value**: `Bearer <YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>` 
+    4. Click `+ Add` to save the header
+    5. Click `Add Extension` to save the extension
+
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
+    1. Run the `configure` command:
+    ```sh
+    goose configure
+    ```
 
-    <CLIExtensionInstructions
-      name="github"
-      command="npx -y @modelcontextprotocol/server-github"
-      timeout={300}
-      envVars={[
-        { key: "GITHUB_TOKEN", value: "••••••••••••••••" }
-      ]}
-      infoNote={
-        <>
-          When creating your access token, you can specify the repositories and granular permissions you'd like Goose to have access to.{" "}
-          <a
-            href="https://github.com/settings/personal-access-tokens"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            Create one here
-          </a>.
-        </>
-      }
-    />
+    2. Choose to add a `Remote Extension (Streaming HTTP)`
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◆  What type of extension would you like to add?
+        │  ○ Built-in Extension 
+        │  ○ Command-line Extension (Run a local command or script)
+        │  ○ Remote Extension (SSE) 
+        // highlight-start    
+        │  ● Remote Extension (Streaming HTTP) 
+        // highlight-end    
+        └ 
+    ```
 
+    3. Give your extension a name
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◇  What type of extension would you like to add?
+        │  Remote Extension (Streaming HTTP) 
+        │
+        // highlight-start
+        ◆  What would you like to call this extension?
+        │  github
+        // highlight-end
+        └ 
+    ```
+
+    4. Enter the Streaming HTTP endpoint URI
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◇  What type of extension would you like to add?
+        │  Remote Extension (Streaming HTTP) 
+        │
+        ◇  What would you like to call this extension?
+        │  github
+        │
+        // highlight-start
+        ◆  What is the Streaming HTTP endpoint URI?
+        │  https://api.githubcopilot.com/mcp/
+        // highlight-end
+        └ 
+    ``` 
+
+    5. Set the timeout (recommended: 100 seconds)
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◇  What type of extension would you like to add?
+        │  Remote Extension (Streaming HTTP) 
+        │
+        ◇  What would you like to call this extension?
+        │  github
+        │
+        ◇  What is the Streaming HTTP endpoint URI?
+        │  https://api.githubcopilot.com/mcp/
+        │
+        // highlight-start
+        ◆  Please set the timeout for this tool (in secs):
+        │  300
+        // highlight-end
+        └ 
+    ``` 
+
+    6. Choose whether to add a description
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◇  What type of extension would you like to add?
+        │  Remote Extension (Streaming HTTP) 
+        │
+        ◇  What would you like to call this extension?
+        │  github
+        │
+        ◇  What is the Streaming HTTP endpoint URI?
+        │  https://api.githubcopilot.com/mcp/
+        │
+        ◇  Please set the timeout for this tool (in secs):
+        │  300
+        │
+        // highlight-start
+        ◆  Would you like to add a description?
+        │  No
+        // highlight-end
+        └ 
+    ```
+
+    7. Add custom headers for authentication
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◇  What type of extension would you like to add?
+        │  Remote Extension (Streaming HTTP) 
+        │
+        ◇  What would you like to call this extension?
+        │  github
+        │
+        ◇  What is the Streaming HTTP endpoint URI?
+        │  https://api.githubcopilot.com/mcp/
+        │
+        ◇  Please set the timeout for this tool (in secs):
+        │  300
+        │
+        ◇  Would you like to add a description?
+        │  No
+        │
+        // highlight-start
+        ◆  Would you like to add custom headers?
+        │  Yes
+        // highlight-end
+        └ 
+    ```
+
+    8. Enter the Authorization header
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◇  What type of extension would you like to add?
+        │  Remote Extension (Streaming HTTP) 
+        │
+        ◇  What would you like to call this extension?
+        │  github
+        │
+        ◇  What is the Streaming HTTP endpoint URI?
+        │  https://api.githubcopilot.com/mcp/
+        │
+        ◇  Please set the timeout for this tool (in secs):
+        │  300
+        │
+        ◇  Would you like to add a description?
+        │  No
+        │
+        ◇  Would you like to add custom headers?
+        │  Yes
+        │
+        // highlight-start
+        ◆  Header name:
+        │  Authorization
+        // highlight-end
+        └ 
+    ```
+
+    9. Enter your GitHub Personal Access Token
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◇  What type of extension would you like to add?
+        │  Remote Extension (Streaming HTTP) 
+        │
+        ◇  What would you like to call this extension?
+        │  github
+        │
+        ◇  What is the Streaming HTTP endpoint URI?
+        │  https://api.githubcopilot.com/mcp/
+        │
+        ◇  Please set the timeout for this tool (in secs):
+        │  300
+        │
+        ◇  Would you like to add a description?
+        │  No
+        │
+        ◇  Would you like to add custom headers?
+        │  Yes
+        │
+        ◇  Header name:
+        │  Authorization
+        │
+        // highlight-start
+        ◆  Header value:
+        │  Bearer ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        // highlight-end
+        └ 
+    ```
+    :::tip Get Your Token
+    Replace `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` with your actual [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens).
+    :::
+
+    10. Choose not to add another header
+    ```sh
+        ┌   goose-configure 
+        │
+        ◇  What would you like to configure?
+        │  Add Extension 
+        │
+        ◇  What type of extension would you like to add?
+        │  Remote Extension (Streaming HTTP) 
+        │
+        ◇  What would you like to call this extension?
+        │  github
+        │
+        ◇  What is the Streaming HTTP endpoint URI?
+        │  https://api.githubcopilot.com/mcp/
+        │
+        ◇  Please set the timeout for this tool (in secs):
+        │  100
+        │
+        ◇  Would you like to add a description?
+        │  No
+        │
+        ◇  Would you like to add custom headers?
+        │  Yes
+        │
+        ◇  Header name:
+        │  Authorization
+        │
+        ◇  Header value:
+        │  Bearer ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+        │
+        // highlight-start
+        ◆  Add another header?
+        │  No 
+        │
+        // highlight-end
+        └  Added github extension
+    ```  
   </TabItem>
 </Tabs>
+  
+ :::info
+ Replace `<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>` with your actual token from [GitHub Settings](https://github.com/settings/personal-access-tokens). When creating your access token, you can specify the repositories and granular permissions you'd like Goose to have access to.
+ :::
 
 ## Example Usage
 

--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -301,9 +301,6 @@ These steps configure the Remote MCP Server. For other deployment options, see t
   </TabItem>
 </Tabs>
   
- :::info Get Your Access Token
- Replace `<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>` with your actual token from [GitHub Settings](https://github.com/settings/personal-access-tokens). When creating your access token, you can specify the repositories and granular permissions you'd like Goose to have access to.
- :::
 
 ## Example Usage
 

--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -12,10 +12,6 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [GitHub MCP Server](https://github.com/github/github-mcp-server) as a Goose extension to enable file operations, repository management, search functionality, and more.
 
-:::warning Migration Notice
-The GitHub MCP Server has moved from the deprecated NPM package `@modelcontextprotocol/server-github` to GitHub's official repository. The server is now available as a remote hosted service with no local installation required.
-:::
-
 :::tip TLDR
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>

--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -225,7 +225,7 @@ These steps configure the Remote MCP Server. For other deployment options, see t
         └ 
     ```
 
-    9. Enter your GitHub Personal Access Token
+    9. Enter your [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens)
     ```sh
         ┌   goose-configure 
         │

--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 This tutorial covers how to add the [GitHub MCP Server](https://github.com/github/github-mcp-server) as a Goose extension to enable file operations, repository management, search functionality, and more.
 
 :::warning Migration Notice
-The GitHub MCP Server has moved from the deprecated NPM package `@modelcontextprotocol/server-github` to GitHub's official repository. The server is now available as a remote hosted service (recommended) with no local installation required.
+The GitHub MCP Server has moved from the deprecated NPM package `@modelcontextprotocol/server-github` to GitHub's official repository. The server is now available as a remote hosted service with no local installation required.
 :::
 
 :::tip TLDR
@@ -42,16 +42,17 @@ These steps configure the Remote MCP Server. For other deployment options, see t
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
     1. Click the gear icon `⚙️` in the top right corner
-    2. Under `Extensions`, click `Add custom extension`
-    3. On the `Add custom extension` modal, enter the following:
+    2. Click `Advanced settings`
+    3. Under `Extensions`, click `Add custom extension`
+    4. On the `Add custom extension` modal, enter the following:
        - **Extension Name**: GitHub
        - **Type**: Streamable HTTP
        - **Endpoint**: `https://api.githubcopilot.com/mcp/`
        - **Request Headers**: 
          - **Header name**: `Authorization`
          - **Value**: `Bearer <YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>` 
-    4. Click `+ Add` to save the header
-    5. Click `Add Extension` to save the extension
+    5. Click `+ Add` to save the header
+    6. Click `Add Extension` to save the extension
 
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
@@ -114,7 +115,7 @@ These steps configure the Remote MCP Server. For other deployment options, see t
         └ 
     ``` 
 
-    5. Set the timeout (recommended: 100 seconds)
+    5. Set the timeout
     ```sh
         ┌   goose-configure 
         │
@@ -163,7 +164,7 @@ These steps configure the Remote MCP Server. For other deployment options, see t
         └ 
     ```
 
-    7. Add custom headers for authentication
+    7. Add a custom header for authentication
     ```sh
         ┌   goose-configure 
         │
@@ -258,9 +259,6 @@ These steps configure the Remote MCP Server. For other deployment options, see t
         // highlight-end
         └ 
     ```
-    :::tip Get Your Token
-    Replace `ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` with your actual [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens).
-    :::
 
     10. Choose not to add another header
     ```sh
@@ -303,7 +301,7 @@ These steps configure the Remote MCP Server. For other deployment options, see t
   </TabItem>
 </Tabs>
   
- :::info
+ :::info Get Your Access Token
  Replace `<YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>` with your actual token from [GitHub Settings](https://github.com/settings/personal-access-tokens). When creating your access token, you can specify the repositories and granular permissions you'd like Goose to have access to.
  :::
 

--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -41,18 +41,19 @@ These steps configure the Remote MCP Server. For other deployment options, see t
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-    1. Click the gear icon `⚙️` in the top right corner
-    2. Click `Advanced settings`
-    3. Under `Extensions`, click `Add custom extension`
-    4. On the `Add custom extension` modal, enter the following:
+    1. Obtain a [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens)
+    2. Click the gear icon `⚙️` in the top right corner
+    3. Click `Advanced settings`
+    4. Under `Extensions`, click `Add custom extension`
+    5. On the `Add custom extension` modal, enter the following:
        - **Extension Name**: GitHub
        - **Type**: Streamable HTTP
        - **Endpoint**: `https://api.githubcopilot.com/mcp/`
        - **Request Headers**: 
          - **Header name**: `Authorization`
          - **Value**: `Bearer <YOUR_GITHUB_PERSONAL_ACCESS_TOKEN>` 
-    5. Click `+ Add` to save the header
-    6. Click `Add Extension` to save the extension
+    6. Click `+ Add` to save the header
+    7. Click `Add Extension` to save the extension
 
   </TabItem>
   <TabItem value="cli" label="Goose CLI">


### PR DESCRIPTION
This PR switches the GitHub MCP extension from the archived npx method to the new streaming server.

Documentation updates:
- `documentation/docs/mcp/github-mcp.md`: Updated configuration steps and links

Also fixes #3322 