### PR TITLE
feat(deps): upgrade crunchy to 0.2.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,8 +1978,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.3"
-source = "git+https://github.com/nmathewson/crunchy?branch=cross-compilation-fix#260ec5f08969480c342bb3fe47f88870ed5c6cce"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,4 +18,4 @@ rmcp = { version = "0.5.0", features = ["schemars", "auth"] }
 
 # Patch for Windows cross-compilation issue with crunchy
 [patch.crates-io]
-crunchy = { git = "https://github.com/nmathewson/crunchy", branch = "cross-compilation-fix" }
+crunchy = { version = "0.2.4" }


### PR DESCRIPTION
upsteam fix cross-compilation between windows and non-windows. https://github.com/nmathewson/crunchy/commit/260ec5f08969480c342bb3fe47f88870ed5c6cce\

don't need extras patch.crates-io

-
-# Patch for Windows cross-compilation issue with crunchy
-[patch.crates-io]
-crunchy = { git = "https://github.com/nmathewson/crunchy", branch = "cross-compilation-fix" }