### PR TITLE
Add Nix flake for reproducible builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,6 @@ do_not_version/
 
 # Error log artifacts from mcp replay tests
 crates/goose/tests/mcp_replays/*errors.txt
+
+# Nix build output
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1755571033,
+        "narHash": "sha256-V8gmZBfMiFGCyGJQx/yO81LFJ4d/I5Jxs2id96rLxrM=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "95487740bb7ac11553445e9249041a6fa4b5eccf",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,114 @@
+{
+  description = "Goose - An AI agent CLI";
+
+  inputs = {
+    flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+    nixpkgs.url = "nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        overlays = [ rust-overlay.overlays.default ];
+        pkgs = import nixpkgs { inherit system overlays; };
+        rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+        
+        # Read package metadata from Cargo.toml
+        cargoToml = builtins.fromTOML (builtins.readFile ./crates/goose-cli/Cargo.toml);
+        workspaceToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
+        
+        commonInputs = [
+          rust
+          pkgs.rust-analyzer
+          pkgs.pkg-config
+          pkgs.openssl
+        ];
+        
+        darwinInputs = with pkgs; [
+          libiconv
+          darwin.apple_sdk.frameworks.Security
+          darwin.apple_sdk.frameworks.SystemConfiguration
+          darwin.apple_sdk.frameworks.CoreServices
+        ];
+        
+        buildInputs = commonInputs
+          ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
+      in
+      {
+        defaultPackage = pkgs.rustPlatform.buildRustPackage {
+          pname = cargoToml.package.name;
+          version = workspaceToml.workspace.package.version;
+          src = ./.;
+
+          cargoLock = {
+            lockFile = ./Cargo.lock;
+            outputHashes = {
+              # Patch required for Windows cross-compilation
+              # See: https://github.com/nmathewson/crunchy/tree/cross-compilation-fix
+              "crunchy-0.2.3" = "sha256-CBW3/JuMoNa6MWia6BQo07LQrH5JQbb20vuCqhyFL0Y=";
+            };
+          };
+
+          nativeBuildInputs = with pkgs; [
+            pkg-config
+          ];
+
+          buildInputs = with pkgs; [
+            openssl
+            xorg.libxcb  # Required for xcap screenshot functionality
+            dbus         # Required for system integration features
+          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
+
+          # Build only the CLI package
+          cargoBuildFlags = [ "--package" "goose-cli" ];
+          
+          # Enable tests with proper environment
+          # Tests need writable HOME and XDG directories for config/cache access
+          doCheck = true;
+          checkPhase = ''
+            export HOME=$(mktemp -d)
+            export XDG_CONFIG_HOME=$HOME/.config
+            export XDG_DATA_HOME=$HOME/.local/share
+            export XDG_STATE_HOME=$HOME/.local/state
+            export XDG_CACHE_HOME=$HOME/.cache
+            mkdir -p $XDG_CONFIG_HOME $XDG_DATA_HOME $XDG_STATE_HOME $XDG_CACHE_HOME
+            
+            # Run tests for goose-cli package only
+            cargo test --package goose-cli --release
+          '';
+
+          meta = with pkgs.lib; {
+            description = workspaceToml.workspace.package.description;
+            homepage = workspaceToml.workspace.package.repository;
+            license = licenses.asl20;  # Maps from "Apache-2.0" in Cargo.toml
+          };
+        };
+
+        devShell = pkgs.mkShell {
+          packages = buildInputs ++ (with pkgs; [
+            cargo-watch
+            cargo-edit
+            clippy
+            rustfmt
+            xorg.libxcb
+            dbus
+          ]);
+          
+          shellHook = ''
+            echo "Goose development environment"
+            echo "Rust version: $(rustc --version)"
+            echo ""
+            echo "Commands:"
+            echo "  nix build           - Build goose CLI"
+            echo "  nix run             - Run goose CLI"
+            echo "  cargo build -p goose-cli - Build with cargo"
+            echo "  cargo run -p goose-cli   - Run with cargo"
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds Nix flake support for reproducible builds of the Goose CLI. The flake provides a consistent build environment across different systems and makes it easy for Nix users to build, develop, and run Goose.

  What's included

  - flake.nix - Main flake configuration that:
    - Dynamically reads package metadata from Cargo.toml files (no hardcoded versions)
    - Builds the goose-cli package with all required dependencies
    - Provides a development shell with cargo tools
    - Configures tests to run with proper HOME/XDG directories
    - Supports both Linux and macOS platforms
  - flake.lock - Pinned dependencies for reproducible builds
  - .gitignore - Added result symlink exclusion

  Testing

  ✅ CLI build and execution tested on NixOS (Linux/aarch64)
  - nix build - Successfully builds the CLI binary
  - nix run - CLI runs and executes commands properly
  - Tests pass with proper environment configuration
  - Development shell (nix develop) works with cargo commands

  ⚠️  Note: Only the CLI has been tested as my NixOS environment doesn't have a desktop environment. The desktop app would need additional testing, but the flake focuses on the CLI package for now.

  Usage
```sh
  # Build the CLI
  nix build

  # Run directly
  nix run . -- --help

  # Development shell
  nix develop
  cargo build -p goose-cli
```

  Future improvements

  - Desktop app support could be added once tested
  - Additional Nix-specific documentation could be added to the main README