### PR TITLE
Fix token usage tracking for streaming providers

### DIFF
--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -308,12 +308,12 @@ impl Agent {
         metadata.message_count = messages_length + 1;
 
         // Keep track of previous values to calculate the delta
-        let prev_total = metadata.accumulated_total_tokens.unwrap_or(0) 
-            - metadata.total_tokens.unwrap_or(0);
-        let prev_input = metadata.accumulated_input_tokens.unwrap_or(0) 
-            - metadata.input_tokens.unwrap_or(0);
-        let prev_output = metadata.accumulated_output_tokens.unwrap_or(0) 
-            - metadata.output_tokens.unwrap_or(0);
+        let prev_total =
+            metadata.accumulated_total_tokens.unwrap_or(0) - metadata.total_tokens.unwrap_or(0);
+        let prev_input =
+            metadata.accumulated_input_tokens.unwrap_or(0) - metadata.input_tokens.unwrap_or(0);
+        let prev_output =
+            metadata.accumulated_output_tokens.unwrap_or(0) - metadata.output_tokens.unwrap_or(0);
 
         // Update accumulated tokens with the new values
         metadata.accumulated_total_tokens = usage.usage.total_tokens.map(|n| prev_total + n);


### PR DESCRIPTION
## Problem

When using streaming providers with the goose CLI, the context token count remains at 0 and doesn't update properly:

```sh
Context: ○○○○○○○○○○ 0% (0/200000 tokens)
( O)> Hello

(...snip...)

Context: ○○○○○○○○○○ 0% (0/200000 tokens)
( O)>
```

## Root Cause

The current implementation overwrites usage metrics with each streaming event instead of properly accumulating them. When streaming APIs send a final event with None values, it resets the usage count to 0.

## Solution

Modified the update_session_metrics method to:
- Properly track cumulative token usage across streaming events
- Handle None values gracefully without resetting existing counts
