### PR TITLE
Fix voice dictation provider selection bug

### DIFF
--- a/ui/desktop/src/components/settings/dictation/DictationSection.tsx
+++ b/ui/desktop/src/components/settings/dictation/DictationSection.tsx
@@ -97,17 +97,15 @@ export default function DictationSection() {
     checkOpenAIKey();
   }, [getProviders]);
 
-  // Also check OpenAI configuration when dropdown is opened
   const handleDropdownToggle = async () => {
     const newShowState = !showProviderDropdown;
     setShowProviderDropdown(newShowState);
-    
-    // Refresh OpenAI configuration status when opening dropdown
+
     if (newShowState) {
       try {
-        const providers = await getProviders(true); // Force refresh
+        const providers = await getProviders(true);
         const openAIProvider = providers.find((p) => p.name === 'openai');
-        const isConfigured = openAIProvider?.is_configured || false;
+        const isConfigured = !!openAIProvider?.is_configured;
         setHasOpenAIKey(isConfigured);
       } catch (error) {
         console.error('Error checking OpenAI configuration:', error);

--- a/ui/desktop/src/components/settings/dictation/DictationSection.tsx
+++ b/ui/desktop/src/components/settings/dictation/DictationSection.tsx
@@ -97,6 +97,25 @@ export default function DictationSection() {
     checkOpenAIKey();
   }, [getProviders]);
 
+  // Also check OpenAI configuration when dropdown is opened
+  const handleDropdownToggle = async () => {
+    const newShowState = !showProviderDropdown;
+    setShowProviderDropdown(newShowState);
+    
+    // Refresh OpenAI configuration status when opening dropdown
+    if (newShowState) {
+      try {
+        const providers = await getProviders(true); // Force refresh
+        const openAIProvider = providers.find((p) => p.name === 'openai');
+        const isConfigured = openAIProvider?.is_configured || false;
+        setHasOpenAIKey(isConfigured);
+      } catch (error) {
+        console.error('Error checking OpenAI configuration:', error);
+        setHasOpenAIKey(false);
+      }
+    }
+  };
+
   const saveSettings = (newSettings: DictationSettings) => {
     setSettings(newSettings);
     localStorage.setItem(DICTATION_SETTINGS_KEY, JSON.stringify(newSettings));
@@ -171,7 +190,7 @@ export default function DictationSection() {
             </div>
             <div className="relative">
               <button
-                onClick={() => setShowProviderDropdown(!showProviderDropdown)}
+                onClick={handleDropdownToggle}
                 className="flex items-center gap-2 px-3 py-1.5 text-sm border border-borderSubtle rounded-md hover:border-borderStandard transition-colors text-textStandard bg-background-default"
               >
                 {getProviderLabel(settings.provider)}
@@ -182,12 +201,7 @@ export default function DictationSection() {
                 <div className="absolute right-0 mt-1 w-48 bg-background-default border border-borderStandard rounded-md shadow-lg z-10">
                   <button
                     onClick={() => handleProviderChange('openai')}
-                    disabled={!hasOpenAIKey}
-                    className={`w-full px-3 py-2 text-left text-sm transition-colors first:rounded-t-md ${
-                      hasOpenAIKey
-                        ? 'hover:bg-bgSubtle text-textStandard'
-                        : 'text-textSubtle cursor-not-allowed'
-                    }`}
+                    className="w-full px-3 py-2 text-left text-sm transition-colors first:rounded-t-md hover:bg-bgSubtle text-textStandard"
                   >
                     OpenAI Whisper
                     {!hasOpenAIKey && <span className="text-xs ml-1">(not configured)</span>}


### PR DESCRIPTION
# Fix voice dictation provider selection bug

## What
- Removed the `disabled` attribute from OpenAI Whisper option in the voice dictation provider dropdown
- Added dropdown refresh logic to update OpenAI configuration status when dropdown is opened
- Users can now switch back to OpenAI Whisper after selecting ElevenLabs
- Maintained visual indicator showing "(not configured)" when OpenAI is not set up

## Why
This fixes a critical UX bug where users would get permanently stuck after exploring ElevenLabs. The issue occurred because:
1. User starts with OpenAI Whisper (working or not)
2. User clicks ElevenLabs to explore it
3. **BUG**: OpenAI Whisper becomes disabled and unclickable
4. User cannot return to OpenAI, even to configure it

The root cause was the `disabled={!hasOpenAIKey}` attribute that prevented any interaction with the OpenAI option once it was deemed "not configured".

## Key File Changes
- `ui/desktop/src/components/settings/dictation/DictationSection.tsx`: 
  - Removed `disabled` attribute from OpenAI Whisper button
  - Added `handleDropdownToggle` function to refresh provider status
  - Updated dropdown button to use new handler
  - Maintained configuration status display logic

## Impact
- **Block Internal users**: Can now select OpenAI Whisper without API key configuration
- **External users**: Can select OpenAI Whisper to configure it or use existing setup
- **All users**: No longer get stuck in ElevenLabs after exploring it

Fixes #3226 and #3280

https://github.com/user-attachments/assets/7106a325-daed-4931-85e5-8d79bf231be6

