### PR TITLE
fix: Fixes structured output after streaming change to agent

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -837,24 +837,6 @@ impl Agent {
 
                                 let num_tool_requests = frontend_requests.len() + remaining_requests.len();
                                 if num_tool_requests == 0 {
-                                    if let Some(final_output_tool) = self.final_output_tool.lock().await.as_ref() {
-                                        if final_output_tool.final_output.is_none() {
-                                            tracing::warn!("Final output tool has not been called yet. Continuing agent loop.");
-                                            let message = Message::assistant().with_text(FINAL_OUTPUT_CONTINUATION_MESSAGE);
-                                            messages.push(message.clone());
-                                            yield AgentEvent::Message(message);
-                                            continue;
-                                        } else {
-                                            let message = Message::assistant().with_text(final_output_tool.final_output.clone().unwrap());
-                                            messages.push(message.clone());
-                                            yield AgentEvent::Message(message);
-                                            // Set added_message to true and continue to end the current iteration
-                                            added_message = true;
-                                            push_message(&mut messages, response);
-                                            continue;
-                                        }
-                                    }
-                                    // If there's no final output tool and no tool requests, continue the loop
                                     continue;
                                 }
 
@@ -1039,10 +1021,14 @@ impl Agent {
                     if let Some(final_output_tool) = self.final_output_tool.lock().await.as_ref() {
                         if final_output_tool.final_output.is_none() {
                             tracing::warn!("Final output tool has not been called yet. Continuing agent loop.");
-                            yield AgentEvent::Message(Message::user().with_text(FINAL_OUTPUT_CONTINUATION_MESSAGE));
+                            let message = Message::user().with_text(FINAL_OUTPUT_CONTINUATION_MESSAGE);
+                            messages.push(message.clone());
+                            yield AgentEvent::Message(message);
                             continue;
                         } else {
-                            yield AgentEvent::Message(Message::assistant().with_text(final_output_tool.final_output.clone().unwrap()));
+                            let message = Message::assistant().with_text(final_output_tool.final_output.clone().unwrap());
+                            messages.push(message.clone());
+                            yield AgentEvent::Message(message);
                         }
                     }
                     break;

--- a/crates/goose/src/agents/final_output_tool.rs
+++ b/crates/goose/src/agents/final_output_tool.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 
 pub const FINAL_OUTPUT_TOOL_NAME: &str = "recipe__final_output";
 pub const FINAL_OUTPUT_CONTINUATION_MESSAGE: &str =
-    "I see I MUST call the `final_output` tool NOW with the final output for the user.";
+    "You MUST call the `final_output` tool NOW with the final output for the user.";
 
 pub struct FinalOutputTool {
     pub response: Response,


### PR DESCRIPTION
When streaming was introduced https://github.com/block/goose/pull/2677 a bug was introduced around structured output. Every text streaming chunk has no tool calls and so the inner loop would check if final output had been recorded yet and send a warning directive to the agent rather than waiting till the end of the llm's response.

<img width="967" height="333" alt="image" src="https://github.com/user-attachments/assets/81f2a98f-80b1-418f-a1ab-d48b5c51fc0f" />

Added a test that would have caught this (tested against main).