### PR TITLE
fix: Remove bold styling from prompt on Windows to prevent cursor shift

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -68,8 +68,16 @@ pub fn get_input(
         rustyline::EventHandler::Conditional(Box::new(CtrlCHandler)),
     );
 
-    let prompt = format!("{} ", console::style("( O)>").cyan().bold());
-
+    // On Windows, we need to be careful with ANSI codes and cursor positioning
+    // Using a simpler prompt format to avoid cursor shift issues
+    let prompt = if cfg!(target_os = "windows") {
+        // For Windows, use a simpler prompt without bold styling which can cause issues
+        format!("{} ", console::style("( O)>").cyan())
+    } else {
+        // For other platforms, keep the original styling
+        format!("{} ", console::style("( O)>").cyan().bold())
+    };
+    
     let input = match editor.readline(&prompt) {
         Ok(text) => text,
         Err(e) => match e {


### PR DESCRIPTION
## Summary
- Fixes #3364 - Cursor shifted to the right using native Windows CLI
- Removes bold ANSI escape code from the prompt specifically on Windows terminals
- Maintains existing styling on other platforms (macOS, Linux)

## Problem
When running Goose CLI on Windows 11, the cursor was shifted to the right in the terminal due to the bold ANSI escape code not being handled correctly by Windows terminals.

## Solution
Added a platform-specific check using `cfg\!(target_os = "windows")` to conditionally apply styling:
- Windows: `console::style("( O)>").cyan()` (no bold)
- Other platforms: `console::style("( O)>").cyan().bold()` (with bold)

## Test Plan
- [x] Code compiles successfully (`cargo check -p goose-cli`)
- [x] Tested on macOS - original behavior preserved
- [ ] Needs testing on Windows to confirm cursor position is fixed

## Note
This is a draft PR as I don't have access to a Windows machine to test the fix. Would appreciate if someone with Windows could verify the cursor position is now correct.