### PR TITLE
fix: Disabled route strategy for recipe in goose cli

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -342,6 +342,7 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> Session {
     // Extensions need to be added after the session is created because we change directory when resuming a session
     // If we get extensions_override, only run those extensions and none other
     let extensions_to_run: Vec<_> = if let Some(extensions) = session_config.extensions_override {
+        agent.disable_router_for_recipe().await;
         extensions.into_iter().collect()
     } else {
         ExtensionConfigManager::get_all()

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -48,7 +48,6 @@ impl Agent {
         };
 
         // Get tools from extension manager
-        // Check if router is disabled for recipe execution first
         let mut tools = if *self.router_disabled_override.lock().await {
             // If router is disabled, use regular tools
             self.list_tools(None).await


### PR DESCRIPTION
**Why**
This PR addresses the issue https://github.com/block/goose/issues/3730

**What**
- The fix in this PR only fixes the CLI
- Currently introduces `router_disabled_override` on agent.rs.   However, I will create followup PRs to refactor agent and simplify the logics