### PR TITLE
fix: View extensions link

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -433,7 +433,7 @@ export default function ChatInput({
         message: `Too many tools can degrade performance.\nTool count: ${toolCount} (recommend: ${TOOLS_MAX_SUGGESTED})`,
         action: {
           text: 'View extensions',
-          onClick: () => setView('settings'),
+          onClick: () => setView('extensions'),
         },
         autoShow: false, // Don't auto-show tool count warnings
       });


### PR DESCRIPTION
<img width="393" height="118" alt="image" src="https://github.com/user-attachments/assets/01c0b609-8762-458f-bd79-41b40946e4cd" />

This `View extensions` link was routing to Settings where Extensions used to live. Now Extensions is its own page, so link needed to be updated.