### PR TITLE
docs: fix markdown for cognee tutorial

### DIFF
--- a/documentation/docs/tutorials/advanced-cognee-usage.md
+++ b/documentation/docs/tutorials/advanced-cognee-usage.md
@@ -49,7 +49,7 @@ Use instruction files for consistent behavior across sessions. This method uses 
 
 Create `~/.config/goose/cognee-instructions.md`:
 
-```markdown
+````markdown
 You are an LLM agent with access to a Cognee knowledge graph for memory.
 
 **IMPORTANT RULES:**
@@ -86,7 +86,7 @@ You are an LLM agent with access to a Cognee knowledge graph for memory.
 - When asked to analyze code repositories
 - Use: `cognee-mcp__codify(\{ repo_path: "path" \})`
 - Only process files returned by `rg --files`
-```
+````
 
 Start Goose with instructions:
 ```bash


### PR DESCRIPTION
I'm not the original author of this tutorial, but it seems that the markdown formatting on this tutorial was slightly incorrect, resulting in the instructions file being cut off prematurely.

## Before
<img width="706" height="749" alt="Screenshot 2025-08-01 at 21 28 57" src="https://github.com/user-attachments/assets/332321bf-cfe3-4f49-86be-7d28ed28e128" />

## After
<img width="715" height="679" alt="Screenshot 2025-08-01 at 21 30 26" src="https://github.com/user-attachments/assets/4f0b0041-3c0b-416e-b693-b40fc3e12329" />
