### PR TITLE
ci: fix markdown file pattern to skip builds for all .md files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,11 @@ jobs:
           filters: |
             docs-only:
               - 'documentation/**'
-              - '*.md'
+              - '**/*.md'
             code:
               - '**'
               - '!documentation/**'
-              - '!*.md'
+              - '!**/*.md'
 
   rust-format:
     name: Check Rust Code Format


### PR DESCRIPTION
The previous pattern `*.md` only matched markdown files in the root directory, but markdown files in subdirectories (like ui/desktop/README.md) were still triggering code builds. It was also triggering the full build run on ALL documentation changes. This updates both the docs-only and code filters to use '**/*.md' to properly match all markdown files recursively.