### PR TITLE
Fix working directory when session has no messages

### DIFF
--- a/crates/goose/src/session/storage.rs
+++ b/crates/goose/src/session/storage.rs
@@ -31,6 +31,12 @@ fn get_home_dir() -> PathBuf {
         .to_path_buf()
 }
 
+fn get_current_working_dir() -> PathBuf {
+    std::env::current_dir()
+        .or_else(|_| Ok::<PathBuf, io::Error>(get_home_dir()))
+        .expect("could not determine the current working directory")
+}
+
 /// Metadata for a session, stored as the first line in the session file
 #[derive(Debug, Clone, Serialize, ToSchema)]
 pub struct SessionMetadata {
@@ -86,7 +92,7 @@ impl<'de> Deserialize<'de> for SessionMetadata {
         let working_dir = helper
             .working_dir
             .filter(|path| path.exists())
-            .unwrap_or_else(get_home_dir);
+            .unwrap_or_else(get_current_working_dir);
 
         Ok(SessionMetadata {
             description: helper.description,
@@ -131,7 +137,7 @@ impl SessionMetadata {
 
 impl Default for SessionMetadata {
     fn default() -> Self {
-        Self::new(get_home_dir())
+        Self::new(get_current_working_dir())
     }
 }
 
@@ -1701,6 +1707,7 @@ mod tests {
 
         // Create metadata with non-existent directory
         let invalid_dir = PathBuf::from("/path/that/does/not/exist");
+
         let metadata = SessionMetadata::new(invalid_dir.clone());
 
         // Should fall back to home directory
@@ -1723,7 +1730,7 @@ mod tests {
         // Read back - should fall back to home dir
         let read_metadata = read_metadata(&file_path)?;
         assert_ne!(read_metadata.working_dir, invalid_dir);
-        assert_eq!(read_metadata.working_dir, get_home_dir());
+        assert_eq!(read_metadata.working_dir, get_current_working_dir());
 
         Ok(())
     }


### PR DESCRIPTION
- Fixes https://github.com/block/goose/issues/2790

Previously, when a session had no messages or an invalid working directory, it would default to the home directory. This changes the behavior to use the current working directory instead, which I think is more intuitive and matches user expectations.

**Questions**
- Is there any drawback to use cwd as the default working directory instead of home directory?

**Step to reproduce the problem**:

* Go to any folder
* call goose to create a new session
* Quit goose
* Resume the session
* Observe the warning  WARNING: The original working directory of this session was set to "your home directory"

**With this Fix**
Next time you resume the session created "after applying this fix" will be associated with the correct working directory even if session is empty.