### PR TITLE
Use cross in linux bundle workflow

### DIFF
--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -15,6 +15,7 @@ on:
         type: string
         required: false
         default: ''
+  pull_request:
 
 name: "Bundle Desktop (Linux)"
 

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -99,41 +99,26 @@ jobs:
           # Check disk space after cleanup
           df -h
 
-      - name: Set up Rust
-        uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # pin@v1
-        with:
-          toolchain: stable
+      - name: Activate hermit and set CARGO_HOME
+        run: |
+          source bin/activate-hermit
+          echo "CARGO_HOME=$CARGO_HOME" >> $GITHUB_ENV
+          echo "RUSTUP_HOME=$RUSTUP_HOME" >> $GITHUB_ENV
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 23
-          cache: 'npm'
-          cache-dependency-path: ui/desktop/package-lock.json
+      - name: Install cross
+        run: source ./bin/activate-hermit && cargo install cross --git https://github.com/cross-rs/cross
 
-      - name: Cache Cargo registry
-        uses: actions/cache@v4
+      - name: Cache Cargo artifacts
+        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
         with:
-          path: ~/.cargo/registry
-          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+          path: |
+            ${{ env.CARGO_HOME }}/bin/
+            ${{ env.CARGO_HOME }}/registry/index/
+            ${{ env.CARGO_HOME }}/registry/cache/
+            ${{ env.CARGO_HOME }}/git/db/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-registry-
-
-      - name: Cache Cargo index
-        uses: actions/cache@v4
-        with:
-          path: ~/.cargo/index
-          key: ${{ runner.os }}-cargo-index
-          restore-keys: |
-            ${{ runner.os }}-cargo-index
-
-      - name: Cache Cargo build
-        uses: actions/cache@v4
-        with:
-          path: target
-          key: ${{ runner.os }}-cargo-build-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-build-
+            ${{ runner.os }}-cargo-
 
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
@@ -148,51 +133,31 @@ jobs:
           echo "temporal-service built successfully"
 
       - name: Build goosed binary
+        env:
+          CROSS_NO_WARNINGS: 0
+          RUST_LOG: debug
+          RUST_BACKTRACE: 1
+          CROSS_VERBOSE: 1
         run: |
-          echo "Building goosed binary for Linux..."
-          cargo build --release -p goose-server
-          ls -la target/release/
-          file target/release/goosed
-
-      - name: Clean up build artifacts
-        run: |
-          echo "Cleaning up to save disk space..."
-          # Remove debug artifacts
-          rm -rf target/debug || true
-          # Remove incremental build files
-          rm -rf target/release/incremental || true
-          rm -rf target/release/deps || true
-          rm -rf target/release/build || true
-          # Remove other target directories that aren't needed
-          find target -name "*.rlib" -delete || true
-          find target -name "*.rmeta" -delete || true
-          # Don't run cargo clean as it will remove our binary
-          # Check disk space
-          df -h
+          source ./bin/activate-hermit
+          export TARGET="x86_64-unknown-linux-gnu"
+          rustup target add "${TARGET}"
+          cross build --release --target ${TARGET} -p goose-server
 
       - name: Copy binaries into Electron folder
         run: |
           echo "Copying binaries to ui/desktop/src/bin/"
+          export TARGET="x86_64-unknown-linux-gnu"
           mkdir -p ui/desktop/src/bin
-          cp target/release/goosed ui/desktop/src/bin/
+          cp target/$TARGET/release/goosed ui/desktop/src/bin/
           cp temporal-service/temporal-service ui/desktop/src/bin/
           chmod +x ui/desktop/src/bin/goosed
           chmod +x ui/desktop/src/bin/temporal-service
           ls -la ui/desktop/src/bin/
 
-      - name: Final cleanup before npm build
-        run: |
-          echo "Final cleanup before npm build..."
-          # Now we can remove the entire target directory since we copied the binary
-          rm -rf target || true
-          # Clean any remaining caches
-          rm -rf ~/.cargo/registry/cache || true
-          rm -rf ~/.cargo/git/db || true
-          # Check final disk space
-          df -h
-
       - name: Install npm dependencies
         run: |
+          source ./bin/activate-hermit
           cd ui/desktop
           npm cache clean --force || true
           npm install
@@ -201,6 +166,7 @@ jobs:
 
       - name: Build Linux packages
         run: |
+          source ./bin/activate-hermit
           cd ui/desktop
           echo "Building Linux packages (.deb and .rpm)..."
           

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -24,15 +24,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      # 1) Check out source
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
-          # Only pass ref if it's explicitly set, otherwise let checkout action use its default behavior
-          ref: ${{ inputs.ref != '' && inputs.ref || '' }}
+          ref: inputs.ref
           fetch-depth: 0
 
-      # 2) Update versions before build
       - name: Update versions
         if: ${{ inputs.version != '' }}
         run: |
@@ -44,7 +41,6 @@ jobs:
           cd ui/desktop
           npm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
 
-      # 3) Debug information
       - name: Debug workflow info
         env:
           WORKFLOW_NAME: ${{ github.workflow }}
@@ -63,7 +59,6 @@ jobs:
           lsb_release -a || true
           df -h
 
-      # 4) Install system dependencies for Linux packaging
       - name: Install system dependencies
         run: |
           sudo apt-get update
@@ -83,7 +78,6 @@ jobs:
             dpkg-dev \
             protobuf-compiler
 
-      # 4a) Pre-build cleanup to ensure enough disk space
       - name: Pre-build cleanup
         run: |
           echo "Performing aggressive pre-build cleanup..."
@@ -104,13 +98,11 @@ jobs:
           # Check disk space after cleanup
           df -h
 
-      # 5) Set up Rust
       - name: Set up Rust
         uses: actions-rust-lang/setup-rust-toolchain@9d7e65c320fdb52dcd45ffaa68deb6c02c8754d9 # pin@v1
         with:
           toolchain: stable
 
-      # 6) Set up Node.js
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
@@ -118,7 +110,6 @@ jobs:
           cache: 'npm'
           cache-dependency-path: ui/desktop/package-lock.json
 
-      # 7) Cache Rust dependencies
       - name: Cache Cargo registry
         uses: actions/cache@v4
         with:
@@ -143,13 +134,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-build-
 
-      # 8) Set up Go for building temporal-service
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
           go-version: '1.21'
 
-      # 9) Build temporal-service using build.sh script
       - name: Build temporal-service
         run: |
           echo "Building temporal-service using build.sh script..."
@@ -157,7 +146,6 @@ jobs:
           ./build.sh
           echo "temporal-service built successfully"
 
-      # 10) Build the Rust goosed binary
       - name: Build goosed binary
         run: |
           echo "Building goosed binary for Linux..."
@@ -165,7 +153,6 @@ jobs:
           ls -la target/release/
           file target/release/goosed
 
-      # 11) Clean up build artifacts to save space
       - name: Clean up build artifacts
         run: |
           echo "Cleaning up to save disk space..."
@@ -182,7 +169,6 @@ jobs:
           # Check disk space
           df -h
 
-      # 12) Copy binaries to Electron folder
       - name: Copy binaries into Electron folder
         run: |
           echo "Copying binaries to ui/desktop/src/bin/"
@@ -193,7 +179,6 @@ jobs:
           chmod +x ui/desktop/src/bin/temporal-service
           ls -la ui/desktop/src/bin/
 
-      # 13) Final cleanup before npm build
       - name: Final cleanup before npm build
         run: |
           echo "Final cleanup before npm build..."
@@ -205,7 +190,6 @@ jobs:
           # Check final disk space
           df -h
 
-      # 14) Install npm dependencies
       - name: Install npm dependencies
         run: |
           cd ui/desktop
@@ -214,7 +198,6 @@ jobs:
           # Verify installation
           ls -la node_modules/.bin/ | head -5
 
-      # 15) Build Electron app with Linux makers (.deb and .rpm)
       - name: Build Linux packages
         run: |
           cd ui/desktop
@@ -227,7 +210,6 @@ jobs:
           ls -la out/
           find out/ -name "*.deb" -o -name "*.rpm" | head -10
 
-      # 16) List all generated files for debugging
       - name: List generated files
         run: |
           echo "=== All files in out/ directory ==="
@@ -239,7 +221,6 @@ jobs:
           echo "=== File sizes ==="
           find ui/desktop/out/ -name "*.deb" -o -name "*.rpm" -exec ls -lh {} \;
 
-      # 17) Upload .deb package
       - name: Upload .deb package
         uses: actions/upload-artifact@v4
         with:
@@ -247,7 +228,6 @@ jobs:
           path: ui/desktop/out/make/deb/x64/*.deb
           if-no-files-found: error
 
-      # 18) Upload .rpm package  
       - name: Upload .rpm package
         uses: actions/upload-artifact@v4
         with:
@@ -255,7 +235,6 @@ jobs:
           path: ui/desktop/out/make/rpm/x64/*.rpm
           if-no-files-found: error
 
-      # 19) Create combined artifact with both packages
       - name: Upload combined Linux packages
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
         with:
-          ref: inputs.ref
+          ref: ${{ inputs.ref }}
           fetch-depth: 0
 
       - name: Update versions


### PR DESCRIPTION
Updates the linux desktop bundle workflow to use https://github.com/cross-rs/cross instead of cargo build. This lets us build for maximum compatibility. We're already using this for the CLI.

fixes #3236 
fixes #3820