### PR TITLE
ci: correctly match doc only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,8 +29,11 @@ jobs:
           filters: |
             docs-only:
               - 'documentation/**'
+              - '*.md'
             code:
+              - '**'
               - '!documentation/**'
+              - '!*.md'
 
   rust-format:
     name: Check Rust Code Format


### PR DESCRIPTION
noticed when editing only `RELEASE.md` in https://github.com/block/goose/pull/4005 that a lot of workflows ran which didn't need to