### PR TITLE
Fix tool vector tests

### DIFF
--- a/crates/goose/src/recipe/mod.rs
+++ b/crates/goose/src/recipe/mod.rs
@@ -432,7 +432,6 @@ impl RecipeBuilder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
 
     #[test]
     fn test_from_content_with_json() {


### PR DESCRIPTION
we were creating dbs but not with unique names and weren't cleaning them up always either which presumably led to test failures when we had an instance that had this already around? this introduces a method to create a new unique db and returns also a clean up task