### PR TITLE
Add GOOSE_MAX_TOKENS as model configurable

### DIFF
--- a/crates/goose/src/macros.rs
+++ b/crates/goose/src/macros.rs
@@ -3,13 +3,9 @@ macro_rules! impl_provider_default {
     ($provider:ty) => {
         impl Default for $provider {
             fn default() -> Self {
-                let model = $crate::model::ModelConfig::new(
+                let model = $crate::model::ModelConfig::new_or_fail(
                     &<$provider as $crate::providers::base::Provider>::metadata().default_model,
-                )
-                .expect(concat!(
-                    "Failed to create model config for ",
-                    stringify!($provider)
-                ));
+                );
 
                 <$provider>::from_env(model)
                     .expect(concat!("Failed to initialize ", stringify!($provider)))

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -114,7 +114,7 @@ impl ModelConfig {
         custom_env_var: Option<&str>,
     ) -> Result<Option<usize>, ConfigError> {
         let config = crate::config::Config::global();
-        
+
         // Try custom env var first
         if let Some(env_var) = custom_env_var {
             match config.get_param::<String>(env_var) {
@@ -169,7 +169,7 @@ impl ModelConfig {
                 }
             }
         }
-        
+
         // Try default GOOSE_CONTEXT_LIMIT
         match config.get_param::<String>("GOOSE_CONTEXT_LIMIT") {
             Ok(val) => {
@@ -215,21 +215,17 @@ impl ModelConfig {
                     }
                 }
             }
-            Err(e) => {
-                Err(ConfigError::InvalidValue(
-                    "GOOSE_CONTEXT_LIMIT".to_string(),
-                    "unknown".to_string(),
-                    format!("config error: {}", e),
-                ))
-            }
+            Err(e) => Err(ConfigError::InvalidValue(
+                "GOOSE_CONTEXT_LIMIT".to_string(),
+                "unknown".to_string(),
+                format!("config error: {}", e),
+            )),
         }
     }
 
-
-
     fn parse_temperature() -> Result<Option<f32>, ConfigError> {
         let config = crate::config::Config::global();
-        
+
         // Try to get as string first to capture the original value for error reporting
         match config.get_param::<String>("GOOSE_TEMPERATURE") {
             Ok(val) => {
@@ -288,7 +284,7 @@ impl ModelConfig {
 
     fn parse_max_tokens() -> Result<Option<i32>, ConfigError> {
         let config = crate::config::Config::global();
-        
+
         // First try to get as string to capture the original value
         match config.get_param::<String>("GOOSE_MAX_TOKENS") {
             Ok(val) => {
@@ -347,20 +343,18 @@ impl ModelConfig {
 
     fn parse_toolshim() -> Result<bool, ConfigError> {
         let config = crate::config::Config::global();
-        
+
         // First try to get as string for validation
         match config.get_param::<String>("GOOSE_TOOLSHIM") {
-            Ok(val) => {
-                match val.to_lowercase().as_str() {
-                    "1" | "true" | "yes" | "on" => Ok(true),
-                    "0" | "false" | "no" | "off" => Ok(false),
-                    _ => Err(ConfigError::InvalidValue(
-                        "GOOSE_TOOLSHIM".to_string(),
-                        val,
-                        "must be one of: 1, true, yes, on, 0, false, no, off".to_string(),
-                    )),
-                }
-            }
+            Ok(val) => match val.to_lowercase().as_str() {
+                "1" | "true" | "yes" | "on" => Ok(true),
+                "0" | "false" | "no" | "off" => Ok(false),
+                _ => Err(ConfigError::InvalidValue(
+                    "GOOSE_TOOLSHIM".to_string(),
+                    val,
+                    "must be one of: 1, true, yes, on, 0, false, no, off".to_string(),
+                )),
+            },
             Err(crate::config::ConfigError::NotFound(_)) => {
                 // Not found is OK, means it's not set
                 Ok(false)
@@ -393,7 +387,7 @@ impl ModelConfig {
 
     fn parse_toolshim_model() -> Result<Option<String>, ConfigError> {
         let config = crate::config::Config::global();
-        
+
         match config.get_param::<String>("GOOSE_TOOLSHIM_OLLAMA_MODEL") {
             Ok(val) if val.trim().is_empty() => Err(ConfigError::InvalidValue(
                 "GOOSE_TOOLSHIM_OLLAMA_MODEL".to_string(),
@@ -454,20 +448,23 @@ impl ModelConfig {
     }
 
     pub fn new_or_fail(model_name: &str) -> ModelConfig {
-        ModelConfig::new(model_name)
-            .unwrap_or_else(|err| {
-                // For tests and backwards compatibility, try creating a basic config
-                // if validation fails, but log the error
-                tracing::warn!("Failed to create validated model config for {}: {}. Creating basic config.", model_name, err);
-                ModelConfig {
-                    model_name: model_name.to_string(),
-                    context_limit: Self::get_model_specific_limit(model_name),
-                    temperature: None,
-                    max_tokens: None,
-                    toolshim: false,
-                    toolshim_model: None,
-                }
-            })
+        ModelConfig::new(model_name).unwrap_or_else(|err| {
+            // For tests and backwards compatibility, try creating a basic config
+            // if validation fails, but log the error
+            tracing::warn!(
+                "Failed to create validated model config for {}: {}. Creating basic config.",
+                model_name,
+                err
+            );
+            ModelConfig {
+                model_name: model_name.to_string(),
+                context_limit: Self::get_model_specific_limit(model_name),
+                temperature: None,
+                max_tokens: None,
+                toolshim: false,
+                toolshim_model: None,
+            }
+        })
     }
 }
 
@@ -593,7 +590,7 @@ mod tests {
                 ConfigError::InvalidRange(var, msg) => {
                     assert_eq!(var, "GOOSE_MAX_TOKENS");
                     assert!(msg.contains("greater than 0"));
-                },
+                }
                 other => {
                     panic!("Expected InvalidRange error, got: {:?}", other);
                 }
@@ -607,7 +604,7 @@ mod tests {
                 ConfigError::InvalidRange(var, msg) => {
                     assert_eq!(var, "GOOSE_MAX_TOKENS");
                     assert!(msg.contains("greater than 0"));
-                },
+                }
                 other => {
                     panic!("Expected InvalidRange error, got: {:?}", other);
                 }

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -85,6 +85,10 @@ impl ModelConfig {
         Self::new_with_context_env(model_name.to_string(), None)
     }
 
+    /// Create a new ModelConfig with the specified model name and custom context limit env var
+    ///
+    /// This is useful for specific model purposes like lead, worker, planner models
+    /// that may have their own context limit environment variables.
     pub fn new_with_context_env(
         model_name: String,
         context_env_var: Option<&str>,


### PR DESCRIPTION
From what I could tell ModelConfig accepts a max_tokens argument but there wasn't any global way to configure it. 

Setting `GOOSE_MAX_TOKENS` in `config.yaml` or as an env variable to 24000 yields model config like this:

```
{"timestamp":"2025-07-25T17:16:08.000742Z","level":"DEBUG","fields":{"model_config":"{\n  \"model_name\": \"claude-4-sonnet\",\n  \"context_limit\": 200000,\n  \"temperature\": null,\n  \"max_tokens\": 24000,\n  \"toolshim\": false,\n  \"toolshim_model\": null\n}","input":"{\n  \"max_tokens\": 24000,\n  \"messages\": [\n    {\n      \"content\":
```

Leaving it unset yields this as it does today:
```
,"fields":{"model_config":"{\n  \"model_name\": \"claude-4-sonnet\",\n  \"context_limit\": 200000,\n  \"temperature\": null,\n  \"max_tokens\": null,\n  \"toolshim\": false,\n  \"toolshim_model\": null\n}","input":"{\n  \"messages\": [\n    {\n      \"content\": \
```
This should help some providers w/ server-side low default max_tokens on requests (like Databricks) have better perf when used w/ Goose and provide more control in general 