### PR TITLE
Use PR number for concurrency group

### DIFF
--- a/.github/workflows/pr-comment-build-cli.yml
+++ b/.github/workflows/pr-comment-build-cli.yml
@@ -17,7 +17,7 @@ permissions:
 name: Build CLI
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.event.issue && github.event.issue.number) || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-comment-bundle-intel.yml
+++ b/.github/workflows/pr-comment-bundle-intel.yml
@@ -19,7 +19,7 @@ permissions:
 name: Bundle Intel Desktop App
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.event.issue && github.event.issue.number) || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-comment-bundle-windows.yml
+++ b/.github/workflows/pr-comment-bundle-windows.yml
@@ -22,7 +22,7 @@ permissions:
 name: Bundle Windows Desktop App
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.event.issue && github.event.issue.number) || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/pr-comment-bundle.yml
+++ b/.github/workflows/pr-comment-bundle.yml
@@ -19,7 +19,7 @@ permissions:
 name: Bundle ARM64 Desktop App
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ (github.event.issue && github.event.issue.number) || github.event.inputs.pr_number }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
for issue_comment events, github.ref points to the default branch, so the builds get canceled when a new one on main starts