### PR TITLE
doc: Update supported container runtimes

### DIFF
--- a/documentation/docs/tutorials/isolated-development-environments.md
+++ b/documentation/docs/tutorials/isolated-development-environments.md
@@ -20,7 +20,7 @@ The **[Container Use MCP](https://github.com/dagger/container-use)** server prov
 
 ## Prerequisites
 
-- Docker installed and running on your system
+- Docker ([Podman](https://docs.dagger.io/ci/integrations/podman), [NerdCtl](https://docs.dagger.io/ci/integrations/nerdctl/) or [Container](https://docs.dagger.io/ci/integrations/apple-container/)) installed and running on your system
 - Git installed and configured
 - Goose installed and configured
 


### PR DESCRIPTION
Officially: "container-use is powered by Dagger under the hood, so you can follow the instructions on Dagger docs". See https://github.com/dagger/container-use/issues/102#issuecomment-2985295271