### PR TITLE
fix: Handle non-default base path for OpenAI compatible model fetching

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -197,7 +197,7 @@ impl Provider for OpenAiProvider {
         let base_url =
             url::Url::parse(&self.host).map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
         let url = base_url
-            .join("v1/models")
+            .join(&self.base_path.replace("v1/chat/completions", "v1/models"))
             .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
         let mut request = self.client.get(url).bearer_auth(&self.api_key);
         if let Some(org) = &self.organization {


### PR DESCRIPTION
when workingon the PR for docs configuring Docker model runner which uses OpenAI compatible API backend, I had some issues when goose configure would error when it wouldn't figure out how to fetch the models. 


This PR fixes an issue when a non-default OPENAI_BASE_PATH is configured. I think it might still fail in some corner cases where API is not on the /v1/chat/completions path, but it's better than hardcoding the v1/models. 