### PR TITLE
fix: don't return full shell output when very large

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -3258,52 +3258,6 @@ mod tests {
     }
 
     #[test]
-    fn test_process_shell_output_long() {
-        let dir = TempDir::new().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        let router = DeveloperRouter::new();
-
-        // Test with long output (> 100 lines)
-        let lines: Vec<String> = (1..=150).map(|i| format!("Line {}", i)).collect();
-        let long_output = lines.join("\n");
-
-        let result = router.process_shell_output(&long_output).unwrap();
-        let (assistant_output, user_output) = result;
-
-        // Assistant output should contain the full message with temp file info
-        assert!(assistant_output.contains("private note: output was"));
-        assert!(assistant_output.contains("Line 51"));
-        assert!(assistant_output.contains("Line 150"));
-        assert!(!assistant_output.contains("Line 50"));
-
-        // User output should only have the prefix and last 100 lines
-        assert!(user_output.starts_with("..."));
-        assert!(user_output.contains("Line 51"));
-        assert!(user_output.contains("Line 150"));
-        assert!(!user_output.contains("Line 50"));
-        assert!(!user_output.contains("private note: output was"));
-    }
-
-    #[test]
-    fn test_process_shell_output_exactly_100_lines() {
-        let dir = TempDir::new().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        let router = DeveloperRouter::new();
-
-        // Test with exactly 100 lines
-        let lines: Vec<String> = (1..=100).map(|i| format!("Line {}", i)).collect();
-        let output = lines.join("\n");
-
-        let result = router.process_shell_output(&output).unwrap();
-
-        // Both outputs should be the same for exactly 100 lines
-        assert_eq!(result.0, output);
-        assert_eq!(result.1, output);
-    }
-
-    #[test]
     fn test_process_shell_output_empty() {
         let dir = TempDir::new().unwrap();
         std::env::set_current_dir(dir.path()).unwrap();

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -3318,22 +3318,4 @@ mod tests {
         assert_eq!(result.0, "");
         assert_eq!(result.1, "");
     }
-
-    #[test]
-    fn test_process_shell_output_handles_temp_file_errors() {
-        // This test is harder to implement without mocking, but the function
-        // should handle temp file creation errors gracefully
-
-        let dir = TempDir::new().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        let router = DeveloperRouter::new();
-
-        // Normal usage should work without errors
-        let lines: Vec<String> = (1..=150).map(|i| format!("Line {}", i)).collect();
-        let output = lines.join("\n");
-
-        let result = router.process_shell_output(&output);
-        assert!(result.is_ok());
-    }
 }

--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -3289,8 +3289,6 @@ mod tests {
         assert!(user_content.text.contains("Line 150"));
         assert!(!user_content.text.contains("Line 50"));
 
-        println!("assistant output: {}", assistant_content.text);
-
         let start_tag = "remainder of lines in";
         let end_tag = "do not show tmp file to user";
 

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -243,8 +243,8 @@ impl ModelConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use temp_env::with_var;
     use serial_test::serial;
+    use temp_env::with_var;
 
     #[test]
     #[serial]

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -244,8 +244,10 @@ impl ModelConfig {
 mod tests {
     use super::*;
     use temp_env::with_var;
+    use serial_test::serial;
 
     #[test]
+    #[serial]
     fn test_model_config_context_limits() {
         let config = ModelConfig::new("claude-3-opus")
             .unwrap()
@@ -263,6 +265,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_invalid_context_limit() {
         with_var("GOOSE_CONTEXT_LIMIT", Some("abc"), || {
             let result = ModelConfig::new("test-model");
@@ -285,6 +288,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_invalid_temperature() {
         with_var("GOOSE_TEMPERATURE", Some("hot"), || {
             let result = ModelConfig::new("test-model");
@@ -298,6 +302,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_invalid_toolshim() {
         with_var("GOOSE_TOOLSHIM", Some("maybe"), || {
             let result = ModelConfig::new("test-model");
@@ -311,6 +316,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_empty_toolshim_model() {
         with_var("GOOSE_TOOLSHIM_OLLAMA_MODEL", Some(""), || {
             let result = ModelConfig::new("test-model");
@@ -328,6 +334,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_valid_configurations() {
         // Test with environment variables set
         with_var("GOOSE_CONTEXT_LIMIT", Some("50000"), || {

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -1862,7 +1862,6 @@
         "description": "A message to or from an LLM",
         "required": [
           "role",
-          "created",
           "content"
         ],
         "properties": {

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -280,7 +280,7 @@ export type ListSchedulesResponse = {
  */
 export type Message = {
     content: Array<MessageContent>;
-    created: number;
+    created?: number;
     id?: string | null;
     role: Role;
 };

--- a/ui/desktop/src/components/context_management/index.ts
+++ b/ui/desktop/src/components/context_management/index.ts
@@ -60,7 +60,7 @@ export function convertApiMessageToFrontendMessage(
     sendToLLM: sendToLLM ?? true,
     id: generateId(),
     role: apiMessage.role as Role,
-    created: apiMessage.created,
+    created: apiMessage.created ?? 0,
     content: apiMessage.content
       .map((apiContent) => mapApiContentToFrontendMessageContent(apiContent))
       .filter((content): content is FrontendMessageContent => content !== null),


### PR DESCRIPTION
The shell (bash) command can result in a lot of pointless context filling, if is running a compile, or log tailing and so on. 

In reality only some of it is relevant, in this case it will limit it to around 100 lines (a few percentage points of context) and allow it to then search for more content when needed. 

For example, you can tell it to run a command like: 

```can you run find /System/Library -type f | head -n 2000```

(that was just an example I could consistently use) 

by default - this eats half the context window in one fell swoop: 
<img width="415" height="50" alt="image" src="https://github.com/user-attachments/assets/6ff41c07-2a41-4ae4-8e24-29fa33946dd0" />

with this change: 

<img width="379" height="48" alt="image" src="https://github.com/user-attachments/assets/7eb55dc0-6366-446c-b811-c6847fb17890" />

that is a contrived example but it isn't uncommon to hit this. 
