### PR TITLE
remove fallback routing to hub/home for unknown routes

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -958,28 +958,6 @@ export default function App() {
               console.log(
                 'Ignoring recipe config changes to prevent navigation conflicts with new window creation'
               );
-            } else {
-              // Only navigate to chat route if we're not already on a valid route
-              const currentHash = window.location.hash;
-              const validRoutes = [
-                '#/',
-                '#/pair',
-                '#/settings',
-                '#/sessions',
-                '#/schedules',
-                '#/recipes',
-                '#/permission',
-                '#/configure-providers',
-                '#/shared-session',
-                '#/recipe-editor',
-                '#/extensions',
-              ];
-
-              if (!validRoutes.includes(currentHash)) {
-                console.log('No valid route detected, navigating to chat route (hub)');
-                window.location.hash = '#/';
-                window.history.replaceState({}, '', '#/');
-              }
             }
           } catch (error) {
             console.error('Error in system initialization:', error);


### PR DESCRIPTION
remove fallback routing to hub/home for unknown routes

fixes https://github.com/block/goose/issues/3899

We didn't need this fallback, tested locally and app works fine with resuming sessions and deeplinks