### PR TITLE
Temporarily disable TODO Tool

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -59,7 +59,8 @@ use super::tool_execution::{ToolCallResult, CHAT_MODE_TOOL_SKIPPED_RESPONSE, DEC
 use crate::agents::subagent_task_config::TaskConfig;
 use crate::agents::todo_tools::{
     // todo_read_tool, todo_write_tool, // TODO: Re-enable after next release
-    TODO_READ_TOOL_NAME, TODO_WRITE_TOOL_NAME,
+    TODO_READ_TOOL_NAME,
+    TODO_WRITE_TOOL_NAME,
 };
 use crate::conversation::message::{Message, ToolRequest};
 

--- a/crates/goose/tests/todo_tools_test.rs
+++ b/crates/goose/tests/todo_tools_test.rs
@@ -6,6 +6,7 @@ use serial_test::serial;
 use std::sync::Arc;
 
 #[tokio::test]
+#[ignore] // TODO: Re-enable after next release when TODO tools are re-enabled
 async fn test_todo_tools_in_agent_list() {
     let agent = Agent::new();
     let tools = agent.list_tools(None).await;


### PR DESCRIPTION
Longer discussion in https://github.com/block/goose/pull/4126

Seeing todo state leaking between sessions, let's disable for now until we can figure out the root cause. 