### PR TITLE
Recipe config to limit tool visibility

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -113,6 +113,8 @@ pub async fn handle_configure() -> Result<(), Box<dyn Error>> {
                                 timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
                                 bundled: Some(true),
                                 description: None,
+                                tools_are_visible_default: true,
+                                tools: HashMap::new(),
                             },
                         })?;
                     }
@@ -641,6 +643,8 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     timeout: Some(timeout),
                     bundled: Some(true),
                     description: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
             })?;
 
@@ -748,6 +752,8 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     description,
                     timeout: Some(timeout),
                     bundled: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
             })?;
 
@@ -850,6 +856,8 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     description,
                     timeout: Some(timeout),
                     bundled: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
             })?;
 
@@ -977,6 +985,8 @@ pub fn configure_extensions_dialog() -> Result<(), Box<dyn Error>> {
                     description,
                     timeout: Some(timeout),
                     bundled: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
             })?;
 
@@ -1619,6 +1629,8 @@ pub async fn handle_openrouter_auth() -> Result<(), Box<dyn Error>> {
                                         timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
                                         bundled: Some(true),
                                         description: None,
+                                        tools_are_visible_default: true,
+                                        tools: HashMap::new(),
                                     },
                                 }) {
                                     Ok(_) => println!("✓ Developer extension enabled"),

--- a/crates/goose-cli/src/recipes/secret_discovery.rs
+++ b/crates/goose-cli/src/recipes/secret_discovery.rs
@@ -143,6 +143,8 @@ mod tests {
                     description: None,
                     timeout: None,
                     bundled: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
                 ExtensionConfig::Stdio {
                     name: "slack-mcp".to_string(),
@@ -153,6 +155,8 @@ mod tests {
                     timeout: None,
                     description: None,
                     bundled: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
                 ExtensionConfig::Builtin {
                     name: "builtin-ext".to_string(),
@@ -160,6 +164,8 @@ mod tests {
                     description: None,
                     timeout: None,
                     bundled: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
             ]),
             context: None,
@@ -237,6 +243,8 @@ mod tests {
                     description: None,
                     timeout: None,
                     bundled: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
                 ExtensionConfig::Stdio {
                     name: "service-b".to_string(),
@@ -247,6 +255,8 @@ mod tests {
                     timeout: None,
                     description: None,
                     bundled: None,
+                    tools_are_visible_default: true,
+                    tools: HashMap::new(),
                 },
             ]),
             context: None,
@@ -294,6 +304,8 @@ mod tests {
                 description: None,
                 timeout: None,
                 bundled: None,
+                tools_are_visible_default: true,
+                tools: HashMap::new(),
             }]),
             sub_recipes: Some(vec![SubRecipe {
                 name: "child-recipe".to_string(),

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -211,6 +211,8 @@ impl Session {
             // TODO: should set timeout
             timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
             bundled: None,
+            tools_are_visible_default: true,
+            tools: HashMap::new(),
         };
 
         self.agent
@@ -244,6 +246,8 @@ impl Session {
             // TODO: should set timeout
             timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
             bundled: None,
+            tools_are_visible_default: true,
+            tools: HashMap::new(),
         };
 
         self.agent
@@ -278,6 +282,8 @@ impl Session {
             // TODO: should set timeout
             timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
             bundled: None,
+            tools_are_visible_default: true,
+            tools: HashMap::new(),
         };
 
         self.agent
@@ -304,6 +310,8 @@ impl Session {
                 timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
                 bundled: None,
                 description: None,
+                tools_are_visible_default: true,
+                tools: HashMap::new(),
             };
             self.agent
                 .add_extension(config)

--- a/crates/goose-server/src/routes/extension.rs
+++ b/crates/goose-server/src/routes/extension.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::env;
 use std::path::Path;
 use std::sync::Arc;
@@ -194,6 +195,8 @@ async fn add_extension(
             description: None,
             timeout,
             bundled: None,
+            tools_are_visible_default: true,
+            tools: HashMap::new(),
         },
         ExtensionConfigRequest::StreamableHttp {
             name,
@@ -211,6 +214,8 @@ async fn add_extension(
             description: None,
             timeout,
             bundled: None,
+            tools_are_visible_default: true,
+            tools: HashMap::new(),
         },
         ExtensionConfigRequest::Stdio {
             name,
@@ -241,6 +246,8 @@ async fn add_extension(
                 env_keys,
                 timeout,
                 bundled: None,
+                tools_are_visible_default: true,
+                tools: HashMap::new(),
             }
         }
         ExtensionConfigRequest::Builtin {
@@ -253,6 +260,8 @@ async fn add_extension(
             timeout,
             bundled: None,
             description: None,
+            tools_are_visible_default: true,
+            tools: HashMap::new(),
         },
         ExtensionConfigRequest::Frontend {
             name,
@@ -263,6 +272,8 @@ async fn add_extension(
             tools,
             instructions,
             bundled: None,
+            tools_are_visible_default: true,
+            tool_configs: HashMap::new(),
         },
     };
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -616,6 +616,8 @@ impl Agent {
                 tools,
                 instructions,
                 bundled: _,
+                tools_are_visible_default: _,
+                tool_configs: _,
             } => {
                 // For frontend tools, just store them in the frontend_tools map
                 let mut frontend_tools = self.frontend_tools.lock().await;

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -68,6 +68,10 @@ pub struct ToolConfig {
     pub visible: bool,
 }
 
+fn default_true() -> bool {
+    true
+}
+
 impl Envs {
     /// List of sensitive env vars that should not be overridden
     const DISALLOWED_KEYS: [&'static str; 31] = [

--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -47,6 +47,8 @@ impl ExtensionConfigManager {
                             timeout: Some(DEFAULT_EXTENSION_TIMEOUT),
                             bundled: Some(true),
                             description: Some(DEFAULT_EXTENSION_DESCRIPTION.to_string()),
+                            tools_are_visible_default: true,
+                            tools: HashMap::new(),
                         },
                     },
                 )]);

--- a/crates/goose/src/recipe/mod.rs
+++ b/crates/goose/src/recipe/mod.rs
@@ -685,6 +685,7 @@ sub_recipes:
                 description,
                 timeout,
                 dependencies,
+                ..
             } => {
                 assert_eq!(name, "test_python");
                 assert_eq!(code, "print('hello world')");


### PR DESCRIPTION
When building recipes we usually have in mind a specific set of tools that we expect the agent to use to achieve the recipes goal. However many mcp extensions have a lot of irrelevant tools for our purpose. For example if we want to find and read files the developer extension is useful but we have no need of image processing, listing windows and screen capture tools.

Less tools are better for agents so having a way to filter out tools from mcps saves us from having to re-write specific mcps for the recipe.

This PR introduces tool config with visibility being the specific feature:
```yaml
extensions:
  - type: builtin
    name: developer
    tools_are_visible_default: true | false (default: true)
    tools:
      bash:
        visible: true
      screen_capture:
        visible: false
      ... the rest of the unspecified tools will inherit 'tools_are_visible_default' default value
```

When a tool as set as not visible then it will be entirely hidden from goose (not returned from `get_prefixed_tools`).

The 'tools' object is designed to be extendable so in the future we can add other keys like 'permissions' similar to [claude code settings](https://docs.anthropic.com/en/docs/claude-code/settings#settings-files) or [amp permissions](https://ampcode.com/manual#permissions).