### PR TITLE
feat: Replace usage of mcp_core Tools/ToolAnnotations in openapi schema

### DIFF
--- a/crates/goose-server/src/openapi.rs
+++ b/crates/goose-server/src/openapi.rs
@@ -11,9 +11,10 @@ use goose::permission::permission_confirmation::PrincipalType;
 use goose::providers::base::{ConfigKey, ModelInfo, ProviderMetadata};
 use goose::session::info::SessionInfo;
 use goose::session::SessionMetadata;
-use mcp_core::tool::{Tool, ToolAnnotations};
-use rmcp::model::ResourceContents;
-use rmcp::model::{Annotations, Content, EmbeddedResource, ImageContent, Role, TextContent};
+use rmcp::model::{
+    Annotations, Content, EmbeddedResource, ImageContent, ResourceContents, Role, TextContent,
+    Tool, ToolAnnotations,
+};
 use utoipa::{OpenApi, ToSchema};
 
 use rmcp::schemars::schema::{InstanceType, SchemaObject, SingleOrVec};
@@ -284,6 +285,8 @@ derive_utoipa!(Content as ContentSchema);
 derive_utoipa!(EmbeddedResource as EmbeddedResourceSchema);
 derive_utoipa!(ImageContent as ImageContentSchema);
 derive_utoipa!(TextContent as TextContentSchema);
+derive_utoipa!(Tool as ToolSchema);
+derive_utoipa!(ToolAnnotations as ToolAnnotationsSchema);
 derive_utoipa!(Annotations as AnnotationsSchema);
 derive_utoipa!(ResourceContents as ResourceContentsSchema);
 
@@ -361,8 +364,8 @@ derive_utoipa!(ResourceContents as ResourceContentsSchema);
         ExtensionConfig,
         ConfigKey,
         Envs,
-        Tool,
-        ToolAnnotations,
+        ToolSchema,
+        ToolAnnotationsSchema,
         ToolInfo,
         PermissionLevel,
         PrincipalType,

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -2881,11 +2881,9 @@
       },
       "Tool": {
         "type": "object",
-        "description": "A tool that can be used by a model.",
         "required": [
-          "name",
-          "description",
-          "inputSchema"
+          "inputSchema",
+          "name"
         ],
         "properties": {
           "annotations": {
@@ -2893,46 +2891,37 @@
               {
                 "$ref": "#/components/schemas/ToolAnnotations"
               }
-            ],
-            "nullable": true
+            ]
           },
           "description": {
-            "type": "string",
-            "description": "A description of what the tool does"
+            "type": "string"
           },
           "inputSchema": {
-            "description": "A JSON Schema object defining the expected parameters for the tool"
+            "type": "object",
+            "additionalProperties": true
           },
           "name": {
-            "type": "string",
-            "description": "The name of the tool"
+            "type": "string"
           }
         }
       },
       "ToolAnnotations": {
         "type": "object",
-        "description": "Additional properties describing a tool to clients.\n\nNOTE: all properties in ToolAnnotations are **hints**.\nThey are not guaranteed to provide a faithful description of\ntool behavior (including descriptive properties like `title`).\n\nClients should never make tool use decisions based on ToolAnnotations\nreceived from untrusted servers.",
         "properties": {
           "destructiveHint": {
-            "type": "boolean",
-            "description": "If true, the tool may perform destructive updates to its environment.\nIf false, the tool performs only additive updates.\n\n(This property is meaningful only when `read_only_hint == false`)\n\nDefault: true"
+            "type": "boolean"
           },
           "idempotentHint": {
-            "type": "boolean",
-            "description": "If true, calling the tool repeatedly with the same arguments\nwill have no additional effect on its environment.\n\n(This property is meaningful only when `read_only_hint == false`)\n\nDefault: false"
+            "type": "boolean"
           },
           "openWorldHint": {
-            "type": "boolean",
-            "description": "If true, this tool may interact with an \"open world\" of external\nentities. If false, the tool's domain of interaction is closed.\nFor example, the world of a web search tool is open, whereas that\nof a memory tool is not.\n\nDefault: true"
+            "type": "boolean"
           },
           "readOnlyHint": {
-            "type": "boolean",
-            "description": "If true, the tool does not modify its environment.\n\nDefault: false"
+            "type": "boolean"
           },
           "title": {
-            "type": "string",
-            "description": "A human-readable title for the tool.",
-            "nullable": true
+            "type": "string"
           }
         }
       },

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -666,73 +666,21 @@ export type ThinkingContent = {
     thinking: string;
 };
 
-/**
- * A tool that can be used by a model.
- */
 export type Tool = {
-    annotations?: ToolAnnotations | null;
-    /**
-     * A description of what the tool does
-     */
-    description: string;
-    /**
-     * A JSON Schema object defining the expected parameters for the tool
-     */
-    inputSchema: unknown;
-    /**
-     * The name of the tool
-     */
+    annotations?: ToolAnnotations;
+    description?: string;
+    inputSchema: {
+        [key: string]: unknown;
+    };
     name: string;
 };
 
-/**
- * Additional properties describing a tool to clients.
- *
- * NOTE: all properties in ToolAnnotations are **hints**.
- * They are not guaranteed to provide a faithful description of
- * tool behavior (including descriptive properties like `title`).
- *
- * Clients should never make tool use decisions based on ToolAnnotations
- * received from untrusted servers.
- */
 export type ToolAnnotations = {
-    /**
-     * If true, the tool may perform destructive updates to its environment.
-     * If false, the tool performs only additive updates.
-     *
-     * (This property is meaningful only when `read_only_hint == false`)
-     *
-     * Default: true
-     */
     destructiveHint?: boolean;
-    /**
-     * If true, calling the tool repeatedly with the same arguments
-     * will have no additional effect on its environment.
-     *
-     * (This property is meaningful only when `read_only_hint == false`)
-     *
-     * Default: false
-     */
     idempotentHint?: boolean;
-    /**
-     * If true, this tool may interact with an "open world" of external
-     * entities. If false, the tool's domain of interaction is closed.
-     * For example, the world of a web search tool is open, whereas that
-     * of a memory tool is not.
-     *
-     * Default: true
-     */
     openWorldHint?: boolean;
-    /**
-     * If true, the tool does not modify its environment.
-     *
-     * Default: false
-     */
     readOnlyHint?: boolean;
-    /**
-     * A human-readable title for the tool.
-     */
-    title?: string | null;
+    title?: string;
 };
 
 export type ToolConfirmationRequest = {


### PR DESCRIPTION
Small one to replace usages of `Tool/ToolAnnotations` in the generated openapi schema

For https://github.com/block/goose/issues/3578