### PR TITLE
feat: add rmcp as a workspace dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3473,6 +3473,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.12",
+ "rmcp",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -3512,6 +3513,7 @@ dependencies = [
  "once_cell",
  "paste",
  "regex",
+ "rmcp",
  "serde",
  "serde_json",
  "tokio",
@@ -3553,6 +3555,7 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.12",
+ "rmcp",
  "rustyline",
  "serde",
  "serde_json",
@@ -3648,6 +3651,7 @@ dependencies = [
  "once_cell",
  "regex",
  "reqwest 0.11.27",
+ "rmcp",
  "serde",
  "serde_json",
  "serde_with",
@@ -3692,6 +3696,7 @@ dependencies = [
  "mcp-server",
  "once_cell",
  "reqwest 0.12.12",
+ "rmcp",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -7119,6 +7124,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "paste",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.99",
+]
+
+[[package]]
 name = "roaring"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7401,6 +7440,7 @@ version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "schemars_derive",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ description = "An AI agent"
 [workspace.lints.clippy]
 uninlined_format_args = "allow"
 
+[workspace.dependencies]
+rmcp = "0.2.1"
+
 # Patch for Windows cross-compilation issue with crunchy
 [patch.crates-io]
 crunchy = { git = "https://github.com/nmathewson/crunchy", branch = "cross-compilation-fix" }

--- a/crates/goose-bench/Cargo.toml
+++ b/crates/goose-bench/Cargo.toml
@@ -10,13 +10,13 @@ description.workspace = true
 [lints]
 workspace = true
 
-
 [dependencies]
 anyhow = "1.0"
 paste = "1.0"
 ctor = "0.2.7"
 goose = { path = "../goose" }
 mcp-core = { path = "../mcp-core" }
+rmcp = { workspace = true }
 async-trait = "0.1.86"
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1.0"

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -21,6 +21,7 @@ goose-mcp = { path = "../goose-mcp" }
 mcp-client = { path = "../mcp-client" }
 mcp-server = { path = "../mcp-server" }
 mcp-core = { path = "../mcp-core" }
+rmcp = { workspace = true }
 clap = { version = "4.4", features = ["derive"] }
 cliclack = "0.3.5"
 console = "0.15.8"

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -13,6 +13,7 @@ workspace = true
 [dependencies]
 mcp-core = { path = "../mcp-core" }
 mcp-server = { path = "../mcp-server" }
+rmcp = { workspace = true }
 anyhow = "1.0.94"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"

--- a/crates/goose-server/Cargo.toml
+++ b/crates/goose-server/Cargo.toml
@@ -15,6 +15,7 @@ goose = { path = "../goose" }
 mcp-core = { path = "../mcp-core" }
 goose-mcp = { path = "../goose-mcp" }
 mcp-server = { path = "../mcp-server" }
+rmcp = { workspace = true }
 axum = { version = "0.8.1", features = ["ws", "macros"] }
 tokio = { version = "1.43", features = ["full"] }
 chrono = "0.4"

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { version = "0.12.9", features = ["json", "rustls-tls-native-roots"], 
 [dependencies]
 mcp-client = { path = "../mcp-client" }
 mcp-core = { path = "../mcp-core" }
+rmcp = { workspace = true }
 anyhow = "1.0"
 thiserror = "1.0"
 futures = "0.3"


### PR DESCRIPTION
Add baseline access to https://github.com/modelcontextprotocol/rust-sdk for all relevant crates in the workspace