### PR TITLE
feat(deps): upgrade rmcp to 0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6988,9 +6988,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a04b2d9da174d72bc0511410242eb3e8f47a02d9e23868e4b076c7c70208eb4"
+checksum = "0ae7b8e0841e6c5e57448784136315356c70eb92d60d5a5a05a209f159083268"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -7016,9 +7016,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "651b4292f292d4a4ba191e64f0ce553aef5455b8ddf831dc6a8cd328dd68d721"
+checksum = "470958f96a5700478601c385ad3d987460372c2223959eddcb682c7273cdfb86"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "An AI agent"
 uninlined_format_args = "allow"
 
 [workspace.dependencies]
-rmcp = { version = "0.4.0", features = ["schemars", "auth"] }
+rmcp = { version = "0.4.1", features = ["schemars", "auth"] }
 
 # Patch for Windows cross-compilation issue with crunchy
 [patch.crates-io]


### PR DESCRIPTION
0.4.1 of https://crates.io/crates/rmcp to get https://github.com/modelcontextprotocol/rust-sdk/pull/359 in