### PR TITLE
fit: default ollama port

### DIFF
--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -56,11 +56,14 @@ impl OllamaProvider {
 
         // Set the default port if missing
         // Don't add default port if:
-        // 1. URL explicitly ends with standard ports (:80 or :443)
-        // 2. URL uses HTTP/S (which implicitly uses port 80 or 443)
-        let explicit_default_port = host.ends_with(":80") || host.ends_with(":443");
+        // 1. URL/host explicitly contains ports
+        // 2. URL/host uses HTTP/S
+        // 3. only set it for localhost
+        let explicit_port = host.contains(':');
+        let is_localhost = host == "localhost" || host == "127.0.0.1" || host == "::1";
 
-        if base_url.port().is_none() && !explicit_default_port && !host.starts_with("http") {
+        if base_url.port().is_none() && !explicit_port && !host.starts_with("http") && is_localhost
+        {
             base_url
                 .set_port(Some(OLLAMA_DEFAULT_PORT))
                 .map_err(|_| anyhow::anyhow!("Failed to set default port"))?;

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -57,11 +57,10 @@ impl OllamaProvider {
         // Set the default port if missing
         // Don't add default port if:
         // 1. URL explicitly ends with standard ports (:80 or :443)
-        // 2. URL uses HTTPS (which implicitly uses port 443)
+        // 2. URL uses HTTP/S (which implicitly uses port 80 or 443)
         let explicit_default_port = host.ends_with(":80") || host.ends_with(":443");
-        let is_https = base_url.scheme() == "https";
 
-        if base_url.port().is_none() && !explicit_default_port && !is_https {
+        if base_url.port().is_none() && !explicit_default_port && !host.starts_with("http") {
             base_url
                 .set_port(Some(OLLAMA_DEFAULT_PORT))
                 .map_err(|_| anyhow::anyhow!("Failed to set default port"))?;


### PR DESCRIPTION
old behavior was odd - really only want to set it in a few local cases, otherwise what they user set is what they mean.

fixes: https://github.com/block/goose/issues/3988 