### PR TITLE
feat: Add timestamps to output in the CLI

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1253,6 +1253,9 @@ impl Session {
                 }
             }
         }
+
+        // Display timestamp to indicate when the response was completed
+        output::display_timestamp();
         println!();
 
         Ok(())

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -762,6 +762,21 @@ pub fn display_context_usage(total_tokens: usize, context_limit: usize) {
     );
 }
 
+/// Display a timestamp indicating when the response was completed
+pub fn display_timestamp() {
+    use console::style;
+
+    let timestamp = format_current_timestamp();
+    println!("{}", style(format!("\n\nCompleted at {}", timestamp)).dim());
+}
+
+fn format_current_timestamp() -> String {
+    use chrono::Local;
+
+    let now = Local::now();
+    now.format("%I:%M %p").to_string()
+}
+
 fn normalize_model_name(model: &str) -> String {
     let mut result = model.to_string();
 


### PR DESCRIPTION
Implements #3641.

This is vibe-coded, as I don't know Rust. I worked with Claude to refactor the original complicated solution to something simpler using `chrono`, which I saw was already in use elsewhere in the project. The final result is concise and AFAICT is idiomatic as well. It compiles, tests pass, and the result is exactly what I was looking for in the original feature request. 

Any feedback would be welcome! Maybe the two functions should just be combined into one? I'm not sure there is any use in having `format` separate from `display`.