### PR TITLE
Only fetch session tokens when chat state is idle to avoid resetting during streaming

### DIFF
--- a/ui/desktop/src/hooks/useChatEngine.ts
+++ b/ui/desktop/src/hooks/useChatEngine.ts
@@ -15,6 +15,7 @@ import {
   TextContent,
 } from '../types/message';
 import { ChatType } from '../types/chat';
+import { ChatState } from '../types/chatState';
 
 // Helper function to determine if a message is a user message
 const isUserMessage = (message: Message): boolean => {
@@ -208,10 +209,11 @@ export const useChatEngine = ({
         console.error('Error fetching session token count:', err);
       }
     };
-    if (chat.id) {
+    // Only fetch session tokens when chat state is idle to avoid resetting during streaming
+    if (chat.id && chatState === ChatState.Idle) {
       fetchSessionTokens();
     }
-  }, [chat.id, messages]);
+  }, [chat.id, messages, chatState]);
 
   // Update token counts when sessionMetadata changes from the message stream
   useEffect(() => {


### PR DESCRIPTION
Related to https://github.com/block/goose/issues/4092 by not resetting the count to 0.0 percent but there is still an issue where the count isn't updated until the stream is finished from the backend.