### PR TITLE
Don't ignore lockfiles on linux/windows builds

### DIFF
--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -209,8 +209,6 @@ jobs:
       - name: Install npm dependencies
         run: |
           cd ui/desktop
-          # Clear npm cache and remove lock file as suggested by the error
-          rm -rf node_modules package-lock.json || true
           npm cache clean --force || true
           npm install
           # Verify installation

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -276,17 +276,7 @@ jobs:
         run: |
           cd ui/desktop
           
-          # Fix for rollup native module issue (npm optional dependencies bug)
-          echo "🔧 Fixing npm optional dependencies issue..."
-          rm -rf node_modules package-lock.json
           npm install
-          
-          # Verify rollup native module is installed
-          if [ ! -d "node_modules/@rollup/rollup-linux-x64-gnu" ]; then
-            echo "⚠️ Rollup native module missing, installing manually..."
-            npm install @rollup/rollup-linux-x64-gnu --save-optional
-          fi
-          
           npm run bundle:windows
 
       # 7) Copy exe/dll to final out folder and prepare flat distribution


### PR DESCRIPTION
Presumably this will fail somewhere (why else would we ignore?) but we should fix the root issue, not ignore the lock file.