### PR TITLE
docs: fix installation command for YouTube Transcript MCP in servers.json

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -534,9 +534,9 @@
     "id": "youtube-transcript-mcp",
     "name": "YouTube Transcript",
     "description": "YouTube video transcript extraction",
-    "command": "npx -y youtube-transcript-mcp",
+    "command": "uvx --from git+https://github.com/jkawamoto/mcp-youtube-transcript mcp-youtube-transcript",
     "link": "https://github.com/jkawamoto/mcp-youtube-transcript",
-    "installation_notes": "Install using npx package manager.",
+    "installation_notes": "Install using uv package manager.",
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []


### PR DESCRIPTION
Following up on #3390, servers.json also needs to be updated.

This is also related to https://github.com/jkawamoto/mcp-youtube-transcript/issues/26.
