### PR TITLE
refactor(forge): employ desktopTemplate to support absolute paths

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -70,7 +70,7 @@ module.exports = {
         maintainer: 'Block, Inc.',
         homepage: 'https://block.github.io/goose/',
         categories: ['Development'],
-        mimeType: ['x-scheme-handler/goose'],
+        desktopTemplate: './forge.deb.desktop',
         options: {
           icon: 'src/images/icon.png'
         }
@@ -84,6 +84,7 @@ module.exports = {
         maintainer: 'Block, Inc.',
         homepage: 'https://block.github.io/goose/',
         categories: ['Development'],
+        desktopTemplate: './forge.rpm.desktop',
         options: {
           icon: 'src/images/icon.png'
         }

--- a/ui/desktop/forge.deb.desktop
+++ b/ui/desktop/forge.deb.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Goose
+Exec=/usr/lib/goose/Goose %U
+Icon=/usr/share/pixmaps/goose.png
+Terminal=false
+Type=Application
+Categories=Development;
+MimeType=x-scheme-handler/goose;

--- a/ui/desktop/forge.rpm.desktop
+++ b/ui/desktop/forge.rpm.desktop
@@ -1,0 +1,8 @@
+[Desktop Entry]
+Name=Goose
+Exec=/usr/lib/Goose/Goose %U
+Icon=/usr/share/pixmaps/Goose.png
+Terminal=false
+Type=Application
+Categories=Development;
+MimeType=x-scheme-handler/goose;


### PR DESCRIPTION
To fix #4079 we'll need electron forge to spit out a desktop file with an absolute path for the 'Exec' line. This change directs each linux maker to use a flat, pre-filled desktop file that electronforge calls a 'desktopTemplate'.

The `Icon` line benefits from this change as well as it is now an absolute path.