### PR TITLE
tests: Add missing `#[serial]` to two tests

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -3316,6 +3316,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_process_shell_output_short() {
         let dir = TempDir::new().unwrap();
         std::env::set_current_dir(dir.path()).unwrap();
@@ -3332,6 +3333,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn test_process_shell_output_empty() {
         let dir = TempDir::new().unwrap();
         std::env::set_current_dir(dir.path()).unwrap();


### PR DESCRIPTION
This makes these like the other tests. This race
condition was introduced by:
bbf1f1eee8eb3bbc33dbb152799ea99712dc0a2b

The real fix here is to stop using `set_current_dir()`, it is process global state and will just keep causing race conditions.