### PR TITLE
fix: auto-compact on context limit error

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1218,11 +1218,29 @@ impl Agent {
                                 messages_to_add.push(final_message_tool_resp);
                             }
                         }
-                        Err(ProviderError::ContextLengthExceeded(_)) => {
-                            yield AgentEvent::Message(Message::assistant().with_context_length_exceeded(
-                                    "The context length of the model has been exceeded. Please start a new session and try again.",
-                                ));
-                            break;
+                        Err(ProviderError::ContextLengthExceeded(error_msg)) => {
+                            info!("Context length exceeded, attempting compaction");
+
+                            match auto_compact::perform_compaction(self, messages.messages()).await {
+                                Ok(compact_result) => {
+                                    messages = compact_result.messages;
+
+                                    yield AgentEvent::Message(
+                                        Message::assistant().with_summarization_requested(
+                                            "Context limit reached. Conversation has been automatically compacted to continue."
+                                        )
+                                    );
+                                    yield AgentEvent::HistoryReplaced(messages.messages().to_vec());
+
+                                    continue;
+                                }
+                                Err(_) => {
+                                    yield AgentEvent::Message(Message::assistant().with_context_length_exceeded(
+                                        format!("Context length exceeded and cannot summarize: {}. Unable to continue.", error_msg)
+                                    ));
+                                    break;
+                                }
+                            }
                         }
                         Err(e) => {
                             error!("Error: {}", e);


### PR DESCRIPTION
## Summary
- When context limit is exceeded, automatically compact the conversation to continue instead of failing.
- Fixes https://github.com/block/goose/issues/1303

## Changes
- Catch `ProviderError::ContextLengthExceeded` in agent reply loop
- Call `auto_compact::perform_compaction` to reduce conversation size without threshold checking
- Refactored compaction logic to separate threshold checking from actual compaction
- Continue conversation if compaction succeeds, fail gracefully with clear error message if not

## Testing
- [X] Builds successfully
- [X] Existing tests pass
- [X] Clippy passes with no warnings
- [X] Code formatted with cargo fmt