### PR TITLE
removed tests from lint-staged

### DIFF
--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -143,8 +143,7 @@
     "src/**/*.{ts,tsx}": [
       "bash -c 'npm run typecheck'",
       "eslint --fix --max-warnings 0 --no-warn-ignored",
-      "prettier --write",
-      "bash -c 'npm run test:run'"
+      "prettier --write"
     ],
     "src/**/*.{css,json}": [
       "prettier --write"


### PR DESCRIPTION
vitest doesn't have an option to only run tests that are affected by related changes so we were running them all

for now lets remove it to speed up commits but we'll keep them in ci