### PR TITLE
Align chat input action buttons to bottom when large amount of text

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -892,7 +892,7 @@ export default function ChatInput({
     >
       <form onSubmit={onFormSubmit} className="flex flex-col">
         {/* Input row with inline action buttons */}
-        <div className="relative flex items-center">
+        <div className="relative flex items-end">
           <div className="relative flex-1">
             <textarea
               data-testid="chat-input"

--- a/ui/desktop/src/hooks/useChatEngine.ts
+++ b/ui/desktop/src/hooks/useChatEngine.ts
@@ -120,7 +120,6 @@ export const useChatEngine = ({
       // If this is the first message in a new session, trigger a refresh immediately
       // Only trigger if we're starting a completely new session (no existing messages)
       if (messages.length === 0 && chat.messages.length === 0) {
-        console.log('ChatEngine: New session detected, emitting session-created event');
         // Emit event to indicate a new session is being created
         window.dispatchEvent(new CustomEvent('session-created'));
       }

--- a/ui/desktop/src/hooks/useMessageStream.ts
+++ b/ui/desktop/src/hooks/useMessageStream.ts
@@ -287,10 +287,7 @@ export function useMessageStream({
                           : parsedEvent.message.sendToLLM,
                     };
 
-                    console.log('New message:', JSON.stringify(newMessage, null, 2));
-
                     // Update messages with the new message
-
                     if (
                       newMessage.id &&
                       currentMessages.length > 0 &&


### PR DESCRIPTION
Align chat input action buttons to bottom when large amount of text. Also removed some console debugging.

<img width="871" height="271" alt="image" src="https://github.com/user-attachments/assets/67833358-f6b6-4a13-b7b8-ee17ff128ef6" />
