### PR TITLE
mcp/developer: Refactor to use tokio SplitStream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -16,6 +16,7 @@ mcp-server = { path = "../mcp-server" }
 rmcp = { workspace = true }
 anyhow = "1.0.94"
 tokio = { version = "1", features = ["full"] }
+tokio-stream = { version = "0.1", features = ["io-util"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tracing-appender = "0.2"


### PR DESCRIPTION
I was working on [a previous PR](https://github.com/block/goose/pull/2817) with a lot larger output set sizes and I *think* I was seeing the last chunk of output sometimes being lost.

That said I asked Gemini to try to reproduce the failure with a case and I couldn't get it to fail offhand. In looking at the original code here it looks OK...

Async rust is hard; `tokio::select!` in particular can cause subtle bugs. For a lot more on this see
https://blog.yoshuawuyts.com/futures-concurrency-3 and various previous and future blog entries.

Anyways this code is I think cleaner, deduplicating the code to send the notification message.