### PR TITLE
fix(cli): fix compiling issue on windows system by adding missing params

### DIFF
--- a/crates/goose-mcp/src/developer/mod.rs
+++ b/crates/goose-mcp/src/developer/mod.rs
@@ -1916,6 +1916,7 @@ mod tests {
                 json!({
                     "command": "Get-ChildItem"
                 }),
+                dummy_sender(),
             )
             .await;
         assert!(result.is_ok());


### PR DESCRIPTION
On windows machine the code is not able to compile due to a missing param to the `call_tool` function at the unit test session in  `crates/goose-mcp/src/developer/mod.rs`, designed for windows under the conditional configuration check `#[cfg(windows)] (which is also the reason why the code can compile for linux machines). This pull request introduces a minor fix to the test code by adding the missing `dummy_sender()` param to the `call_tool` function.

## before
<img width="1324" height="608" alt="image" src="https://github.com/user-attachments/assets/cc7eccba-715a-4ce9-b12c-cb1296ddb748" />

## after
<img width="1328" height="540" alt="image" src="https://github.com/user-attachments/assets/dd9cf185-18a6-4685-9874-cd1e5c8c5733" />
