### PR TITLE
feat: User vs System quit

### DIFF
--- a/test_quit_integration.js
+++ b/test_quit_integration.js
@@ -1,0 +1,93 @@
+// Integration test for the Goose Desktop app quit detection system
+// Add this to your main.ts file to enable testing
+
+// Add after the existing imports
+const QuitInitiatorTester = require('./test_quit_scenarios.js');
+
+// Add this function after the createChat function
+function setupQuitTesting() {
+  // Only enable testing in development or when explicitly requested
+  if (!MAIN_WINDOW_VITE_DEV_SERVER_URL && process.env.GOOSE_TEST_QUIT !== 'true') {
+    return;
+  }
+
+  console.log('🧪 Setting up quit testing environment...');
+
+  // Initialize the tester
+  const tester = new QuitInitiatorTester();
+  
+  // Make it available globally for console access
+  global.QuitTester = tester;
+
+  // Add IPC handlers for testing from renderer process
+  ipcMain.handle('test-quit-scenario', async (_event, scenario) => {
+    console.log(`🧪 Testing quit scenario: ${scenario}`);
+    
+    switch (scenario) {
+      case 'user-quit':
+        return tester.testUserQuit();
+      case 'system-shutdown':
+        return tester.testSystemShutdown();
+      case 'user-logout':
+        return tester.testUserLogout();
+      case 'app-quit':
+        return tester.testAppQuit();
+      case 'squirrel-quit':
+        return tester.testSquirrelQuit();
+      case 'all-tests':
+        return tester.runAllTests();
+      default:
+        throw new Error(`Unknown test scenario: ${scenario}`);
+    }
+  });
+
+  // Add IPC handler to get test results
+  ipcMain.handle('get-quit-test-results', () => {
+    return tester.getAllResults();
+  });
+
+  // Add IPC handler to clear test results
+  ipcMain.handle('clear-quit-test-results', () => {
+    tester.clearResults();
+    return true;
+  });
+
+  // Add IPC handler to mock system events
+  ipcMain.handle('simulate-system-event', (_event, eventType) => {
+    console.log(`🧪 Simulating system event: ${eventType}`);
+    
+    switch (eventType) {
+      case 'shutdown':
+        // Simulate powerMonitor shutdown event
+        isSystemShutdown = true;
+        console.log('🧪 Simulated system shutdown event');
+        return { event: 'shutdown', isSystemShutdown: true };
+        
+      case 'user-resign':
+        // Simulate powerMonitor user-did-resign-active event
+        isSystemShutdown = true;
+        console.log('🧪 Simulated user resign active event');
+        return { event: 'user-resign', isSystemShutdown: true };
+        
+      case 'reset':
+        // Reset system shutdown state
+        isSystemShutdown = false;
+        quitInitiator = 'app';
+        console.log('🧪 Reset system state');
+        return { event: 'reset', isSystemShutdown: false };
+        
+      default:
+        throw new Error(`Unknown system event: ${eventType}`);
+    }
+  });
+
+  console.log('🧪 Quit testing setup complete!');
+  console.log('🧪 Available test commands:');
+  console.log('  - global.QuitTester.runAllTests()');
+  console.log('  - global.QuitTester.testUserQuit()');
+  console.log('  - global.QuitTester.testSystemShutdown()');
+  console.log('  - Use renderer IPC: window.electron.testQuitScenario("user-quit")');
+}
+
+// Call this in your app.whenReady() after window creation
+// setupQuitTesting();

--- a/test_quit_renderer.js
+++ b/test_quit_renderer.js
@@ -1,0 +1,130 @@
+// Renderer process test interface for quit detection
+// Add this to your preload.js or create a test component
+
+// Test interface for renderer process
+const quitTestInterface = {
+  // Test individual scenarios
+  testQuitScenario: (scenario) => ipcRenderer.invoke('test-quit-scenario', scenario),
+  
+  // Get test results
+  getQuitTestResults: () => ipcRenderer.invoke('get-quit-test-results'),
+  
+  // Clear test results
+  clearQuitTestResults: () => ipcRenderer.invoke('clear-quit-test-results'),
+  
+  // Simulate system events
+  simulateSystemEvent: (eventType) => ipcRenderer.invoke('simulate-system-event', eventType),
+  
+  // Test the actual quit initiator detection
+  testQuitInitiatorDetection: async () => {
+    try {
+      const quitInfo = await ipcRenderer.invoke('get-quit-initiator');
+      console.log('🧪 Current quit initiator info:', quitInfo);
+      return quitInfo;
+    } catch (error) {
+      console.error('🧪 Failed to get quit initiator:', error);
+      return null;
+    }
+  }
+};
+
+// Make available globally in renderer
+if (typeof window !== 'undefined') {
+  window.quitTester = quitTestInterface;
+}
+
+// Example React component for testing
+const QuitTestPanel = () => {
+  const [testResults, setTestResults] = React.useState([]);
+  const [currentQuitInfo, setCurrentQuitInfo] = React.useState(null);
+
+  const runTest = async (scenario) => {
+    try {
+      const result = await window.quitTester.testQuitScenario(scenario);
+      console.log(`🧪 Test result for ${scenario}:`, result);
+      
+      // Refresh results
+      const allResults = await window.quitTester.getQuitTestResults();
+      setTestResults(allResults);
+    } catch (error) {
+      console.error(`🧪 Test failed for ${scenario}:`, error);
+    }
+  };
+
+  const checkCurrentState = async () => {
+    const info = await window.quitTester.testQuitInitiatorDetection();
+    setCurrentQuitInfo(info);
+  };
+
+  const simulateEvent = async (eventType) => {
+    try {
+      const result = await window.quitTester.simulateSystemEvent(eventType);
+      console.log(`🧪 Simulated ${eventType}:`, result);
+      
+      // Check current state after simulation
+      await checkCurrentState();
+    } catch (error) {
+      console.error(`🧪 Failed to simulate ${eventType}:`, error);
+    }
+  };
+
+  return (
+    <div style={{ padding: '20px', border: '1px solid #ccc', margin: '10px' }}>
+      <h3>🧪 Quit Detection Testing Panel</h3>
+      
+      <div style={{ marginBottom: '20px' }}>
+        <h4>Current State</h4>
+        <button onClick={checkCurrentState}>Check Current Quit Info</button>
+        {currentQuitInfo && (
+          <pre style={{ background: '#f5f5f5', padding: '10px' }}>
+            {JSON.stringify(currentQuitInfo, null, 2)}
+          </pre>
+        )}
+      </div>
+
+      <div style={{ marginBottom: '20px' }}>
+        <h4>Test Scenarios</h4>
+        <button onClick={() => runTest('user-quit')}>Test User Quit</button>
+        <button onClick={() => runTest('system-shutdown')}>Test System Shutdown</button>
+        <button onClick={() => runTest('user-logout')}>Test User Logout</button>
+        <button onClick={() => runTest('app-quit')}>Test App Quit</button>
+        <button onClick={() => runTest('all-tests')}>Run All Tests</button>
+      </div>
+
+      <div style={{ marginBottom: '20px' }}>
+        <h4>Simulate System Events</h4>
+        <button onClick={() => simulateEvent('shutdown')}>Simulate Shutdown</button>
+        <button onClick={() => simulateEvent('user-resign')}>Simulate User Logout</button>
+        <button onClick={() => simulateEvent('reset')}>Reset State</button>
+      </div>
+
+      <div>
+        <h4>Test Results</h4>
+        <button onClick={async () => {
+          const results = await window.quitTester.getQuitTestResults();
+          setTestResults(results);
+        }}>Refresh Results</button>
+        <button onClick={async () => {
+          await window.quitTester.clearQuitTestResults();
+          setTestResults([]);
+        }}>Clear Results</button>
+        
+        {testResults.length > 0 && (
+          <div style={{ maxHeight: '300px', overflow: 'auto', background: '#f5f5f5', padding: '10px' }}>
+            {testResults.map((result, index) => (
+              <div key={index} style={{ marginBottom: '10px', borderBottom: '1px solid #ddd', paddingBottom: '5px' }}>
+                <strong>{result.reason}</strong> ({result.initiator})
+                <br />
+                <small>{result.timestamp}</small>
+                <br />
+                System Shutdown: {result.isSystemShutdown ? 'Yes' : 'No'}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+console.log('🧪 Quit test interface loaded. Use window.quitTester for testing.');

--- a/test_quit_scenarios.js
+++ b/test_quit_scenarios.js
@@ -1,0 +1,195 @@
+const { app, powerMonitor, BrowserWindow } = require('electron');
+
+// Mock testing utility for quit initiator scenarios
+class QuitInitiatorTester {
+  constructor() {
+    this.originalQuitApp = null;
+    this.testResults = [];
+  }
+
+  // Mock the quitApp function to capture calls instead of actually quitting
+  mockQuitApp() {
+    // Store reference to original function if it exists
+    if (global.quitApp) {
+      this.originalQuitApp = global.quitApp;
+    }
+
+    // Replace with mock that logs instead of quitting
+    global.quitApp = (reason, initiator = 'user', callStack = new Error().stack) => {
+      const testResult = {
+        timestamp: new Date().toISOString(),
+        reason,
+        initiator,
+        callStack: callStack.split('\n').slice(0, 5).join('\n'), // First 5 lines
+        isSystemShutdown: global.isSystemShutdown || false
+      };
+      
+      this.testResults.push(testResult);
+      console.log('🧪 MOCK QUIT CALLED:', testResult);
+      
+      // Don't actually quit, just log
+      return testResult;
+    };
+  }
+
+  // Restore original quitApp function
+  restoreQuitApp() {
+    if (this.originalQuitApp) {
+      global.quitApp = this.originalQuitApp;
+    }
+  }
+
+  // Simulate system shutdown event
+  testSystemShutdown() {
+    console.log('🧪 Testing system shutdown scenario...');
+    
+    // Simulate the powerMonitor shutdown event
+    global.isSystemShutdown = true;
+    
+    // Trigger the quit with system initiator
+    if (global.quitApp) {
+      global.quitApp('system shutdown/reboot detected', 'system');
+    }
+    
+    return this.getLastResult();
+  }
+
+  // Simulate user logout
+  testUserLogout() {
+    console.log('🧪 Testing user logout scenario...');
+    
+    // Simulate the powerMonitor user-did-resign-active event
+    global.isSystemShutdown = true; // This gets set in the actual handler
+    
+    if (global.quitApp) {
+      global.quitApp('user logout/session switch detected', 'system');
+    }
+    
+    return this.getLastResult();
+  }
+
+  // Simulate user-initiated quit
+  testUserQuit() {
+    console.log('🧪 Testing user-initiated quit...');
+    
+    global.isSystemShutdown = false;
+    
+    if (global.quitApp) {
+      global.quitApp('user requested quit', 'user');
+    }
+    
+    return this.getLastResult();
+  }
+
+  // Simulate app-initiated quit (like single instance check)
+  testAppQuit() {
+    console.log('🧪 Testing app-initiated quit...');
+    
+    global.isSystemShutdown = false;
+    
+    if (global.quitApp) {
+      global.quitApp('single instance lock not acquired', 'system');
+    }
+    
+    return this.getLastResult();
+  }
+
+  // Simulate squirrel startup quit
+  testSquirrelQuit() {
+    console.log('🧪 Testing squirrel startup quit...');
+    
+    global.isSystemShutdown = false;
+    
+    if (global.quitApp) {
+      global.quitApp('electron-squirrel-startup detected', 'system');
+    }
+    
+    return this.getLastResult();
+  }
+
+  // Test the before-quit event handler
+  testBeforeQuitEvent() {
+    console.log('🧪 Testing before-quit event scenarios...');
+    
+    const results = [];
+    
+    // Test with system shutdown
+    global.isSystemShutdown = true;
+    const systemEvent = { preventDefault: () => console.log('preventDefault called') };
+    // You'd call your actual before-quit handler here
+    results.push({ scenario: 'system-shutdown', shouldPreventDefault: false });
+    
+    // Test with user quit
+    global.isSystemShutdown = false;
+    const userEvent = { preventDefault: () => console.log('preventDefault called') };
+    // You'd call your actual before-quit handler here
+    results.push({ scenario: 'user-quit', shouldPreventDefault: true });
+    
+    return results;
+  }
+
+  // Get the last test result
+  getLastResult() {
+    return this.testResults[this.testResults.length - 1] || null;
+  }
+
+  // Get all test results
+  getAllResults() {
+    return this.testResults;
+  }
+
+  // Clear test results
+  clearResults() {
+    this.testResults = [];
+  }
+
+  // Run all tests
+  runAllTests() {
+    console.log('🧪 Running all quit initiator tests...\n');
+    
+    this.clearResults();
+    this.mockQuitApp();
+    
+    const tests = [
+      () => this.testUserQuit(),
+      () => this.testSystemShutdown(),
+      () => this.testUserLogout(),
+      () => this.testAppQuit(),
+      () => this.testSquirrelQuit()
+    ];
+    
+    tests.forEach((test, index) => {
+      console.log(`\n--- Test ${index + 1} ---`);
+      test();
+    });
+    
+    console.log('\n🧪 All tests completed!');
+    console.log('📊 Test Summary:');
+    this.testResults.forEach((result, index) => {
+      console.log(`${index + 1}. ${result.reason} (${result.initiator})`);
+    });
+    
+    this.restoreQuitApp();
+    return this.testResults;
+  }
+}
+
+// Export for use in main process
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = QuitInitiatorTester;
+}
+
+// Global instance for console testing
+if (typeof global !== 'undefined') {
+  global.QuitTester = new QuitInitiatorTester();
+}
+
+console.log('🧪 Quit Initiator Tester loaded. Use global.QuitTester to run tests.');
+
+// Auto-run tests if GOOSE_TEST_QUIT is set
+if (process.env.GOOSE_TEST_QUIT === 'true') {
+  setTimeout(() => {
+    console.log('🧪 Auto-running quit tests due to GOOSE_TEST_QUIT=true');
+    global.QuitTester.runAllTests();
+  }, 2000);
+}

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -113,6 +113,7 @@ type ElectronAPI = {
   hasAcceptedRecipeBefore: (recipeConfig: Recipe) => Promise<boolean>;
   recordRecipeHash: (recipeConfig: Recipe) => Promise<boolean>;
   openDirectoryInExplorer: (directoryPath: string) => Promise<boolean>;
+  getQuitInitiator: () => Promise<{ initiator: 'user' | 'system' | 'app'; isSystemShutdown: boolean }>;
 };
 
 type AppConfigAPI = {
@@ -243,6 +244,8 @@ const electronAPI: ElectronAPI = {
     ipcRenderer.invoke('record-recipe-hash', recipeConfig),
   openDirectoryInExplorer: (directoryPath: string) =>
     ipcRenderer.invoke('open-directory-in-explorer', directoryPath),
+  getQuitInitiator: () =>
+    ipcRenderer.invoke('get-quit-initiator'),
 };
 
 const appConfigAPI: AppConfigAPI = {


### PR DESCRIPTION
- differentiate who initiated `quit` (user/system/app)
- track system shutdown state
- add `quitApp()` wrapper
- Skip `quit` confirmation dialog when `system` initiated the `quit`
- IPC handlers for quit initiator information
- tests to mock quitApp() without actual shutdowns

WIP for [#4014](https://github.com/block/goose/issues/4014)