### PR TITLE
chore: adding in some new models token limits

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -28,11 +28,10 @@ static MODEL_SPECIFIC_LIMITS: Lazy<HashMap<&'static str, usize>> = Lazy::new(|| 
     map.insert("llama3.3", 128_000);
 
     // x.ai Grok models, https://docs.x.ai/docs/overview
-    map.insert("grok", 131_072);
+    map.insert("grok-3", 131_072);
+    map.insert("grok-4", 256_000); // 256K
 
-    // Additional OpenRouter models
-    map.insert("qwen/qwen3-coder", 262_144); // 262K
-    map.insert("x-ai/grok-4", 256_000); // 256K
+    map.insert("qwen3-coder", 262_144); // 262K
 
     map
 });

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -29,6 +29,11 @@ static MODEL_SPECIFIC_LIMITS: Lazy<HashMap<&'static str, usize>> = Lazy::new(|| 
 
     // x.ai Grok models, https://docs.x.ai/docs/overview
     map.insert("grok", 131_072);
+
+    // Additional OpenRouter models
+    map.insert("qwen/qwen3-coder", 262_144); // 262K
+    map.insert("x-ai/grok-4", 256_000); // 256K
+
     map
 });
 


### PR DESCRIPTION
I did have a look at making openrouter load models context sizes (as it does return them in a list) but wasn't reliably able to get the correct size, so this just adds some new popular models with the correct context size