### PR TITLE
Adding better deeplink support for streamable-http

### DIFF
--- a/ui/desktop/src/components/settings/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings/extensions/deeplink.ts
@@ -79,7 +79,8 @@ function getStreamableHttpConfig(
   remoteUrl: string,
   name: string,
   description: string,
-  timeout: number
+  timeout: number,
+  headers?: { [key: string]: string }
 ) {
   const config: ExtensionConfig = {
     name,
@@ -87,6 +88,7 @@ function getStreamableHttpConfig(
     uri: remoteUrl,
     description,
     timeout: timeout,
+    headers: headers,
   };
 
   return config;
@@ -143,11 +145,25 @@ export async function addExtensionFromDeepLink(
 
   const cmd = parsedUrl.searchParams.get('cmd');
   const remoteUrl = parsedUrl.searchParams.get('url');
-  const transportType = parsedUrl.searchParams.get('transport') || 'sse'; // Default to SSE for backward compatibility
+  // Support both 'transport' and 'type' parameters for consistency
+  const transportType =
+    parsedUrl.searchParams.get('transport') || parsedUrl.searchParams.get('type') || 'sse'; // Default to SSE for backward compatibility
+
+  // Extract headers from URL parameters for streamable_http extensions
+  const headerParams = parsedUrl.searchParams.getAll('header');
+  const headers =
+    headerParams.length > 0
+      ? Object.fromEntries(
+          headerParams.map((header) => {
+            const [key, value] = header.split('=');
+            return [key, decodeURIComponent(value || '')];
+          })
+        )
+      : undefined;
 
   const config = remoteUrl
     ? transportType === 'streamable_http'
-      ? getStreamableHttpConfig(remoteUrl, name, description || '', timeout)
+      ? getStreamableHttpConfig(remoteUrl, name, description || '', timeout, headers)
       : getSseConfig(remoteUrl, name, description || '', timeout)
     : getStdioConfig(cmd!, parsedUrl, name, description || '', timeout);
 
@@ -159,7 +175,6 @@ export async function addExtensionFromDeepLink(
     return;
   }
 
-  // If no env vars are required, proceed with adding the extension
   try {
     console.log('No env vars required, activating extension directly');
     await activateExtension({ extensionConfig: config, addToConfig: addExtensionFn });

--- a/ui/desktop/src/components/settings/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings/extensions/deeplink.ts
@@ -149,7 +149,6 @@ export async function addExtensionFromDeepLink(
   const transportType =
     parsedUrl.searchParams.get('transport') || parsedUrl.searchParams.get('type') || 'sse'; // Default to SSE for backward compatibility
 
-  // Extract headers from URL parameters for streamable_http extensions
   const headerParams = parsedUrl.searchParams.getAll('header');
   const headers =
     headerParams.length > 0


### PR DESCRIPTION
### Problem
Deeplinks for streamable HTTP extensions had two issues:
1. Only recognized `transport=streamable_http`, ignored `type=streamable_http` (some organizations like Kiwi Flight search have the goose URI
2. No support for authentication headers

This caused extensions like Kiwi.com to be registered as SSE instead of streamable_http, and prevented GitHub-style extensions requiring auth headers from working via deeplinks.

### Solution
Enhanced the deeplink parser to:
- Support both `transport` and `type` parameters
- Parse `header=key%3Dvalue` parameters for streamable HTTP extensions
- Maintain backward compatibility

### Why `type` Parameter Support?

The deeplink parser only recognized `transport=streamable_http` but the actual config schema uses `type: 'streamable_http'`. This inconsistency led extension developers (like Kiwi.com) to naturally use `type=streamable_http` in their deeplinks, expecting it to match the config field name.

The fix maintains backward compatibility with `transport` while adding support for the more intuitive `type` parameter that aligns with the config schema.

### Examples Now Working
```bash
# Kiwi.com (now correctly registered as streamable_http)
goose://extension?url=https%3A%2F%2Fmcp.kiwi.com&name=Kiwi&type=streamable_http

# GitHub with auth headers
goose://extension?url=https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2F&name=GitHub&type=streamable_http&header=Authorization%3DBearer%20token
```

Fixes #3438