### PR TITLE
feat: ToolError migration to ErrorData

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3519,7 +3519,7 @@ dependencies = [
 
 [[package]]
 name = "goose-test"
-version = "1.1.0"
+version = "1.3.0"
 dependencies = [
  "clap",
  "serde_json",

--- a/crates/goose-cli/src/scenario_tests/mock_client.rs
+++ b/crates/goose-cli/src/scenario_tests/mock_client.rs
@@ -2,11 +2,10 @@
 //! add a tool you want to have around and then add the client to the extension router
 
 use mcp_client::client::{Error, McpClientTrait};
-use mcp_core::ToolError;
 use rmcp::{
     model::{
-        CallToolResult, Content, GetPromptResult, ListPromptsResult, ListResourcesResult,
-        ListToolsResult, ReadResourceResult, ServerNotification, Tool,
+        CallToolResult, Content, ErrorData, GetPromptResult, ListPromptsResult,
+        ListResourcesResult, ListToolsResult, ReadResourceResult, ServerNotification, Tool,
     },
     object,
 };
@@ -17,7 +16,7 @@ use tokio_util::sync::CancellationToken;
 
 pub struct MockClient {
     tools: HashMap<String, Tool>,
-    handlers: HashMap<String, Box<dyn Fn(&Value) -> Result<Vec<Content>, ToolError> + Send + Sync>>,
+    handlers: HashMap<String, Box<dyn Fn(&Value) -> Result<Vec<Content>, ErrorData> + Send + Sync>>,
 }
 
 impl MockClient {
@@ -30,7 +29,7 @@ impl MockClient {
 
     pub(crate) fn add_tool<F>(mut self, tool: Tool, handler: F) -> Self
     where
-        F: Fn(&Value) -> Result<Vec<Content>, ToolError> + Send + Sync + 'static,
+        F: Fn(&Value) -> Result<Vec<Content>, ErrorData> + Send + Sync + 'static,
     {
         let tool_name = tool.name.to_string();
         self.tools.insert(tool_name.clone(), tool);

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -34,9 +34,9 @@ use goose::config::Config;
 use goose::providers::pricing::initialize_pricing_cache;
 use goose::session;
 use input::InputResult;
-use mcp_core::handler::ToolError;
 use rmcp::model::PromptMessage;
 use rmcp::model::ServerNotification;
+use rmcp::model::{ErrorCode, ErrorData};
 
 use goose::conversation::message::{Message, MessageContent};
 use rand::{distributions::Alphanumeric, Rng};
@@ -927,7 +927,7 @@ impl Session {
                                     let mut response_message = Message::user();
                                     response_message.content.push(MessageContent::tool_response(
                                         confirmation.id.clone(),
-                                        Err(ToolError::ExecutionError("Tool call cancelled by user".to_string()))
+                                        Err(ErrorData { code: ErrorCode::INVALID_REQUEST, message: std::borrow::Cow::from("Tool call cancelled by user".to_string()), data: None })
                                     ));
                                     self.messages.push(response_message);
                                     if let Some(session_file) = &self.session_file {
@@ -1294,7 +1294,11 @@ impl Session {
             for (req_id, _) in &tool_requests {
                 response_message.content.push(MessageContent::tool_response(
                     req_id.clone(),
-                    Err(ToolError::ExecutionError(notification.clone())),
+                    Err(ErrorData {
+                        code: ErrorCode::INTERNAL_ERROR,
+                        message: std::borrow::Cow::from(notification.clone()),
+                        data: None,
+                    }),
                 ));
             }
             self.push_message(response_message);

--- a/crates/goose-mcp/src/computercontroller/pdf_tool.rs
+++ b/crates/goose-mcp/src/computercontroller/pdf_tool.rs
@@ -1,16 +1,20 @@
 use lopdf::{content::Content as PdfContent, Document, Object};
-use mcp_core::ToolError;
-use rmcp::model::Content;
+use rmcp::model::{Content, ErrorCode, ErrorData};
 use std::{fs, path::Path};
 
 pub async fn pdf_tool(
     path: &str,
     operation: &str,
     cache_dir: &Path,
-) -> Result<Vec<Content>, ToolError> {
+) -> Result<Vec<Content>, ErrorData> {
     // Open and parse the PDF file
-    let doc = Document::load(path)
-        .map_err(|e| ToolError::ExecutionError(format!("Failed to open PDF file: {}", e)))?;
+    let doc = Document::load(path).map_err(|e| {
+        ErrorData::new(
+            ErrorCode::INTERNAL_ERROR,
+            format!("Failed to open PDF file: {}", e),
+            None,
+        )
+    })?;
 
     let result = match operation {
         "extract_text" => {
@@ -115,7 +119,11 @@ pub async fn pdf_tool(
         "extract_images" => {
             let cache_dir = cache_dir.join("pdf_images");
             fs::create_dir_all(&cache_dir).map_err(|e| {
-                ToolError::ExecutionError(format!("Failed to create image cache directory: {}", e))
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to create image cache directory: {}", e),
+                    None,
+                )
             })?;
 
             let mut images = Vec::new();
@@ -167,14 +175,19 @@ pub async fn pdf_tool(
             // Process each page
             for (page_num, page_id) in doc.get_pages() {
                 let page = doc.get_object(page_id).map_err(|e| {
-                    ToolError::ExecutionError(format!("Failed to get page {}: {}", page_num, e))
+                    ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to get page {}: {}", page_num, e),
+                        None,
+                    )
                 })?;
 
                 let page_dict = page.as_dict().map_err(|e| {
-                    ToolError::ExecutionError(format!(
-                        "Failed to get page dict {}: {}",
-                        page_num, e
-                    ))
+                    ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to get page dict {}: {}", page_num, e),
+                        None,
+                    )
                 })?;
 
                 // Get page resources - handle both direct dict and reference
@@ -184,27 +197,32 @@ pub async fn pdf_tool(
                         Object::Reference(id) => doc
                             .get_object(*id)
                             .map_err(|e| {
-                                ToolError::ExecutionError(format!(
-                                    "Failed to get resource reference: {}",
-                                    e
-                                ))
+                                ErrorData::new(
+                                    ErrorCode::RESOURCE_NOT_FOUND,
+                                    format!("Failed to get resource reference: {}", e),
+                                    None,
+                                )
                             })
                             .and_then(|obj| {
                                 obj.as_dict().map_err(|e| {
-                                    ToolError::ExecutionError(format!(
-                                        "Resource reference is not a dictionary: {}",
-                                        e
-                                    ))
+                                    ErrorData::new(
+                                        ErrorCode::RESOURCE_NOT_FOUND,
+                                        format!("Resource reference is not a dictionary: {}", e),
+                                        None,
+                                    )
                                 })
                             }),
-                        _ => Err(ToolError::ExecutionError(
+                        _ => Err(ErrorData::new(
+                            ErrorCode::INTERNAL_ERROR,
                             "Resources is neither dictionary nor reference".to_string(),
+                            None,
                         )),
                     },
-                    Err(e) => Err(ToolError::ExecutionError(format!(
-                        "Failed to get Resources: {}",
-                        e
-                    ))),
+                    Err(e) => Err(ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to get Resources: {}", e),
+                        None,
+                    )),
                 }?;
 
                 // Look for XObject dictionary - handle both direct dict and reference
@@ -214,37 +232,50 @@ pub async fn pdf_tool(
                         Object::Reference(id) => doc
                             .get_object(*id)
                             .map_err(|e| {
-                                ToolError::ExecutionError(format!(
-                                    "Failed to get XObject reference: {}",
-                                    e
-                                ))
+                                ErrorData::new(
+                                    ErrorCode::INTERNAL_ERROR,
+                                    format!("Failed to get XObject reference: {}", e),
+                                    None,
+                                )
                             })
                             .and_then(|obj| {
                                 obj.as_dict().map_err(|e| {
-                                    ToolError::ExecutionError(format!(
-                                        "XObject reference is not a dictionary: {}",
-                                        e
-                                    ))
+                                    ErrorData::new(
+                                        ErrorCode::INTERNAL_ERROR,
+                                        format!("XObject reference is not a dictionary: {}", e),
+                                        None,
+                                    )
                                 })
                             }),
-                        _ => Err(ToolError::ExecutionError(
+                        _ => Err(ErrorData::new(
+                            ErrorCode::INTERNAL_ERROR,
                             "XObject is neither dictionary nor reference".to_string(),
+                            None,
                         )),
                     },
-                    Err(e) => Err(ToolError::ExecutionError(format!(
-                        "Failed to get XObject: {}",
-                        e
-                    ))),
+                    Err(e) => Err(ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to get XObject: {}", e),
+                        None,
+                    )),
                 };
 
                 if let Ok(xobjects) = xobjects {
                     for (name, xobject) in xobjects.iter() {
                         let xobject_id = xobject.as_reference().map_err(|_| {
-                            ToolError::ExecutionError("Failed to get XObject reference".to_string())
+                            ErrorData::new(
+                                ErrorCode::INTERNAL_ERROR,
+                                "Failed to get XObject reference".to_string(),
+                                None,
+                            )
                         })?;
 
                         let xobject = doc.get_object(xobject_id).map_err(|e| {
-                            ToolError::ExecutionError(format!("Failed to get XObject: {}", e))
+                            ErrorData::new(
+                                ErrorCode::INTERNAL_ERROR,
+                                format!("Failed to get XObject: {}", e),
+                                None,
+                            )
                         })?;
 
                         if let Ok(stream) = xobject.as_stream() {
@@ -283,10 +314,11 @@ pub async fn pdf_tool(
                                         ));
 
                                         fs::write(&image_path, &data).map_err(|e| {
-                                            ToolError::ExecutionError(format!(
-                                                "Failed to write image: {}",
-                                                e
-                                            ))
+                                            ErrorData::new(
+                                                ErrorCode::INTERNAL_ERROR,
+                                                format!("Failed to write image: {}", e),
+                                                None,
+                                            )
                                         })?;
 
                                         images.push(format!(
@@ -313,10 +345,14 @@ pub async fn pdf_tool(
         }
 
         _ => {
-            return Err(ToolError::InvalidParameters(format!(
-                "Invalid operation: {}. Valid operations are: 'extract_text', 'extract_images'",
-                operation
-            )))
+            return Err(ErrorData::new(
+                ErrorCode::INVALID_PARAMS,
+                format!(
+                    "Invalid operation: {}. Valid operations are: 'extract_text', 'extract_images'",
+                    operation
+                ),
+                None,
+            ))
         }
     };
 

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -44,9 +44,11 @@ use crate::scheduler_trait::SchedulerTrait;
 use crate::session;
 use crate::tool_monitor::{ToolCall, ToolMonitor};
 use crate::utils::is_token_cancelled;
-use mcp_core::{ToolError, ToolResult};
+use mcp_core::ToolResult;
 use regex::Regex;
-use rmcp::model::{Content, GetPromptResult, Prompt, ServerNotification, Tool};
+use rmcp::model::{
+    Content, ErrorCode, ErrorData, GetPromptResult, Prompt, ServerNotification, Tool,
+};
 use serde_json::Value;
 use tokio::sync::{mpsc, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -376,7 +378,7 @@ impl Agent {
         tool_call: mcp_core::tool::ToolCall,
         request_id: String,
         cancellation_token: Option<CancellationToken>,
-    ) -> (String, Result<ToolCallResult, ToolError>) {
+    ) -> (String, Result<ToolCallResult, ErrorData>) {
         // Check if this tool call should be allowed based on repetition monitoring
         if let Some(monitor) = self.tool_monitor.lock().await.as_mut() {
             let tool_call_info = ToolCall::new(tool_call.name.clone(), tool_call.arguments.clone());
@@ -384,8 +386,10 @@ impl Agent {
             if !monitor.check_tool_call(tool_call_info) {
                 return (
                     request_id,
-                    Err(ToolError::ExecutionError(
+                    Err(ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
                         "Tool call rejected: exceeded maximum allowed repetitions".to_string(),
+                        None,
                     )),
                 );
             }
@@ -425,8 +429,10 @@ impl Agent {
             } else {
                 (
                     request_id,
-                    Err(ToolError::ExecutionError(
+                    Err(ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
                         "Final output tool not defined".to_string(),
+                        None,
                     )),
                 )
             };
@@ -478,8 +484,10 @@ impl Agent {
             ToolCallResult::from(extension_manager.search_available_extensions().await)
         } else if self.is_frontend_tool(&tool_call.name).await {
             // For frontend tools, return an error indicating we need frontend execution
-            ToolCallResult::from(Err(ToolError::ExecutionError(
+            ToolCallResult::from(Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
                 "Frontend tool execution required".to_string(),
+                None,
             )))
         } else if tool_call.name == TODO_READ_TOOL_NAME {
             // Handle task planner read tool
@@ -505,11 +513,13 @@ impl Agent {
             if max_chars > 0 && char_count > max_chars {
                 return (
                     request_id,
-                    Ok(ToolCallResult::from(Err(ToolError::ExecutionError(
+                    Ok(ToolCallResult::from(Err(ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
                         format!(
                             "Todo list too large: {} chars (max: {})",
                             char_count, max_chars
                         ),
+                        None,
                     )))),
                 );
             }
@@ -537,7 +547,11 @@ impl Agent {
                 .dispatch_tool_call(tool_call.clone(), cancellation_token.unwrap_or_default())
                 .await;
             result.unwrap_or_else(|e| {
-                ToolCallResult::from(Err(ToolError::ExecutionError(e.to_string())))
+                ToolCallResult::from(Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    e.to_string(),
+                    None,
+                )))
             })
         };
 
@@ -554,12 +568,13 @@ impl Agent {
         )
     }
 
+    #[allow(clippy::too_many_lines)]
     pub(super) async fn manage_extensions(
         &self,
         action: String,
         extension_name: String,
         request_id: String,
-    ) -> (String, Result<Vec<Content>, ToolError>) {
+    ) -> (String, Result<Vec<Content>, ErrorData>) {
         let selector = self.tool_route_manager.get_router_tool_selector().await;
         if ToolRouterIndexManager::is_tool_router_enabled(&selector) {
             if let Some(selector) = selector {
@@ -576,10 +591,11 @@ impl Agent {
                 {
                     return (
                         request_id,
-                        Err(ToolError::ExecutionError(format!(
-                            "Failed to update vector index: {}",
-                            e
-                        ))),
+                        Err(ErrorData::new(
+                            ErrorCode::INTERNAL_ERROR,
+                            format!("Failed to update vector index: {}", e),
+                            None,
+                        )),
                     );
                 }
             }
@@ -595,7 +611,7 @@ impl Agent {
                         extension_name
                     ))]
                 })
-                .map_err(|e| ToolError::ExecutionError(e.to_string()));
+                .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None));
             return (request_id, result);
         }
 
@@ -604,19 +620,24 @@ impl Agent {
             Ok(None) => {
                 return (
                     request_id,
-                    Err(ToolError::ExecutionError(format!(
+                    Err(ErrorData::new(
+                        ErrorCode::RESOURCE_NOT_FOUND,
+                        format!(
                         "Extension '{}' not found. Please check the extension name and try again.",
                         extension_name
-                    ))),
+                    ),
+                        None,
+                    )),
                 )
             }
             Err(e) => {
                 return (
                     request_id,
-                    Err(ToolError::ExecutionError(format!(
-                        "Failed to get extension config: {}",
-                        e
-                    ))),
+                    Err(ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to get extension config: {}", e),
+                        None,
+                    )),
                 )
             }
         };
@@ -629,7 +650,7 @@ impl Agent {
                     extension_name
                 ))]
             })
-            .map_err(|e| ToolError::ExecutionError(e.to_string()));
+            .map_err(|e| ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None));
 
         drop(extension_manager);
         // Update vector index if operation was successful and vector routing is enabled
@@ -650,10 +671,11 @@ impl Agent {
                     {
                         return (
                             request_id,
-                            Err(ToolError::ExecutionError(format!(
-                                "Failed to update vector index: {}",
-                                e
-                            ))),
+                            Err(ErrorData::new(
+                                ErrorCode::INTERNAL_ERROR,
+                                format!("Failed to update vector index: {}", e),
+                                None,
+                            )),
                         );
                     }
                 }

--- a/crates/goose/src/agents/final_output_tool.rs
+++ b/crates/goose/src/agents/final_output_tool.rs
@@ -1,9 +1,10 @@
 use crate::agents::tool_execution::ToolCallResult;
 use crate::recipe::Response;
 use indoc::formatdoc;
-use mcp_core::{ToolCall, ToolError};
-use rmcp::model::{Content, Tool, ToolAnnotations};
+use mcp_core::ToolCall;
+use rmcp::model::{Content, ErrorCode, ErrorData, Tool, ToolAnnotations};
 use serde_json::Value;
+use std::borrow::Cow;
 
 pub const FINAL_OUTPUT_TOOL_NAME: &str = "recipe__final_output";
 pub const FINAL_OUTPUT_CONTINUATION_MESSAGE: &str =
@@ -127,13 +128,18 @@ impl FinalOutputTool {
                             "Final output successfully collected.".to_string(),
                         )]))
                     }
-                    Err(error) => ToolCallResult::from(Err(ToolError::InvalidParameters(error))),
+                    Err(error) => ToolCallResult::from(Err(ErrorData {
+                        code: ErrorCode::INVALID_PARAMS,
+                        message: Cow::from(error),
+                        data: None,
+                    })),
                 }
             }
-            _ => ToolCallResult::from(Err(ToolError::NotFound(format!(
-                "Unknown tool: {}",
-                tool_call.name
-            )))),
+            _ => ToolCallResult::from(Err(ErrorData {
+                code: ErrorCode::INVALID_REQUEST,
+                message: Cow::from(format!("Unknown tool: {}", tool_call.name)),
+                data: None,
+            })),
         }
     }
 

--- a/crates/goose/src/agents/router_tool_selector.rs
+++ b/crates/goose/src/agents/router_tool_selector.rs
@@ -1,11 +1,11 @@
-use mcp_core::ToolError;
-use rmcp::model::Content;
 use rmcp::model::Tool;
+use rmcp::model::{Content, ErrorCode, ErrorData};
 
 use anyhow::{Context, Result};
 use async_trait::async_trait;
 use serde::Serialize;
 use serde_json::Value;
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::env;
@@ -32,11 +32,11 @@ pub enum RouterToolSelectionStrategy {
 
 #[async_trait]
 pub trait RouterToolSelector: Send + Sync {
-    async fn select_tools(&self, params: Value) -> Result<Vec<Content>, ToolError>;
-    async fn index_tools(&self, tools: &[Tool], extension_name: &str) -> Result<(), ToolError>;
-    async fn remove_tool(&self, tool_name: &str) -> Result<(), ToolError>;
-    async fn record_tool_call(&self, tool_name: &str) -> Result<(), ToolError>;
-    async fn get_recent_tool_calls(&self, limit: usize) -> Result<Vec<String>, ToolError>;
+    async fn select_tools(&self, params: Value) -> Result<Vec<Content>, ErrorData>;
+    async fn index_tools(&self, tools: &[Tool], extension_name: &str) -> Result<(), ErrorData>;
+    async fn remove_tool(&self, tool_name: &str) -> Result<(), ErrorData>;
+    async fn record_tool_call(&self, tool_name: &str) -> Result<(), ErrorData>;
+    async fn get_recent_tool_calls(&self, limit: usize) -> Result<Vec<String>, ErrorData>;
     fn selector_type(&self) -> RouterToolSelectionStrategy;
 }
 
@@ -80,11 +80,15 @@ impl VectorToolSelector {
 
 #[async_trait]
 impl RouterToolSelector for VectorToolSelector {
-    async fn select_tools(&self, params: Value) -> Result<Vec<Content>, ToolError> {
+    async fn select_tools(&self, params: Value) -> Result<Vec<Content>, ErrorData> {
         let query = params
             .get("query")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::InvalidParameters("Missing 'query' parameter".to_string()))?;
+            .ok_or_else(|| ErrorData {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("Missing 'query' parameter"),
+                data: None,
+            })?;
 
         let k = params.get("k").and_then(|v| v.as_u64()).unwrap_or(5) as usize;
 
@@ -93,29 +97,38 @@ impl RouterToolSelector for VectorToolSelector {
 
         // Check if provider supports embeddings
         if !self.embedding_provider.supports_embeddings() {
-            return Err(ToolError::ExecutionError(
-                "Embedding provider does not support embeddings".to_string(),
-            ));
+            return Err(ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from("Embedding provider does not support embeddings"),
+                data: None,
+            });
         }
 
         let embeddings = self
             .embedding_provider
             .create_embeddings(vec![query.to_string()])
             .await
-            .map_err(|e| {
-                ToolError::ExecutionError(format!("Failed to generate query embedding: {}", e))
+            .map_err(|e| ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Failed to generate query embedding: {}", e)),
+                data: None,
             })?;
 
-        let query_embedding = embeddings
-            .into_iter()
-            .next()
-            .ok_or_else(|| ToolError::ExecutionError("No embedding returned".to_string()))?;
+        let query_embedding = embeddings.into_iter().next().ok_or_else(|| ErrorData {
+            code: ErrorCode::INTERNAL_ERROR,
+            message: Cow::from("No embedding returned"),
+            data: None,
+        })?;
 
         let vector_db = self.vector_db.read().await;
         let tools = vector_db
             .search_tools(query_embedding, k, extension_name)
             .await
-            .map_err(|e| ToolError::ExecutionError(format!("Failed to search tools: {}", e)))?;
+            .map_err(|e| ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Failed to search tools: {}", e)),
+                data: None,
+            })?;
 
         let selected_tools: Vec<Content> = tools
             .into_iter()
@@ -131,7 +144,7 @@ impl RouterToolSelector for VectorToolSelector {
         Ok(selected_tools)
     }
 
-    async fn index_tools(&self, tools: &[Tool], extension_name: &str) -> Result<(), ToolError> {
+    async fn index_tools(&self, tools: &[Tool], extension_name: &str) -> Result<(), ErrorData> {
         let texts_to_embed: Vec<String> = tools
             .iter()
             .map(|tool| {
@@ -150,17 +163,21 @@ impl RouterToolSelector for VectorToolSelector {
             .collect();
 
         if !self.embedding_provider.supports_embeddings() {
-            return Err(ToolError::ExecutionError(
-                "Embedding provider does not support embeddings".to_string(),
-            ));
+            return Err(ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from("Embedding provider does not support embeddings"),
+                data: None,
+            });
         }
 
         let embeddings = self
             .embedding_provider
             .create_embeddings(texts_to_embed)
             .await
-            .map_err(|e| {
-                ToolError::ExecutionError(format!("Failed to generate tool embeddings: {}", e))
+            .map_err(|e| ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Failed to generate tool embeddings: {}", e)),
+                data: None,
             })?;
 
         // Create tool records
@@ -194,8 +211,10 @@ impl RouterToolSelector for VectorToolSelector {
             let existing_tools = vector_db
                 .search_tools(record.vector.clone(), 1, Some(&record.extension_name))
                 .await
-                .map_err(|e| {
-                    ToolError::ExecutionError(format!("Failed to search for existing tools: {}", e))
+                .map_err(|e| ErrorData {
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: Cow::from(format!("Failed to search for existing tools: {}", e)),
+                    data: None,
                 })?;
 
             // Only add if no exact match found
@@ -212,21 +231,30 @@ impl RouterToolSelector for VectorToolSelector {
             vector_db
                 .index_tools(new_tool_records)
                 .await
-                .map_err(|e| ToolError::ExecutionError(format!("Failed to index tools: {}", e)))?;
+                .map_err(|e| ErrorData {
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: Cow::from(format!("Failed to index tools: {}", e)),
+                    data: None,
+                })?;
         }
 
         Ok(())
     }
 
-    async fn remove_tool(&self, tool_name: &str) -> Result<(), ToolError> {
+    async fn remove_tool(&self, tool_name: &str) -> Result<(), ErrorData> {
         let vector_db = self.vector_db.read().await;
-        vector_db.remove_tool(tool_name).await.map_err(|e| {
-            ToolError::ExecutionError(format!("Failed to remove tool {}: {}", tool_name, e))
-        })?;
+        vector_db
+            .remove_tool(tool_name)
+            .await
+            .map_err(|e| ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Failed to remove tool {}: {}", tool_name, e)),
+                data: None,
+            })?;
         Ok(())
     }
 
-    async fn record_tool_call(&self, tool_name: &str) -> Result<(), ToolError> {
+    async fn record_tool_call(&self, tool_name: &str) -> Result<(), ErrorData> {
         let mut recent_calls = self.recent_tool_calls.write().await;
         if recent_calls.len() >= 100 {
             recent_calls.pop_front();
@@ -235,7 +263,7 @@ impl RouterToolSelector for VectorToolSelector {
         Ok(())
     }
 
-    async fn get_recent_tool_calls(&self, limit: usize) -> Result<Vec<String>, ToolError> {
+    async fn get_recent_tool_calls(&self, limit: usize) -> Result<Vec<String>, ErrorData> {
         let recent_calls = self.recent_tool_calls.read().await;
         Ok(recent_calls.iter().rev().take(limit).cloned().collect())
     }
@@ -263,11 +291,15 @@ impl LLMToolSelector {
 
 #[async_trait]
 impl RouterToolSelector for LLMToolSelector {
-    async fn select_tools(&self, params: Value) -> Result<Vec<Content>, ToolError> {
+    async fn select_tools(&self, params: Value) -> Result<Vec<Content>, ErrorData> {
         let query = params
             .get("query")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::InvalidParameters("Missing 'query' parameter".to_string()))?;
+            .ok_or_else(|| ErrorData {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from("Missing 'query' parameter"),
+                data: None,
+            })?;
 
         let extension_name = params
             .get("extension_name")
@@ -297,8 +329,10 @@ impl RouterToolSelector for LLMToolSelector {
             };
 
             let user_prompt =
-                render_global_file("router_tool_selector.md", &context).map_err(|e| {
-                    ToolError::ExecutionError(format!("Failed to render prompt template: {}", e))
+                render_global_file("router_tool_selector.md", &context).map_err(|e| ErrorData {
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: Cow::from(format!("Failed to render prompt template: {}", e)),
+                    data: None,
                 })?;
 
             let user_message = Message::user().with_text(&user_prompt);
@@ -306,7 +340,11 @@ impl RouterToolSelector for LLMToolSelector {
                 .llm_provider
                 .complete("", &[user_message], &[])
                 .await
-                .map_err(|e| ToolError::ExecutionError(format!("Failed to search tools: {}", e)))?;
+                .map_err(|e| ErrorData {
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: Cow::from(format!("Failed to search tools: {}", e)),
+                    data: None,
+                })?;
 
             // Extract just the message content from the response
             let (message, _usage) = response;
@@ -325,7 +363,7 @@ impl RouterToolSelector for LLMToolSelector {
         }
     }
 
-    async fn index_tools(&self, tools: &[Tool], extension_name: &str) -> Result<(), ToolError> {
+    async fn index_tools(&self, tools: &[Tool], extension_name: &str) -> Result<(), ErrorData> {
         let mut tool_strings = self.tool_strings.write().await;
 
         for tool in tools {
@@ -354,7 +392,7 @@ impl RouterToolSelector for LLMToolSelector {
 
         Ok(())
     }
-    async fn remove_tool(&self, tool_name: &str) -> Result<(), ToolError> {
+    async fn remove_tool(&self, tool_name: &str) -> Result<(), ErrorData> {
         let mut tool_strings = self.tool_strings.write().await;
         if let Some(extension_name) = tool_name.split("__").next() {
             tool_strings.remove(extension_name);
@@ -362,7 +400,7 @@ impl RouterToolSelector for LLMToolSelector {
         Ok(())
     }
 
-    async fn record_tool_call(&self, tool_name: &str) -> Result<(), ToolError> {
+    async fn record_tool_call(&self, tool_name: &str) -> Result<(), ErrorData> {
         let mut recent_calls = self.recent_tool_calls.write().await;
         if recent_calls.len() >= 100 {
             recent_calls.pop_front();
@@ -371,7 +409,7 @@ impl RouterToolSelector for LLMToolSelector {
         Ok(())
     }
 
-    async fn get_recent_tool_calls(&self, limit: usize) -> Result<Vec<String>, ToolError> {
+    async fn get_recent_tool_calls(&self, limit: usize) -> Result<Vec<String>, ErrorData> {
         let recent_calls = self.recent_tool_calls.read().await;
         Ok(recent_calls.iter().rev().take(limit).cloned().collect())
     }

--- a/crates/goose/src/agents/schedule_tool.rs
+++ b/crates/goose/src/agents/schedule_tool.rs
@@ -6,8 +6,8 @@
 use std::sync::Arc;
 
 use chrono::Utc;
-use mcp_core::{ToolError, ToolResult};
-use rmcp::model::Content;
+use mcp_core::ToolResult;
+use rmcp::model::{Content, ErrorCode, ErrorData};
 
 use crate::recipe::Recipe;
 use crate::scheduler_trait::SchedulerTrait;
@@ -24,8 +24,10 @@ impl Agent {
         let scheduler = match self.scheduler_service.lock().await.as_ref() {
             Some(s) => s.clone(),
             None => {
-                return Err(ToolError::ExecutionError(
+                return Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
                     "Scheduler not available. This tool only works in server mode.".to_string(),
+                    None,
                 ))
             }
         };
@@ -33,7 +35,13 @@ impl Agent {
         let action = arguments
             .get("action")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::ExecutionError("Missing 'action' parameter".to_string()))?;
+            .ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INVALID_PARAMS,
+                    "Missing 'action' parameter".to_string(),
+                    None,
+                )
+            })?;
 
         match action {
             "list" => self.handle_list_jobs(scheduler).await,
@@ -46,10 +54,11 @@ impl Agent {
             "inspect" => self.handle_inspect_job(scheduler, arguments).await,
             "sessions" => self.handle_list_sessions(scheduler, arguments).await,
             "session_content" => self.handle_session_content(arguments).await,
-            _ => Err(ToolError::ExecutionError(format!(
-                "Unknown action: {}",
-                action
-            ))),
+            _ => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Unknown action: {}", action),
+                None,
+            )),
         }
     }
 
@@ -61,17 +70,22 @@ impl Agent {
         match scheduler.list_scheduled_jobs().await {
             Ok(jobs) => {
                 let jobs_json = serde_json::to_string_pretty(&jobs).map_err(|e| {
-                    ToolError::ExecutionError(format!("Failed to serialize jobs: {}", e))
+                    ErrorData::new(
+                        ErrorCode::INTERNAL_ERROR,
+                        format!("Failed to serialize jobs: {}", e),
+                        None,
+                    )
                 })?;
                 Ok(vec![Content::text(format!(
                     "Scheduled Jobs:\n{}",
                     jobs_json
                 ))])
             }
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to list jobs: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to list jobs: {}", e),
+                None,
+            )),
         }
     }
 
@@ -85,14 +99,22 @@ impl Agent {
             .get("recipe_path")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                ToolError::ExecutionError("Missing 'recipe_path' parameter".to_string())
+                ErrorData::new(
+                    ErrorCode::INVALID_PARAMS,
+                    "Missing 'recipe_path' parameter".to_string(),
+                    None,
+                )
             })?;
 
         let cron_expression = arguments
             .get("cron_expression")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                ToolError::ExecutionError("Missing 'cron_expression' parameter".to_string())
+                ErrorData::new(
+                    ErrorCode::INVALID_PARAMS,
+                    "Missing 'cron_expression' parameter".to_string(),
+                    None,
+                )
             })?;
 
         // Get the execution_mode parameter, defaulting to "background" if not provided
@@ -103,18 +125,23 @@ impl Agent {
 
         // Validate execution_mode is either "foreground" or "background"
         if execution_mode != "foreground" && execution_mode != "background" {
-            return Err(ToolError::ExecutionError(format!(
-                "Invalid execution_mode: {}. Must be 'foreground' or 'background'",
-                execution_mode
-            )));
+            return Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!(
+                    "Invalid execution_mode: {}. Must be 'foreground' or 'background'",
+                    execution_mode
+                ),
+                None,
+            ));
         }
 
         // Validate recipe file exists and is readable
         if !std::path::Path::new(recipe_path).exists() {
-            return Err(ToolError::ExecutionError(format!(
-                "Recipe file not found: {}",
-                recipe_path
-            )));
+            return Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Recipe file not found: {}", recipe_path),
+                None,
+            ));
         }
 
         // Validate it's a valid recipe by trying to parse it
@@ -122,19 +149,28 @@ impl Agent {
             Ok(content) => {
                 if recipe_path.ends_with(".json") {
                     serde_json::from_str::<Recipe>(&content).map_err(|e| {
-                        ToolError::ExecutionError(format!("Invalid JSON recipe: {}", e))
+                        ErrorData::new(
+                            ErrorCode::INTERNAL_ERROR,
+                            format!("Invalid JSON recipe: {}", e),
+                            None,
+                        )
                     })?;
                 } else {
                     serde_yaml::from_str::<Recipe>(&content).map_err(|e| {
-                        ToolError::ExecutionError(format!("Invalid YAML recipe: {}", e))
+                        ErrorData::new(
+                            ErrorCode::INTERNAL_ERROR,
+                            format!("Invalid YAML recipe: {}", e),
+                            None,
+                        )
                     })?;
                 }
             }
             Err(e) => {
-                return Err(ToolError::ExecutionError(format!(
-                    "Cannot read recipe file: {}",
-                    e
-                )))
+                return Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Cannot read recipe file: {}", e),
+                    None,
+                ))
             }
         }
 
@@ -158,10 +194,11 @@ impl Agent {
                 "Successfully created scheduled job '{}' for recipe '{}' with cron expression '{}' in {} mode",
                 job_id, recipe_path, cron_expression, execution_mode
             ))]),
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to create job: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to create job: {}", e),
+                None,
+            )),
         }
     }
 
@@ -174,17 +211,24 @@ impl Agent {
         let job_id = arguments
             .get("job_id")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::ExecutionError("Missing 'job_id' parameter".to_string()))?;
+            .ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INVALID_PARAMS,
+                    "Missing 'job_id' parameter".to_string(),
+                    None,
+                )
+            })?;
 
         match scheduler.run_now(job_id).await {
             Ok(session_id) => Ok(vec![Content::text(format!(
                 "Successfully started job '{}'. Session ID: {}",
                 job_id, session_id
             ))]),
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to run job: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to run job: {}", e),
+                None,
+            )),
         }
     }
 
@@ -197,17 +241,24 @@ impl Agent {
         let job_id = arguments
             .get("job_id")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::ExecutionError("Missing 'job_id' parameter".to_string()))?;
+            .ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Missing 'job_id' parameter".to_string(),
+                    None,
+                )
+            })?;
 
         match scheduler.pause_schedule(job_id).await {
             Ok(()) => Ok(vec![Content::text(format!(
                 "Successfully paused job '{}'",
                 job_id
             ))]),
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to pause job: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to pause job: {}", e),
+                None,
+            )),
         }
     }
 
@@ -220,17 +271,24 @@ impl Agent {
         let job_id = arguments
             .get("job_id")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::ExecutionError("Missing 'job_id' parameter".to_string()))?;
+            .ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Missing 'job_id' parameter".to_string(),
+                    None,
+                )
+            })?;
 
         match scheduler.unpause_schedule(job_id).await {
             Ok(()) => Ok(vec![Content::text(format!(
                 "Successfully unpaused job '{}'",
                 job_id
             ))]),
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to unpause job: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to unpause job: {}", e),
+                None,
+            )),
         }
     }
 
@@ -243,17 +301,24 @@ impl Agent {
         let job_id = arguments
             .get("job_id")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::ExecutionError("Missing 'job_id' parameter".to_string()))?;
+            .ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Missing 'job_id' parameter".to_string(),
+                    None,
+                )
+            })?;
 
         match scheduler.remove_scheduled_job(job_id).await {
             Ok(()) => Ok(vec![Content::text(format!(
                 "Successfully deleted job '{}'",
                 job_id
             ))]),
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to delete job: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to delete job: {}", e),
+                None,
+            )),
         }
     }
 
@@ -266,17 +331,24 @@ impl Agent {
         let job_id = arguments
             .get("job_id")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::ExecutionError("Missing 'job_id' parameter".to_string()))?;
+            .ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Missing 'job_id' parameter".to_string(),
+                    None,
+                )
+            })?;
 
         match scheduler.kill_running_job(job_id).await {
             Ok(()) => Ok(vec![Content::text(format!(
                 "Successfully killed running job '{}'",
                 job_id
             ))]),
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to kill job: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to kill job: {}", e),
+                None,
+            )),
         }
     }
 
@@ -289,7 +361,13 @@ impl Agent {
         let job_id = arguments
             .get("job_id")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::ExecutionError("Missing 'job_id' parameter".to_string()))?;
+            .ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Missing 'job_id' parameter".to_string(),
+                    None,
+                )
+            })?;
 
         match scheduler.get_running_job_info(job_id).await {
             Ok(Some((session_id, start_time))) => {
@@ -303,10 +381,11 @@ impl Agent {
                 "Job '{}' is not currently running",
                 job_id
             ))]),
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to inspect job: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to inspect job: {}", e),
+                None,
+            )),
         }
     }
 
@@ -319,7 +398,13 @@ impl Agent {
         let job_id = arguments
             .get("job_id")
             .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolError::ExecutionError("Missing 'job_id' parameter".to_string()))?;
+            .ok_or_else(|| {
+                ErrorData::new(
+                    ErrorCode::INVALID_PARAMS,
+                    "Missing 'job_id' parameter".to_string(),
+                    None,
+                )
+            })?;
 
         let limit = arguments
             .get("limit")
@@ -353,10 +438,11 @@ impl Agent {
                     ))])
                 }
             }
-            Err(e) => Err(ToolError::ExecutionError(format!(
-                "Failed to list sessions: {}",
-                e
-            ))),
+            Err(e) => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Failed to list sessions: {}", e),
+                None,
+            )),
         }
     }
 
@@ -369,7 +455,11 @@ impl Agent {
             .get("session_id")
             .and_then(|v| v.as_str())
             .ok_or_else(|| {
-                ToolError::ExecutionError("Missing 'session_id' parameter".to_string())
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    "Missing 'session_id' parameter".to_string(),
+                    None,
+                )
             })?;
 
         // Get the session file path
@@ -378,29 +468,32 @@ impl Agent {
         ) {
             Ok(path) => path,
             Err(e) => {
-                return Err(ToolError::ExecutionError(format!(
-                    "Invalid session ID '{}': {}",
-                    session_id, e
-                )));
+                return Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Invalid session ID '{}': {}", session_id, e),
+                    None,
+                ));
             }
         };
 
         // Check if session file exists
         if !session_path.exists() {
-            return Err(ToolError::ExecutionError(format!(
-                "Session '{}' not found",
-                session_id
-            )));
+            return Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                format!("Session '{}' not found", session_id),
+                None,
+            ));
         }
 
         // Read session metadata
         let metadata = match crate::session::storage::read_metadata(&session_path) {
             Ok(metadata) => metadata,
             Err(e) => {
-                return Err(ToolError::ExecutionError(format!(
-                    "Failed to read session metadata: {}",
-                    e
-                )));
+                return Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to read session metadata: {}", e),
+                    None,
+                ));
             }
         };
 
@@ -408,10 +501,11 @@ impl Agent {
         let messages = match crate::session::storage::read_messages(&session_path) {
             Ok(messages) => messages,
             Err(e) => {
-                return Err(ToolError::ExecutionError(format!(
-                    "Failed to read session messages: {}",
-                    e
-                )));
+                return Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to read session messages: {}", e),
+                    None,
+                ));
             }
         };
 
@@ -419,20 +513,22 @@ impl Agent {
         let metadata_json = match serde_json::to_string_pretty(&metadata) {
             Ok(json) => json,
             Err(e) => {
-                return Err(ToolError::ExecutionError(format!(
-                    "Failed to serialize metadata: {}",
-                    e
-                )));
+                return Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to serialize metadata: {}", e),
+                    None,
+                ));
             }
         };
 
         let messages_json = match serde_json::to_string_pretty(&messages) {
             Ok(json) => json,
             Err(e) => {
-                return Err(ToolError::ExecutionError(format!(
-                    "Failed to serialize messages: {}",
-                    e
-                )));
+                return Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to serialize messages: {}", e),
+                    None,
+                ));
             }
         };
 

--- a/crates/goose/src/agents/sub_recipe_manager.rs
+++ b/crates/goose/src/agents/sub_recipe_manager.rs
@@ -1,7 +1,7 @@
-use mcp_core::ToolError;
-use rmcp::model::Content;
 use rmcp::model::Tool;
+use rmcp::model::{Content, ErrorCode, ErrorData};
 use serde_json::Value;
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::{
@@ -63,7 +63,11 @@ impl SubRecipeManager {
             .await;
         match result {
             Ok(call_result) => ToolCallResult::from(Ok(call_result)),
-            Err(e) => ToolCallResult::from(Err(ToolError::ExecutionError(e.to_string()))),
+            Err(e) => ToolCallResult::from(Err(ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(e.to_string()),
+                data: None,
+            })),
         }
     }
 
@@ -72,25 +76,33 @@ impl SubRecipeManager {
         tool_name: &str,
         params: Value,
         tasks_manager: &TasksManager,
-    ) -> Result<Vec<Content>, ToolError> {
+    ) -> Result<Vec<Content>, ErrorData> {
         let sub_recipe = self.sub_recipes.get(tool_name).ok_or_else(|| {
             let sub_recipe_name = tool_name
                 .strip_prefix(SUB_RECIPE_TASK_TOOL_NAME_PREFIX)
                 .and_then(|s| s.strip_prefix("_"))
-                .ok_or_else(|| {
-                    ToolError::InvalidParameters(format!(
+                .ok_or_else(|| ErrorData {
+                    code: ErrorCode::INVALID_PARAMS,
+                    message: Cow::from(format!(
                         "Invalid sub-recipe tool name format: {}",
                         tool_name
-                    ))
+                    )),
+                    data: None,
                 })
                 .unwrap();
 
-            ToolError::InvalidParameters(format!("Sub-recipe '{}' not found", sub_recipe_name))
+            ErrorData {
+                code: ErrorCode::INVALID_PARAMS,
+                message: Cow::from(format!("Sub-recipe '{}' not found", sub_recipe_name)),
+                data: None,
+            }
         })?;
         let output = create_sub_recipe_task(sub_recipe, params, tasks_manager)
             .await
-            .map_err(|e| {
-                ToolError::ExecutionError(format!("Sub-recipe task createion failed: {}", e))
+            .map_err(|e| ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(format!("Sub-recipe task creation failed: {}", e)),
+                data: None,
             })?;
         Ok(vec![Content::text(output)])
     }

--- a/crates/goose/src/agents/subagent.rs
+++ b/crates/goose/src/agents/subagent.rs
@@ -8,8 +8,8 @@ use crate::{
 };
 use anyhow::anyhow;
 use chrono::{DateTime, Utc};
-use mcp_core::handler::ToolError;
 use rmcp::model::Tool;
+use rmcp::model::{ErrorCode, ErrorData};
 use serde::{Deserialize, Serialize};
 // use serde_json::{self};
 use crate::conversation::message::{Message, MessageContent, ToolRequest};
@@ -206,7 +206,11 @@ impl SubAgent {
                                 .await
                             {
                                 Ok(result) => result.result.await,
-                                Err(e) => Err(ToolError::ExecutionError(e.to_string())),
+                                Err(e) => Err(ErrorData::new(
+                                    ErrorCode::INTERNAL_ERROR,
+                                    e.to_string(),
+                                    None,
+                                )),
                             };
 
                             match tool_result {
@@ -220,7 +224,11 @@ impl SubAgent {
                                     // Create a user message with the tool error
                                     let tool_error_message = Message::user().with_tool_response(
                                         request.id.clone(),
-                                        Err(ToolError::ExecutionError(e.to_string())),
+                                        Err(ErrorData::new(
+                                            ErrorCode::INTERNAL_ERROR,
+                                            e.to_string(),
+                                            None,
+                                        )),
                                     );
                                     messages.push(tool_error_message);
                                 }

--- a/crates/goose/src/agents/subagent_execution_tool/subagent_execute_task_tool.rs
+++ b/crates/goose/src/agents/subagent_execution_tool/subagent_execute_task_tool.rs
@@ -1,5 +1,6 @@
-use mcp_core::ToolError;
-use rmcp::model::{Content, ServerNotification, Tool, ToolAnnotations};
+use std::borrow::Cow;
+
+use rmcp::model::{Content, ErrorCode, ErrorData, ServerNotification, Tool, ToolAnnotations};
 use serde_json::Value;
 
 use crate::agents::subagent_task_config::TaskConfig;
@@ -90,7 +91,11 @@ pub async fn run_tasks(
                 let output = serde_json::to_string(&result).unwrap();
                 Ok(vec![Content::text(output)])
             }
-            Err(e) => Err(ToolError::ExecutionError(e.to_string())),
+            Err(e) => Err(ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(e.to_string()),
+                data: None,
+            }),
         }
     };
 

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -1,7 +1,7 @@
 use crate::agents::subagent::SubAgent;
 use crate::agents::subagent_task_config::TaskConfig;
 use anyhow::Result;
-use mcp_core::ToolError;
+use rmcp::model::{ErrorCode, ErrorData};
 
 /// Standalone function to run a complete subagent task
 pub async fn run_complete_subagent_task(
@@ -9,9 +9,13 @@ pub async fn run_complete_subagent_task(
     task_config: TaskConfig,
 ) -> Result<String, anyhow::Error> {
     // Create the subagent with the parent agent's provider
-    let subagent = SubAgent::new(task_config.clone())
-        .await
-        .map_err(|e| ToolError::ExecutionError(format!("Failed to create subagent: {}", e)))?;
+    let subagent = SubAgent::new(task_config.clone()).await.map_err(|e| {
+        ErrorData::new(
+            ErrorCode::INTERNAL_ERROR,
+            format!("Failed to create subagent: {}", e),
+            None,
+        )
+    })?;
 
     // Execute the subagent task
     let messages = subagent

--- a/crates/goose/src/agents/tool_route_manager.rs
+++ b/crates/goose/src/agents/tool_route_manager.rs
@@ -10,8 +10,7 @@ use crate::config::Config;
 use crate::conversation::message::ToolRequest;
 use crate::providers::base::Provider;
 use anyhow::{anyhow, Result};
-use mcp_core::ToolError;
-use rmcp::model::Tool;
+use rmcp::model::{ErrorCode, ErrorData, Tool};
 use serde_json::Value;
 use std::sync::Arc;
 use tokio::sync::Mutex;
@@ -52,18 +51,21 @@ impl ToolRouteManager {
     pub async fn dispatch_route_search_tool(
         &self,
         arguments: Value,
-    ) -> Result<ToolCallResult, ToolError> {
+    ) -> Result<ToolCallResult, ErrorData> {
         let selector = self.router_tool_selector.lock().await.clone();
         match selector.as_ref() {
             Some(selector) => match selector.select_tools(arguments).await {
                 Ok(tools) => Ok(ToolCallResult::from(Ok(tools))),
-                Err(e) => Err(ToolError::ExecutionError(format!(
-                    "Failed to select tools: {}",
-                    e
-                ))),
+                Err(e) => Err(ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to select tools: {}", e),
+                    None,
+                )),
             },
-            None => Err(ToolError::ExecutionError(
+            None => Err(ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
                 "No tool selector available".to_string(),
+                None,
             )),
         }
     }

--- a/crates/goose/src/conversation/tool_result_serde.rs
+++ b/crates/goose/src/conversation/tool_result_serde.rs
@@ -1,6 +1,8 @@
-use mcp_core::handler::{ToolError, ToolResult};
+use mcp_core::ToolResult;
+use rmcp::model::{ErrorCode, ErrorData};
 use serde::ser::SerializeStruct;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Cow;
 
 pub fn serialize<T, S>(value: &ToolResult<T>, serializer: S) -> Result<S::Ok, S::Error>
 where
@@ -52,7 +54,11 @@ where
         }
         ResultFormat::Error { status, error } => {
             if status == "error" {
-                Ok(Err(ToolError::ExecutionError(error)))
+                Ok(Err(ErrorData {
+                    code: ErrorCode::INTERNAL_ERROR,
+                    message: Cow::from(error),
+                    data: None,
+                }))
             } else {
                 Err(serde::de::Error::custom(format!(
                     "Expected status 'error', got '{}'",

--- a/crates/goose/src/providers/formats/google.rs
+++ b/crates/goose/src/providers/formats/google.rs
@@ -3,9 +3,10 @@ use crate::providers::base::Usage;
 use crate::providers::errors::ProviderError;
 use crate::providers::utils::{is_valid_function_name, sanitize_function_name};
 use anyhow::Result;
-use mcp_core::tool::ToolCall;
+use mcp_core::ToolCall;
 use rand::{distributions::Alphanumeric, Rng};
-use rmcp::model::{AnnotateAble, RawContent, Role, Tool};
+use rmcp::model::{AnnotateAble, ErrorCode, ErrorData, RawContent, Role, Tool};
+use std::borrow::Cow;
 
 use crate::conversation::message::{Message, MessageContent};
 use serde_json::{json, Map, Value};
@@ -254,10 +255,14 @@ pub fn response_to_message(response: Value) -> Result<Message> {
                 .unwrap_or_default()
                 .to_string();
             if !is_valid_function_name(&name) {
-                let error = mcp_core::ToolError::NotFound(format!(
-                    "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
-                    name
-                ));
+                let error = ErrorData {
+                    code: ErrorCode::INVALID_REQUEST,
+                    message: Cow::from(format!(
+                        "The provided function name '{}' had invalid characters, it must match this regex [a-zA-Z0-9_-]+",
+                        name
+                    )),
+                    data: None,
+                };
                 content.push(MessageContent::tool_request(id, Err(error)));
             } else {
                 let parameters = function_call.get("args");
@@ -741,7 +746,14 @@ mod tests {
         assert_eq!(message.role, Role::Assistant);
         assert_eq!(message.content.len(), 1);
         if let Err(error) = &message.content[0].as_tool_request().unwrap().tool_call {
-            assert!(matches!(error, mcp_core::ToolError::NotFound(_)));
+            assert!(matches!(
+                error,
+                ErrorData {
+                    code: ErrorCode::INVALID_REQUEST,
+                    message: _,
+                    data: None,
+                }
+            ));
         } else {
             panic!("Expected tool request error");
         }

--- a/crates/goose/tests/private_tests.rs
+++ b/crates/goose/tests/private_tests.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
 
-use mcp_core::ToolError;
+use rmcp::model::ErrorCode;
 use serde_json::json;
 
 use goose::agents::platform_tools::PLATFORM_MANAGE_SCHEDULE_TOOL_NAME;
@@ -94,9 +94,10 @@ async fn test_schedule_tool_list_action_error() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Failed to list jobs"));
-        assert!(msg.contains("Database error"));
+    if let Err(err) = result {
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("Failed to list jobs"));
+        assert!(err.message.contains("Database error"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -153,8 +154,9 @@ async fn test_schedule_tool_create_action_missing_params() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Missing 'recipe_path' parameter"));
+    if let Err(err) = result {
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("Missing 'recipe_path' parameter"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -171,8 +173,9 @@ async fn test_schedule_tool_create_action_missing_params() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Missing 'cron_expression' parameter"));
+    if let Err(err) = result {
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("Missing 'cron_expression' parameter"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -194,8 +197,9 @@ async fn test_schedule_tool_create_action_nonexistent_recipe() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Recipe file not found"));
+    if let Err(err) = result {
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("Recipe file not found"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -220,8 +224,9 @@ async fn test_schedule_tool_create_action_invalid_recipe() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Invalid JSON recipe"));
+    if let Err(err) = result {
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("Invalid JSON recipe"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -253,9 +258,10 @@ async fn test_schedule_tool_create_action_scheduler_error() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Failed to create job"));
-        assert!(msg.contains("job1"));
+    if let Err(err) = result {
+        assert_eq!(err.code, ErrorCode::INTERNAL_ERROR);
+        assert!(err.message.contains("Failed to create job"));
+        assert!(err.message.contains("job1"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -311,8 +317,9 @@ async fn test_schedule_tool_run_now_action_missing_job_id() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Missing 'job_id' parameter"));
+    if let Err(err) = result {
+        assert_eq!(err.code, ErrorCode::INVALID_PARAMS);
+        assert!(err.message.contains("Missing 'job_id' parameter"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -337,9 +344,9 @@ async fn test_schedule_tool_run_now_action_nonexistent_job() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Failed to run job"));
-        assert!(msg.contains("nonexistent"));
+    if let Err(err) = result {
+        assert!(err.message.contains("Failed to run job"));
+        assert!(err.message.contains("nonexistent"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -391,10 +398,11 @@ async fn test_schedule_tool_pause_action_missing_job_id() {
     let result = agent
         .handle_schedule_management(arguments, "test_req".to_string())
         .await;
+
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Missing 'job_id' parameter"));
+    if let Err(err) = result {
+        assert!(err.message.contains("Missing 'job_id' parameter"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -422,9 +430,9 @@ async fn test_schedule_tool_pause_action_running_job() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Failed to pause job"));
-        assert!(msg.contains("job1"));
+    if let Err(err) = result {
+        assert!(err.message.contains("Failed to pause job"));
+        assert!(err.message.contains("job1"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -551,8 +559,8 @@ async fn test_schedule_tool_kill_action_not_running() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Failed to kill job"));
+    if let Err(err) = result {
+        assert!(err.message.contains("Failed to kill job"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -764,8 +772,10 @@ async fn test_schedule_tool_session_content_action() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Session 'non_existent_session' not found"));
+    if let Err(err) = result {
+        assert!(err
+            .message
+            .contains("Session 'non_existent_session' not found"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -840,8 +850,8 @@ async fn test_schedule_tool_session_content_action_missing_session_id() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Missing 'session_id' parameter"));
+    if let Err(err) = result {
+        assert!(err.message.contains("Missing 'session_id' parameter"));
     } else {
         panic!("Expected ExecutionError");
     }
@@ -861,8 +871,8 @@ async fn test_schedule_tool_unknown_action() {
         .await;
     assert!(result.is_err());
 
-    if let Err(ToolError::ExecutionError(msg)) = result {
-        assert!(msg.contains("Unknown action"));
+    if let Err(err) = result {
+        assert!(err.message.contains("Unknown action"));
     } else {
         panic!("Expected ExecutionError");
     }

--- a/crates/mcp-core/src/handler.rs
+++ b/crates/mcp-core/src/handler.rs
@@ -1,22 +1,7 @@
-use serde::{Deserialize, Serialize};
-#[allow(unused_imports)] // this is used in schema below
-use serde_json::{json, Value};
+use rmcp::model::{ErrorCode, ErrorData};
 use thiserror::Error;
 
-#[non_exhaustive]
-#[derive(Error, Debug, Clone, Deserialize, Serialize, PartialEq)]
-pub enum ToolError {
-    #[error("Invalid parameters: {0}")]
-    InvalidParameters(String),
-    #[error("Execution failed: {0}")]
-    ExecutionError(String),
-    #[error("Schema error: {0}")]
-    SchemaError(String),
-    #[error("Tool not found: {0}")]
-    NotFound(String),
-}
-
-pub type ToolResult<T> = std::result::Result<T, ToolError>;
+pub type ToolResult<T> = std::result::Result<T, ErrorData>;
 
 #[derive(Error, Debug)]
 pub enum ResourceError {
@@ -36,31 +21,43 @@ pub enum PromptError {
     NotFound(String),
 }
 
-/// Helper function to require a string, returning a ToolError
+/// Helper function to require a string, returning an ErrorData
 pub fn require_str_parameter<'a>(
     v: &'a serde_json::Value,
     name: &str,
-) -> Result<&'a str, ToolError> {
-    let v = v
-        .get(name)
-        .ok_or_else(|| ToolError::InvalidParameters(format!("The parameter {name} is required")))?;
+) -> Result<&'a str, ErrorData> {
+    let v = v.get(name).ok_or_else(|| {
+        ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!("The parameter {name} is required"),
+            None,
+        )
+    })?;
     match v.as_str() {
         Some(r) => Ok(r),
-        None => Err(ToolError::InvalidParameters(format!(
-            "The parameter {name} must be a string"
-        ))),
+        None => Err(ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!("The parameter {name} must be a string"),
+            None,
+        )),
     }
 }
 
-/// Helper function to require a u64, returning a ToolError
-pub fn require_u64_parameter(v: &serde_json::Value, name: &str) -> Result<u64, ToolError> {
-    let v = v
-        .get(name)
-        .ok_or_else(|| ToolError::InvalidParameters(format!("The parameter {name} is required")))?;
+/// Helper function to require a u64, returning an ErrorData
+pub fn require_u64_parameter(v: &serde_json::Value, name: &str) -> Result<u64, ErrorData> {
+    let v = v.get(name).ok_or_else(|| {
+        ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!("The parameter {name} is required"),
+            None,
+        )
+    })?;
     match v.as_u64() {
         Some(r) => Ok(r),
-        None => Err(ToolError::InvalidParameters(format!(
-            "The parameter {name} must be a number"
-        ))),
+        None => Err(ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!("The parameter {name} is required"),
+            None,
+        )),
     }
 }

--- a/crates/mcp-core/src/lib.rs
+++ b/crates/mcp-core/src/lib.rs
@@ -2,4 +2,4 @@ pub mod handler;
 pub mod tool;
 pub use tool::{Tool, ToolCall};
 pub mod protocol;
-pub use handler::{ToolError, ToolResult};
+pub use handler::ToolResult;

--- a/crates/mcp-server/src/main.rs
+++ b/crates/mcp-server/src/main.rs
@@ -1,13 +1,15 @@
 use anyhow::Result;
 use mcp_core::handler::{PromptError, ResourceError};
-use mcp_core::{handler::ToolError, protocol::ServerCapabilities};
+use mcp_core::protocol::ServerCapabilities;
 use mcp_server::router::{CapabilitiesBuilder, RouterService};
 use mcp_server::{ByteTransport, Router, Server};
 use rmcp::model::{
-    Content, JsonRpcMessage, Prompt, PromptArgument, RawResource, Resource, Tool, ToolAnnotations,
+    Content, ErrorCode, ErrorData, JsonRpcMessage, Prompt, PromptArgument, RawResource, Resource,
+    Tool, ToolAnnotations,
 };
 use rmcp::object;
 use serde_json::Value;
+use std::borrow::Cow;
 use std::{future::Future, pin::Pin, sync::Arc};
 use tokio::sync::mpsc;
 use tokio::{
@@ -30,19 +32,19 @@ impl CounterRouter {
         }
     }
 
-    async fn increment(&self) -> Result<i32, ToolError> {
+    async fn increment(&self) -> Result<i32, ErrorData> {
         let mut counter = self.counter.lock().await;
         *counter += 1;
         Ok(*counter)
     }
 
-    async fn decrement(&self) -> Result<i32, ToolError> {
+    async fn decrement(&self) -> Result<i32, ErrorData> {
         let mut counter = self.counter.lock().await;
         *counter -= 1;
         Ok(*counter)
     }
 
-    async fn get_value(&self) -> Result<i32, ToolError> {
+    async fn get_value(&self) -> Result<i32, ErrorData> {
         let counter = self.counter.lock().await;
         Ok(*counter)
     }
@@ -127,7 +129,7 @@ impl Router for CounterRouter {
         tool_name: &str,
         _arguments: Value,
         _notifier: mpsc::Sender<JsonRpcMessage>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ToolError>> + Send + 'static>> {
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ErrorData>> + Send + 'static>> {
         let this = self.clone();
         let tool_name = tool_name.to_string();
 
@@ -145,7 +147,11 @@ impl Router for CounterRouter {
                     let value = this.get_value().await?;
                     Ok(vec![Content::text(value.to_string())])
                 }
-                _ => Err(ToolError::NotFound(format!("Tool {} not found", tool_name))),
+                _ => Err(ErrorData {
+                    code: ErrorCode::INVALID_REQUEST,
+                    message: Cow::from(format!("Tool {} not found", tool_name)),
+                    data: None,
+                }),
             }
         })
     }

--- a/crates/mcp-server/src/router.rs
+++ b/crates/mcp-server/src/router.rs
@@ -6,7 +6,7 @@ use std::{
 
 type PromptFuture = Pin<Box<dyn Future<Output = Result<String, PromptError>> + Send + 'static>>;
 use mcp_core::{
-    handler::{PromptError, ResourceError, ToolError},
+    handler::{PromptError, ResourceError},
     protocol::{
         CallToolResult, Implementation, InitializeResult, ListPromptsResult, ListResourcesResult,
         ListToolsResult, PromptsCapability, ReadResourceResult, ResourcesCapability,
@@ -14,8 +14,9 @@ use mcp_core::{
     },
 };
 use rmcp::model::{
-    Content, GetPromptResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse, JsonRpcVersion2_0,
-    Prompt, PromptMessage, PromptMessageRole, RequestId, Resource, ResourceContents,
+    Content, ErrorData, GetPromptResult, JsonRpcMessage, JsonRpcRequest, JsonRpcResponse,
+    JsonRpcVersion2_0, Prompt, PromptMessage, PromptMessageRole, RequestId, Resource,
+    ResourceContents,
 };
 use serde_json::Value;
 use tokio::sync::mpsc;
@@ -92,7 +93,7 @@ pub trait Router: Send + Sync + 'static {
         tool_name: &str,
         arguments: Value,
         notifier: mpsc::Sender<JsonRpcMessage>,
-    ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ToolError>> + Send + 'static>>;
+    ) -> Pin<Box<dyn Future<Output = Result<Vec<Content>, ErrorData>> + Send + 'static>>;
     fn list_resources(&self) -> Vec<Resource>;
     fn read_resource(
         &self,

--- a/documentation/docs/goose-architecture/extensions-design.md
+++ b/documentation/docs/goose-architecture/extensions-design.md
@@ -48,7 +48,7 @@ async fn echo(&self, params: Value) -> AgentResult<Value>
 ### Error Handling
 
 The system uses two main error types:
-- `ToolError`: Specific errors related to tool execution
+- `ErrorData`: Specific errors related to tool execution
 - `anyhow::Error`: General purpose errors for extension status and other operations
 
 This split allows precise error handling for tool execution while maintaining flexibility for general extension operations.
@@ -65,7 +65,7 @@ This split allows precise error handling for tool execution while maintaining fl
 ### Extension Implementation
 
 1. **State Encapsulation**: Keep extension state private and controlled
-2. **Error Propagation**: Use `?` operator with `ToolError` for tool execution
+2. **Error Propagation**: Use `?` operator with `ErrorData` for tool execution
 3. **Status Clarity**: Provide clear, structured status information
 4. **Documentation**: Document all tools and their effects
 
@@ -90,7 +90,11 @@ impl FileSystem {
         let full_path = self.root_path.join(path);
         let content = tokio::fs::read_to_string(full_path)
             .await
-            .map_err(|e| ToolError::ExecutionError(e.to_string()))?;
+            .map_err(|e| ErrorData {
+                code: ErrorCode::INTERNAL_ERROR,
+                message: Cow::from(e.to_string(),
+                data: None,
+            }))?;
             
         Ok(json!({ "content": content }))
     }


### PR DESCRIPTION
Converts all usages of our internal MCP crate `ToolError` concept to rmcp's `ErrorData`

There were some conversions which were automated and uses the `ErrorData { ... }` variant, which requires providing the message manually as a `std::borrow::Cow` vs the `ErrorData::new(...)` option which allows strings.

Related https://github.com/block/goose/issues/3578