### PR TITLE
fix: resolve HTMLSpanElement undefined error in Pill component

### DIFF
--- a/ui/desktop/src/components/ui/Pill.tsx
+++ b/ui/desktop/src/components/ui/Pill.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { cn } from '../../utils';
 
-interface PillProps extends React.HTMLAttributes<HTMLSpanElement> {
+interface PillProps extends React.ComponentPropsWithoutRef<'span'> {
   variant?: 'default' | 'success' | 'warning' | 'error' | 'info';
   size?: 'sm' | 'md' | 'lg';
   children: React.ReactNode;


### PR DESCRIPTION
- Replace React.HTMLAttributes<HTMLSpanElement> with React.ComponentPropsWithoutRef<'span'>
- This avoids the HTMLSpanElement global type dependency while maintaining the same functionality
- React.ComponentPropsWithoutRef<'span'> provides the same span element props without requiring DOM globals

Fixes the no-undef lint error for HTMLSpanElement.