### PR TITLE
fix: resolve TypeScript lint errors

### DIFF
--- a/ui/desktop/src/components/InterruptionHandler.tsx
+++ b/ui/desktop/src/components/InterruptionHandler.tsx
@@ -87,7 +87,6 @@ export const InterruptionHandler: React.FC<InterruptionHandlerProps> = ({
   };
 
   const colors = getActionColor();
-  const message = getInterruptionMessage(match);
 
   const handleConfirm = () => {
     if (showRedirectInput && onRedirect && redirectMessage.trim()) {

--- a/ui/desktop/src/components/MessageQueue.tsx
+++ b/ui/desktop/src/components/MessageQueue.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, Clock, Send, GripVertical, Zap, Sparkles, ChevronDown, ChevronUp, MoreHorizontal } from 'lucide-react';
+import { X, Clock, Send, GripVertical, Zap, Sparkles, ChevronDown, ChevronUp } from 'lucide-react';
 import { Button } from './ui/button';
 
 interface QueuedMessage {

--- a/ui/desktop/src/components/dashboard/DashboardCanvas.tsx
+++ b/ui/desktop/src/components/dashboard/DashboardCanvas.tsx
@@ -8,7 +8,7 @@ interface DashboardCanvasProps {
   onWidgetResize: (id: string, size: { width: number; height: number }) => void;
 }
 
-export function DashboardCanvas({ widgets, onWidgetMove, onWidgetResize }: DashboardCanvasProps) {
+export function DashboardCanvas({ widgets, onWidgetMove }: DashboardCanvasProps) {
   const canvasRef = useRef<HTMLDivElement>(null);
   const [draggedWidget, setDraggedWidget] = useState<string | null>(null);
   const [dragOffset, setDragOffset] = useState({ x: 0, y: 0 });

--- a/ui/desktop/src/components/dashboard/DashboardWidget.tsx
+++ b/ui/desktop/src/components/dashboard/DashboardWidget.tsx
@@ -8,10 +8,9 @@ interface DashboardWidgetProps {
   widget: WidgetData;
   onMouseDown: (e: React.MouseEvent) => void;
   isDragging: boolean;
-  onReset?: () => void; // Optional reset callback
 }
 
-export function DashboardWidget({ widget, onMouseDown, isDragging, onReset }: DashboardWidgetProps) {
+export function DashboardWidget({ widget, onMouseDown, isDragging }: DashboardWidgetProps) {
   const [showSavedIndicator, setShowSavedIndicator] = useState(false);
 
   // Show saved indicator when position changes (but not during dragging)


### PR DESCRIPTION
- Remove unused onWidgetResize parameter from DashboardCanvas
- Remove unused onReset parameter from DashboardWidget
- Remove unused message variable from InterruptionHandler
- Remove unused MoreHorizontal import from MessageQueue

All lint errors have been resolved while maintaining functionality.