### PR TITLE
refine global checkpoints UI

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -2,23 +2,6 @@ import { useEffect, useRef, useState } from 'react';
 import { IpcRendererEvent } from 'electron';
 import { HashRouter, Routes, Route, useNavigate, useLocation } from 'react-router-dom';
 
-// Component to conditionally show sidecar based on route and chat state
-const ConditionalSidecarProvider = ({ children }: { children: React.ReactNode }) => {
-  const location = useLocation();
-  
-  // Only show sidecar on specific chat routes when there are messages
-  const isChatRoute = location.pathname === '/' || location.pathname === '/pair';
-
-  // We'll pass the chat state check to the SidecarProvider
-  // The sidecar will only show the collapsed panel when there are messages with potential actions
-  const showSidecar = isChatRoute;
-  
-  return (
-    <SidecarProvider showSidecar={showSidecar}>
-      {children}
-    </SidecarProvider>
-  );
-};
 import { openSharedSessionFromDeepLink, type SessionLinksViewOptions } from './sessionLinks';
 import { type SharedSessionDetails } from './sharedSessions';
 import { initializeSystem } from './utils/providerUtils';
@@ -45,7 +28,6 @@ import RecipesView from './components/RecipesView';
 import { useChat } from './hooks/useChat';
 import { AppLayout } from './components/Layout/AppLayout';
 import { ChatProvider } from './contexts/ChatContext';
-import { SidecarProvider } from './components/SidecarLayout';
 import { DraftProvider } from './contexts/DraftContext';
 
 import 'react-toastify/dist/ReactToastify.css';
@@ -63,6 +45,7 @@ import PermissionSettingsView from './components/settings/permission/PermissionS
 
 import { type SessionDetails } from './sessions';
 import ExtensionsView, { ExtensionsViewOptions } from './components/extensions/ExtensionsView';
+import { Recipe } from './recipe';
 // import ProjectsContainer from './components/projects/ProjectsContainer';
 
 export type View =
@@ -1337,9 +1320,7 @@ export default function App() {
               path="/"
               element={
                 <ChatProvider chat={chat} setChat={setChat} contextKey="hub">
-                  <ConditionalSidecarProvider>
-                    <AppLayout setIsGoosehintsModalOpen={setIsGoosehintsModalOpen} />
-                  </ConditionalSidecarProvider>
+                  <AppLayout setIsGoosehintsModalOpen={setIsGoosehintsModalOpen} />
                 </ChatProvider>
               }
             >

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1174,7 +1174,7 @@ export default function ChatInput({
         )}
 
         {/* Secondary actions and controls row below input */}
-        <div className="flex flex-row items-center gap-1 p-2 relative">
+        <div className="flex flex-row items-center gap-x-1 gap-y-2 p-2 relative flex-wrap">
           {/* Directory path */}
           <DirSwitcher hasMessages={messages.length > 0} className="mr-0" />
           <div className="w-px h-4 bg-border-default mx-2" />

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -264,7 +264,7 @@ export default function GooseMessage({
                     }
                   }
                 }}
-                className="p-2 bg-background-muted hover:bg-background-subtle border border-borderSubtle rounded-lg transition-all duration-200 hover:scale-105 text-textSubtle hover:text-primary cursor-pointer"
+                className="p-2 bg-background-muted hover:bg-background-subtle border border-borderSubtle rounded-lg transition-all duration-200 hover:scale-105 text-textSubtle hover:text-primary cursor-pointer focus:outline-none focus:ring-1 focus:ring-borderProminent"
               >
                 <FileDiff size={16} />
               </button>

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -20,7 +20,7 @@ import {
 import ToolCallConfirmation from './ToolCallConfirmation';
 import MessageCopyLink from './MessageCopyLink';
 import { NotificationEvent } from '../hooks/useMessageStream';
-import { GitBranch } from 'lucide-react';
+import { FileDiff } from 'lucide-react';
 import { useSidecar } from './SidecarLayout';
 
 interface GooseMessageProps {
@@ -264,7 +264,7 @@ export default function GooseMessage({
             className="p-2 bg-background-muted hover:bg-background-subtle border border-borderSubtle rounded-lg transition-all duration-200 hover:scale-105 group"
             title="View diff"
           >
-            <GitBranch
+            <FileDiff
               size={16}
               className="text-textSubtle group-hover:text-primary transition-colors"
             />

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -22,6 +22,7 @@ import MessageCopyLink from './MessageCopyLink';
 import { NotificationEvent } from '../hooks/useMessageStream';
 import { FileDiff } from 'lucide-react';
 import { useSidecar } from './SidecarLayout';
+import { Tooltip, TooltipTrigger, TooltipContent } from './ui/Tooltip';
 
 interface GooseMessageProps {
   // messages up to this index are presumed to be "history" from a resumed session, this is used to track older tool confirmation requests
@@ -238,42 +239,40 @@ export default function GooseMessage({
 
       {hasDiff && sidecar && (
         <div className="absolute top-2 sidecar-button z-50">
-          <button
-            onClick={() => {
-              // Find the first tool request with diff content and show its diff
-              const toolRequestWithDiff = toolRequests.find((toolRequest) =>
-                hasDiffContent(toolResponsesMap.get(toolRequest.id))
-              );
-              if (toolRequestWithDiff) {
-                const diffContent = extractDiffContent(
-                  toolResponsesMap.get(toolRequestWithDiff.id)
-                );
-                if (diffContent) {
-                  // Extract filename from tool arguments if available
-                  const toolCall =
-                    toolRequestWithDiff.toolCall.status === 'success'
-                      ? toolRequestWithDiff.toolCall.value
-                      : null;
-                  const args = toolCall?.arguments as Record<string, never>;
-                  const fileName = args?.path ? String(args.path) : 'File';
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <button
+                onClick={() => {
+                  // Find the first tool request with diff content and show its diff
+                  const toolRequestWithDiff = toolRequests.find((toolRequest) =>
+                    hasDiffContent(toolResponsesMap.get(toolRequest.id))
+                  );
+                  if (toolRequestWithDiff) {
+                    const diffContent = extractDiffContent(
+                      toolResponsesMap.get(toolRequestWithDiff.id)
+                    );
+                    if (diffContent) {
+                      // Extract filename from tool arguments if available
+                      const toolCall =
+                        toolRequestWithDiff.toolCall.status === 'success'
+                          ? toolRequestWithDiff.toolCall.value
+                          : null;
+                      const args = toolCall?.arguments as Record<string, never>;
+                      const fileName = args?.path ? String(args.path) : 'File';
 
-                  sidecar.showDiffViewer(diffContent, fileName);
-                }
-              }
-            }}
-            className="p-2 bg-background-muted hover:bg-background-subtle border border-borderSubtle rounded-lg transition-all duration-200 hover:scale-105 group"
-            title="View diff"
-          >
-            <FileDiff
-              size={16}
-              className="text-textSubtle group-hover:text-primary transition-colors"
-            />
-
-            {/* Tooltip */}
-            <div className="absolute right-full mr-2 top-1/2 -translate-y-1/2 px-2 py-1 bg-background-subtle border border-borderSubtle rounded text-xs text-textStandard opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none">
+                      sidecar.showDiffViewer(diffContent, fileName);
+                    }
+                  }
+                }}
+                className="p-2 bg-background-muted hover:bg-background-subtle border border-borderSubtle rounded-lg transition-all duration-200 hover:scale-105 text-textSubtle hover:text-primary"
+              >
+                <FileDiff size={16} />
+              </button>
+            </TooltipTrigger>
+            <TooltipContent side="top" sideOffset={8}>
               View diff
-            </div>
-          </button>
+            </TooltipContent>
+          </Tooltip>
         </div>
       )}
 

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -264,14 +264,12 @@ export default function GooseMessage({
                     }
                   }
                 }}
-                className="p-2 bg-background-muted hover:bg-background-subtle border border-borderSubtle rounded-lg transition-all duration-200 hover:scale-105 text-textSubtle hover:text-primary"
+                className="p-2 bg-background-muted hover:bg-background-subtle border border-borderSubtle rounded-lg transition-all duration-200 hover:scale-105 text-textSubtle hover:text-primary cursor-pointer"
               >
                 <FileDiff size={16} />
               </button>
             </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={8}>
-              View diff
-            </TooltipContent>
+            <TooltipContent side="top">View diff</TooltipContent>
           </Tooltip>
         </div>
       )}

--- a/ui/desktop/src/components/Layout/MainPanelLayout.tsx
+++ b/ui/desktop/src/components/Layout/MainPanelLayout.tsx
@@ -1,17 +1,27 @@
 import React from 'react';
+import { Sidecar, useSidecar } from '../SidecarLayout';
 
 export const MainPanelLayout: React.FC<{
   children: React.ReactNode;
   removeTopPadding?: boolean;
   backgroundColor?: string;
 }> = ({ children, removeTopPadding = false, backgroundColor = 'bg-background-default' }) => {
+  const sidecar = useSidecar();
+  const isVisible = sidecar?.activeView && sidecar?.views.find((v) => v.id === sidecar.activeView);
+
   return (
     <div className={`h-dvh`}>
       {/* Padding top matches the app toolbar drag area height - can be removed for full bleed */}
       <div
-        className={`flex flex-col ${backgroundColor} flex-1 min-w-0 h-full min-h-0 ${removeTopPadding ? '' : 'pt-[32px]'}`}
+        className={`flex ${backgroundColor} flex-1 min-w-0 h-full min-h-0 ${removeTopPadding ? '' : 'pt-[32px]'}`}
       >
-        {children}
+        {/* Main Content Area */}
+        <div className="flex flex-col flex-1 min-w-0 transition-all duration-300 ease-out">
+          {children}
+        </div>
+
+        {/* Sidecar Panel */}
+        {isVisible && <Sidecar className="flex-1 transition-all duration-300 ease-out" />}
       </div>
     </div>
   );

--- a/ui/desktop/src/components/SidecarLayout.tsx
+++ b/ui/desktop/src/components/SidecarLayout.tsx
@@ -371,59 +371,51 @@ export function SidecarProvider({ children, showSidecar = true }: SidecarProvide
     hideDiffViewer,
   };
 
-  const currentView = views.find((v) => v.id === activeView);
-  const isVisible = activeView && currentView;
-
   // Don't render sidecar if showSidecar is false
   if (!showSidecar) {
     return <SidecarContext.Provider value={contextValue}>{children}</SidecarContext.Provider>;
   }
 
+  // Just provide context, layout will be handled by MainPanelLayout
+  return <SidecarContext.Provider value={contextValue}>{children}</SidecarContext.Provider>;
+}
+
+// Separate Sidecar component that can be used as a sibling
+export function Sidecar({ className = '' }: { className?: string }) {
+  const sidecar = useSidecar();
+
+  if (!sidecar) return null;
+
+  const { activeView, views, hideView } = sidecar;
+  const currentView = views.find((v) => v.id === activeView);
+  const isVisible = activeView && currentView;
+
+  if (!isVisible) return null;
+
   return (
-    <SidecarContext.Provider value={contextValue}>
-      <div className="flex h-full relative">
-        {/* Main Content */}
-        <div 
-          className={`flex-1 transition-all duration-300 ease-out ${
-            isVisible ? 'mr-96' : 'mr-0'
-          }`}
-        >
-          {children}
-        </div>
-
-        {/* Sidecar Panel Container - Fixed positioning similar to sidebar */}
-        <div
-          className={`fixed inset-y-0 right-0 z-10 h-full w-96 transition-transform duration-300 ease-out will-change-transform ${
-            isVisible ? 'translate-x-0' : 'translate-x-full'
-          }`}
-        >
-          {/* Sidecar Panel */}
-          <div className="h-full bg-background-default m-4 rounded-lg border border-borderSubtle shadow-lg">
-            {currentView && (
-              <>
-                {/* Sidecar Header */}
-                <div className="flex items-center justify-between p-4 border-b border-borderSubtle">
-                  <div className="flex items-center space-x-2">
-                    {currentView.icon}
-                    <span className="text-textStandard font-medium">{currentView.title}</span>
-                  </div>
-                  <Button
-                    variant="ghost"
-                    size="sm"
-                    onClick={hideView}
-                    className="text-textSubtle hover:text-textStandard"
-                  >
-                    <X size={16} />
-                  </Button>
-                </div>
-
-                {/* Sidecar Content */}
-                <div className="h-[calc(100%-60px)] overflow-hidden">{currentView.content}</div>
-              </>
-            )}
+    <div className={`bg-background-default overflow-hidden rounded-2xl m-7 ${className}`}>
+      {currentView && (
+        <>
+          {/* Sidecar Header */}
+          <div className="flex items-center justify-between p-4 border-b border-borderSubtle flex-shrink-0">
+            <div className="flex items-center space-x-2">
+              {currentView.icon}
+              <span className="text-textStandard font-medium">{currentView.title}</span>
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={hideView}
+              className="text-textSubtle hover:text-textStandard"
+            >
+              <X size={16} />
+            </Button>
           </div>
-        </div>
-      </div>
-    </SidecarContext.Provider>
+
+          {/* Sidecar Content */}
+          <div className="h-[calc(100%-60px)] overflow-hidden">{currentView.content}</div>
+        </>
+      )}
+    </div>
   );
 }

--- a/ui/desktop/src/components/SidecarLayout.tsx
+++ b/ui/desktop/src/components/SidecarLayout.tsx
@@ -257,7 +257,11 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
   // Expose the view mode controls to parent
   useEffect(() => {
     // Store the setViewMode function in a way the parent can access it
-    (window as unknown as { diffViewerControls?: { viewMode: string; setViewMode: (mode: 'split' | 'unified') => void } }).diffViewerControls = { viewMode, setViewMode };
+    (
+      window as unknown as {
+        diffViewerControls?: { viewMode: string; setViewMode: (mode: 'split' | 'unified') => void };
+      }
+    ).diffViewerControls = { viewMode, setViewMode };
   }, [viewMode, setViewMode]);
 
   return (
@@ -363,9 +367,26 @@ export function Sidecar({ className = '' }: { className?: string }) {
       const { activeView, views } = sidecar;
       const currentView = views.find((v) => v.id === activeView);
       const isDiffViewer = currentView?.id === 'diff';
-      
-      if (isDiffViewer && (window as unknown as { diffViewerControls?: { viewMode: string; setViewMode: (mode: 'split' | 'unified') => void } }).diffViewerControls) {
-        (window as unknown as { diffViewerControls?: { viewMode: string; setViewMode: (mode: 'split' | 'unified') => void } }).diffViewerControls!.setViewMode(viewMode);
+
+      if (
+        isDiffViewer &&
+        (
+          window as unknown as {
+            diffViewerControls?: {
+              viewMode: string;
+              setViewMode: (mode: 'split' | 'unified') => void;
+            };
+          }
+        ).diffViewerControls
+      ) {
+        (
+          window as unknown as {
+            diffViewerControls?: {
+              viewMode: string;
+              setViewMode: (mode: 'split' | 'unified') => void;
+            };
+          }
+        ).diffViewerControls!.setViewMode(viewMode);
       }
     }
   }, [viewMode, sidecar]);
@@ -400,25 +421,23 @@ export function Sidecar({ className = '' }: { className?: string }) {
             <div className="flex items-center space-x-2">
               {/* View Mode Toggle - Only show for diff viewer */}
               {isDiffViewer && (
-                <div className="flex items-center space-x-1 bg-background-muted rounded-md p-1">
+                <div className="flex items-center space-x-1">
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
                         variant="ghost"
                         size="sm"
                         onClick={() => setViewMode('split')}
-                        className={`px-2 py-1 ${
+                        className={`px-2 py-1 cursor-pointer ${
                           viewMode === 'split'
-                            ? 'bg-background-subtle text-textStandard'
-                            : 'text-textSubtle hover:text-textStandard hover:bg-background-subtle'
+                            ? 'bg-background-muted text-textStandard'
+                            : 'text-textSubtle hover:text-textStandard hover:bg-background-muted'
                         }`}
                       >
                         <SquareSplitHorizontal size={14} />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={8}>
-                      Split View
-                    </TooltipContent>
+                    <TooltipContent side="bottom">Split View</TooltipContent>
                   </Tooltip>
 
                   <Tooltip>
@@ -427,18 +446,16 @@ export function Sidecar({ className = '' }: { className?: string }) {
                         variant="ghost"
                         size="sm"
                         onClick={() => setViewMode('unified')}
-                        className={`px-2 py-1 ${
+                        className={`px-2 py-1 cursor-pointer ${
                           viewMode === 'unified'
-                            ? 'bg-background-subtle text-textStandard'
-                            : 'text-textSubtle hover:text-textStandard hover:bg-background-subtle'
+                            ? 'bg-background-muted text-textStandard'
+                            : 'text-textSubtle hover:text-textStandard hover:bg-background-muted'
                         }`}
                       >
                         <BetweenHorizontalStart size={14} />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom" sideOffset={8}>
-                      Unified View
-                    </TooltipContent>
+                    <TooltipContent side="bottom">Unified View</TooltipContent>
                   </Tooltip>
                 </div>
               )}
@@ -450,14 +467,12 @@ export function Sidecar({ className = '' }: { className?: string }) {
                     variant="ghost"
                     size="sm"
                     onClick={hideView}
-                    className="text-textSubtle hover:text-textStandard"
+                    className="text-textSubtle hover:text-textStandard cursor-pointer"
                   >
                     <X size={16} />
                   </Button>
                 </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={8}>
-                  Close
-                </TooltipContent>
+                <TooltipContent side="bottom">Close</TooltipContent>
               </Tooltip>
             </div>
           </div>

--- a/ui/desktop/src/components/SidecarLayout.tsx
+++ b/ui/desktop/src/components/SidecarLayout.tsx
@@ -176,7 +176,7 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
     return (
       <div
         key={`${side}-${line.lineNumber}`}
-        className={`flex font-mono text-sm ${getLineStyle()}`}
+        className={`flex font-mono text-xs ${getLineStyle()}`}
       >
         <div className="w-12 text-textSubtle text-right pr-2 py-1 select-none flex-shrink-0">
           {line.lineNumber}
@@ -237,7 +237,7 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
     };
 
     return (
-      <div key={`unified-${index}`} className={`flex font-mono text-sm ${getLineStyle()}`}>
+      <div key={`unified-${index}`} className={`flex font-mono text-xs ${getLineStyle()}`}>
         <div className="w-12 text-textSubtle text-right pr-1 py-1 select-none flex-shrink-0">
           {line.beforeLineNumber || ''}
         </div>
@@ -265,13 +265,13 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
   }, [viewMode, setViewMode]);
 
   return (
-    <div className="h-full flex flex-col bg-background-default">
+    <div className="h-full flex flex-col bg-background-default ">
       {viewMode === 'split' ? (
         /* Split Diff Content */
         <div className="flex-1 overflow-hidden flex">
           {/* Before (Left Side) */}
           <div className="flex-1 border-r border-borderSubtle">
-            <div className="bg-background-muted text-textStandard px-4 py-2 text-sm font-medium border-b border-borderSubtle">
+            <div className="bg-background-muted text-textStandard px-4 py-2 text-xs font-medium border-b border-borderSubtle">
               Before
             </div>
             <div className="h-[calc(100%-40px)] overflow-auto">
@@ -281,7 +281,7 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
 
           {/* After (Right Side) */}
           <div className="flex-1">
-            <div className="bg-background-muted text-textStandard px-4 py-2 text-sm font-medium border-b border-borderSubtle">
+            <div className="bg-background-muted text-textStandard px-4 py-2 text-xs font-medium border-b border-borderSubtle">
               After
             </div>
             <div className="h-[calc(100%-40px)] overflow-auto">
@@ -292,7 +292,7 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
       ) : (
         /* Unified Diff Content */
         <div className="flex-1 overflow-hidden">
-          <div className="h-full overflow-auto">
+          <div className="h-full overflow-auto pb-(--radius-2xl)">
             {parsedDiff.unifiedLines.map((line, index) => renderUnifiedLine(line, index))}
           </div>
         </div>
@@ -403,11 +403,13 @@ export function Sidecar({ className = '' }: { className?: string }) {
   const isDiffViewer = currentView.id === 'diff';
 
   return (
-    <div className={`bg-background-default overflow-hidden rounded-2xl m-5 ${className}`}>
+    <div
+      className={`bg-background-default overflow-hidden rounded-2xl flex flex-col m-5 ${className}`}
+    >
       {currentView && (
         <>
           {/* Sidecar Header */}
-          <div className="flex items-center justify-between p-4 border-b border-borderSubtle flex-shrink-0">
+          <div className="flex items-center justify-between p-4 border-b border-borderSubtle flex-shrink-0 flex-grow-0">
             <div className="flex items-center space-x-2">
               {currentView.icon}
               <div className="flex flex-col">
@@ -428,9 +430,9 @@ export function Sidecar({ className = '' }: { className?: string }) {
                         variant="ghost"
                         size="sm"
                         onClick={() => setViewMode('unified')}
-                        className={`px-2 py-1 cursor-pointer focus:outline-none focus:ring-2 focus:ring-borderProminent focus:ring-offset-1  ${
+                        className={`px-2 py-1 cursor-pointer focus:outline-none focus:ring-2 focus:ring-borderProminent focus:ring-offset-1 ${
                           viewMode === 'unified'
-                            ? 'bg-background-default text-textStandard hover:text-textStandard hover:bg-background-default'
+                            ? 'bg-background-default text-textStandard hover:bg-background-default dark:hover:bg-background-default'
                             : 'text-textSubtle'
                         }`}
                       >
@@ -450,7 +452,7 @@ export function Sidecar({ className = '' }: { className?: string }) {
                         onClick={() => setViewMode('split')}
                         className={`px-2 py-1 cursor-pointer focus:outline-none focus:ring-2 focus:ring-borderProminent focus:ring-offset-1  ${
                           viewMode === 'split'
-                            ? 'bg-background-default text-textStandard hover:text-textStandard hover:bg-background-default'
+                            ? 'bg-background-default text-textStandard hover:bg-background-default dark:hover:bg-background-default'
                             : 'text-textSubtle'
                         }`}
                       >
@@ -482,7 +484,9 @@ export function Sidecar({ className = '' }: { className?: string }) {
           </div>
 
           {/* Sidecar Content */}
-          <div className="h-[calc(100%-60px)] overflow-hidden">{currentView.content}</div>
+          <div className="flex-1  border-4 overflow-hidden border-background-default border-t-0 rounded-b-2xl">
+            {currentView.content}
+          </div>
         </>
       )}
     </div>

--- a/ui/desktop/src/components/SidecarLayout.tsx
+++ b/ui/desktop/src/components/SidecarLayout.tsx
@@ -35,7 +35,7 @@ interface SidecarProviderProps {
 
 // Monaco Editor Diff Component
 function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fileName: string }) {
-  const [viewMode, setViewMode] = useState<'split' | 'unified'>('split');
+  const [viewMode, setViewMode] = useState<'split' | 'unified'>('unified');
   const [parsedDiff, setParsedDiff] = useState<{
     beforeLines: Array<{
       content: string;
@@ -359,7 +359,7 @@ export function SidecarProvider({ children, showSidecar = true }: SidecarProvide
 // Separate Sidecar component that can be used as a sibling
 export function Sidecar({ className = '' }: { className?: string }) {
   const sidecar = useSidecar();
-  const [viewMode, setViewMode] = useState<'split' | 'unified'>('split');
+  const [viewMode, setViewMode] = useState<'split' | 'unified'>('unified');
 
   // Update the diff viewer when view mode changes
   useEffect(() => {
@@ -403,7 +403,7 @@ export function Sidecar({ className = '' }: { className?: string }) {
   const isDiffViewer = currentView.id === 'diff';
 
   return (
-    <div className={`bg-background-default overflow-hidden rounded-2xl m-7 ${className}`}>
+    <div className={`bg-background-default overflow-hidden rounded-2xl m-5 ${className}`}>
       {currentView && (
         <>
           {/* Sidecar Header */}
@@ -413,7 +413,7 @@ export function Sidecar({ className = '' }: { className?: string }) {
               <div className="flex flex-col">
                 <span className="text-textStandard font-medium">{currentView.title}</span>
                 {currentView.fileName && (
-                  <span className="text-textSubtle text-sm">{currentView.fileName}</span>
+                  <span className="text-xs font-mono text-text-muted">{currentView.fileName}</span>
                 )}
               </div>
             </div>
@@ -421,23 +421,25 @@ export function Sidecar({ className = '' }: { className?: string }) {
             <div className="flex items-center space-x-2">
               {/* View Mode Toggle - Only show for diff viewer */}
               {isDiffViewer && (
-                <div className="flex items-center space-x-1">
+                <div className="flex items-center space-x-1 bg-background-muted rounded-lg p-1">
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => setViewMode('split')}
-                        className={`px-2 py-1 cursor-pointer ${
-                          viewMode === 'split'
-                            ? 'bg-background-muted text-textStandard'
-                            : 'text-textSubtle hover:text-textStandard hover:bg-background-muted'
+                        onClick={() => setViewMode('unified')}
+                        className={`px-2 py-1 cursor-pointer focus:outline-none focus:ring-2 focus:ring-borderProminent focus:ring-offset-1  ${
+                          viewMode === 'unified'
+                            ? 'bg-background-default text-textStandard hover:text-textStandard hover:bg-background-default'
+                            : 'text-textSubtle'
                         }`}
                       >
-                        <SquareSplitHorizontal size={14} />
+                        <BetweenHorizontalStart size={14} />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Split View</TooltipContent>
+                    <TooltipContent side="bottom" sideOffset={8}>
+                      Unified View
+                    </TooltipContent>
                   </Tooltip>
 
                   <Tooltip>
@@ -445,17 +447,19 @@ export function Sidecar({ className = '' }: { className?: string }) {
                       <Button
                         variant="ghost"
                         size="sm"
-                        onClick={() => setViewMode('unified')}
-                        className={`px-2 py-1 cursor-pointer ${
-                          viewMode === 'unified'
-                            ? 'bg-background-muted text-textStandard'
-                            : 'text-textSubtle hover:text-textStandard hover:bg-background-muted'
+                        onClick={() => setViewMode('split')}
+                        className={`px-2 py-1 cursor-pointer focus:outline-none focus:ring-2 focus:ring-borderProminent focus:ring-offset-1  ${
+                          viewMode === 'split'
+                            ? 'bg-background-default text-textStandard hover:text-textStandard hover:bg-background-default'
+                            : 'text-textSubtle'
                         }`}
                       >
-                        <BetweenHorizontalStart size={14} />
+                        <SquareSplitHorizontal size={14} />
                       </Button>
                     </TooltipTrigger>
-                    <TooltipContent side="bottom">Unified View</TooltipContent>
+                    <TooltipContent side="bottom" sideOffset={8}>
+                      Split View
+                    </TooltipContent>
                   </Tooltip>
                 </div>
               )}
@@ -467,7 +471,7 @@ export function Sidecar({ className = '' }: { className?: string }) {
                     variant="ghost"
                     size="sm"
                     onClick={hideView}
-                    className="text-textSubtle hover:text-textStandard cursor-pointer"
+                    className="text-textSubtle hover:text-textStandard cursor-pointer focus:outline-none focus:ring-2 focus:ring-borderProminent focus:ring-offset-1"
                   >
                     <X size={16} />
                   </Button>

--- a/ui/desktop/src/components/SidecarLayout.tsx
+++ b/ui/desktop/src/components/SidecarLayout.tsx
@@ -152,9 +152,9 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
     const getTextColor = () => {
       switch (line.type) {
         case 'removed':
-          return 'text-red-400';
+          return 'text-red-500';
         case 'added':
-          return 'text-green-400';
+          return 'text-green-500';
         case 'context':
         default:
           return 'text-textStandard';
@@ -215,9 +215,9 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
     const getTextColor = () => {
       switch (line.type) {
         case 'removed':
-          return 'text-red-400';
+          return 'text-red-500';
         case 'added':
-          return 'text-green-400';
+          return 'text-green-500';
         case 'context':
         default:
           return 'text-textStandard';
@@ -268,25 +268,21 @@ function MonacoDiffViewer({ diffContent, _fileName }: { diffContent: string; _fi
     <div className="h-full flex flex-col bg-background-default ">
       {viewMode === 'split' ? (
         /* Split Diff Content */
-        <div className="flex-1 overflow-hidden flex">
+        <div className="flex-1 overflow-auto flex">
           {/* Before (Left Side) */}
           <div className="flex-1 border-r border-borderSubtle">
-            <div className="bg-background-muted text-textStandard px-4 py-2 text-xs font-medium border-b border-borderSubtle">
+            <div className="py-2  text-textStandard text-xs font-mono text-center border-b-1 border-borderSubtle">
               Before
             </div>
-            <div className="h-[calc(100%-40px)] overflow-auto">
-              {parsedDiff.beforeLines.map((line) => renderDiffLine(line, 'before'))}
-            </div>
+            <div>{parsedDiff.beforeLines.map((line) => renderDiffLine(line, 'before'))}</div>
           </div>
 
           {/* After (Right Side) */}
           <div className="flex-1">
-            <div className="bg-background-muted text-textStandard px-4 py-2 text-xs font-medium border-b border-borderSubtle">
+            <div className="py-2  text-textStandard text-xs font-mono text-center border-b-1 border-borderSubtle">
               After
             </div>
-            <div className="h-[calc(100%-40px)] overflow-auto">
-              {parsedDiff.afterLines.map((line) => renderDiffLine(line, 'after'))}
-            </div>
+            <div>{parsedDiff.afterLines.map((line) => renderDiffLine(line, 'after'))}</div>
           </div>
         </div>
       ) : (

--- a/ui/desktop/src/components/SidecarLayout.tsx
+++ b/ui/desktop/src/components/SidecarLayout.tsx
@@ -372,6 +372,7 @@ export function SidecarProvider({ children, showSidecar = true }: SidecarProvide
   };
 
   const currentView = views.find((v) => v.id === activeView);
+  const isVisible = activeView && currentView;
 
   // Don't render sidecar if showSidecar is false
   if (!showSidecar) {
@@ -382,38 +383,46 @@ export function SidecarProvider({ children, showSidecar = true }: SidecarProvide
     <SidecarContext.Provider value={contextValue}>
       <div className="flex h-full relative">
         {/* Main Content */}
-        <div className={`flex-1 transition-all duration-300 ${activeView ? 'mr-[700px]' : ''}`}>
+        <div 
+          className={`flex-1 transition-all duration-300 ease-out ${
+            isVisible ? 'mr-96' : 'mr-0'
+          }`}
+        >
           {children}
         </div>
 
-        {/* Collapsed Sidecar Panel - Only visible when not expanded */}
-        {!activeView && (
-          <div className="fixed top-0 right-0 h-full w-16 bg-background-default border-l border-borderSubtle opacity-0 pointer-events-none" />
-        )}
+        {/* Sidecar Panel Container - Fixed positioning similar to sidebar */}
+        <div
+          className={`fixed inset-y-0 right-0 z-10 h-full w-96 transition-transform duration-300 ease-out will-change-transform ${
+            isVisible ? 'translate-x-0' : 'translate-x-full'
+          }`}
+        >
+          {/* Sidecar Panel */}
+          <div className="h-full bg-background-default m-4 rounded-lg border border-borderSubtle shadow-lg">
+            {currentView && (
+              <>
+                {/* Sidecar Header */}
+                <div className="flex items-center justify-between p-4 border-b border-borderSubtle">
+                  <div className="flex items-center space-x-2">
+                    {currentView.icon}
+                    <span className="text-textStandard font-medium">{currentView.title}</span>
+                  </div>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={hideView}
+                    className="text-textSubtle hover:text-textStandard"
+                  >
+                    <X size={16} />
+                  </Button>
+                </div>
 
-        {/* Expanded Sidecar Panel - Only visible when there's an active view */}
-        {activeView && currentView && (
-          <div className="fixed right-0 top-0 h-full w-[700px] bg-background-default border-l border-borderSubtle transition-transform duration-300">
-            {/* Sidecar Header */}
-            <div className="flex items-center justify-between p-4 border-b border-borderSubtle">
-              <div className="flex items-center space-x-2">
-                {currentView.icon}
-                <span className="text-textStandard font-medium">{currentView.title}</span>
-              </div>
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={hideView}
-                className="text-textSubtle hover:text-textStandard"
-              >
-                <X size={16} />
-              </Button>
-            </div>
-
-            {/* Sidecar Content */}
-            <div className="h-[calc(100%-60px)] overflow-hidden">{currentView.content}</div>
+                {/* Sidecar Content */}
+                <div className="h-[calc(100%-60px)] overflow-hidden">{currentView.content}</div>
+              </>
+            )}
           </div>
-        )}
+        </div>
       </div>
     </SidecarContext.Provider>
   );


### PR DESCRIPTION
This PR cleans up the text diff sidecar UI to match the new look and feel:

https://github.com/user-attachments/assets/7066b666-028e-4a48-8f1f-01037d9e44ad

Currently lacks window width management and sidecar entrance animations. 