### PR TITLE
Add YouTube video embed to using-goosehints.md

### DIFF
--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -6,11 +6,20 @@ sidebar_label: Using Goosehints
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
-
-<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/kWXJC5p0608" />
 
 `.goosehints` is a text file used to provide additional context about your project and improve the communication with Goose. The use of `goosehints` ensures that Goose understands your requirements better and can execute tasks more effectively.
+
+<details>
+  <summary>Goose Hints Video Walkthrough</summary>
+  <iframe
+  class="aspect-ratio"
+  src="https://www.youtube.com/embed/kWXJC5p0608"
+  title="Goose Hints"
+  frameBorder="0"
+  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+  allowFullScreen
+  ></iframe>
+</details>
 
 :::info Developer extension required
 To make use of the hints file, you need to have the `Developer` extension [enabled](/docs/getting-started/using-extensions).

--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -6,7 +6,9 @@ sidebar_label: Using Goosehints
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/kWXJC5p0608" />
 
 `.goosehints` is a text file used to provide additional context about your project and improve the communication with Goose. The use of `goosehints` ensures that Goose understands your requirements better and can execute tasks more effectively.
 


### PR DESCRIPTION
This PR adds a YouTube video embed to the using-goosehints.md documentation page. The video (https://www.youtube.com/watch?v=kWXJC5p0608) provides additional context about using Goose hints and follows the same pattern as other embedded videos in the documentation.