### PR TITLE
docs: cli command history search

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -621,6 +621,31 @@ Goose CLI supports several shortcuts and built-in commands for easier navigation
 - **`Ctrl+C`** - Interrupt the current request
 - **`Ctrl+J`** - Add a newline
 - **`Cmd+Up/Down arrows`** - Navigate through command history
+- **`Ctrl+R`** - Interactive command history search (reverse search)
+
+### Command History Search
+
+The `Ctrl+R` shortcut provides interactive search through your stored CLI [command history](/docs/guides/logs#command-history). This feature makes it easy to find and reuse recent commands without retyping them. When you type a search term, Goose searches backwards through your history for matches.
+
+**How it works:**
+1. Press `Ctrl+R` in your Goose CLI session
+2. Type a search term
+3. Navigate through the results using:
+   - `Ctrl+R` to cycle backwards through earlier matches
+   - `Ctrl+S` to cycle forward through newer matches
+4. Press `Return` (or `Enter`) to run the found command, or `Esc` to cancel
+
+For example, instead of retyping this long command:
+
+```
+analyze the performance issues in the sales database queries and suggest optimizations
+```
+
+Use the `"sales database"` or `"optimization"` search term to find and rerun it.
+
+**Search tips:**
+- **Distinctive terms work best**: Choose unique words or phrases to help filter the results
+- **Partial matches and multiple words are supported**: You can search for phrases like `"gith"` and `"run the unit test"`
 
 ### Slash Commands
 - **`/exit` or `/quit`** - Exit the session


### PR DESCRIPTION
This PR documents the Ctrl+R command history search feature for the Goose CLI.

Documentation updates:
- `documentation/docs/guides/goose-cli-commands.md`: Add Command History Search section