### PR TITLE
fix(ui): extension command text overflow

### DIFF
--- a/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
+++ b/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
@@ -73,7 +73,7 @@ export default function ExtensionItem({
 
   return (
     <Card
-      className="transition-all duration-200 hover:shadow-default hover:cursor-pointer min-h-[120px]"
+      className="transition-all duration-200 hover:shadow-default hover:cursor-pointer min-h-[120px] overflow-hidden"
       onClick={() => handleToggle(extension)}
     >
       <CardHeader>
@@ -98,7 +98,9 @@ export default function ExtensionItem({
           </div>
         </CardAction>
       </CardHeader>
-      <CardContent className="px-4 text-sm text-text-muted">{renderSubtitle()}</CardContent>
+      <CardContent className="px-4 text-sm text-text-muted overflow-hidden break-words">
+        {renderSubtitle()}
+      </CardContent>
     </Card>
   );
 }


### PR DESCRIPTION
The command text in the extensions card would sometimes overflow off of the card when you had a long command.

<img width="1651" height="1519" alt="Screenshot 2025-08-01 at 11 39 19 AM" src="https://github.com/user-attachments/assets/06be2ac4-9b76-4c5f-a074-b275b6463532" />

<img width="308" height="191" alt="Screenshot 2025-08-01 at 11 39 17 AM" src="https://github.com/user-attachments/assets/4137efb3-d4aa-41ab-9c0e-bbc689f89a68" />

This wraps on word for the subtitle and hides any overflow if something were to render outsidde of the card..

https://github.com/user-attachments/assets/25b02693-0f72-4e64-aa6b-fbf27034d365

