### PR TITLE
Don't default to main for build-cli

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -17,7 +17,7 @@ on:
       ref:
         type: string
         required: false
-        default: 'refs/heads/main'
+        default: ""
 
 name: "Reusable workflow to build CLI"
 


### PR DESCRIPTION
Rather than checking out main by default, we should pass an empty string, which actions/checkout interprets as the triggering ref.

Fixes #3466