### PR TITLE
feat: linux computer control for android (termux)

### DIFF
--- a/BUILDING_LINUX.md
+++ b/BUILDING_LINUX.md
@@ -27,6 +27,18 @@ sudo dnf install dpkg-dev fakeroot gcc gcc-c++ make
 sudo zypper install dpkg fakeroot gcc gcc-c++ make
 ```
 
+**android / termux:**
+
+goose is not officially support termux build yet, you need some minor patch to fix build issues.
+We will publish goose (block-goose) into termux-packages.
+If you want to try there is a non-official build, https://github.com/shawn111/goose/releases/download/termux/goose-termux-aarch64.tar.bz2
+For more details, see: https://github.com/block/goose/pull/3890
+
+```bash
+pkg install rust
+pkg install cmake protobuf clang build-essential
+```
+
 ### Development Tools
 
 - **Rust**: Install via [rustup](https://rustup.rs/)

--- a/crates/goose-mcp/src/computercontroller/platform/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/platform/mod.rs
@@ -8,7 +8,7 @@ pub use self::windows::WindowsAutomation;
 #[cfg(target_os = "macos")]
 pub use self::macos::MacOSAutomation;
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "android"))]
 pub use self::linux::LinuxAutomation;
 
 pub trait SystemAutomation: Send + Sync {


### PR DESCRIPTION
Updated,

Just support  linux computer control for android.
For build issue, let termux-package (termux upstream) to handle.

----
Updated,

We need some minor changes to support goose run on termux.
 1. (goose-mcp) linux computer control add termux support
 2. (goose-mcp) -  I use android-patch.sh to handle  xcap
      - latest xcap required ubuntu newer than 20.04 but cross.rs only support 20.04
      - xcap support android build not merge to upstream yet.
      - latest xcap handle w.tilte() is different to xcap 0.0.14
 3.  create [.github/workflows/build-termux-cli.yml](https://github.com/block/goose/pull/3890/files#diff-c92a843ffd904619ba4c9359133dd6f452e2f670877e25cfd93ae8e89642d7c0) to trigger termux build.
  
If people like to try https://github.com/shawn111/goose/releases/download/termux/goose-termux-aarch64.tar.bz2,
it is v1.5.0 now, I'll keep fellow latest release.

Once it merged, we can have canary and release build for termux just like all other platforms.