### PR TITLE
docs: update extensions library

### DIFF
--- a/documentation/docs/mcp/context7-mcp.mdx
+++ b/documentation/docs/mcp/context7-mcp.mdx
@@ -1,7 +1,6 @@
 ---
 title: Context7 Extension
-
-escription: Add Context7 MCP Server as a Goose Extension
+description: Add Context7 MCP Server as a Goose Extension
 ---
 
 import Tabs from '@theme/Tabs';

--- a/documentation/docs/mcp/mongodb-mcp.md
+++ b/documentation/docs/mcp/mongodb-mcp.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
-The MongoDB MCP Server extension allows Goose to interact directly with your MongoDB databases, enabling comprehensive database operations including querying, document manipulation, collection management, and database administration. This makes it easy to work with your MongoDB databases through natural language interactions.
+The [MongoDB MCP Server](https://github.com/mongodb-js/mongodb-mcp-server) extension allows Goose to interact directly with your MongoDB databases, enabling comprehensive database operations including querying, document manipulation, collection management, and database administration. This makes it easy to work with your MongoDB databases through natural language interactions.
 
 :::tip TLDR
 <Tabs groupId="interface">
@@ -201,23 +201,23 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 The MongoDB extension provides comprehensive database management capabilities through natural language interactions. You can perform a wide range of operations including:
 
-### **Query Operations**
+### Query Operations
 - **Find documents** with complex filters and sorting
 - **Aggregate data** using MongoDB's powerful aggregation pipeline
 - **Count documents** in collections with optional filtering
 
-### **Document Management**
+### Document Management
 - **Insert** single or multiple documents
 - **Update** one or many documents with specified criteria
 - **Delete** specific documents or bulk deletions
 
-### **Collection & Database Administration**
+### Collection & Database Administration
 - **Create indexes** to optimize query performance
 - **Rename collections** for better organization
 - **Drop collections** when no longer needed
 - **Drop entire databases** (use with caution!)
 
-### **Schema & Analytics**
+### Schema & Analytics
 - **Analyze collection schemas** to understand document structure
 - **List databases and collections** for exploration
 - **View collection indexes** and their configurations

--- a/documentation/src/components/server-card.tsx
+++ b/documentation/src/components/server-card.tsx
@@ -80,7 +80,7 @@ export function ServerCard({ server }: { server: MCPServer }) {
                     style={{ fontSize: "12px" }}
                     className="text-textSubtle leading-normal"
                   >
-                    Can be enabled in the goose settings page
+                    Can be enabled on the Extensions page in Goose
                   </span>
                   </div>
                 )}

--- a/documentation/src/pages/extensions/detail.tsx
+++ b/documentation/src/pages/extensions/detail.tsx
@@ -99,7 +99,7 @@ const getDocumentationPath = (serverId: string): string => {
                       <div className="flex items-center gap-2">
                         <Info className="h-4 w-4 text-textSubtle shrink-0" />
                         <span className="text-sm text-textSubtle">
-                          Can be enabled in the goose settings page
+                           Can be enabled on the Extensions page in Goose
                         </span>
                       </div>
                     ) : (
@@ -182,7 +182,7 @@ const getDocumentationPath = (serverId: string): string => {
                     {server.is_builtin ? (
                       <div
                         className="built-in-badge"
-                        title="This extension is built into goose and can be enabled in the settings page"
+                        title="This extension is built into Goose and can be enabled on the Extensions page"
                       >
                         Built-in
                       </div>

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -5,7 +5,7 @@
     "description": "Built-in developer tools for file editing and shell command execution",
     "command": "",
     "link": "https://github.com/block/goose/tree/main/crates/goose-mcp/src/developer",
-    "installation_notes": "This is a built-in extension that comes with goose by default. No installation required.",
+    "installation_notes": "This is a built-in extension that comes with Goose by default. No installation required.",
     "is_builtin": true,
     "endorsed": true,
     "environmentVariables": []
@@ -16,7 +16,7 @@
     "description": "Built-in computer controls for webscraping, file caching, and automations",
     "command": "",
     "link": "https://github.com/block/goose/tree/main/crates/goose-mcp/src/computercontroller",
-    "installation_notes": "This is a built-in extension that comes with goose and can be enabled in the Settings page under 'Extensions'.",
+    "installation_notes": "This is a built-in extension that comes with Goose and can be enabled on the Extensions page.",
     "is_builtin": true,
     "endorsed": true,
     "environmentVariables": []
@@ -27,7 +27,7 @@
     "description": "Built-in memory system for persistent context and information storage",
     "command": "",
     "link": "https://github.com/block/goose/tree/main/crates/goose-mcp/src/memory",
-    "installation_notes": "This is a built-in extension that comes with goose and can be enabled in the Settings page under 'Extensions'.",
+    "installation_notes": "This is a built-in extension that comes with Goose and can be enabled on the Extensions page.",
     "is_builtin": true,
     "endorsed": true,
     "environmentVariables": []
@@ -38,7 +38,7 @@
     "description": "Built-in JetBrains IDE integration for development workflows",
     "command": "",
     "link": "https://github.com/block/goose/tree/main/crates/goose-mcp/src/jetbrains",
-    "installation_notes": "This is a built-in extension that comes with goose and can be enabled in the Settings page under 'Extensions'.",
+    "installation_notes": "This is a built-in extension that comes with Goose and can be enabled on the Extensions page.",
     "is_builtin": true,
     "endorsed": true,
     "environmentVariables": []
@@ -414,7 +414,7 @@
     "description": "MongoDB database integration",
     "command": "npx -y mongodb-mcp-server --connection-string mongodb://localhost:27017",
     "link": "https://github.com/mongodb-js/mongodb-mcp-server",
-    "installation_notes": "Install using npx package manager.",
+    "installation_notes": "Install using npx package manager. Update connection-string as needed to match your MongoDB environment.",
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": []
@@ -544,11 +544,11 @@
   {
     "id": "tutorial-mcp",
     "name": "Tutorial",
-    "description": "Tutorial and learning management system",
-    "command": "npx -y tutorial-mcp",
+    "description": "Built-in tutorial and learning management system",
+    "command": "",
     "link": "https://github.com/tutorial/tutorial-mcp",
-    "installation_notes": "Install using npx package manager.",
-    "is_builtin": false,
+    "installation_notes": "This is a built-in extension that comes with Goose and can be enabled on the Extensions page.",
+    "is_builtin": true,
     "endorsed": false,
     "environmentVariables": []
   },

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -314,7 +314,7 @@
     "link": "https://github.com/upstash/context7",
     "installation_notes": "Install using npx package manager.",
     "is_builtin": false,
-    "endorsed": false,
+    "endorsed": true,
     "environmentVariables": []
   },
   {
@@ -416,7 +416,7 @@
     "link": "https://github.com/mongodb-js/mongodb-mcp-server",
     "installation_notes": "Install using npx package manager.",
     "is_builtin": false,
-    "endorsed": false,
+    "endorsed": true,
     "environmentVariables": []
   },
   {

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -307,6 +307,17 @@
     "environmentVariables": []
   },
   {
+    "id": "context7",
+    "name": "Context7",
+    "description": "Use up-to-date code and docs",
+    "command": "npx -y @upstash/context7-mcp",
+    "link": "https://github.com/upstash/context7",
+    "installation_notes": "Install using npx package manager.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
     "id": "elevenlabs-mcp",
     "name": "ElevenLabs",
     "description": "Text-to-speech and voice synthesis",
@@ -392,6 +403,17 @@
     "description": "Chatbot and conversational AI integration",
     "command": "npx -y mbot-mcp",
     "link": "https://github.com/deemkeen/mbotmcp",
+    "installation_notes": "Install using npx package manager.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": []
+  },
+  {
+    "id": "mongodb",
+    "name": "MongoDB",
+    "description": "MongoDB database integration",
+    "command": "npx -y mongodb-mcp-server --connection-string mongodb://localhost:27017",
+    "link": "https://github.com/mongodb-js/mongodb-mcp-server",
     "installation_notes": "Install using npx package manager.",
     "is_builtin": false,
     "endorsed": false,


### PR DESCRIPTION
This PR adds the Context7 MongoDB and Context7 MongoDB extensions to the Extensions library.

Documentation updates:
- `documentation/docs/mcp/context7-mcp.mdx`: Fix typo
- `documentation/docs/mcp/mongodb-mcp.md`: Add link to server repo and remove bold on headers
- `documentation/static/servers.json`: Add context7 and mongodb

Updates after approval:
- `documentation/static/servers.json`: 
   - Changed tutorial to use built-in patterns
   - Updated `installation_notes` for other built-ins to sync with new UI
   - Updated `installation_notes` for mongodb to mention connection-string
- `documentation/src/pages/extensions/detail.tsx` and `documentation/static/servers.json`: Updated built-in strings to sync with new UI

TODO future task: Update jetbrains server info and tutorial as needed per https://github.com/block/goose/pull/2589 