### PR TITLE
fix: disable signing for release branches until we figure out keys for this flow

### DIFF
--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -10,8 +10,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    with:
-      signing: true
 
   comment-on-pr:
     needs: bundle-desktop
@@ -29,6 +27,4 @@ jobs:
             [📱 Download macOS Desktop App (arm64, signed)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/Goose-darwin-arm64.zip)
 
             **Instructions:**
-            After downloading, unzip the file and drag the Goose.app to your Applications folder. The app is signed and notarized for macOS.
-
-            This link is provided by nightly.link and will work even if you're not logged into GitHub.
+            After downloading, unzip the file and drag the Goose.app to a location you prefer. The app is unsigned, so to run it run `xattr -r -d com.apple.quarantine '/path/to/Goose.app'` and then open the app


### PR DESCRIPTION
This will give us unsigned pre-release builds for now (given current signing doesn't work https://github.com/block/goose/actions/runs/16833234629/job/47686043767?pr=3921) that can be run if the appropriate steps are taken for testing.

We will come up with a better signing system soon to enable:

1. Official releases
2. Pre-releases from release branches
3. Nightly builds from main

to all be signed