### PR TITLE
docs: add CLIStreamExtensionInstructions component

### DIFF
--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -6,7 +6,7 @@ description: Add GitHub MCP Server as a Goose Extension
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
-import CLIRemoteStreamingExtensionInstructions from '@site/src/components/CLIRemoteStreamingExtensionInstructions';
+import CLIStreamExtensionInstructions from '@site/src/components/CLIStreamExtensionInstructions';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/TbmQDv3SQOE" />
 
@@ -53,7 +53,7 @@ These steps configure the Remote MCP Server. For other deployment options, see t
 
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
-    <CLIRemoteStreamingExtensionInstructions
+    <CLIStreamExtensionInstructions
       name="github"
       endpointUri="https://api.githubcopilot.com/mcp/"
       timeout={300}

--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -6,7 +6,7 @@ description: Add GitHub MCP Server as a Goose Extension
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
-import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import CLIRemoteStreamingExtensionInstructions from '@site/src/components/CLIRemoteStreamingExtensionInstructions';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/TbmQDv3SQOE" />
 
@@ -53,251 +53,22 @@ These steps configure the Remote MCP Server. For other deployment options, see t
 
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
-    1. Run the `configure` command:
-    ```sh
-    goose configure
-    ```
+    <CLIRemoteStreamingExtensionInstructions
+      name="github"
+      endpointUri="https://api.githubcopilot.com/mcp/"
+      timeout={300}
+      headers={[
+        { key: "Authorization", value: "Bearer ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
+      ]}
+      infoNote={
+        <>
+          Obtain your <a href="https://github.com/settings/personal-access-tokens" target="_blank" rel="noopener noreferrer">GitHub Personal Access Token</a> and paste it in
+        </>
+      }
+    />
 
-    2. Choose to add a `Remote Extension (Streaming HTTP)`
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◆  What type of extension would you like to add?
-        │  ○ Built-in Extension 
-        │  ○ Command-line Extension (Run a local command or script)
-        │  ○ Remote Extension (SSE) 
-        // highlight-start    
-        │  ● Remote Extension (Streaming HTTP) 
-        // highlight-end    
-        └ 
-    ```
-
-    3. Give your extension a name
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◇  What type of extension would you like to add?
-        │  Remote Extension (Streaming HTTP) 
-        │
-        // highlight-start
-        ◆  What would you like to call this extension?
-        │  github
-        // highlight-end
-        └ 
-    ```
-
-    4. Enter the Streaming HTTP endpoint URI
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◇  What type of extension would you like to add?
-        │  Remote Extension (Streaming HTTP) 
-        │
-        ◇  What would you like to call this extension?
-        │  github
-        │
-        // highlight-start
-        ◆  What is the Streaming HTTP endpoint URI?
-        │  https://api.githubcopilot.com/mcp/
-        // highlight-end
-        └ 
-    ``` 
-
-    5. Set the timeout
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◇  What type of extension would you like to add?
-        │  Remote Extension (Streaming HTTP) 
-        │
-        ◇  What would you like to call this extension?
-        │  github
-        │
-        ◇  What is the Streaming HTTP endpoint URI?
-        │  https://api.githubcopilot.com/mcp/
-        │
-        // highlight-start
-        ◆  Please set the timeout for this tool (in secs):
-        │  300
-        // highlight-end
-        └ 
-    ``` 
-
-    6. Choose whether to add a description
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◇  What type of extension would you like to add?
-        │  Remote Extension (Streaming HTTP) 
-        │
-        ◇  What would you like to call this extension?
-        │  github
-        │
-        ◇  What is the Streaming HTTP endpoint URI?
-        │  https://api.githubcopilot.com/mcp/
-        │
-        ◇  Please set the timeout for this tool (in secs):
-        │  300
-        │
-        // highlight-start
-        ◆  Would you like to add a description?
-        │  No
-        // highlight-end
-        └ 
-    ```
-
-    7. Add a custom header for authentication
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◇  What type of extension would you like to add?
-        │  Remote Extension (Streaming HTTP) 
-        │
-        ◇  What would you like to call this extension?
-        │  github
-        │
-        ◇  What is the Streaming HTTP endpoint URI?
-        │  https://api.githubcopilot.com/mcp/
-        │
-        ◇  Please set the timeout for this tool (in secs):
-        │  300
-        │
-        ◇  Would you like to add a description?
-        │  No
-        │
-        // highlight-start
-        ◆  Would you like to add custom headers?
-        │  Yes
-        // highlight-end
-        └ 
-    ```
-
-    8. Enter the Authorization header
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◇  What type of extension would you like to add?
-        │  Remote Extension (Streaming HTTP) 
-        │
-        ◇  What would you like to call this extension?
-        │  github
-        │
-        ◇  What is the Streaming HTTP endpoint URI?
-        │  https://api.githubcopilot.com/mcp/
-        │
-        ◇  Please set the timeout for this tool (in secs):
-        │  300
-        │
-        ◇  Would you like to add a description?
-        │  No
-        │
-        ◇  Would you like to add custom headers?
-        │  Yes
-        │
-        // highlight-start
-        ◆  Header name:
-        │  Authorization
-        // highlight-end
-        └ 
-    ```
-
-    9. Enter your [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens)
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◇  What type of extension would you like to add?
-        │  Remote Extension (Streaming HTTP) 
-        │
-        ◇  What would you like to call this extension?
-        │  github
-        │
-        ◇  What is the Streaming HTTP endpoint URI?
-        │  https://api.githubcopilot.com/mcp/
-        │
-        ◇  Please set the timeout for this tool (in secs):
-        │  300
-        │
-        ◇  Would you like to add a description?
-        │  No
-        │
-        ◇  Would you like to add custom headers?
-        │  Yes
-        │
-        ◇  Header name:
-        │  Authorization
-        │
-        // highlight-start
-        ◆  Header value:
-        │  Bearer ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        // highlight-end
-        └ 
-    ```
-
-    10. Choose not to add another header
-    ```sh
-        ┌   goose-configure 
-        │
-        ◇  What would you like to configure?
-        │  Add Extension 
-        │
-        ◇  What type of extension would you like to add?
-        │  Remote Extension (Streaming HTTP) 
-        │
-        ◇  What would you like to call this extension?
-        │  github
-        │
-        ◇  What is the Streaming HTTP endpoint URI?
-        │  https://api.githubcopilot.com/mcp/
-        │
-        ◇  Please set the timeout for this tool (in secs):
-        │  100
-        │
-        ◇  Would you like to add a description?
-        │  No
-        │
-        ◇  Would you like to add custom headers?
-        │  Yes
-        │
-        ◇  Header name:
-        │  Authorization
-        │
-        ◇  Header value:
-        │  Bearer ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        │
-        // highlight-start
-        ◆  Add another header?
-        │  No 
-        │
-        // highlight-end
-        └  Added github extension
-    ```  
   </TabItem>
 </Tabs>
-  
 
 ## Example Usage
 

--- a/documentation/src/components/CLIRemoteStreamingExtensionInstructions.js
+++ b/documentation/src/components/CLIRemoteStreamingExtensionInstructions.js
@@ -1,0 +1,244 @@
+import React from 'react';
+import CodeBlock from '@theme/CodeBlock';
+import Admonition from '@theme/Admonition';
+
+export default function CLIRemoteStreamingExtensionInstructions({
+  name,
+  endpointUri,
+  timeout = 300,
+  headers = [],
+  infoNote,
+}) {
+  const hasHeaders = headers.length > 0;
+  const headerStepText = hasHeaders
+    ? `Choose Yes when asked to add custom headers`
+    : 'Choose No when asked to add custom headers';
+
+  return (
+    <div>
+      <ol>
+        <li>Run the <code>configure</code> command:</li>
+      </ol>
+      <CodeBlock language="sh">{`goose configure`}</CodeBlock>
+
+      <ol start={2}>
+        <li>Choose to add a <code>Remote Extension (Streaming HTTP)</code></li>
+      </ol>
+      <CodeBlock language="sh">{`┌   goose-configure 
+│
+◇  What would you like to configure?
+│  Add Extension
+│
+◆  What type of extension would you like to add?
+│  ○ Built-in Extension 
+│  ○ Command-line Extension
+│  ○ Remote Extension (SSE)
+// highlight-start    
+│  ● Remote Extension (Streaming HTTP) (Connect to a remote extension via MCP Streaming HTTP)
+// highlight-end  
+└`}</CodeBlock>
+
+      <ol start={3}>
+        <li>Give your extension a name</li>
+      </ol>
+      <CodeBlock language="sh">{`┌   goose-configure 
+│
+◇  What would you like to configure?
+│  Add Extension
+│
+◇  What type of extension would you like to add?
+│  Remote Extension (Streaming HTTP)
+│
+// highlight-start
+◆  What would you like to call this extension?
+│  ${name}
+// highlight-end
+└`}</CodeBlock>
+
+      <ol start={4}>
+        <li>Enter the endpoint URI</li>
+      </ol>
+      <CodeBlock language="sh">{`┌   goose-configure 
+│
+◇  What would you like to configure?
+│  Add Extension
+│
+◇  What type of extension would you like to add?
+│  Remote Extension (Streaming HTTP)
+│
+◇  What would you like to call this extension?
+│  ${name}
+│
+// highlight-start
+◆  What is the Streaming HTTP endpoint URI?
+│  ${endpointUri}
+// highlight-end
+└`}</CodeBlock>
+
+      <ol start={5}>
+        <li>
+          Enter the number of seconds Goose should wait for actions to complete before timing out. Default is <code>300</code> seconds
+        </li>
+      </ol>
+      <CodeBlock language="sh">{`┌   goose-configure 
+│
+◇  What would you like to configure?
+│  Add Extension
+│
+◇  What type of extension would you like to add?
+│  Remote Extension (Streaming HTTP)
+│
+◇  What would you like to call this extension?
+│  ${name}
+│
+◇  What is the Streaming HTTP endpoint URI?
+│  ${endpointUri}
+│
+// highlight-start
+◆  Please set the timeout for this tool (in secs):
+│  ${timeout}
+// highlight-end
+└`}</CodeBlock>
+
+      <ol start={6}>
+        <li>Choose to add a description. If you select <code>Yes</code>, you'll be prompted to enter a description for the extension</li>
+      </ol>
+      <CodeBlock language="sh">{`┌   goose-configure 
+│
+◇  What would you like to configure?
+│  Add Extension
+│
+◇  What type of extension would you like to add?
+│  Remote Extension (Streaming HTTP)
+│
+◇  What would you like to call this extension?
+│  ${name}
+│
+◇  What is the Streaming HTTP endpoint URI?
+│  ${endpointUri}
+│
+◇  Please set the timeout for this tool (in secs):
+│  ${timeout}
+│
+// highlight-start
+◆  Would you like to add a description?
+│  No
+// highlight-end
+└`}</CodeBlock>
+
+      <ol start={7}>
+        <li>{headerStepText}</li>
+      </ol>
+
+      {!hasHeaders && (
+        <CodeBlock language="sh">{`┌   goose-configure 
+│
+◇  What would you like to configure?
+│  Add Extension
+│
+◇  What type of extension would you like to add?
+│  Remote Extension (Streaming HTTP)
+│
+◇  What would you like to call this extension?
+│  ${name}
+│
+◇  What is the Streaming HTTP endpoint URI?
+│  ${endpointUri}
+│
+◇  Please set the timeout for this tool (in secs):
+│  ${timeout}
+│
+◇  Would you like to add a description?
+│  No
+│
+// highlight-start
+◆  Would you like to add custom headers?
+│  No
+// highlight-end
+└  Added ${name} extension`}</CodeBlock>
+      )}
+
+      {hasHeaders && (
+        <>
+          <CodeBlock language="sh">{`┌   goose-configure 
+│
+◇  What would you like to configure?
+│  Add Extension
+│
+◇  What type of extension would you like to add?
+│  Remote Extension (Streaming HTTP)
+│
+◇  What would you like to call this extension?
+│  ${name}
+│
+◇  What is the Streaming HTTP endpoint URI?
+│  ${endpointUri}
+│
+◇  Please set the timeout for this tool (in secs):
+│  ${timeout}
+│
+◇  Would you like to add a description?
+│  No
+│
+// highlight-start
+◆  Would you like to add custom headers?
+│  Yes
+// highlight-end
+└`}</CodeBlock>
+
+          <ol start={8}>
+            <li>Add your custom header{headers.length > 1 ? 's' : ''}</li>
+          </ol>
+
+          {infoNote && (
+            <>
+              <Admonition type="info">
+                {infoNote}
+              </Admonition>
+              <div style={{ marginBottom: '0.5rem' }} />
+            </>
+          )}
+
+          <CodeBlock language="sh">{`┌   goose-configure 
+│
+◇  What would you like to configure?
+│  Add Extension
+│
+◇  What type of extension would you like to add?
+│  Remote Extension (Streaming HTTP)
+│
+◇  What would you like to call this extension?
+│  ${name}
+│
+◇  What is the Streaming HTTP endpoint URI?
+│  ${endpointUri}
+│
+◇  Please set the timeout for this tool (in secs):
+│  ${timeout}
+│
+◇  Would you like to add a description?
+│  No
+│
+◇  Would you like to add custom headers?
+│  Yes
+│
+// highlight-start
+${headers
+  .map(
+    ({ key, value }, i) => `◇  Header name:
+│  ${key}
+│
+◇  Header value:
+│  ${value}
+│
+◇  Add another header?
+│  ${i === headers.length - 1 ? 'No' : 'Yes'}`
+  )
+  .join('\n│\n')}
+// highlight-end
+└  Added ${name} extension`}</CodeBlock>
+        </>
+      )}
+    </div>
+  );
+}

--- a/documentation/src/components/CLIStreamExtensionInstructions.js
+++ b/documentation/src/components/CLIStreamExtensionInstructions.js
@@ -2,7 +2,7 @@ import React from 'react';
 import CodeBlock from '@theme/CodeBlock';
 import Admonition from '@theme/Admonition';
 
-export default function CLIRemoteStreamingExtensionInstructions({
+export default function CLIStreamExtensionInstructions({
   name,
   endpointUri,
   timeout = 300,


### PR DESCRIPTION
This PR adds a component for Add Extension -> Remote Extension (Streaming HTTP) reusable steps. It also updates the GitHub extension tutorial to use the component

Documentation updates:
- `documentation/docs/mcp/github-mcp.md`: Use CLIRemoteStreamingExtensionInstructions for CLI steps

Components:
- `documentation/src/components/CLIStreamExtensionInstructions.js`: New component based on CLIExtensionInstructions but with streaming-http config options 