### PR TITLE
add CODEOWNERS file with /documentation owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# CODEOWNERS file for block/goose repository
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Documentation owned by DevRel team
+/documentation/ @block/goose-devrel
+


### PR DESCRIPTION
This PR adds the .github/CODEOWNERS file with the goose-devrel team listed as /documentation owners so we can be notified of changes. 

Goose recommended putting this in the .github folder, which is one of the [three supported locations](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-file-location).