### PR TITLE
feat: Add `tool_vectordb` feature to `goose` crate

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -96,11 +96,13 @@ dashmap = "6.1"
 ahash = "0.8"
 tokio-util = "0.7.15"
 unicode-normalization = "0.1"
-
-# Vector database for tool selection
-lancedb = "0.13"
-arrow = "52.2"
 oauth2 = "5.0.0"
+lancedb = { version = "0.13", optional = true }
+arrow = { version = "52.2", optional = true }
+
+[features]
+default = []
+tool_vectordb = ["lancedb", "arrow"]
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -21,6 +21,7 @@ pub mod todo_tools;
 mod tool_execution;
 mod tool_route_manager;
 mod tool_router_index_manager;
+#[cfg(feature = "tool_vectordb")]
 pub(crate) mod tool_vectordb;
 pub mod types;
 

--- a/crates/goose/src/agents/router_tool_selector.rs
+++ b/crates/goose/src/agents/router_tool_selector.rs
@@ -12,6 +12,7 @@ use std::env;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+#[cfg(feature = "tool_vectordb")]
 use crate::agents::tool_vectordb::ToolVectorDB;
 use crate::conversation::message::Message;
 use crate::model::ModelConfig;
@@ -40,12 +41,14 @@ pub trait RouterToolSelector: Send + Sync {
     fn selector_type(&self) -> RouterToolSelectionStrategy;
 }
 
+#[cfg(feature = "tool_vectordb")]
 pub struct VectorToolSelector {
     vector_db: Arc<RwLock<ToolVectorDB>>,
     embedding_provider: Arc<dyn Provider>,
     recent_tool_calls: Arc<RwLock<VecDeque<String>>>,
 }
 
+#[cfg(feature = "tool_vectordb")]
 impl VectorToolSelector {
     pub async fn new(provider: Arc<dyn Provider>, table_name: String) -> Result<Self> {
         let vector_db = ToolVectorDB::new(Some(table_name)).await?;
@@ -79,6 +82,7 @@ impl VectorToolSelector {
 }
 
 #[async_trait]
+#[cfg(feature = "tool_vectordb")]
 impl RouterToolSelector for VectorToolSelector {
     async fn select_tools(&self, params: Value) -> Result<Vec<Content>, ErrorData> {
         let query = params
@@ -427,8 +431,17 @@ pub async fn create_tool_selector(
 ) -> Result<Box<dyn RouterToolSelector>> {
     match strategy {
         Some(RouterToolSelectionStrategy::Vector) => {
-            let selector = VectorToolSelector::new(provider, table_name.unwrap()).await?;
-            Ok(Box::new(selector))
+            #[cfg(feature = "tool_vectordb")]
+            {
+                let selector = VectorToolSelector::new(provider, table_name.unwrap()).await?;
+                Ok(Box::new(selector))
+            }
+            #[cfg(not(feature = "tool_vectordb"))]
+            {
+                Err(anyhow::anyhow!(
+                    "Vector tool selection is not enabled. Enable 'tool_vectordb' feature."
+                ))
+            }
         }
         Some(RouterToolSelectionStrategy::Llm) => {
             let selector = LLMToolSelector::new(provider).await?;

--- a/crates/goose/src/agents/tool_route_manager.rs
+++ b/crates/goose/src/agents/tool_route_manager.rs
@@ -5,6 +5,7 @@ use crate::agents::router_tool_selector::{
 use crate::agents::router_tools::{self};
 use crate::agents::tool_execution::ToolCallResult;
 use crate::agents::tool_router_index_manager::ToolRouterIndexManager;
+#[cfg(feature = "tool_vectordb")]
 use crate::agents::tool_vectordb::generate_table_id;
 use crate::config::Config;
 use crate::conversation::message::ToolRequest;
@@ -96,11 +97,21 @@ impl ToolRouteManager {
         let strategy = self.get_router_tool_selection_strategy().await;
         let selector = match strategy {
             Some(RouterToolSelectionStrategy::Vector) => {
-                let table_name = generate_table_id();
-                let selector = create_tool_selector(strategy, provider.clone(), Some(table_name))
-                    .await
-                    .map_err(|e| anyhow!("Failed to create tool selector: {}", e))?;
-                Arc::new(selector)
+                #[cfg(feature = "tool_vectordb")]
+                {
+                    let table_name = generate_table_id();
+                    let selector =
+                        create_tool_selector(strategy, provider.clone(), Some(table_name))
+                            .await
+                            .map_err(|e| anyhow!("Failed to create tool selector: {}", e))?;
+                    Arc::new(selector)
+                }
+                #[cfg(not(feature = "tool_vectordb"))]
+                {
+                    return Err(anyhow!(
+                        "Vector tool selection is not enabled. Enable 'tool_vectordb' feature."
+                    ));
+                }
             }
             Some(RouterToolSelectionStrategy::Llm) => {
                 let selector = create_tool_selector(strategy, provider.clone(), None)


### PR DESCRIPTION
I'm trying build goose on termux and found it is too slow to build.

In https://github.com/block/goose/issues/3914, discuss how to reduce the size of goose.

Change `tool_vectordb` not as default maybe a quick way to improve.