### PR TITLE
Update filename in contributing docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,7 +61,7 @@ As you make changes to the rust code, you can try it out on the CLI, or also run
 cargo check  # do your changes compile
 cargo test  # do the tests pass with your changes
 cargo fmt   # format your code
-./scripts/clippy-lint # run the linter
+./scripts/clippy-lint.sh # run the linter
 ```
 
 ### Node


### PR DESCRIPTION
Adding  missing `.sh` extension for running `./scripts/clippy-lint.sh`