### PR TITLE
add missing dependencies for developer setup

### DIFF
--- a/BUILDING_LINUX.md
+++ b/BUILDING_LINUX.md
@@ -9,7 +9,7 @@ This guide covers building the Goose Desktop application from source on various 
 **Debian/Ubuntu:**
 ```bash
 sudo apt update
-sudo apt install -y dpkg fakeroot build-essential
+sudo apt install -y dpkg fakeroot build-essential libxcb1-dev libxcb-util-dev protobuf-compiler
 ```
 
 **Arch/Manjaro:**


### PR DESCRIPTION
I needed to install **libxcb1-dev libxcb-util-dev protobuf-compiler** to compile the goose cli on a quite clean system. Maybe that should be added to the BUILDING_LINUX.md