### PR TITLE
Fixing grants path

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -451,7 +451,7 @@ const config: Config = {
     announcementBar: {
       id: 'goose-grants',
       content:
-        '✨ goose grant program now open: <a href="grants">apply now</a>! ✨',
+        '✨ goose grant program now open: <a href="/goose/grants">apply now</a>! ✨',
       backgroundColor: '#20232a',
       textColor: '#fff',
       isCloseable: false,


### PR DESCRIPTION
Path in announcement banner was relative and only sometimes led to the grants program page

This pull request includes a small update to the `announcementBar` configuration in the Docusaurus site settings. The change updates the link for the Goose Grant program to use a more specific path (`/goose/grants`) for improved navigation.