### PR TITLE
feat: migrate ErrorData from internal mcp crates to rmcp version

### DIFF
--- a/crates/mcp-core/src/protocol.rs
+++ b/crates/mcp-core/src/protocol.rs
@@ -1,6 +1,6 @@
 /// The protocol messages exchanged between client and server
 use crate::tool::Tool;
-use rmcp::model::{Content, Prompt, PromptMessage, Resource, ResourceContents};
+use rmcp::model::{Content, ErrorData, Prompt, PromptMessage, Resource, ResourceContents};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -126,21 +126,6 @@ pub const INVALID_REQUEST: i32 = -32600;
 pub const METHOD_NOT_FOUND: i32 = -32601;
 pub const INVALID_PARAMS: i32 = -32602;
 pub const INTERNAL_ERROR: i32 = -32603;
-
-/// Error information for JSON-RPC error responses.
-#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
-pub struct ErrorData {
-    /// The error type that occurred.
-    pub code: i32,
-
-    /// A short description of the error. The message SHOULD be limited to a concise single sentence.
-    pub message: String,
-
-    /// Additional information about the error. The value of this member is defined by the
-    /// sender (e.g. detailed error information, nested errors etc.).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub data: Option<Value>,
-}
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]

--- a/crates/mcp-server/src/errors.rs
+++ b/crates/mcp-server/src/errors.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use thiserror::Error;
 
 pub type BoxError = Box<dyn std::error::Error + Sync + Send>;
@@ -56,38 +58,38 @@ pub enum RouterError {
     PromptNotFound(String),
 }
 
-impl From<RouterError> for mcp_core::protocol::ErrorData {
+impl From<RouterError> for rmcp::model::ErrorData {
     fn from(err: RouterError) -> Self {
-        use mcp_core::protocol::*;
+        use rmcp::model::*;
         match err {
             RouterError::MethodNotFound(msg) => ErrorData {
-                code: METHOD_NOT_FOUND,
-                message: msg,
+                code: ErrorCode::METHOD_NOT_FOUND,
+                message: Cow::from(msg),
                 data: None,
             },
             RouterError::InvalidParams(msg) => ErrorData {
-                code: INVALID_PARAMS,
-                message: msg,
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(msg),
                 data: None,
             },
             RouterError::Internal(msg) => ErrorData {
-                code: INTERNAL_ERROR,
-                message: msg,
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(msg),
                 data: None,
             },
             RouterError::ToolNotFound(msg) => ErrorData {
-                code: INVALID_REQUEST,
-                message: msg,
+                code: ErrorCode::INVALID_REQUEST,
+                message: Cow::from(msg),
                 data: None,
             },
             RouterError::ResourceNotFound(msg) => ErrorData {
-                code: INVALID_REQUEST,
-                message: msg,
+                code: ErrorCode::INVALID_REQUEST,
+                message: Cow::from(msg),
                 data: None,
             },
             RouterError::PromptNotFound(msg) => ErrorData {
-                code: INVALID_REQUEST,
-                message: msg,
+                code: ErrorCode::INVALID_REQUEST,
+                message: Cow::from(msg),
                 data: None,
             },
         }


### PR DESCRIPTION
Remove definition and usage of `ErrorData` from the internal MCP crates and replace with `rmcp`'s version