### PR TITLE
Remove unused Memory Mode / Computer-Controller Mode code

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -30,7 +30,6 @@ import log from './utils/logger';
 import { ensureWinShims } from './utils/winShims';
 import { addRecentDir, loadRecentDirs } from './utils/recentDirs';
 import {
-  createEnvironmentMenu,
   EnvToggles,
   loadSettings,
   saveSettings,
@@ -1820,25 +1819,6 @@ app.whenReady().then(async () => {
       new MenuItem({
         label: 'Find',
         submenu: findSubmenu,
-      })
-    );
-  }
-
-  // Add Environment menu items to View menu
-  const viewMenu = menu?.items.find((item) => item.label === 'View');
-  if (viewMenu?.submenu) {
-    viewMenu.submenu.append(new MenuItem({ type: 'separator' }));
-    viewMenu.submenu.append(
-      new MenuItem({
-        label: 'Environment',
-        submenu: Menu.buildFromTemplate(
-          createEnvironmentMenu(envToggles, (newToggles) => {
-            envToggles = newToggles;
-            const currentSettings = loadSettings();
-            saveSettings({ ...currentSettings, envToggles: newToggles });
-            updateEnvironmentVariables(newToggles);
-          })
-        ),
       })
     );
   }

--- a/ui/desktop/src/utils/settings.ts
+++ b/ui/desktop/src/utils/settings.ts
@@ -1,4 +1,4 @@
-import { app, MenuItem } from 'electron';
+import { app } from 'electron';
 import fs from 'fs';
 import path from 'path';
 
@@ -77,37 +77,4 @@ export function updateSchedulingEngineEnvironment(schedulingEngine: SchedulingEn
   } else {
     process.env.GOOSE_SCHEDULER_TYPE = 'legacy';
   }
-}
-
-// Menu management
-export function createEnvironmentMenu(
-  envToggles: EnvToggles,
-  onToggle: (newToggles: EnvToggles) => void
-) {
-  return [
-    {
-      label: 'Enable Memory Mode',
-      type: 'checkbox' as const,
-      checked: envToggles.GOOSE_SERVER__MEMORY,
-      click: (menuItem: MenuItem) => {
-        const newToggles = {
-          ...envToggles,
-          GOOSE_SERVER__MEMORY: menuItem.checked,
-        };
-        onToggle(newToggles);
-      },
-    },
-    {
-      label: 'Enable Computer Controller Mode',
-      type: 'checkbox' as const,
-      checked: envToggles.GOOSE_SERVER__COMPUTER_CONTROLLER,
-      click: (menuItem: MenuItem) => {
-        const newToggles = {
-          ...envToggles,
-          GOOSE_SERVER__COMPUTER_CONTROLLER: menuItem.checked,
-        };
-        onToggle(newToggles);
-      },
-    },
-  ];
 }


### PR DESCRIPTION
Memory Mode / Computer-Controller Mode was unused in the UI and superseded by mcp's that do the same thing.

The settings essentially act as feature flags that control which specialized toolsets are available to the AI agent, allowing users to enable memory persistence and/or computer automation capabilities as needed.