### PR TITLE
Fix: deep link extension installation to show dialog for headers configuration

### DIFF
--- a/ui/desktop/src/components/settings/extensions/deeplink.ts
+++ b/ui/desktop/src/components/settings/extensions/deeplink.ts
@@ -166,9 +166,13 @@ export async function addExtensionFromDeepLink(
       : getSseConfig(remoteUrl, name, description || '', timeout)
     : getStdioConfig(cmd!, parsedUrl, name, description || '', timeout);
 
-  // Check if extension requires env vars and go to settings if so
-  if (config.envs && Object.keys(config.envs).length > 0) {
-    console.log('Environment variables required, redirecting to settings');
+  // Check if extension requires env vars or headers and go to settings if so
+  const hasEnvVars = config.envs && Object.keys(config.envs).length > 0;
+  const hasHeaders =
+    config.type === 'streamable_http' && config.headers && Object.keys(config.headers).length > 0;
+
+  if (hasEnvVars || hasHeaders) {
+    console.log('Environment variables or headers required, redirecting to settings');
     console.log('Calling setView with:', { deepLinkConfig: config, showEnvVars: true });
     setView('settings', { deepLinkConfig: config, showEnvVars: true });
     return;


### PR DESCRIPTION
When clicking deep links for extensions that include headers (like the GitHub MCP server with Authorization tokens), the extension would try to install directly without opening the configuration dialog. The user needs to see the dialog to review and edit the placeholder tokens. For example the below would just try to install and fail with the value YOUR_ACTUAL_TOKEN_HERE:

```
goose://extension?url=https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2F&name=GitHub&description=GitHub%20MCP%20Server&type=streamable_http&header=Authorization%3DBearer%20ghs_YOUR_ACTUAL_TOKEN_HERE
```

The deep link handler in addExtensionFromDeepLink only checked for environment variables (config.envs) to determine whether to show the settings dialog, but didnt account for headers. 

I chatted with goose to figure out where this was happening, and I added it in.