### PR TITLE
Docs: Access settings in new UI

### DIFF
--- a/documentation/docs/guides/goose-permissions.md
+++ b/documentation/docs/guides/goose-permissions.md
@@ -49,9 +49,9 @@ Here's how to configure:
       Click the Goose Mode option from the bottom menu. 
       </TabItem>
       <TabItem value="settings" label="From Settings">
-        1. Click `...` in the upper right corner
-        2. Click `Settings`
-        3. Under `Mode Selection`, choose the mode you'd like
+        1. Click the `Settings` button on the left sidebar.
+        2. Click `Chat`
+        3. Under `Mode`, choose the mode you'd like
       </TabItem>
     </Tabs>   
   </TabItem>

--- a/documentation/docs/guides/goose-permissions.md
+++ b/documentation/docs/guides/goose-permissions.md
@@ -45,8 +45,9 @@ Here's how to configure:
 
     You can change modes before or during a session and it will take effect immediately.
 
-     <Tabs>
+     <Tabs groupId="method">
       <TabItem value="session" label="In Session" default>
+
       Click the Goose Mode option from the bottom menu. 
       </TabItem>
       <TabItem value="settings" label="From Settings">
@@ -59,7 +60,7 @@ Here's how to configure:
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
 
-    <Tabs>
+    <Tabs groupId="method">
       <TabItem value="session" label="In Session" default>
         To change modes mid-session, use the `/mode` command.
 

--- a/documentation/docs/guides/goose-permissions.md
+++ b/documentation/docs/guides/goose-permissions.md
@@ -6,6 +6,7 @@ sidebar_label: Goose Permissions
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { PanelLeft } from 'lucide-react';
 
 Goose’s permissions determine how much autonomy it has when modifying files, using extensions, and performing automated actions. By selecting a permission mode, you have full control over how Goose interacts with your development environment.
 
@@ -49,9 +50,10 @@ Here's how to configure:
       Click the Goose Mode option from the bottom menu. 
       </TabItem>
       <TabItem value="settings" label="From Settings">
-        1. Click the `Settings` button on the left sidebar.
-        2. Click `Chat`
-        3. Under `Mode`, choose the mode you'd like
+        1. Click the <PanelLeft className="inline" size={16} /> button on the top-left to open the sidebar.
+        2. Click the `Settings` button on the sidebar.
+        3. Click `Chat`.
+        4. Under `Mode`, choose the mode you'd like.
       </TabItem>
     </Tabs>   
   </TabItem>

--- a/documentation/docs/guides/managing-tools/adjust-tool-output.md
+++ b/documentation/docs/guides/managing-tools/adjust-tool-output.md
@@ -11,8 +11,8 @@ import TabItem from '@theme/TabItem';
 Response Styles customize how tool interactions are displayed in the Goose Desktop chat window. 
 
 To change this setting:
-1. Click the menu icon in the top right corner.
-2. Select `Advanced Settings` from the menu.
+1. Click the `Settings` button on the left sidebar.
+2. Click `Chat`.
 3. Under `Response Styles`, select either `Detailed` or `Concise`.
 
 - **Concise** (Default)

--- a/documentation/docs/guides/managing-tools/adjust-tool-output.md
+++ b/documentation/docs/guides/managing-tools/adjust-tool-output.md
@@ -5,15 +5,17 @@ sidebar_label: Adjust Tool Output
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { PanelLeft } from 'lucide-react';
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
 Response Styles customize how tool interactions are displayed in the Goose Desktop chat window. 
 
 To change this setting:
-1. Click the `Settings` button on the left sidebar.
-2. Click `Chat`.
-3. Under `Response Styles`, select either `Detailed` or `Concise`.
+1. Click the <PanelLeft className="inline" size={16} /> button on the top-left to open the sidebar.
+2. Click the `Settings` button on the sidebar.
+3. Click `Chat`.
+4. Under `Response Styles`, select either `Detailed` or `Concise`.
 
 - **Concise** (Default)
     - Tool calls are collapsed by default

--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -35,14 +35,16 @@ You can use both global and local hints at the same time. When both exist, Goose
 
      #### Local hints file
 
-    1. Change the directory to where you'd like to set up the file. You can do this by clicking the directory path in the lower left bottom of the screen
-    2. Click `...` in the upper right corner
-    3. Click `Configure .goosehints`
-    4. Enter your local tips into the textarea
-    5. Click `Save`
+    1. Change the directory to where you'd like to set up the file. You can do this by clicking the directory path on the bottom of the Goose window.
+    2. Click the `Configure goosehints` icon on the bottom right of the Goose window.
+    4. Enter your local tips into the text area.
+    5. Click `Save`.
+    6. Restart your session so Goose can read the updated `.goosehints`.
+
+    If a `.goosehints` file already exists in the given directory, you can edit or add to it from this screen.
 
     :::tip
-    You may have to adjust the screen size to fully see the Save and Cancel buttons.
+    You may have to scroll or adjust the screen size to fully see the Save and Cancel buttons.
     :::
 
     </TabItem>

--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -27,7 +27,7 @@ Goose supports two types of hint files:
 You can use both global and local hints at the same time. When both exist, Goose will consider both your global preferences and project-specific requirements. If the instructions in your local hints file conflict with your global preferences, Goose will prioritize the local hints.
 :::
 
-<Tabs>
+<Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
 
     #### Global hints file


### PR DESCRIPTION
Updates the following doc pages with Desktop instructions for the new Goose UI:

* **Using Goosehints**
* **Adjust Tool Output**
* **Goose Permissions**