### PR TITLE
Fix leaky env variable causing flaky test

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -247,19 +247,28 @@ mod tests {
 
     #[test]
     fn test_model_config_context_limits() {
-        let config = ModelConfig::new("claude-3-opus")
-            .unwrap()
-            .with_context_limit(Some(150_000));
-        assert_eq!(config.context_limit(), 150_000);
+        // Clear all GOOSE environment variables to ensure clean test environment
+        with_var("GOOSE_TEMPERATURE", None::<&str>, || {
+            with_var("GOOSE_CONTEXT_LIMIT", None::<&str>, || {
+                with_var("GOOSE_TOOLSHIM", None::<&str>, || {
+                    with_var("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>, || {
+                        let config = ModelConfig::new("claude-3-opus")
+                            .unwrap()
+                            .with_context_limit(Some(150_000));
+                        assert_eq!(config.context_limit(), 150_000);
 
-        let config = ModelConfig::new("claude-3-opus").unwrap();
-        assert_eq!(config.context_limit(), 200_000);
+                        let config = ModelConfig::new("claude-3-opus").unwrap();
+                        assert_eq!(config.context_limit(), 200_000);
 
-        let config = ModelConfig::new("gpt-4-turbo").unwrap();
-        assert_eq!(config.context_limit(), 128_000);
+                        let config = ModelConfig::new("gpt-4-turbo").unwrap();
+                        assert_eq!(config.context_limit(), 128_000);
 
-        let config = ModelConfig::new("unknown-model").unwrap();
-        assert_eq!(config.context_limit(), DEFAULT_CONTEXT_LIMIT);
+                        let config = ModelConfig::new("unknown-model").unwrap();
+                        assert_eq!(config.context_limit(), DEFAULT_CONTEXT_LIMIT);
+                    });
+                });
+            });
+        });
     }
 
     #[test]

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -518,7 +518,6 @@ impl Provider for ClaudeCodeProvider {
 mod tests {
     use super::ModelConfig;
     use super::*;
-    use temp_env::with_var;
 
     #[test]
     fn test_claude_code_model_config() {


### PR DESCRIPTION
I'm not sure what's actually causing this to leak, but this seems to get rid of the flakiness from having the value:

GOOSE_TEMPERATURE="hot" set from a different test.

Also removed an unused symbol warning.