### PR TITLE
docs: remove figma MCP from suggested servers

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -223,23 +223,6 @@
     "environmentVariables": []
   },
   {
-    "id": "figma",
-    "name": "Figma",
-    "description": "Figma design tool integration",
-    "command": "npx -y @hapins/figma-mcp",
-    "link": "https://github.com/hapins/figma-mcp",
-    "installation_notes": "Install using npx package manager. Requires Figma access token from user settings.",
-    "is_builtin": false,
-    "endorsed": false,
-    "environmentVariables": [
-      {
-        "name": "FIGMA_ACCESS_TOKEN",
-        "description": "Access token from Figma user settings",
-        "required": true
-      }
-    ]
-  },
-  {
     "id": "filesystem-mcp",
     "name": "Filesystem",
     "description": "File system operations and management",


### PR DESCRIPTION
https://github.com/hapins/figma-mcp won't work with Goose due to some invalid protocol messages it emits. We could file an issue, but the repo does not appear to be actively maintained, and googling for figma MCPs leads me to some seemingly better alternatives:

https://www.figma.com/blog/introducing-figmas-dev-mode-mcp-server/
https://github.com/GLips/Figma-Context-MCP