### PR TITLE
fix: resolve remaining TypeScript lint errors

### DIFF
--- a/ui/desktop/src/components/InterruptionHandler.tsx
+++ b/ui/desktop/src/components/InterruptionHandler.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { AlertTriangle, StopCircle, PauseCircle, RotateCcw, Zap, AlertCircle } from 'lucide-react';
 import { Button } from './ui/button';
-import { InterruptionMatch, getInterruptionMessage } from '../utils/interruptionDetector';
+import { InterruptionMatch } from '../utils/interruptionDetector';
 
 interface InterruptionHandlerProps {
   match: InterruptionMatch | null;

--- a/ui/desktop/src/components/dashboard/DashboardCanvas.tsx
+++ b/ui/desktop/src/components/dashboard/DashboardCanvas.tsx
@@ -88,6 +88,7 @@ export function DashboardCanvas({ widgets, onWidgetMove, onWidgetResize }: Dashb
         document.removeEventListener('mouseup', handleMouseUp);
       };
     }
+    return () => {}; // Return empty cleanup function when no draggedWidget
   }, [draggedWidget, handleMouseMove, handleMouseUp]);
 
   // Clean up on unmount

--- a/ui/desktop/src/components/dashboard/DashboardWidget.tsx
+++ b/ui/desktop/src/components/dashboard/DashboardWidget.tsx
@@ -23,6 +23,7 @@ export function DashboardWidget({ widget, onMouseDown, isDragging, onReset }: Da
       }, 1000);
       return () => clearTimeout(timer);
     }
+    return () => {}; // Return empty cleanup function when dragging
   }, [widget.position.x, widget.position.y, isDragging]);
 
   const renderWidgetContent = () => {


### PR DESCRIPTION
- Add explicit return statements to useEffect hooks in DashboardCanvas and DashboardWidget
- Remove unused getInterruptionMessage import from InterruptionHandler

All TypeScript errors related to missing return values and unused imports are now resolved.