### PR TITLE
fix: multi-tool calls in streamed openai-compatible responses

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -1129,9 +1129,22 @@ data: [DONE]
         pin!(messages);
 
         while let Some(Ok((message, _usage))) = messages.next().await {
-            println!("Message: {:?}", message);
+            if let Some(msg) = message {
+                if msg.content.len() == 2 {
+                    if let (MessageContent::ToolRequest(req1), MessageContent::ToolRequest(req2)) =
+                        (&msg.content[0], &msg.content[1])
+                    {
+                        if req1.tool_call.is_ok() && req2.tool_call.is_ok() {
+                            // We expect two tool calls in the response
+                            assert_eq!(req1.tool_call.as_ref().unwrap().name, "developer__shell");
+                            assert_eq!(req2.tool_call.as_ref().unwrap().name, "developer__shell");
+                            return Ok(());
+                        }
+                    }
+                }
+            }
         }
 
-        Ok(())
+        panic!("Expected tool call message with two calls, but did not see it");
     }
 }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -1165,6 +1165,7 @@ data: [DONE]
 
         while let Some(Ok((message, _usage))) = messages.next().await {
             if let Some(msg) = message {
+                println!("{:?}", msg);
                 if msg.content.len() == 2 {
                     if let (MessageContent::ToolRequest(req1), MessageContent::ToolRequest(req2)) =
                         (&msg.content[0], &msg.content[1])


### PR DESCRIPTION
Previously this did not properly handle when the provider streams back a reply with >1 tool call.

The stream used here for the test was captured with a simple proxy. We should consider doing more of this, perhaps building out something like the scenario test to capture at the request level to test this provider code.