### PR TITLE
fix: pricing estimation for OpenRouter in goose-cli

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -3,6 +3,7 @@ use console::{style, Color};
 use goose::config::Config;
 use goose::message::{Message, MessageContent, ToolRequest, ToolResponse};
 use goose::providers::pricing::get_model_pricing;
+use goose::providers::pricing::parse_model_id;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use mcp_core::tool::ToolCall;
 use regex::Regex;
@@ -732,9 +733,21 @@ async fn estimate_cost_usd(
     input_tokens: usize,
     output_tokens: usize,
 ) -> Option<f64> {
+    // For OpenRouter, parse the model name to extract real provider/model
+    let openrouter_data = if provider == "openrouter" {
+        parse_model_id(model)
+    } else {
+        None
+    };
+
+    let (provider_to_use, model_to_use) = match &openrouter_data {
+        Some((real_provider, real_model)) => (real_provider.as_str(), real_model.as_str()),
+        None => (provider, model),
+    };
+
     // Use the pricing module's get_model_pricing which handles model name mapping internally
-    let cleaned_model = normalize_model_name(model);
-    let pricing_info = get_model_pricing(provider, &cleaned_model).await;
+    let cleaned_model = normalize_model_name(model_to_use);
+    let pricing_info = get_model_pricing(provider_to_use, &cleaned_model).await;
 
     match pricing_info {
         Some(pricing) => {


### PR DESCRIPTION
This PR fixes cost estimation for OpenRouter. OpenRouter model are of the format "provider/model", which need to be parsed to get the actual provider and model, how goose-server does it.