### PR TITLE
fix not being able to add spaces to activity message area

### DIFF
--- a/ui/desktop/src/components/RecipeActivityEditor.tsx
+++ b/ui/desktop/src/components/RecipeActivityEditor.tsx
@@ -17,7 +17,7 @@ export default function RecipeActivityEditor({
       activity.toLowerCase().startsWith('message:')
     );
     if (messageActivity) {
-      setMessageContent(messageActivity.replace(/^message:/i, '').trim());
+      setMessageContent(messageActivity.replace(/^message:/i, ''));
     }
   }, [activities]);
 
@@ -45,7 +45,7 @@ export default function RecipeActivityEditor({
       (activity) => !activity.toLowerCase().startsWith('message:')
     );
 
-    if (value.trim()) {
+    if (value.length > 0) {
       setActivities([`message:${value}`, ...otherActivities]);
     } else {
       setActivities(otherActivities);
@@ -77,6 +77,9 @@ export default function RecipeActivityEditor({
           className="w-full px-4 py-3 border rounded-lg bg-background-default text-textStandard placeholder-textPlaceholder focus:outline-none focus:ring-2 focus:ring-borderProminent resize-vertical"
           placeholder="Enter a message for your recipe (supports **bold**, *italic*, `code`, etc.)"
           rows={3}
+          autoCorrect="off"
+          autoCapitalize="off"
+          spellCheck="false"
         />
       </div>
 


### PR DESCRIPTION
fix not being able to add spaces to activity message area and OS adding periods after double spaces

<img width="782" height="571" alt="image" src="https://github.com/user-attachments/assets/65e617d0-b783-45b6-bdc7-341b78550d06" />
