### PR TITLE
Docs: provider and model run options

### DIFF
--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -144,7 +144,14 @@ To configure your chosen provider or see available options, run `goose configure
     │
     ◓  Checking your configuration...                                                                                       
     └  Configuration saved successfully
-```
+    ```
+  Set the model for an individual session using the [`run` command](/docs/guides/goose-cli-commands.md#run-options):
+
+  ```bash
+  goose run --model goose-claude-4-sonnet -t "initial prompt"
+  ```
+
+
   </TabItem>
 </Tabs>
 

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -383,6 +383,8 @@ Execute commands from an instruction file or stdin. Check out the [full guide](/
 - **`--explain`**: Show a recipe's title, description, and parameters
 - **`--no-session`**: Run goose commands without creating or storing a session file
 - **`--max-turns <NUMBER>`**: Limit the maximum number of turns the agent can take before asking for user input to continue (default: 1000)
+- **`--provider`**: Specify the provider to use for this session (overrides environment variable).
+- **`--model`**: Specify the model to use for this session (overrides environment variable).
 
 **Usage:**
 
@@ -415,6 +417,9 @@ goose run --max-turns 25 -i plan.md
 
 #Run with limited turns before prompting user
 goose run --recipe recipe.yaml --max-turns 10
+
+#Run with a specified provider and model
+goose run --provider anthropic --model claude-4-sonnet -t "initial prompt"
 ```
 
 ---

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -97,6 +97,12 @@ You can also run commands without creating or storing a session file by using th
 # Run a command without creating a session file
 goose run --no-session -t "your command here"
 ```
+### Set Provider and Model
+You can run Goose sessions with a specific provider and model, which overrides the provider and model settings in your [environment variables](/docs/guides/environment-variables.md).
+
+```bash
+goose run --provider anthropic --model claude-4-sonnet -t "initial prompt"
+```
 
 ### Working with Extensions
 


### PR DESCRIPTION
Document the `--provider` and `--model` options for the CLI `run` command.