### PR TITLE
feat(cli): Add --name/-n to session remove and --id/-i alias for session export

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -44,7 +44,8 @@ struct Identifier {
         value_name = "NAME",
         help = "Name for the chat session (e.g., 'project-x')",
         long_help = "Specify a name for your chat session. When used with --resume, will resume this specific session if it exists.",
-        alias = "id"
+        long_alias = "id",
+        short_alias = 'i'
     )]
     name: Option<String>,
 
@@ -99,7 +100,7 @@ enum SessionCommand {
     },
     #[command(about = "Remove sessions. Runs interactively if no ID or regex is provided.")]
     Remove {
-        #[arg(short, long, help = "Session ID to be removed (optional)")]
+        #[arg(short, long, long_alias = "name", short_alias = 'n', help = "Session ID to be removed (optional)")]
         id: Option<String>,
         #[arg(short, long, help = "Regex for removing matched sessions (optional)")]
         regex: Option<String>,

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -254,6 +254,7 @@ Remove one or more saved sessions.
 
 **Options:**
 - **`-i, --id <id>`**: Remove a specific session by its ID
+- **`-n, --name <name>`**: Remove a specific session by its name
 - **`-r, --regex <pattern>`**: Remove sessions matching a regex pattern. For example:
 
 **Usage:**
@@ -261,6 +262,9 @@ Remove one or more saved sessions.
 ```bash
 # Remove a specific session by ID
 goose session remove -i 20250305_113223
+
+# Remove a specific session by its name
+goose session remove -n my-session
 
 # Remove all sessions starting with "project-"
 goose session remove -r "project-.*"
@@ -280,6 +284,7 @@ Session removal is permanent and cannot be undone. Goose will show which session
 Export a session to Markdown format for sharing, documentation, or archival purposes.
 
 **Options:**
+- **`-i, --id <id>`**: Export a specific session by ID
 - **`-n, --name <name>`**: Export a specific session by name
 - **`-p, --path <path>`**: Export a specific session by file path  
 - **`-o, --output <file>`**: Save exported content to a file (default: stdout)
@@ -621,31 +626,6 @@ Goose CLI supports several shortcuts and built-in commands for easier navigation
 - **`Ctrl+C`** - Interrupt the current request
 - **`Ctrl+J`** - Add a newline
 - **`Cmd+Up/Down arrows`** - Navigate through command history
-- **`Ctrl+R`** - Interactive command history search (reverse search)
-
-### Command History Search
-
-The `Ctrl+R` shortcut provides interactive search through your stored CLI [command history](/docs/guides/logs#command-history). This feature makes it easy to find and reuse recent commands without retyping them. When you type a search term, Goose searches backwards through your history for matches.
-
-**How it works:**
-1. Press `Ctrl+R` in your Goose CLI session
-2. Type a search term
-3. Navigate through the results using:
-   - `Ctrl+R` to cycle backwards through earlier matches
-   - `Ctrl+S` to cycle forward through newer matches
-4. Press `Return` (or `Enter`) to run the found command, or `Esc` to cancel
-
-For example, instead of retyping this long command:
-
-```
-analyze the performance issues in the sales database queries and suggest optimizations
-```
-
-Use the `"sales database"` or `"optimization"` search term to find and rerun it.
-
-**Search tips:**
-- **Distinctive terms work best**: Choose unique words or phrases to help filter the results
-- **Partial matches and multiple words are supported**: You can search for phrases like `"gith"` and `"run the unit test"`
 
 ### Slash Commands
 - **`/exit` or `/quit`** - Exit the session


### PR DESCRIPTION
Following #3018, I noticed `name` and `id` are interchangeable for locating a goose session. This pull request introduces enhancements and clarifications to the Goose CLI's session management commands, primarily focusing on improved support for session removal and export by both ID and name. The documentation is updated to reflect these changes, and some outdated information about command history search is removed for clarity.

### CLI Improvements

* Added support for removing sessions by name in addition to ID, including new `--name`/`-n` aliases for the remove command in `SessionCommand` and updated argument definitions in `crates/goose-cli/src/cli.rs`. [[1]](diffhunk://#diff-e3686cf79310667255279b17b910093cee665accac23ec12c8240d0911bd494cL47-R48) [[2]](diffhunk://#diff-e3686cf79310667255279b17b910093cee665accac23ec12c8240d0911bd494cL102-R103)

### Documentation Updates

* Updated documentation for the remove command to include instructions and examples for removing sessions by name, and clarified option descriptions in `documentation/docs/guides/goose-cli-commands.md`. [[1]](diffhunk://#diff-3dcfd1ace334a91a35076b1c7e66337d2466d0aa1a5a13ee7e20db186fe401e4R257) [[2]](diffhunk://#diff-3dcfd1ace334a91a35076b1c7e66337d2466d0aa1a5a13ee7e20db186fe401e4R266-R268)
* Clarified export command options to explicitly document support for exporting by ID as well as by name and path.

### Documentation Cleanup

* Removed the section describing interactive command history search (`Ctrl+R`) from the CLI guide, streamlining the documentation and removing references to a feature that is no longer present.