### PR TITLE
fix: cli tool logging

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1113,12 +1113,10 @@ impl Session {
                                             }
                                         }
                                     }
-                                    else {
-                                        if output::is_showing_thinking() {
-                                            output::set_thinking_message(&formatted_message);
-                                        } else {
-                                            progress_bars.log(&formatted_message);
-                                        }
+                                    else if output::is_showing_thinking() {
+                                        output::set_thinking_message(&formatted_message);
+                                    } else {
+                                        progress_bars.log(&formatted_message);
                                     }
                                 },
                                 ServerNotification::ProgressNotification(notification) => {

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1039,8 +1039,7 @@ impl Session {
                                             if let Some(Value::String(msg)) = o.get("message") {
                                                 // Extract subagent info for better display
                                                 let subagent_id = o.get("subagent_id")
-                                                    .and_then(|v| v.as_str())
-                                                    .unwrap_or("unknown");
+                                                    .and_then(|v| v.as_str());
                                                 let notification_type = o.get("type")
                                                     .and_then(|v| v.as_str())
                                                     .unwrap_or("");
@@ -1079,7 +1078,7 @@ impl Session {
                                                         msg.to_string()
                                                     }
                                                 };
-                                                (formatted, Some(subagent_id.to_string()), Some(notification_type.to_string()))
+                                                (formatted, subagent_id.map(|s|s.to_string()), Some(notification_type.to_string()))
                                             } else if let Some(Value::String(output)) = o.get("output") {
                                                 // Fallback for other MCP notification types
                                                 (output.to_owned(), None, None)

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1114,10 +1114,8 @@ impl Session {
                                         }
                                     }
                                     else {
-                                        // Non-subagent notification, display immediately with compact spacing
-                                        if interactive {
-                                            let _ = progress_bars.hide();
-                                            println!("{}", console::style(&formatted_message).green().dim());
+                                        if output::is_showing_thinking() {
+                                            output::set_thinking_message(&formatted_message);
                                         } else {
                                             progress_bars.log(&formatted_message);
                                         }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1041,20 +1041,19 @@ impl Session {
                                                 let subagent_id = o.get("subagent_id")
                                                     .and_then(|v| v.as_str());
                                                 let notification_type = o.get("type")
-                                                    .and_then(|v| v.as_str())
-                                                    .unwrap_or("");
+                                                    .and_then(|v| v.as_str());
 
                                                 let formatted = match notification_type {
-                                                    "subagent_created" | "completed" | "terminated" => {
+                                                    Some("subagent_created") | Some("completed") | Some("terminated") => {
                                                         format!("🤖 {}", msg)
                                                     }
-                                                    "tool_usage" | "tool_completed" | "tool_error" => {
+                                                    Some("tool_usage") | Some("tool_completed") | Some("tool_error") => {
                                                         format!("🔧 {}", msg)
                                                     }
-                                                    "message_processing" | "turn_progress" => {
+                                                    Some("message_processing") | Some("turn_progress") => {
                                                         format!("💭 {}", msg)
                                                     }
-                                                    "response_generated" => {
+                                                    Some("response_generated") => {
                                                         // Check verbosity setting for subagent response content
                                                         let config = Config::global();
                                                         let min_priority = config
@@ -1078,7 +1077,7 @@ impl Session {
                                                         msg.to_string()
                                                     }
                                                 };
-                                                (formatted, subagent_id.map(|s|s.to_string()), Some(notification_type.to_string()))
+                                                (formatted, subagent_id.map(str::to_string), notification_type.map(str::to_string))
                                             } else if let Some(Value::String(output)) = o.get("output") {
                                                 // Fallback for other MCP notification types
                                                 (output.to_owned(), None, None)

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -115,6 +115,10 @@ impl ThinkingIndicator {
             spinner.stop("");
         }
     }
+
+    pub fn is_shown(&self) -> bool {
+        self.spinner.is_some()
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -138,7 +142,10 @@ pub fn hide_thinking() {
     THINKING.with(|t| t.borrow_mut().hide());
 }
 
-#[allow(dead_code)]
+pub fn is_showing_thinking() -> bool {
+    THINKING.with(|t| t.borrow().is_shown())
+}
+
 pub fn set_thinking_message(s: &String) {
     THINKING.with(|t| {
         if let Some(spinner) = t.borrow_mut().spinner.as_mut() {


### PR DESCRIPTION
There is a check here to write the output differently if it's a sub-agent, but with .unwrap_or(), we'd always hit that path