### PR TITLE
fix: Fixes importing url encoded recipe deeplinks

### DIFF
--- a/ui/desktop/src/components/RecipesView.tsx
+++ b/ui/desktop/src/components/RecipesView.tsx
@@ -110,7 +110,8 @@ export default function RecipesView({ onBack }: RecipesViewProps) {
       if (!configBase64) {
         throw new Error('No recipe configuration found in deeplink');
       }
-      const configJson = Buffer.from(configBase64, 'base64').toString('utf-8');
+      const urlDecoded = decodeURIComponent(configBase64);
+      const configJson = Buffer.from(urlDecoded, 'base64').toString('utf-8');
       const recipe = JSON.parse(configJson) as Recipe;
 
       if (!recipe.title || !recipe.description || !recipe.instructions) {


### PR DESCRIPTION
Looks like in https://github.com/block/goose/pull/2845 we starting url encoding deeplinks in the cli and the ui was updated for opening deeplinks in that pr. However since then there is an Import recipe dialogue and that code has a different execution path that was not urldecoding.

This PR fixes that for https://github.com/block/goose/issues/3373 . Just exploring if there is a way to unify some of the code a little.

We should have a separate discussion around the expected recipe deeplink format: url-encoded vs base64 no padding etc.

Also unifying this import code with the existing code in main.ts#processProtocolUrl is a deeper investigation and needs to wait for the new UI to land.