### PR TITLE
Handle missing keys with a default

### DIFF
--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -333,8 +333,8 @@
               }
             }
           },
-          "404": {
-            "description": "Configuration key not found"
+          "500": {
+            "description": "Unable to get the configuration value"
           }
         }
       }

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -1007,9 +1007,9 @@ export type ReadConfigData = {
 
 export type ReadConfigErrors = {
     /**
-     * Configuration key not found
+     * Unable to get the configuration value
      */
-    404: unknown;
+    500: unknown;
 };
 
 export type ReadConfigResponses = {


### PR DESCRIPTION
we were returning a 404 for missing keys in the server which is the not found code, so not unreasonable. except that the client expects null for not found, so made it so. now no more 404s showing up in the developer console.

fixes #3679 
fixes #3551
