### PR TITLE
docs: update jetbrains tutorial

### DIFF
--- a/documentation/docs/mcp/_template_.mdx
+++ b/documentation/docs/mcp/_template_.mdx
@@ -42,7 +42,7 @@ This tutorial covers how to add the [{Extension Name} MCP Server](/) as a Goose 
       <GooseDesktopInstaller
         extensionId="{extension_id}"
         extensionName="{Extension Name}"
-        extensionDescription="{Extension description}"
+        description="{Extension description}"
         command="npx"
         args={["-y", "@package/name"]}
         cliCommand="{command}"
@@ -53,7 +53,7 @@ This tutorial covers how to add the [{Extension Name} MCP Server](/) as a Goose 
       <!-- For built-in extensions -->
       <GooseBuiltinInstaller
         extensionName="{Extension Name}"
-        extensionDescription="{Extension description}"
+        description="{Extension description}"
         extensionId="{extension_id}"
       />
 
@@ -61,7 +61,7 @@ This tutorial covers how to add the [{Extension Name} MCP Server](/) as a Goose 
       <GooseDesktopInstaller
         extensionId="{extension_id}"
         extensionName="{Extension Name}"
-        extensionDescription="{Extension description}"
+        description="{Extension description}"
         command="npx"
         args={["-y", "@package/name"]}
         cliCommand="{command}"

--- a/documentation/docs/mcp/context7-mcp.mdx
+++ b/documentation/docs/mcp/context7-mcp.mdx
@@ -34,7 +34,7 @@ This tutorial covers how to add the [Context7 MCP Server](https://github.com/ups
 <GooseDesktopInstaller
   extensionId="context7"
   extensionName="Context7"
-  extensionDescription="Context7 MCP server for up-to-date code and docs"
+  description="Context7 MCP server for up-to-date code and docs"
   command="npx"
   args={["-y", "@upstash/context7-mcp"]}
   cliCommand="npx -y @upstash/context7-mcp"

--- a/documentation/docs/mcp/gitmcp-mcp.md
+++ b/documentation/docs/mcp/gitmcp-mcp.md
@@ -36,7 +36,7 @@ This tutorial covers how to add the [Git MCP Server](https://github.com/idosal/g
     <GooseDesktopInstaller
         extensionId="Git-mcp"
         extensionName="Git mcp"
-        extensionDescription="Git MCP server for up-to-date docs and project insights"
+        description="Git MCP server for up-to-date docs and project insights"
         command="npx"
         args={["-y", "mcp-remote" , "https://gitmcp.io/docs"]}
         cliCommand="npx -y mcp-remote https://gitmcp.io/docs"

--- a/documentation/docs/mcp/goose-docs-mcp.md
+++ b/documentation/docs/mcp/goose-docs-mcp.md
@@ -35,7 +35,7 @@ This tutorial covers how to add the [Goose Docs MCP Server](https://github.com/i
     <GooseDesktopInstaller
       extensionId="goose-docs"
       extensionName="Goose Docs"
-      extensionDescription="GitMCP for Goose documentation"
+      description="GitMCP for Goose documentation"
       command="npx"
       args={["mcp-remote", "https://block.gitmcp.io/goose/"]}
       cliCommand="npx mcp-remote https://block.gitmcp.io/goose/"

--- a/documentation/docs/mcp/jetbrains-mcp.md
+++ b/documentation/docs/mcp/jetbrains-mcp.md
@@ -6,117 +6,61 @@ description: Use JetBrains MCP Server as a Goose Extension
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
-import GooseBuiltinInstaller from '@site/src/components/GooseBuiltinInstaller';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/1fP5elf9qQM" />
 
 The JetBrains extension is designed to work within your IDE. Goose can accomplish a lot of the developer-centric tasks with the Developer extension that is enabled on install, however, the JetBrains extension provides a more integrated and project-aware way to work with code.
 
-This tutorial covers how to enable and use the JetBrains MCP Server as a built-in Goose extension to integrate with any JetBrains IDE.
+This tutorial covers how to add the [JetBrains MCP Proxy Server](https://github.com/JetBrains/mcp-jetbrains) as a Goose extension to integrate with any JetBrains IDE.
+
+:::tip TLDR
+<Tabs groupId="interface">
+  <TabItem value="ui" label="Goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40jetbrains%2Fmcp-proxy&id=jetbrains&name=JetBrains&description=Integrate%20Goose%20with%20any%20JetBrains%20IDE)
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
+  **Command**
+  ```sh
+  npx -y @jetbrains/mcp-proxy
+  ```
+  </TabItem>
+</Tabs>
+
+**Required Setup**
+
+Add the [MCP Server plugin](https://plugins.jetbrains.com/plugin/26071-mcp-server) to your IDE.
+:::
 
 ## Configuration
 
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
+:::
+
 1. Add the [MCP Server plugin](https://plugins.jetbrains.com/plugin/26071-mcp-server) to your IDE.
 
-2. Enable built-in Goose extension:
+2. Add the JetBrains extension to Goose:
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-  <GooseBuiltinInstaller
-    extensionName="Jetbrains"
-    description="Integrate Goose with any JetBrains IDE"
-  />
+    <GooseDesktopInstaller
+      extensionId="jetbrains"
+      extensionName="JetBrains"
+      description="Integrate Goose with any JetBrains IDE"
+      command="npx"
+      args={["-y", "@jetbrains/mcp-proxy"]}
+      timeout={300}
+    />
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
+      <CLIExtensionInstructions
+        name="jetbrains"
+        command="npx -y @jetbrains/mcp-proxy"
+        timeout={300}
+      />
 
-  1. Run the `configure` command:
-  ```sh
-  goose configure
-  ```
-
-  2. Choose to add a `Built-in Extension`
-  ```sh
-  ┌   goose-configure 
-  │
-  ◇  What would you like to configure?
-  │  Add Extension (Connect to a new extension) 
-  │
-  ◆  What type of extension would you like to add?
-  // highlight-start    
-  │  ● Built-in Extension (Use an extension that comes with Goose)
-  // highlight-end  
-  │  ○ Command-line Extension 
-  │  ○ Remote Extension (SSE) 
-  │  ○ Remote Extension (Streaming HTTP) 
-  └  
-  ```
-
-  3. Arrow down to the `JetBrains` extension and press Enter
-  ```sh
-  ┌   goose-configure 
-  │
-  ◇  What would you like to configure?
-  │  Add Extension (Connect to a new extension) 
-  │
-  ◇  What type of extension would you like to add?
-  │  Built-in Extension 
-  │
-  ◆  Which built-in extension would you like to enable?
-  │  ○ Developer Tools 
-  │  ○ Computer Controller 
-  │  ○ Google Drive 
-  │  ○ Memory 
-  // highlight-start
-  │  ● JetBrains (Connect to jetbrains IDEs)
-  // highlight-end
-  └
-  ```
-
-  4. Enter the number of seconds Goose should wait for actions to complete before timing out. Default is 300s
-
-  ```sh
-  ┌   goose-configure 
-  │
-  ◇  What would you like to configure?
-  │  Add Extension (Connect to a new extension) 
-  │
-  ◇  What type of extension would you like to add?
-  │  Built-in Extension 
-  │
-  ◇  Which built-in extension would you like to enable?
-  │  JetBrains
-  │
-  // highlight-start
-  ◆  Please set the timeout for this tool (in secs):
-  │  300
-  // highlight-end
-  │
-  └  Enabled jetbrains extension
-  ```
-
-  5. Choose to add a description. If you select "Yes" here, you will be prompted to enter a description for the extension.
-  ```sh
-  ┌   goose-configure 
-  │
-  ◇  What would you like to configure?
-  │  Add Extension (Connect to a new extension) 
-  │
-  ◇  What type of extension would you like to add?
-  │  Built-in Extension 
-  │
-  ◇  Which built-in extension would you like to enable?
-  │  JetBrains
-  │
-  ◇  Please set the timeout for this tool (in secs):
-  │  300
-  │
-  // highlight-start
-  ◆  Would you like to add a description?
-  │  No
-  // highlight-end
-  │
-  └
-  ```
   </TabItem>
 </Tabs>
 

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -33,17 +33,6 @@
     "environmentVariables": []
   },
   {
-    "id": "jetbrains",
-    "name": "JetBrains",
-    "description": "Built-in JetBrains IDE integration for development workflows",
-    "command": "",
-    "link": "https://github.com/block/goose/tree/main/crates/goose-mcp/src/jetbrains",
-    "installation_notes": "This is a built-in extension that comes with Goose and can be enabled on the Extensions page.",
-    "is_builtin": true,
-    "endorsed": true,
-    "environmentVariables": []
-  },
-  {
     "id": "knowledge_graph_memory",
     "name": "Knowledge Graph Memory",
     "description": "Graph-based memory system for persistent knowledge storage",
@@ -396,6 +385,17 @@
         "required": true
       }
     ]
+  },
+  {
+    "id": "jetbrains",
+    "name": "JetBrains",
+    "description": "Integrate Goose with any JetBrains IDE",
+    "command": "npx -y @jetbrains/mcp-proxy",
+    "link": "https://github.com/JetBrains/mcp-jetbrains",
+    "installation_notes": "Install using npx package manager. Requires the MCP Server plugin to be installed in your JetBrains IDE.",
+    "is_builtin": false,
+    "endorsed": true,
+    "environmentVariables": []
   },
   {
     "id": "mbot-mcp",


### PR DESCRIPTION
This PR migrates the Jetbrains tutorial from its previous built-in status. It also updates references to the `description` property in [GooseDesktopInstaller](https://github.com/block/goose/blob/main/documentation/src/components/GooseDesktopInstaller.tsx#L12) from the template and other tutorials.

Documentation updates:
- `documentation/docs/mcp/_template_.mdx`, `documentation/docs/mcp/context7-mcp.mdx`, `documentation/docs/mcp/gitmcp-mcp.md`, `documentation/docs/mcp/goose-docs-mcp.md`:
   - Changed `extensionDescription` to `description` (currently rendering as `undefined`)
- `documentation/docs/mcp/jetbrains-mcp.md`:
   - Updated tutorial
- `documentation/static/servers.json`:
   - Updated card
   
 Fixes https://github.com/block/goose/issues/3965