### PR TITLE
docs: custom context files improvements

### DIFF
--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -133,7 +133,7 @@ export GOOSE_MAX_TURNS=25
 export GOOSE_MAX_TURNS=100
 
 # Use multiple context files
-export CONTEXT_FILE_NAMES='["CLAUDE.md", ".goosehints", "project_rules.txt"]'
+export CONTEXT_FILE_NAMES='["CLAUDE.md", ".goosehints", ".cursorrules", "project_rules.txt"]'
 
 # Set the ANSI theme for the session
 export GOOSE_CLI_THEME=ansi

--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -339,7 +339,7 @@ You can turn your current Goose session into a reusable recipe that includes the
 
        **Basic Usage** - Run once and exit (see [run options](/docs/guides/goose-cli-commands#run-options) and [recipe commands](/docs/guides/goose-cli-commands#recipe) for more):
        ```sh
-       # Using recipe file in current directory or GOOSE_RECIPE_PATH directories
+       # Using recipe file in current directory or `GOOSE_RECIPE_PATH` directories
        goose run --recipe recipe.yaml
 
        # Using full path

--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -37,8 +37,8 @@ Goose supports two types of hint files:
 
 You can use both global and local hints at the same time. When both exist, Goose will consider both your global preferences and project-specific requirements. If the instructions in your local hints file conflict with your global preferences, Goose will prioritize the local hints.
 
-:::tip Custom Context File
-You can [customize context file names](#custom-context-files) using the `CONTEXT_FILE_NAMES` environment variable.
+:::tip Custom Context Files
+You can use other agent rule files with Goose by using the [`CONTEXT_FILE_NAMES` environment variable](#custom-context-files).
 :::
 
 <Tabs groupId="interface">
@@ -140,12 +140,15 @@ Here's how it works:
 
 ### Configuration
 
-Set the `CONTEXT_FILE_NAMES` environment variable to a JSON array of filenames. If not set, it defaults to `[".goosehints"]`.
+Set the `CONTEXT_FILE_NAMES` environment variable to a JSON array of filenames. The default is `[".goosehints"]`.
 
 ```bash
 # Single custom file
 export CONTEXT_FILE_NAMES='["AGENTS.md"]'
 
-# Multiple files (loaded in order)
+# Project toolchain files
+export CONTEXT_FILE_NAMES='[".cursorrules", "AGENTS.md"]'
+
+# Multiple files
 export CONTEXT_FILE_NAMES='["CLAUDE.md", ".goosehints", "project_rules.txt"]'
 ```


### PR DESCRIPTION
This PR adds .cursorrule examples and clarifies the use case per feedback:

Documentation updates: 
- `documentation/docs/guides/environment-variables.md`: Add ". cursorrules" to example
- `documentation/docs/guides/recipes/session-recipes.md`: Format env var name
- `documentation/docs/guides/using-goosehints.md`: 
   - Clarify use case in tip
   - Add toolchain example