### PR TITLE
fix(build): feed electronforge the icon explicitly for linux

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -58,7 +58,7 @@ module.exports = {
       config: {
         arch: process.env.ELECTRON_ARCH === 'x64' ? ['x64'] : ['arm64'],
         options: {
-          icon: process.platform === 'linux' ? 'src/images/icon.png' : 'src/images/icon.ico',
+          icon: 'src/images/icon.ico',
         },
       },
     },
@@ -70,7 +70,10 @@ module.exports = {
         maintainer: 'Block, Inc.',
         homepage: 'https://block.github.io/goose/',
         categories: ['Development'],
-        mimeType: ['x-scheme-handler/goose']
+        mimeType: ['x-scheme-handler/goose'],
+        options: {
+          icon: 'src/images/icon.png'
+        }
       },
     },
     {
@@ -80,7 +83,10 @@ module.exports = {
         bin: 'Goose',
         maintainer: 'Block, Inc.',
         homepage: 'https://block.github.io/goose/',
-        categories: ['Development']
+        categories: ['Development'],
+        options: {
+          icon: 'src/images/icon.png'
+        }
       },
     },
   ],


### PR DESCRIPTION
Electron forge has not been packaging the icon on rpm & deb builds, resulting in the electron icon getting distributed.

I removed the conditional logic in the config, and explicitly set the icon path in each linux maker, leaving the *.ico (windows) as the default.

To confirm after `npm run make`, assuming you build on x64, this is how to open the packaged logo — before this PR it will be electron, goose after: 

Deb:
```
cd out/make/deb/x64 && dpkg-deb -R goose_1.3.0_amd64.deb pkg && open pkg/usr/share/pixmaps/goose.png
```

Rpm:
```
cd out/make/rpm/x64 && rpm2cpio Goose-1.3.0-1.x86_64.rpm | cpio -idm && open usr/share/pixmaps/Goose.png
```