### PR TITLE
docs: add window title

### DIFF
--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -351,9 +351,6 @@ Here are some local providers we support:
 
 <Tabs groupId="local-llms">
   <TabItem value="ollama" label="Ollama" default>
-
-    Ollama models with tool support can be used in [chat only mode](/docs/guides/goose-permissions) for analysis, writing, and reasoning tasks. Chat only mode is optimized for Ollama with streamlined processing and reduced overhead.
-    
     <Tabs groupId="ollama-models">
       <TabItem value="ramalala" label="Ramalala">
         1. [Download Ramalama](https://github.com/containers/ramalama?tab=readme-ov-file#install).

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -351,6 +351,9 @@ Here are some local providers we support:
 
 <Tabs groupId="local-llms">
   <TabItem value="ollama" label="Ollama" default>
+
+    Ollama models with tool support can be used in [chat only mode](/docs/guides/goose-permissions) for analysis, writing, and reasoning tasks. Chat only mode is optimized for Ollama with streamlined processing and reduced overhead.
+    
     <Tabs groupId="ollama-models">
       <TabItem value="ramalala" label="Ramalala">
         1. [Download Ramalama](https://github.com/containers/ramalama?tab=readme-ov-file#install).

--- a/documentation/docs/guides/config-file.md
+++ b/documentation/docs/guides/config-file.md
@@ -22,7 +22,7 @@ The following settings can be configured at the root level of your config.yaml f
 | `GOOSE_PROVIDER` | Primary [LLM provider](/docs/getting-started/providers) | "anthropic", "openai", etc. | None | Yes |
 | `GOOSE_MODEL` | Default model to use | Model name (e.g., "claude-3.5-sonnet", "gpt-4") | None | Yes |
 | `GOOSE_TEMPERATURE` | Model response randomness | Float between 0.0 and 1.0 | Model-specific | No |
-| `GOOSE_MODE` | Tool execution behavior | "auto", "approve", "chat", "smart_approve" | "smart_approve" | No |
+| `GOOSE_MODE` | [Tool execution behavior](/docs/guides/goose-permissions) | "auto", "approve", "chat", "smart_approve" | "smart_approve" | No |
 | `GOOSE_MAX_TURNS` | [Maximum number of turns](/docs/guides/smart-context-management#maximum-turns) allowed without user input | Integer (e.g., 10, 50, 100) | 1000 | No |
 | `GOOSE_LEAD_PROVIDER` | Provider for lead model in [lead/worker mode](/docs/guides/environment-variables#leadworker-model-configuration) | Same as `GOOSE_PROVIDER` options | Falls back to `GOOSE_PROVIDER` | No |
 | `GOOSE_LEAD_MODEL` | Lead model for lead/worker mode | Model name | None | No |

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -176,7 +176,7 @@ For more details and examples, see [Model Context Limit Overrides](/docs/guides/
 
 ## Tool Configuration
 
-These variables control how Goose handles [tool permissions](/docs/guides/managing-tools/tool-permissions) and their execution.
+These variables control how Goose handles [tool execution](/docs/guides/goose-permissions) and [tool management](/docs/guides/managing-tools/).
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|

--- a/documentation/docs/guides/goose-permissions.md
+++ b/documentation/docs/guides/goose-permissions.md
@@ -29,7 +29,7 @@ Goose’s permissions determine how much autonomy it has when modifying files, u
 | **Completely Autonomous**           | Goose can modify files, use extensions, and delete files **without requiring approval**.              | Users who want **full automation** and seamless integration into their workflow.           |
 | **Manual Approval**| Goose **asks for confirmation** before using any tools or extensions.                                 | Users who want to **review and approve** every change and tool usage.                      |
 | **Smart Approval** | Goose uses a risk-based approach to **automatically approve low-risk actions** and **flag others** for approval. | Users who want a **balanced mix of autonomy and oversight** based on the action’s impact. |
-| **Chat Only**      | Goose **only engages in chat**, with no extension use or file modifications.                          | Users who prefer a **conversational AI experience** without automation.                    |
+| **Chat Only**      | Goose **only engages in chat**, with no extension use or file modifications.                          | Users who prefer a **conversational AI experience** for analysis, writing, and reasoning tasks without automation.                    |
        |
 
 :::warning
@@ -134,7 +134,7 @@ Here's how to configure:
 </Tabs>
 
   :::info
-  If you choose `Approve` mode, you will see "Allow" and "Deny" buttons in your session windows during tool calls. 
+  If you choose `Manual` (in Goose Desktop) or `Approve Mode` (in Goose CLI), you will see "Allow" and "Deny" buttons in your session windows during tool calls. 
   Goose will only ask for permission for tools that it deems are 'write' tools, e.g. any 'text editor write', 'text editor edit', 'bash - rm, cp, mv' commands. 
   
   Read/write approval makes best effort attempt at classifying read or write tools. This is interpreted by your LLM provider. 

--- a/documentation/docs/guides/managing-goose-sessions.md
+++ b/documentation/docs/guides/managing-goose-sessions.md
@@ -83,6 +83,9 @@ If this is your first session, Goose will prompt you for an API key to access an
         4. Click the <Edit2 className="inline" size={16} /> button that appears on the session card
         5. Enter the new session name
         6. Click `Save`
+
+        Session names can also help you manage multiple Goose windows. When you're in the Goose chat interface, session names appear in the `Window` menu and in the Dock (macOS) or taskbar (Windows) menu, making it easy to identify and switch between different Goose sessions.
+
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
         By default, Goose names your session using the current timestamp in the format `YYYYMMDD_HHMMSS`. If you'd like to provide a specific name, this is where you'd do so. For example to name your session `react-migration`, you would run:


### PR DESCRIPTION
This PR makes misc updates for window titles and chat mode.

Documentation updates:
- `documentation/docs/guides/config-file.md` and `documentation/docs/guides/environment-variables.md`: 
   - Add cross links
- `documentation/docs/guides/managing-goose-sessions.md`: 
   - Note how session names appear in window titles
- `documentation/docs/guides/goose-permissions.md`: 
   - Add more description for chat mode and add Desktop label