### PR TITLE
docs: add streamable_http install links

### DIFF
--- a/documentation/blog/2025-08-11-mcp-ui-post-browser-world/index.md
+++ b/documentation/blog/2025-08-11-mcp-ui-post-browser-world/index.md
@@ -45,17 +45,17 @@ Starting from Goose v1.3.0, you can add MCP-UI as an extension.
 :::tip Add MCP-UI to Goose
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-  Use `Add custom extension` in Settings → Extensions to add a `Streamable HTTP` extension type with:
+  [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp-aharvard.netlify.app%2Fmcp&id=mcpuidemo&name=MCP-UI%20Demo&description=Demo%20MCP-UI-enabled%20extension)
   </TabItem>
   <TabItem value="cli" label="Goose CLI">
   Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
-  </TabItem>
-</Tabs>
 
   **Endpoint URL**
   ```
   https://mcp-aharvard.netlify.app/mcp
   ```
+  </TabItem>
+</Tabs>
 :::
 
 

--- a/documentation/docs/guides/interactive-chat/mcp-ui.md
+++ b/documentation/docs/guides/interactive-chat/mcp-ui.md
@@ -41,15 +41,13 @@ For this exercise, we'll add an MCP-UI-enabled extension that connects to [MCP-U
 
   <Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
-      1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
-      2. Click `Extensions`
-      3. Click `Add custom extension`
-      4. On the `Add custom extension` modal, enter the following:
-         - **Extension Name**: Rich Demo
-         - **Type**: Streamable HTTP
-         - **Endpoint**: `https://mcp-aharvard.netlify.app/mcp`
-      5. Click `Add Extension` to save the extension
-      6. Navigate to the chat
+      <GooseDesktopInstaller
+        extensionId="richdemo"
+        extensionName="Rich Demo"
+        description="Demo MCP-UI-enabled extension"
+        type="http"
+        url="https://mcp-aharvard.netlify.app/mcp"
+      />
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
         <CLIExtensionInstructions

--- a/documentation/docs/mcp/dev.to-mcp.md
+++ b/documentation/docs/mcp/dev.to-mcp.md
@@ -15,11 +15,25 @@ import { PanelLeft } from 'lucide-react';
 This tutorial covers how to add the [Dev.to MCP Server](https://github.com/nickytonline/dev-to-mcp) as a Goose extension to enable access to the Dev.to public API. With this extension, Goose can fetch articles, tags, user info, comments, and more—without requiring authentication.
 
 :::tip TLDR
-**Endpoint URL**
-```sh
-http://localhost:3000/mcp
-```
-Make sure your server is running before adding the extension in Goose 
+<Tabs groupId="interface">
+  <TabItem value="ui" label="Goose Desktop" default>
+  [Launch the installer](goose://extension?type=streamable_http&url=http%3A%2F%2Flocalhost%3A3000%2Fmcp&id=dev-to&name=Dev.to&description=Access%20Dev.to%20articles%20and%20content)
+  </TabItem>
+  <TabItem value="cli" label="Goose CLI">
+  Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
+
+  **Endpoint URL**
+
+  ```
+  http://localhost:3000/mcp
+  ```
+
+</TabItem>
+</Tabs>
+
+**Required Setup** 
+
+Make sure your Dev.to MCP server is running before adding the extension
 :::
 
 ## Configuration
@@ -44,17 +58,13 @@ Your server will now be running at:
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
-  1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
-  2. Navigate to `Extensions`
-  3. Click `Add Custom Extension`
-  4. In `Extension Name`, enter: `dev.to`
-  5. In the `Type` dropdown, select: `Streamable HTTP`
-  6. (Optional) Add a Description 
-  7. In `Endpoint URL`, enter:` http://localhost:3000/mcp`
-  8. Set `Timeout` to `300` (default)
-  9. Leave `Environment Variables` empty
-  10. Leave `Request Headers` empty
-  11. Click `Add Extension`
+    <GooseDesktopInstaller
+      extensionId="dev-to"
+      extensionName="Dev.to"
+      description="Access Dev.to articles and content"
+      type="http"
+      url="http://localhost:3000/mcp"
+    />
 
   </TabItem>
   <TabItem value="cli" label="Goose CLI" default>

--- a/documentation/docs/mcp/neon-mcp.md
+++ b/documentation/docs/mcp/neon-mcp.md
@@ -27,17 +27,17 @@ The Neon MCP Server grants powerful database management capabilities and is inte
   :::tip TLDR
   <Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
-    Use `Add custom extension` in Settings → Extensions to add a `Streamable HTTP` extension type with:
+    [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.neon.tech%2Fmcp&id=neon&name=Neon&description=Manage%20Neon%20Postgres%20databases%2C%20projects%2C%20and%20branches)
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
     Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
+
+    **Endpoint URL**
+    ```
+    https://mcp.neon.tech/mcp
+    ```
     </TabItem>
   </Tabs>
-
-  **Endpoint URL**
-  ```
-  https://mcp.neon.tech/mcp
-  ```
   :::
 
   :::info OAUTH FLOW
@@ -46,15 +46,13 @@ The Neon MCP Server grants powerful database management capabilities and is inte
 
   <Tabs groupId="interface">
     <TabItem value="ui" label="Goose Desktop" default>
-    1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
-    2. Click `Extensions`
-    3. Click `Add custom extension`
-    4. On the `Add custom extension` modal, enter the following:
-       - **Extension Name**: Neon
-       - **Type**: Streamable HTTP
-       - **Endpoint**: `https://mcp.neon.tech/mcp`
-    5. Click `Add Extension` to save the extension
-    6. Navigate to the chat
+      <GooseDesktopInstaller
+        extensionId="neon"
+        extensionName="Neon"
+        description="Manage Neon Postgres databases, projects, and branches"
+        type="http"
+        url="https://mcp.neon.tech/mcp"
+      />
     </TabItem>
     <TabItem value="cli" label="Goose CLI">
       <CLIExtensionInstructions

--- a/documentation/src/utils/install-links.ts
+++ b/documentation/src/utils/install-links.ts
@@ -14,6 +14,8 @@ export function getGooseInstallLink(server: MCPServer): string {
   // Handle the case where the command is a URL
   if (server.url) {
     const queryParams = [
+      // Map the type to the expected format for the deep link
+      ...(server.type === "streamable-http" ? [`type=streamable_http`] : []),
       `url=${encodeURIComponent(server.url)}`,
       `id=${encodeURIComponent(server.id)}`,
       `name=${encodeURIComponent(server.name)}`,

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -195,6 +195,18 @@
     "environmentVariables": []
   },
   {
+    "id": "dev-to",
+    "name": "Dev.to",
+    "description": "Access Dev.to articles and content (requires local server setup)",
+    "url": "http://localhost:3000/mcp",
+    "link": "https://github.com/nickytonline/dev-to-mcp",
+    "installation_notes": "This is a local extension. You must first clone, install, and run the Dev.to MCP server locally before adding this extension.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [],
+    "type": "streamable-http"
+  },
+  {
     "id": "elevenlabs-mcp",
     "name": "ElevenLabs",
     "description": "Text-to-speech and voice synthesis",
@@ -393,9 +405,10 @@
     "id": "neon",
     "name": "Neon",
     "description": "Manage Neon Postgres databases, projects, and branches",
-    "command": "npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>",
+    "type": "streamable-http",
+    "url": "https://mcp.neon.tech/mcp",
     "link": "https://github.com/neondatabase-labs/mcp-server-neon",
-    "installation_notes": "Install using npx package manager (add your Neon API key to the command) or connect to the remote server.",
+    "installation_notes": "Streaming HTTP extension with OAuth browser authentication to your Neon account.",
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": []


### PR DESCRIPTION
This PR adds install links for streaming HTTP extensions that currently support it.

Documentation and blog updates: 
- Add install links to:
  - `documentation/blog/2025-08-11-mcp-ui-post-browser-world/index.md` blog
  - `documentation/docs/guides/interactive-chat/mcp-ui.md` guide topic
  - `documentation/docs/mcp/neon-mcp.md` tutorial
  - `documentation/docs/mcp/dev.to-mcp.md` tutorial

Extension library:
- `documentation/src/utils/install-links.ts`: 
  - Add type=streamable_http parameter to deeplink
- `documentation/static/servers.json`:
  - Change Neon entry to streamable
  - Add Dev.to entry
