### PR TITLE
skip app-related CI jobs for doc/blog PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ on:
 name: CI
 
 jobs:
-  # Detect what files have changed to conditionally run jobs
   changes:
     runs-on: ubuntu-latest
     outputs:
@@ -37,7 +36,6 @@ jobs:
     name: Check Rust Code Format
     runs-on: ubuntu-latest
     needs: changes
-    # Skip Rust formatting for documentation-only changes
     if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout Code
@@ -50,7 +48,6 @@ jobs:
     name: Build and Test Rust Project
     runs-on: goose
     needs: changes
-    # Skip expensive Rust build and test for documentation-only changes
     if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       # Add disk space cleanup before linting
@@ -171,7 +168,6 @@ jobs:
     name: Lint Electron Desktop App
     runs-on: macos-latest
     needs: changes
-    # Skip desktop linting for documentation-only changes since it only checks TypeScript/React code
     if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout Code
@@ -190,7 +186,6 @@ jobs:
   bundle-desktop-unsigned:
     uses: ./.github/workflows/bundle-desktop.yml
     needs: changes
-    # Skip desktop bundle for documentation-only changes to save resources
     if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
     with:
       signing: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,9 +5,13 @@ on:
   pull_request:
     branches:
       - main
+    paths-ignore:
+      - "documentation/**"
   merge_group:
     branches:
       - main
+    paths-ignore:
+      - "documentation/**"
   workflow_dispatch:
 
 name: CI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
       
       - name: Check for file changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # pin@v3
         id: filter
         with:
           filters: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,21 +5,40 @@ on:
   pull_request:
     branches:
       - main
-    paths-ignore:
-      - "documentation/**"
   merge_group:
     branches:
       - main
-    paths-ignore:
-      - "documentation/**"
   workflow_dispatch:
 
 name: CI
 
 jobs:
+  # Detect what files have changed to conditionally run jobs
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      docs-only: ${{ steps.filter.outputs.docs-only }}
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      
+      - name: Check for file changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            docs-only:
+              - 'documentation/**'
+            code:
+              - '!documentation/**'
+
   rust-format:
     name: Check Rust Code Format
     runs-on: ubuntu-latest
+    needs: changes
+    # Skip Rust formatting for documentation-only changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
@@ -30,6 +49,9 @@ jobs:
   rust-build-and-test:
     name: Build and Test Rust Project
     runs-on: goose
+    needs: changes
+    # Skip expensive Rust build and test for documentation-only changes
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       # Add disk space cleanup before linting
       - name: Check disk space before build
@@ -148,6 +170,9 @@ jobs:
   desktop-lint:
     name: Lint Electron Desktop App
     runs-on: macos-latest
+    needs: changes
+    # Skip desktop linting for documentation-only changes since it only checks TypeScript/React code
+    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout Code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
@@ -164,6 +189,8 @@ jobs:
   # Faster Desktop App build for PRs only
   bundle-desktop-unsigned:
     uses: ./.github/workflows/bundle-desktop.yml
-    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    needs: changes
+    # Skip desktop bundle for documentation-only changes to save resources
+    if: (github.event_name == 'pull_request' || github.event_name == 'merge_group') && (needs.changes.outputs.code == 'true' || github.event_name != 'pull_request')
     with:
       signing: false


### PR DESCRIPTION
This pull request updates the CI workflow configuration to optimize when the workflow is triggered. The most important change is the addition of `paths-ignore` rules to exclude documentation-only changes from triggering the CI workflow.

### Workflow optimization:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR8-R14): Added `paths-ignore` rules under both `pull_request` and `merge_group` triggers to prevent the CI workflow from running for changes made exclusively in the `documentation/**` directory.