### PR TITLE
add gpt-5 to openai provider format

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -562,7 +562,8 @@ pub fn create_request(
         ));
     }
 
-    let is_ox_model = model_config.model_name.starts_with("o");
+    let is_ox_model =
+        model_config.model_name.starts_with("o") || model_config.model_name.starts_with("gpt-5");
 
     // Only extract reasoning effort for O1/O3 models
     let (model_name, reasoning_effort) = if is_ox_model {


### PR DESCRIPTION
GPT-5 (and derivaties) uses the same config and reasoning format as the oX models. Adding GPT-5 to the is_ox_model flag allows the model to be used in Goose.

Fixes #3923 