### PR TITLE
fix: extension list not refreshing after installing from deeplink

### DIFF
--- a/ui/desktop/src/components/settings/extensions/extension-manager.ts
+++ b/ui/desktop/src/components/settings/extensions/extension-manager.ts
@@ -336,7 +336,7 @@ export async function deleteExtension({ name, removeFromConfig }: DeleteExtensio
   // remove from agent
   let agentRemoveError = null;
   try {
-    await removeFromAgent(name);
+    await removeFromAgent(name, { isDelete: true });
   } catch (error) {
     console.error('Failed to remove extension from agent during deletion:', error);
     agentRemoveError = error;


### PR DESCRIPTION
Fixed race conditions from manually updating extension list by calling `setExtensions`

Extensions is now a computed value that automatically updates when `extensionsList` from context changes (memoized for performance)

Bonus: fixed toast message that was always showing "Removed" for deactivated extensions.

Tested and verified locally with manual and deeplink extensions.
