### PR TITLE
Fix Google Analytics error for local dev

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -65,10 +65,10 @@ const config: Config = {
             "./src/css/tailwind.css",
           ],
         },
-        gtag: {
+        gtag: process.env.NODE_ENV === 'production' ? {
           trackingID: 'G-ZS5D6SB4ZJ',
           anonymizeIP: true,
-        },
+        } : undefined,
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
This pull request updates the `documentation/docusaurus.config.ts` file to conditionally enable Google Analytics tracking based on the environment. 

* [`documentation/docusaurus.config.ts`](diffhunk://#diff-18363c0e89010c49d5f105f49fdc20200f1de368a3ec607c830d47b4a6b7d06cL68-R71): Modified the `gtag` configuration to enable tracking only in the production environment by checking `process.env.NODE_ENV`. If not in production, it sets `gtag` to `undefined`.