### PR TITLE
docs: Add missing references to smart_approve mode.

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -597,7 +597,7 @@ The CLI provides a set of slash commands that can be accessed during a session. 
 - `/builtin <names>` - Add builtin extensions by name (comma-separated)
 - `/exit` or `/quit` - Exit the current session
 - `/extension <command>` - Add a stdio extension (format: ENV1=val1 command args...)
-- `/mode <n>` - Set the goose mode to use ('auto', 'approve', 'chat')
+- `/mode <n>` - Set the goose mode to use ('auto', 'approve', 'chat', 'smart_approve')
 - `/plan <message>` - Create a structured plan based on the given message
 - `/prompt <n> [--info] [key=value...]` - Get prompt info or execute a prompt
 - `/prompts [--extension <n>]` - List all available prompts, optionally filtered by extension

--- a/documentation/docs/guides/goose-permissions.md
+++ b/documentation/docs/guides/goose-permissions.md
@@ -67,6 +67,7 @@ Here's how to configure:
         * Autonomous: `/mode auto`
         * Approve: `/mode approve`
         * Chat: `/mode chat`     
+        * Smart Approve: `/mode smart_approve`
       </TabItem>
       <TabItem value="settings" label="From Settings">
         1. Run the following command:


### PR DESCRIPTION
### Description

Adds missing references to "smart_approve" goose mode in CLI and Permissions documentation.