### PR TITLE
fix(build): add arm64 support for linux pkgs .deb/.rpm

### DIFF
--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -7,14 +7,14 @@ on:
   workflow_call:
     inputs:
       version:
-        description: 'Version to set for the build'
+        description: "Version to set for the build"
         required: false
         default: ""
         type: string
       ref:
         type: string
         required: false
-        default: ''
+        default: ""
 
 name: "Bundle Desktop (Linux)"
 
@@ -84,8 +84,27 @@ jobs:
           echo "CARGO_HOME=$CARGO_HOME" >> $GITHUB_ENV
           echo "RUSTUP_HOME=$RUSTUP_HOME" >> $GITHUB_ENV
 
+      # Install arm64 tooling
+      - name: Install arm64 tooling
+        run: |
+          sudo apt-get install -y \
+            gcc-aarch64-linux-gnu \
+            g++-aarch64-linux-gnu
+
+          rustup target add aarch64-unknown-linux-gnu
+
+          mkdir -p ~/.cargo
+          cat >> ~/.cargo/config.toml << EOF
+          [target.aarch64-unknown-linux-gnu]
+          linker = "aarch64-linux-gnu-gcc"
+          EOF
+
       - name: Install cross
         run: source ./bin/activate-hermit && cargo install cross --git https://github.com/cross-rs/cross
+
+      # Add arm64 target
+      - name: Add arm64 target
+        run: rustup target add aarch64-unknown-linux-gnu
 
       - name: Cache Cargo artifacts
         uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
@@ -102,7 +121,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # pin@v5
         with:
-          go-version: '1.21'
+          go-version: "1.21"
 
       - name: Build temporal-service
         run: |
@@ -152,18 +171,27 @@ jobs:
           # Verify installation
           ls -la node_modules/.bin/ | head -5
 
-      - name: Build Linux packages
+      # Build Electron app with Linux makers (.deb and .rpm) for x64
+      - name: Build Linux packages (x64)
         run: |
           source ./bin/activate-hermit
           cd ui/desktop
-          echo "Building Linux packages (.deb and .rpm)..."
-          
-          # Build both .deb and .rpm packages
+          echo "Building Linux packages (.deb and .rpm) for x64..."
           npm run make -- --platform=linux --arch=x64
-          
-          echo "Build completed. Checking output..."
-          ls -la out/
-          find out/ -name "*.deb" -o -name "*.rpm" | head -10
+
+      # 15a) build linux packages - arm64
+      - name: Build Linux packages (arm64)
+        run: |
+          cd ui/desktop
+          echo "Building Linux packages (.deb and .rpm) for arm64..."
+
+          cd ../..
+          cargo build --release --target aarch64-unknown-linux-gnu -p goose-server
+          cp target/aarch64-unknown-linux-gnu/release/goosed ui/desktop/src/bin/
+
+          # build packages
+          cd ui/desktop
+          ELECTRON_ARCH=arm64 npm run make -- --platform=linux --arch=arm64
 
       - name: List generated files
         run: |
@@ -176,18 +204,24 @@ jobs:
           echo "=== File sizes ==="
           find ui/desktop/out/ -name "*.deb" -o -name "*.rpm" -exec ls -lh {} \;
 
-      - name: Upload .deb package
+      # Upload .deb packages (both x64 and arm64)
+      - name: Upload .deb packages
         uses: actions/upload-artifact@v4
         with:
-          name: Goose-linux-x64-deb
-          path: ui/desktop/out/make/deb/x64/*.deb
+          name: Goose-linux-deb
+          path: |
+            ui/desktop/out/make/deb/x64/*.deb
+            ui/desktop/out/make/deb/arm64/*.deb
           if-no-files-found: error
 
-      - name: Upload .rpm package
+      # Upload .rpm packages (both x64 and arm64)
+      - name: Upload .rpm packages
         uses: actions/upload-artifact@v4
         with:
-          name: Goose-linux-x64-rpm
-          path: ui/desktop/out/make/rpm/x64/*.rpm
+          name: Goose-linux-rpm
+          path: |
+            ui/desktop/out/make/rpm/x64/*.rpm
+            ui/desktop/out/make/rpm/arm64/*.rpm
           if-no-files-found: error
 
       - name: Upload combined Linux packages

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -26,12 +26,12 @@ let cfg = {
     // Document types for drag-and-drop support onto dock icon
     CFBundleDocumentTypes: [
       {
-        CFBundleTypeName: "Folders",
-        CFBundleTypeRole: "Viewer",
-        LSHandlerRank: "Alternate",
-        LSItemContentTypes: ["public.directory", "public.folder"]
-      }
-    ]
+        CFBundleTypeName: 'Folders',
+        CFBundleTypeRole: 'Viewer',
+        LSHandlerRank: 'Alternate',
+        LSItemContentTypes: ['public.directory', 'public.folder'],
+      },
+    ],
   },
 };
 
@@ -72,8 +72,9 @@ module.exports = {
         categories: ['Development'],
         mimeType: ['x-scheme-handler/goose'],
         options: {
-          icon: 'src/images/icon.png'
-        }
+          icon: 'src/images/icon.png',
+          arch: process.env.ELECTRON_ARCH || 'x64',
+        },
       },
     },
     {
@@ -85,8 +86,9 @@ module.exports = {
         homepage: 'https://block.github.io/goose/',
         categories: ['Development'],
         options: {
-          icon: 'src/images/icon.png'
-        }
+          icon: 'src/images/icon.png',
+          arch: process.env.ELECTRON_ARCH || 'x64',
+        },
       },
     },
   ],


### PR DESCRIPTION
FIxes: #3705 

Docker test results:

```bash
root@f9da7f568647:/workspace/ui/desktop# find out/ -name "*.deb" -o -name "*.rpm"
out/make/deb/arm64/goose_1.2.0_arm64.deb
out/make/rpm/arm64/Goose-1.2.0-1.arm64.rpm
root@f9da7f568647:/workspace/ui/desktop#
```

```bash
root@f9da7f568647:/workspace/ui/desktop# dpkg --info out/make/deb/arm64/goose_1.2.0_arm64.deb
 new Debian package, version 2.0.
 size 170568084 bytes: control archive=422 bytes.
     477 bytes,    13 lines      control
 Package: goose
 Version: 1.2.0
 Section: utils
 Priority: optional
 Architecture: arm64
 Depends: libgtk-3-0, libnotify4, libnss3, xdg-utils, libatspi2.0-0, libdrm2, libgbm1, libxcb-dri3-0, kde-cli-tools | kde-runtime | trash-cli | libglib2.0-bin | gvfs-bin
 Recommends: pulseaudio | libasound2
 Suggests: gir1.2-gnomekeyring-1.0, libgnome-keyring0, lsb-release
 Installed-Size: 614069
 Maintainer: Block, Inc.
 Homepage: https://block.github.io/goose/
 Description: Goose App
  Goose App
root@f9da7f568647:/workspace/ui/desktop#
```

```bash
root@f9da7f568647:/workspace/ui/desktop# rpm -qip out/make/rpm/arm64/Goose-1.2.0-1.arm64.rpm
Name        : Goose
Version     : 1.2.0
Release     : 1
Architecture: aarch64
Install Date: (not installed)
Group       : Unspecified
Size        : 629126916
License     : Apache-2.0
Signature   : (none)
Source RPM  : Goose-1.2.0-1.src.rpm
Build Date  : Mon Aug 18 15:24:07 2025
Build Host  : f9da7f568647
URL         : https://block.github.io/goose/
Summary     : Goose App
Description :
Goose App
root@f9da7f568647:/workspace/ui/desktop#
```