### PR TITLE
Skip ci builds for docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,10 +29,8 @@ jobs:
           filters: |
             docs-only:
               - 'documentation/**'
-              - '**/*.md'
             code:
               - '!documentation/**'
-              - '!**/*.md'
 
   rust-format:
     name: Check Rust Code Format


### PR DESCRIPTION
Many CI builds are still not skipping for doc related PRs. Let's just put it back to where it was before