### PR TITLE
Unlist figma tutorial

### DIFF
--- a/documentation/docs/mcp/figma-mcp.md
+++ b/documentation/docs/mcp/figma-mcp.md
@@ -1,5 +1,5 @@
 ---
-unlist: true
+unlisted: true
 title: Figma Extension
 description: Add Figma MCP Server as a Goose Extension
 ---

--- a/documentation/docs/mcp/figma-mcp.md
+++ b/documentation/docs/mcp/figma-mcp.md
@@ -1,4 +1,5 @@
 ---
+unlist: true
 title: Figma Extension
 description: Add Figma MCP Server as a Goose Extension
 ---


### PR DESCRIPTION
Unlisting figma tutorial to be replaced with official Figma MCP Server