### PR TITLE
Remove confusing status output when testing sharing url connection and it shows 404

### DIFF
--- a/ui/desktop/src/components/settings/sessions/SessionSharingSection.tsx
+++ b/ui/desktop/src/components/settings/sessions/SessionSharingSection.tsx
@@ -118,7 +118,7 @@ export default function SessionSharingSection() {
       if (response.status < 500) {
         setTestResult({
           status: 'success',
-          message: `Connection successful! Server responded with status ${response.status}.`,
+          message: 'Connection successful!',
         });
       } else {
         setTestResult({


### PR DESCRIPTION
It was confusing to report connection successful but show a 404 status in the ui.

No need to output the response status here, we only want to check if the server is responding with a non 500 for sharing purposes.