### PR TITLE
Fix navigation bugs after provider selection

### DIFF
--- a/ui/desktop/src/components/ProviderGuard.tsx
+++ b/ui/desktop/src/components/ProviderGuard.tsx
@@ -75,6 +75,9 @@ export default function ProviderGuard({ children }: ProviderGuardProps) {
           setOpenRouterSetupState(null);
           setShowFirstTimeSetup(false);
           setHasProvider(true);
+          
+          // Navigate to chat after successful setup
+          navigate('/', { replace: true });
         } else {
           throw new Error('Provider or model not found after OpenRouter setup');
         }
@@ -182,6 +185,8 @@ export default function ProviderGuard({ children }: ProviderGuardProps) {
             onSuccess={() => {
               setShowOllamaSetup(false);
               setHasProvider(true);
+              // Navigate to chat after successful setup
+              navigate('/', { replace: true });
             }}
             onCancel={() => {
               setShowOllamaSetup(false);


### PR DESCRIPTION
- Add explicit navigation to chat after successful OpenRouter setup
- Add explicit navigation to chat after successful Ollama setup
- Fixes issue where users couldn't click navigation items after provider setup
- Ensures proper routing state after provider configuration