### PR TITLE
docs: Dynamic linux install buttons

### DIFF
--- a/documentation/src/components/LinuxDesktopInstallButtons.js
+++ b/documentation/src/components/LinuxDesktopInstallButtons.js
@@ -1,20 +1,72 @@
 import Link from "@docusaurus/Link";
 import { IconDownload } from "@site/src/components/icons/download";
+import { useState, useEffect } from "react";
 
 const LinuxDesktopInstallButtons = () => {
+  const [downloadUrls, setDownloadUrls] = useState({
+    deb: "https://github.com/block/goose/releases/download/v1.1.4/goose_1.1.4_amd64.deb",
+    rpm: "https://github.com/block/goose/releases/download/v1.1.4/Goose-1.1.4-1.x86_64.rpm"
+  });
+
+  useEffect(() => {
+    const fetchLatestRelease = async () => {
+      try {
+        // Check cache first (1 hour expiry)
+        const cached = localStorage.getItem('goose-release-cache');
+        const cacheTime = localStorage.getItem('goose-release-cache-time');
+        const now = Date.now();
+        
+        if (cached && cacheTime && (now - parseInt(cacheTime)) < 3600000) {
+          // Use cached data if less than 1 hour old
+          const cachedData = JSON.parse(cached);
+          setDownloadUrls(cachedData);
+          return;
+        }
+
+        // Fetch latest release from GitHub API
+        const response = await fetch('https://api.github.com/repos/block/goose/releases/latest');
+        if (!response.ok) throw new Error('API request failed');
+        
+        const release = await response.json();
+        const assets = release.assets || [];
+        
+        // Find DEB and RPM files
+        const debAsset = assets.find(asset => asset.name.includes('.deb') && asset.name.includes('amd64'));
+        const rpmAsset = assets.find(asset => asset.name.includes('.rpm') && asset.name.includes('x86_64'));
+        
+        if (debAsset && rpmAsset) {
+          const newUrls = {
+            deb: debAsset.browser_download_url,
+            rpm: rpmAsset.browser_download_url
+          };
+          
+          // Update state and cache
+          setDownloadUrls(newUrls);
+          localStorage.setItem('goose-release-cache', JSON.stringify(newUrls));
+          localStorage.setItem('goose-release-cache-time', now.toString());
+        }
+      } catch (error) {
+        console.warn('Failed to fetch latest release, using fallback URLs:', error);
+        // Fallback URLs are already set in initial state
+      }
+    };
+
+    fetchLatestRelease();
+  }, []);
+
   return (
     <div>
       <p>To download Goose Desktop for Linux, choose the buttons below:</p>
       <div className="pill-button" style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
         <Link
           className="button button--primary button--lg"
-          to="https://github.com/block/goose/releases/download/stable/goose_1.0.29_amd64.deb"
+          to={downloadUrls.deb}
         >
           <IconDownload /> DEB Package (Ubuntu/Debian)
         </Link>
         <Link
           className="button button--primary button--lg"
-          to="https://github.com/block/goose/releases/download/stable/Goose-1.0.29-1.x86_64.rpm"
+          to={downloadUrls.rpm}
         >
           <IconDownload /> RPM Package (RHEL/Fedora)
         </Link>

--- a/documentation/src/components/LinuxDesktopInstallButtons.js
+++ b/documentation/src/components/LinuxDesktopInstallButtons.js
@@ -4,8 +4,8 @@ import { useState, useEffect } from "react";
 
 const LinuxDesktopInstallButtons = () => {
   const [downloadUrls, setDownloadUrls] = useState({
-    deb: "https://github.com/block/goose/releases/download/v1.1.4/goose_1.1.4_amd64.deb",
-    rpm: "https://github.com/block/goose/releases/download/v1.1.4/Goose-1.1.4-1.x86_64.rpm"
+    deb: "https://github.com/block/goose/releases/latest",
+    rpm: "https://github.com/block/goose/releases/latest"
   });
 
   useEffect(() => {

--- a/documentation/src/components/LinuxDesktopInstallButtons.js
+++ b/documentation/src/components/LinuxDesktopInstallButtons.js
@@ -2,10 +2,12 @@ import Link from "@docusaurus/Link";
 import { IconDownload } from "@site/src/components/icons/download";
 import { useState, useEffect } from "react";
 
+const FALLBACK_URL = "https://github.com/block/goose/releases/latest";
+
 const LinuxDesktopInstallButtons = () => {
   const [downloadUrls, setDownloadUrls] = useState({
-    deb: "https://github.com/block/goose/releases/latest",
-    rpm: "https://github.com/block/goose/releases/latest"
+    deb: FALLBACK_URL,
+    rpm: FALLBACK_URL
   });
 
   useEffect(() => {
@@ -18,8 +20,7 @@ const LinuxDesktopInstallButtons = () => {
         
         if (cached && cacheTime && (now - parseInt(cacheTime)) < 3600000) {
           // Use cached data if less than 1 hour old
-          const cachedData = JSON.parse(cached);
-          setDownloadUrls(cachedData);
+          setDownloadUrls(JSON.parse(cached));
           return;
         }
 


### PR DESCRIPTION
Linux install buttons were hard coded to 1.0.29. Community members were asking about this. 

This PR replaces hardcoded version URLs by fetching the latest using GitHub API. 
If the API call fails, it brings users to the release page with the latest binaries.