### PR TITLE
Remove PR trigger for Linux build workflow

### DIFF
--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -15,7 +15,6 @@ on:
         type: string
         required: false
         default: ''
-  pull_request:
 
 name: "Bundle Desktop (Linux)"
 


### PR DESCRIPTION
This got inadvertently added with https://github.com/block/goose/pull/3950 and then fixed in main, but never fixed on the release branch, so when the release branch merged into main, this got re-added.

What should have happened: I should have also cherry-picked https://github.com/block/goose/pull/3961 after merging it into main.