### PR TITLE
refactor: Renames recipe route to recipes to be consistent

### DIFF
--- a/crates/goose-server/src/routes/recipe.rs
+++ b/crates/goose-server/src/routes/recipe.rs
@@ -131,7 +131,7 @@ async fn decode_recipe(
 
 pub fn routes(state: Arc<AppState>) -> Router {
     Router::new()
-        .route("/recipe/create", post(create_recipe))
+        .route("/recipes/create", post(create_recipe))
         .route("/recipes/encode", post(encode_recipe))
         .route("/recipes/decode", post(decode_recipe))
         .with_state(state)

--- a/ui/desktop/src/recipe/index.ts
+++ b/ui/desktop/src/recipe/index.ts
@@ -49,7 +49,7 @@ export interface CreateRecipeResponse {
 }
 
 export async function createRecipe(request: CreateRecipeRequest): Promise<CreateRecipeResponse> {
-  const url = getApiUrl('/recipe/create');
+  const url = getApiUrl('/recipes/create');
   console.log('Creating recipe at:', url);
   console.log('Request:', JSON.stringify(request, null, 2));
 


### PR DESCRIPTION
More consistent route naming (and one step closer to restful given we will have a lot more crud recipe routes in the future).