### PR TITLE
docs: local LLMs context size tip

### DIFF
--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -306,7 +306,7 @@ Ollama and Ramalama are both options to provide local LLMs, each which requires 
 2. Run any [model supporting tool-calling](https://ollama.com/search?c=tools):
 
 :::warning Limited Support for models without tool calling
-Goose extensively uses tool calling, so models without it (e.g. `DeepSeek-r1`) can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions). As an alternative, you can use a [custom DeepSeek-r1 model](/docs/getting-started/providers#deepseek-r1) we've made specifically for Goose.
+Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose extensions must be disabled.
 :::
 
 Example:
@@ -407,7 +407,7 @@ If you notice that Goose is having trouble using extensions or is ignoring [.goo
 2. Run any Ollama [model supporting tool-calling](https://ollama.com/search?c=tools) or [GGUF format HuggingFace Model](https://huggingface.co/search/full-text?q=%22tools+support%22+%2B+%22gguf%22&type=model) :
 
 :::warning Limited Support for models without tool calling
-Goose extensively uses tool calling, so models without it (e.g. `DeepSeek-r1`) can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions). As an alternative, you can use a [custom DeepSeek-r1 model](/docs/getting-started/providers#deepseek-r1) we've made specifically for Goose.
+Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose extensions must be disabled.
 :::
 
 Example:

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -305,8 +305,10 @@ Ollama and Ramalama are both options to provide local LLMs, each which requires 
 1. [Download Ollama](https://ollama.com/download). 
 2. Run any [model supporting tool-calling](https://ollama.com/search?c=tools):
 
-:::warning Limited Support for models without tool calling
-Goose extensively uses tool calling, so models without it (e.g. `DeepSeek-r1`) can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions). As an alternative, you can use a [custom DeepSeek-r1 model](/docs/getting-started/providers#deepseek-r1) we've made specifically for Goose.
+:::warning Tool calling support and Context size
+Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose extensions must be disabled.
+
+Also, ensure that the `OLLAMA_CONTEXT_LENGTH` environment variable is set high enough to accommodate the instructions required for Goose and extensions. If Goose uses extensions incorrectly or ignores `.goosehits` file, the context length is likely too low. Refer to the [Ollama documentation](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size) for more details.
 :::
 
 Example:
@@ -402,15 +404,17 @@ If you're running Ollama on a different server, you'll have to set `OLLAMA_HOST=
 1. [Download Ramalama](https://github.com/containers/ramalama?tab=readme-ov-file#install).
 2. Run any Ollama [model supporting tool-calling](https://ollama.com/search?c=tools) or [GGUF format HuggingFace Model](https://huggingface.co/search/full-text?q=%22tools+support%22+%2B+%22gguf%22&type=model) :
 
-:::warning Limited Support for models without tool calling
-Goose extensively uses tool calling, so models without it (e.g. `DeepSeek-r1`) can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions). As an alternative, you can use a [custom DeepSeek-r1 model](/docs/getting-started/providers#deepseek-r1) we've made specifically for Goose.
+:::warning Tool calling support and Context size
+Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose extensions must be disabled.
+
+Using `ramalama serve`, ensure that the `--ctx-size, -c` option is set high enough to accommodate the instructions required for Goose and extensions. If Goose uses extensions incorrectly or ignores `.goosehits` file, the context length is likely too low. Refer to the [Ramalama documentation](https://github.com/containers/ramalama/blob/main/docs/ramalama-serve.1.md#--ctx-size--c) for more details.
 :::
 
 Example:
 
 ```sh
 # NOTE: the --runtime-args="--jinja" flag is required for Ramalama to work with the Goose Ollama provider.
-ramalama serve --runtime-args="--jinja" ollama://qwen2.5
+ramalama serve --runtime-args="--jinja" --ctx-size=8192 ollama://qwen2.5
 ```
 
 3. In a separate terminal window, configure with Goose:

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -305,7 +305,7 @@ Ollama and Ramalama are both options to provide local LLMs, each which requires 
 1. [Download Ollama](https://ollama.com/download). 
 2. Run any [model supporting tool-calling](https://ollama.com/search?c=tools):
 
-:::warning Tool calling support
+:::warning Limited Support for models without tool calling
 Goose extensively uses tool calling, so models without it (e.g. `DeepSeek-r1`) can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions). As an alternative, you can use a [custom DeepSeek-r1 model](/docs/getting-started/providers#deepseek-r1) we've made specifically for Goose.
 :::
 
@@ -406,7 +406,7 @@ If you notice that Goose is having trouble using extensions or is ignoring [.goo
 1. [Download Ramalama](https://github.com/containers/ramalama?tab=readme-ov-file#install).
 2. Run any Ollama [model supporting tool-calling](https://ollama.com/search?c=tools) or [GGUF format HuggingFace Model](https://huggingface.co/search/full-text?q=%22tools+support%22+%2B+%22gguf%22&type=model) :
 
-:::warning Tool calling support
+:::warning Limited Support for models without tool calling
 Goose extensively uses tool calling, so models without it (e.g. `DeepSeek-r1`) can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions). As an alternative, you can use a [custom DeepSeek-r1 model](/docs/getting-started/providers#deepseek-r1) we've made specifically for Goose.
 :::
 

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -305,10 +305,8 @@ Ollama and Ramalama are both options to provide local LLMs, each which requires 
 1. [Download Ollama](https://ollama.com/download). 
 2. Run any [model supporting tool-calling](https://ollama.com/search?c=tools):
 
-:::warning Tool calling support and Context size
-Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose extensions must be disabled.
-
-Also, ensure that the `OLLAMA_CONTEXT_LENGTH` environment variable is set high enough to accommodate the instructions required for Goose and extensions. If Goose uses extensions incorrectly or ignores `.goosehits` file, the context length is likely too low. Refer to the [Ollama documentation](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size) for more details.
+:::warning Tool calling support
+Goose extensively uses tool calling, so models without it (e.g. `DeepSeek-r1`) can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions). As an alternative, you can use a [custom DeepSeek-r1 model](/docs/getting-started/providers#deepseek-r1) we've made specifically for Goose.
 :::
 
 Example:
@@ -399,15 +397,17 @@ If you're running Ollama on a different server, you'll have to set `OLLAMA_HOST=
 └  Configuration saved successfully
 ```
 
+:::tip Context Length
+If you notice that Goose is having trouble using extensions or is ignoring [.goosehints](/docs/guides/using-goosehints), it is likely that the model's default context length of 4096 tokens is too low. Set the `OLLAMA_CONTEXT_LENGTH` environment variable to a [higher value](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size). 
+:::
+
 #### Ramalama
 
 1. [Download Ramalama](https://github.com/containers/ramalama?tab=readme-ov-file#install).
 2. Run any Ollama [model supporting tool-calling](https://ollama.com/search?c=tools) or [GGUF format HuggingFace Model](https://huggingface.co/search/full-text?q=%22tools+support%22+%2B+%22gguf%22&type=model) :
 
-:::warning Tool calling support and Context size
-Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose extensions must be disabled.
-
-Using `ramalama serve`, ensure that the `--ctx-size, -c` option is set high enough to accommodate the instructions required for Goose and extensions. If Goose uses extensions incorrectly or ignores `.goosehits` file, the context length is likely too low. Refer to the [Ramalama documentation](https://github.com/containers/ramalama/blob/main/docs/ramalama-serve.1.md#--ctx-size--c) for more details.
+:::warning Tool calling support
+Goose extensively uses tool calling, so models without it (e.g. `DeepSeek-r1`) can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions). As an alternative, you can use a [custom DeepSeek-r1 model](/docs/getting-started/providers#deepseek-r1) we've made specifically for Goose.
 :::
 
 Example:
@@ -496,6 +496,11 @@ For the Ollama provider, if you don't provide a host, we set it to `localhost:11
 │
 └  Configuration saved successfully
 ```
+
+:::tip Context Length
+If you notice that Goose is having trouble using extensions or is ignoring [.goosehints](/docs/guides/using-goosehints), it is likely that the model's default context length of 2048 tokens is too low. Use `ramalama serve` to set the `--ctx-size, -c` option to a [higher value](https://github.com/containers/ramalama/blob/main/docs/ramalama-serve.1.md#--ctx-size--c). 
+:::
+
 
 ### DeepSeek-R1
 

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -306,7 +306,7 @@ Ollama and Ramalama are both options to provide local LLMs, each which requires 
 2. Run any [model supporting tool-calling](https://ollama.com/search?c=tools):
 
 :::warning Limited Support for models without tool calling
-Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose extensions must be disabled.
+Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions).
 :::
 
 Example:
@@ -407,7 +407,7 @@ If you notice that Goose is having trouble using extensions or is ignoring [.goo
 2. Run any Ollama [model supporting tool-calling](https://ollama.com/search?c=tools) or [GGUF format HuggingFace Model](https://huggingface.co/search/full-text?q=%22tools+support%22+%2B+%22gguf%22&type=model) :
 
 :::warning Limited Support for models without tool calling
-Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose extensions must be disabled.
+Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions).
 :::
 
 Example:


### PR DESCRIPTION
Hi everyone! Personally had issues with context size and Ollama, and saw several other cases. So I've extended tool calling warning with information about context size. Updated this one for Ollama and Ramalama.

Before: 
<img width="1988" height="234" alt="image" src="https://github.com/user-attachments/assets/e3b35fdd-5094-42bd-b5cb-2608d73e3eee" />

After, for Ollama:
<img width="1978" height="414" alt="image" src="https://github.com/user-attachments/assets/6c39d500-c80f-4a1d-b1ea-74eb038863f6" />
> Note: Ollama docs poorly explain how to set this variable in the desktop app. I'm using systemd and cli but I guess most of the users will go for UI. There will be a reference by now, but it's not really useful. Need to contribute to their docs too :smiling_face_with_tear: 

After, for Ramalama:
<img width="1993" height="420" alt="image" src="https://github.com/user-attachments/assets/8e922c05-eb83-4076-bb86-02e0e51338bc" />

and small change in Ramalama example:

<img width="1984" height="262" alt="image" src="https://github.com/user-attachments/assets/f9855e27-6393-4c1b-8832-a08a78bf8c11" />




If you wan't to change something I'm happy to help!