### PR TITLE
docs: make accurate the comments with links to unsigned builds of the app

### DIFF
--- a/.github/workflows/pr-comment-bundle.yml
+++ b/.github/workflows/pr-comment-bundle.yml
@@ -135,9 +135,7 @@ jobs:
           body: |
             ### macOS ARM64 Desktop App (Apple Silicon)
 
-            [📱 Download macOS Desktop App (arm64, signed)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/Goose-darwin-arm64.zip)
+            [📱 Download macOS Desktop App (arm64, unsigned)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/Goose-darwin-arm64.zip)
 
             **Instructions:**
-            After downloading, unzip the file and drag the Goose.app to your Applications folder. The app is signed and notarized for macOS.
-
-            This link is provided by nightly.link and will work even if you're not logged into GitHub.
+            After downloading, unzip the file and drag the Goose.app to a location you prefer. The app is unsigned, so to run it run `xattr -r -d com.apple.quarantine '/path/to/Goose.app'` and then open the app

--- a/.github/workflows/release-branches.yml
+++ b/.github/workflows/release-branches.yml
@@ -24,7 +24,7 @@ jobs:
           body: |
             ### macOS ARM64 Desktop App (Apple Silicon)
 
-            [📱 Download macOS Desktop App (arm64, signed)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/Goose-darwin-arm64.zip)
+            [📱 Download macOS Desktop App (arm64, unsigned)](https://nightly.link/${{ github.repository }}/actions/runs/${{ github.run_id }}/Goose-darwin-arm64.zip)
 
             **Instructions:**
             After downloading, unzip the file and drag the Goose.app to a location you prefer. The app is unsigned, so to run it run `xattr -r -d com.apple.quarantine '/path/to/Goose.app'` and then open the app


### PR DESCRIPTION
Right now we don't have signed builds from `.bundle` comments or on release branches, so messages like this need to be made accurate https://github.com/block/goose/pull/4069#issuecomment-3184371477