### PR TITLE
docs: rename sessions

### DIFF
--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -5,7 +5,7 @@ sidebar_label: Managing Sessions
 ---
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
-import { AppWindow, PanelLeft, FolderDot, Paperclip, Copy } from 'lucide-react';
+import { AppWindow, PanelLeft, FolderDot, Paperclip, Copy, Edit2 } from 'lucide-react';
 
 
 A session is a single, continuous interaction between you and Goose, providing a space to ask questions and prompt action. In this guide, we'll cover how to start, exit, and resume a session. 
@@ -74,6 +74,15 @@ If this is your first session, Goose will prompt you for an API key to access an
 <Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
         Within the Desktop app, sessions are automatically named based on the context of your initial prompt.
+
+        You can rename sessions after they're created:
+
+        1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
+        2. Click `History` in the sidebar
+        3. Hover over the session you'd like to rename
+        4. Click the <Edit2 className="inline" size={16} /> button that appears on the session card
+        5. Enter the new session name
+        6. Click `Save`
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
         By default, Goose names your session using the current timestamp in the format `YYYYMMDD_HHMMSS`. If you'd like to provide a specific name, this is where you'd do so. For example to name your session `react-migration`, you would run:
@@ -142,7 +151,11 @@ Search allows you to find specific content within sessions or find specific sess
     4. Enter your search term
     5. Use keyboard shortcuts and search bar buttons to navigate the results (`Cmd+E` not supported)
 
-     This is a metadata-only search. It doesn't search conversation content. Note that searching by file name is supported (e.g. `20250727_130002.jsonl`), but this property isn't displayed in the UI.
+    This is a metadata-only search. It doesn't search conversation content. Note that searching by file name is supported (e.g. `20250727_130002.jsonl`), but this property isn't displayed in the UI.
+
+    :::tip
+    You can [rename sessions](#name-session) to give them descriptive names that you'll remember later.
+    :::
 
     #### Search Within Historical Session
     


### PR DESCRIPTION
This PR documents the ability to rename sessions in Desktop.

Documentation updates:
- `documentation/docs/guides/managing-goose-sessions.md`: 
   - Added steps to rename session
   - Link to Name Session section from Search Sessions