### PR TITLE
feat: integrate tool call icons with status indicators

### DIFF
--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -134,7 +134,7 @@ export GOOSE_MAX_TURNS=25
 export GOOSE_MAX_TURNS=100
 
 # Use multiple context files
-export CONTEXT_FILE_NAMES='["CLAUDE.md", ".goosehints", "project_rules.txt"]'
+export CONTEXT_FILE_NAMES='["CLAUDE.md", ".goosehints", ".cursorrules", "project_rules.txt"]'
 
 # Set the ANSI theme for the session
 export GOOSE_CLI_THEME=ansi

--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -339,7 +339,7 @@ You can turn your current Goose session into a reusable recipe that includes the
 
        **Basic Usage** - Run once and exit (see [run options](/docs/guides/goose-cli-commands#run-options) and [recipe commands](/docs/guides/goose-cli-commands#recipe) for more):
        ```sh
-       # Using recipe file in current directory or GOOSE_RECIPE_PATH directories
+       # Using recipe file in current directory or `GOOSE_RECIPE_PATH` directories
        goose run --recipe recipe.yaml
 
        # Using full path

--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -37,8 +37,8 @@ Goose supports two types of hint files:
 
 You can use both global and local hints at the same time. When both exist, Goose will consider both your global preferences and project-specific requirements. If the instructions in your local hints file conflict with your global preferences, Goose will prioritize the local hints.
 
-:::tip Custom Context File
-You can [customize context file names](#custom-context-files) using the `CONTEXT_FILE_NAMES` environment variable.
+:::tip Custom Context Files
+You can use other agent rule files with Goose by using the [`CONTEXT_FILE_NAMES` environment variable](#custom-context-files).
 :::
 
 <Tabs groupId="interface">
@@ -143,12 +143,15 @@ Here's how it works:
 
 ### Configuration
 
-Set the `CONTEXT_FILE_NAMES` environment variable to a JSON array of filenames. If not set, it defaults to `[".goosehints"]`.
+Set the `CONTEXT_FILE_NAMES` environment variable to a JSON array of filenames. The default is `[".goosehints"]`.
 
 ```bash
 # Single custom file
 export CONTEXT_FILE_NAMES='["AGENTS.md"]'
 
-# Multiple files (loaded in order)
+# Project toolchain files
+export CONTEXT_FILE_NAMES='[".cursorrules", "AGENTS.md"]'
+
+# Multiple files
 export CONTEXT_FILE_NAMES='["CLAUDE.md", ".goosehints", "project_rules.txt"]'
 ```

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -180,7 +180,6 @@ export default function GooseMessage({
 
   // Determine rendering logic based on chain membership and content
   const isFirstInChain = messageChain && messageChain[0] === messageIndex;
-  const hasText = displayText.trim().length > 0;
 
   return (
     <div className="group relative w-full">

--- a/ui/desktop/src/components/GooseMessage.tsx
+++ b/ui/desktop/src/components/GooseMessage.tsx
@@ -1,12 +1,13 @@
 import { useEffect, useMemo, useRef } from 'react';
 import LinkPreview from './LinkPreview';
 import ImagePreview from './ImagePreview';
-import GooseResponseForm from './GooseResponseForm';
 import { extractUrls } from '../utils/urlUtils';
 import { extractImagePaths, removeImagePathsFromText } from '../utils/imageUtils';
 import { formatMessageTimestamp } from '../utils/timeUtils';
 import MarkdownContent from './MarkdownContent';
 import ToolCallWithResponse from './ToolCallWithResponse';
+import ToolCallChain from './ToolCallChain';
+import { identifyConsecutiveToolCalls, shouldHideMessage, getChainForMessage } from '../utils/toolCallChaining';
 import {
   Message,
   getTextContent,
@@ -35,39 +36,21 @@ interface GooseMessageProps {
 export default function GooseMessage({
   messageHistoryIndex,
   message,
-  metadata,
   messages,
+  metadata: _metadata,
   toolCallNotifications,
-  append,
+  append: _append,
   appendMessage,
   isStreaming = false,
 }: GooseMessageProps) {
-  const contentRef = useRef<HTMLDivElement | null>(null);
-  // Track which tool confirmations we've already handled to prevent infinite loops
+  const contentRef = useRef<HTMLDivElement>(null);
   const handledToolConfirmations = useRef<Set<string>>(new Set());
 
-  // Extract text content from the message
-  let textContent = getTextContent(message);
+  // Extract image paths from the message content
+  const imagePaths = extractImagePaths(getTextContent(message));
 
-  // Utility to split Chain-of-Thought (CoT) from the visible assistant response.
-  // If the text contains a <think>...</think> block, everything inside is treated as the
-  // CoT and removed from the user-visible text.
-  const splitChainOfThought = (text: string): { visibleText: string; cotText: string | null } => {
-    const regex = /<think>([\s\S]*?)<\/think>/i;
-    const match = text.match(regex);
-    if (!match) {
-      return { visibleText: text, cotText: null };
-    }
-
-    const cotRaw = match[1].trim();
-    const visible = text.replace(match[0], '').trim();
-    return { visibleText: visible, cotText: cotRaw.length > 0 ? cotRaw : null };
-  };
-
-  const { visibleText: textWithoutCot, cotText } = splitChainOfThought(textContent);
-
-  // Extract image paths from the visible part of the message (exclude CoT)
-  const imagePaths = extractImagePaths(textWithoutCot);
+  // Get text content without Chain of Thought
+  const textWithoutCot = getTextContent(message);
 
   // Remove image paths from text for display
   const displayText =
@@ -79,11 +62,53 @@ export default function GooseMessage({
   // Get tool requests from the message
   const toolRequests = getToolRequests(message);
 
+  // Get current message index
+  const messageIndex = messages.findIndex((msg) => msg.id === message.id);
+
+  // Enhanced chain detection that works during streaming
+  const toolCallChains = useMemo(() => {
+    // Always run chain detection, but handle streaming messages specially
+    const chains = identifyConsecutiveToolCalls(messages);
+    
+    // If this message is streaming and has tool calls but no text, 
+    // check if it should extend an existing chain
+    if (isStreaming && toolRequests.length > 0 && !displayText.trim()) {
+      // Look for an existing chain that this message could extend
+      const previousMessage = messageIndex > 0 ? messages[messageIndex - 1] : null;
+      if (previousMessage) {
+        const prevToolRequests = getToolRequests(previousMessage);
+        
+        // If previous message has tool calls (with or without text), extend its chain
+        if (prevToolRequests.length > 0) {
+          // Find if previous message is part of a chain
+          const prevChain = chains.find(chain => chain.includes(messageIndex - 1));
+          if (prevChain) {
+            // Extend the existing chain to include this streaming message
+            const extendedChains = chains.map(chain => 
+              chain === prevChain ? [...chain, messageIndex] : chain
+            );
+            return extendedChains;
+          } else {
+            // Create a new chain with previous and current message
+            return [...chains, [messageIndex - 1, messageIndex]];
+          }
+        }
+      }
+    }
+    
+    return chains;
+  }, [messages, isStreaming, messageIndex, toolRequests, displayText]);
+
+  // Check if this message should be hidden (part of chain but not first)
+  const shouldHide = shouldHideMessage(messageIndex, toolCallChains);
+  
+  // Get the chain this message belongs to
+  const messageChain = getChainForMessage(messageIndex, toolCallChains);
+
   // Extract URLs under a few conditions
   // 1. The message is purely text
   // 2. The link wasn't also present in the previous message
   // 3. The message contains the explicit http:// or https:// protocol at the beginning
-  const messageIndex = messages?.findIndex((msg) => msg.id === message.id);
   const previousMessage = messageIndex > 0 ? messages[messageIndex - 1] : null;
   const previousUrls = previousMessage ? extractUrls(getTextContent(previousMessage)) : [];
   const urls = toolRequests.length === 0 ? extractUrls(displayText, previousUrls) : [];
@@ -132,7 +157,10 @@ export default function GooseMessage({
         handledToolConfirmations.current.add(toolConfirmationContent.id);
 
         appendMessage(
-          createToolErrorResponseMessage(toolConfirmationContent.id, 'The tool call is cancelled.')
+          createToolErrorResponseMessage(
+            toolConfirmationContent.id,
+            'Tool execution was cancelled or interrupted.'
+          )
         );
       }
     }
@@ -145,76 +173,97 @@ export default function GooseMessage({
     appendMessage,
   ]);
 
+  // If this message should be hidden (part of chain but not first), don't render it
+  if (shouldHide) {
+    return null;
+  }
+
+  // Determine rendering logic based on chain membership and content
+  const isFirstInChain = messageChain && messageChain[0] === messageIndex;
+  const hasText = displayText.trim().length > 0;
+
   return (
-    <div className="goose-message flex w-[90%] justify-start min-w-0">
-      <div className="flex flex-col w-full min-w-0">
-        {/* Chain-of-Thought (hidden by default) */}
-        {cotText && (
-          <details className="bg-bgSubtle border border-borderSubtle rounded p-2 mb-2">
-            <summary className="cursor-pointer text-sm text-textSubtle select-none">
-              Show thinking
-            </summary>
-            <div className="mt-2">
-              <MarkdownContent content={cotText} />
-            </div>
-          </details>
-        )}
-
-        {/* Visible assistant response */}
+    <div className="group relative w-full">
+      <div className="flex flex-col items-start w-full">
+        {/* Regular text content - ALWAYS show if present */}
         {displayText && (
-          <div className="flex flex-col group">
-            <div className={`goose-message-content py-2`}>
-              <div ref={contentRef}>{<MarkdownContent content={displayText} />}</div>
+          <div className="flex flex-col w-full">
+            <div ref={contentRef} className="w-full">
+              <MarkdownContent content={displayText} />
             </div>
 
-            {/* Render images if any */}
+            {/* Image previews */}
             {imagePaths.length > 0 && (
-              <div className="flex flex-wrap gap-2 mt-2 mb-2">
+              <div className="mt-4">
                 {imagePaths.map((imagePath, index) => (
-                  <ImagePreview key={index} src={imagePath} alt={`Image ${index + 1}`} />
+                  <ImagePreview key={index} src={imagePath} />
                 ))}
               </div>
             )}
 
-            {/* Only show timestamp and copy link when not streaming */}
-            <div className="relative flex justify-start">
-              {toolRequests.length === 0 && !isStreaming && (
-                <div className="text-xs font-mono text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
-                  {timestamp}
-                </div>
-              )}
-              {displayText &&
-                message.content.every((content) => content.type === 'text') &&
-                !isStreaming && (
+            {/* URLs */}
+            {urls.length > 0 && (
+              <div className="mt-4">
+                {urls.map((url, index) => (
+                  <LinkPreview key={index} url={url} />
+                ))}
+              </div>
+            )}
+
+            {/* Show timestamp for text-only messages */}
+            {toolRequests.length === 0 && (
+              <div className="relative flex justify-start">
+                {!isStreaming && (
+                  <div className="text-xs font-mono text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
+                    {timestamp}
+                  </div>
+                )}
+                {message.content.every((content) => content.type === 'text') && !isStreaming && (
                   <div className="absolute left-0 pt-1">
                     <MessageCopyLink text={displayText} contentRef={contentRef} />
                   </div>
                 )}
-            </div>
+              </div>
+            )}
           </div>
         )}
 
+        {/* Tool calls - either as chain or individual */}
         {toolRequests.length > 0 && (
-          <div className="relative flex flex-col w-full">
-            {toolRequests.map((toolRequest) => (
-              <div className={`goose-message-tool pb-2`} key={toolRequest.id}>
-                <ToolCallWithResponse
-                  // If the message is resumed and not matched tool response, it means the tool is broken or cancelled.
-                  isCancelledMessage={
-                    messageIndex < messageHistoryIndex &&
-                    toolResponsesMap.get(toolRequest.id) == undefined
-                  }
-                  toolRequest={toolRequest}
-                  toolResponse={toolResponsesMap.get(toolRequest.id)}
-                  notifications={toolCallNotifications.get(toolRequest.id)}
-                  isStreamingMessage={isStreaming}
-                />
+          <>
+            {isFirstInChain ? (
+              // This is the first message in a chain - render the entire chain
+              <ToolCallChain
+                messages={messages}
+                chainIndices={messageChain}
+                toolCallNotifications={toolCallNotifications}
+                toolResponsesMap={toolResponsesMap}
+                messageHistoryIndex={messageHistoryIndex}
+                isStreaming={isStreaming}
+              />
+            ) : !messageChain ? (
+              // This message is not part of any chain - render individual tool calls
+              <div className="relative flex flex-col w-full">
+                {toolRequests.map((toolRequest) => (
+                  <div className={`goose-message-tool pb-2`} key={toolRequest.id}>
+                    <ToolCallWithResponse
+                      isCancelledMessage={
+                        messageIndex < messageHistoryIndex &&
+                        toolResponsesMap.get(toolRequest.id) == undefined
+                      }
+                      toolRequest={toolRequest}
+                      toolResponse={toolResponsesMap.get(toolRequest.id)}
+                      notifications={toolCallNotifications.get(toolRequest.id)}
+                      isStreamingMessage={isStreaming}
+                    />
+                  </div>
+                ))}
+                <div className="text-xs text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
+                  {!isStreaming && timestamp}
+                </div>
               </div>
-            ))}
-            <div className="text-xs text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
-              {!isStreaming && timestamp}
-            </div>
-          </div>
+            ) : null}
+          </>
         )}
 
         {hasToolConfirmation && (
@@ -226,25 +275,6 @@ export default function GooseMessage({
           />
         )}
       </div>
-
-      {/* TODO(alexhancock): Re-enable link previews once styled well again */}
-      {/* eslint-disable-next-line no-constant-binary-expression */}
-      {false && urls.length > 0 && (
-        <div className="flex flex-wrap mt-[16px]">
-          {urls.map((url, index) => (
-            <LinkPreview key={index} url={url} />
-          ))}
-        </div>
-      )}
-
-      {/* enable or disable prompts here */}
-      {/* NOTE from alexhancock on 1/14/2025 - disabling again temporarily due to non-determinism in when the forms show up */}
-      {/* eslint-disable-next-line no-constant-binary-expression */}
-      {false && metadata && (
-        <div className="flex mt-[16px]">
-          <GooseResponseForm message={displayText} metadata={metadata || null} append={append} />
-        </div>
-      )}
     </div>
   );
 }

--- a/ui/desktop/src/components/GooseMessage.tsx.backup
+++ b/ui/desktop/src/components/GooseMessage.tsx.backup
@@ -1,0 +1,250 @@
+import { useEffect, useMemo, useRef } from 'react';
+import LinkPreview from './LinkPreview';
+import ImagePreview from './ImagePreview';
+import GooseResponseForm from './GooseResponseForm';
+import { extractUrls } from '../utils/urlUtils';
+import { extractImagePaths, removeImagePathsFromText } from '../utils/imageUtils';
+import { formatMessageTimestamp } from '../utils/timeUtils';
+import MarkdownContent from './MarkdownContent';
+import ToolCallWithResponse from './ToolCallWithResponse';
+import {
+  Message,
+  getTextContent,
+  getToolRequests,
+  getToolResponses,
+  getToolConfirmationContent,
+  createToolErrorResponseMessage,
+} from '../types/message';
+import ToolCallConfirmation from './ToolCallConfirmation';
+import MessageCopyLink from './MessageCopyLink';
+import { NotificationEvent } from '../hooks/useMessageStream';
+
+interface GooseMessageProps {
+  // messages up to this index are presumed to be "history" from a resumed session, this is used to track older tool confirmation requests
+  // anything before this index should not render any buttons, but anything after should
+  messageHistoryIndex: number;
+  message: Message;
+  messages: Message[];
+  metadata?: string[];
+  toolCallNotifications: Map<string, NotificationEvent[]>;
+  append: (value: string) => void;
+  appendMessage: (message: Message) => void;
+  isStreaming?: boolean; // Whether this message is currently being streamed
+}
+
+export default function GooseMessage({
+  messageHistoryIndex,
+  message,
+  metadata,
+  messages,
+  toolCallNotifications,
+  append,
+  appendMessage,
+  isStreaming = false,
+}: GooseMessageProps) {
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // Track which tool confirmations we've already handled to prevent infinite loops
+  const handledToolConfirmations = useRef<Set<string>>(new Set());
+
+  // Extract text content from the message
+  let textContent = getTextContent(message);
+
+  // Utility to split Chain-of-Thought (CoT) from the visible assistant response.
+  // If the text contains a <think>...</think> block, everything inside is treated as the
+  // CoT and removed from the user-visible text.
+  const splitChainOfThought = (text: string): { visibleText: string; cotText: string | null } => {
+    const regex = /<think>([\s\S]*?)<\/think>/i;
+    const match = text.match(regex);
+    if (!match) {
+      return { visibleText: text, cotText: null };
+    }
+
+    const cotRaw = match[1].trim();
+    const visible = text.replace(match[0], '').trim();
+    return { visibleText: visible, cotText: cotRaw.length > 0 ? cotRaw : null };
+  };
+
+  const { visibleText: textWithoutCot, cotText } = splitChainOfThought(textContent);
+
+  // Extract image paths from the visible part of the message (exclude CoT)
+  const imagePaths = extractImagePaths(textWithoutCot);
+
+  // Remove image paths from text for display
+  const displayText =
+    imagePaths.length > 0 ? removeImagePathsFromText(textWithoutCot, imagePaths) : textWithoutCot;
+
+  // Memoize the timestamp
+  const timestamp = useMemo(() => formatMessageTimestamp(message.created), [message.created]);
+
+  // Get tool requests from the message
+  const toolRequests = getToolRequests(message);
+
+  // Extract URLs under a few conditions
+  // 1. The message is purely text
+  // 2. The link wasn't also present in the previous message
+  // 3. The message contains the explicit http:// or https:// protocol at the beginning
+  const messageIndex = messages?.findIndex((msg) => msg.id === message.id);
+  const previousMessage = messageIndex > 0 ? messages[messageIndex - 1] : null;
+  const previousUrls = previousMessage ? extractUrls(getTextContent(previousMessage)) : [];
+  const urls = toolRequests.length === 0 ? extractUrls(displayText, previousUrls) : [];
+
+  const toolConfirmationContent = getToolConfirmationContent(message);
+  const hasToolConfirmation = toolConfirmationContent !== undefined;
+
+  // Find tool responses that correspond to the tool requests in this message
+  const toolResponsesMap = useMemo(() => {
+    const responseMap = new Map();
+
+    // Look for tool responses in subsequent messages
+    if (messageIndex !== undefined && messageIndex >= 0) {
+      for (let i = messageIndex + 1; i < messages.length; i++) {
+        const responses = getToolResponses(messages[i]);
+
+        for (const response of responses) {
+          // Check if this response matches any of our tool requests
+          const matchingRequest = toolRequests.find((req) => req.id === response.id);
+          if (matchingRequest) {
+            responseMap.set(response.id, response);
+          }
+        }
+      }
+    }
+
+    return responseMap;
+  }, [messages, messageIndex, toolRequests]);
+
+  useEffect(() => {
+    // If the message is the last message in the resumed session and has tool confirmation, it means the tool confirmation
+    // is broken or cancelled, to contonue use the session, we need to append a tool response to avoid mismatch tool result error.
+    if (
+      messageIndex === messageHistoryIndex - 1 &&
+      hasToolConfirmation &&
+      toolConfirmationContent &&
+      !handledToolConfirmations.current.has(toolConfirmationContent.id)
+    ) {
+      // Only append the error message if there isn't already a response for this tool confirmation
+      const hasExistingResponse = messages.some((msg) =>
+        getToolResponses(msg).some((response) => response.id === toolConfirmationContent.id)
+      );
+
+      if (!hasExistingResponse) {
+        // Mark this tool confirmation as handled to prevent infinite loop
+        handledToolConfirmations.current.add(toolConfirmationContent.id);
+
+        appendMessage(
+          createToolErrorResponseMessage(toolConfirmationContent.id, 'The tool call is cancelled.')
+        );
+      }
+    }
+  }, [
+    messageIndex,
+    messageHistoryIndex,
+    hasToolConfirmation,
+    toolConfirmationContent,
+    messages,
+    appendMessage,
+  ]);
+
+  return (
+    <div className="goose-message flex w-[90%] justify-start min-w-0">
+      <div className="flex flex-col w-full min-w-0">
+        {/* Chain-of-Thought (hidden by default) */}
+        {cotText && (
+          <details className="bg-bgSubtle border border-borderSubtle rounded p-2 mb-2">
+            <summary className="cursor-pointer text-sm text-textSubtle select-none">
+              Show thinking
+            </summary>
+            <div className="mt-2">
+              <MarkdownContent content={cotText} />
+            </div>
+          </details>
+        )}
+
+        {/* Visible assistant response */}
+        {displayText && (
+          <div className="flex flex-col group">
+            <div className={`goose-message-content py-2`}>
+              <div ref={contentRef}>{<MarkdownContent content={displayText} />}</div>
+            </div>
+
+            {/* Render images if any */}
+            {imagePaths.length > 0 && (
+              <div className="flex flex-wrap gap-2 mt-2 mb-2">
+                {imagePaths.map((imagePath, index) => (
+                  <ImagePreview key={index} src={imagePath} alt={`Image ${index + 1}`} />
+                ))}
+              </div>
+            )}
+
+            {/* Only show timestamp and copy link when not streaming */}
+            <div className="relative flex justify-start">
+              {toolRequests.length === 0 && !isStreaming && (
+                <div className="text-xs font-mono text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
+                  {timestamp}
+                </div>
+              )}
+              {displayText &&
+                message.content.every((content) => content.type === 'text') &&
+                !isStreaming && (
+                  <div className="absolute left-0 pt-1">
+                    <MessageCopyLink text={displayText} contentRef={contentRef} />
+                  </div>
+                )}
+            </div>
+          </div>
+        )}
+
+        {toolRequests.length > 0 && (
+          <div className="relative flex flex-col w-full">
+            {toolRequests.map((toolRequest) => (
+              <div className={`goose-message-tool pb-2`} key={toolRequest.id}>
+                <ToolCallWithResponse
+                  // If the message is resumed and not matched tool response, it means the tool is broken or cancelled.
+                  isCancelledMessage={
+                    messageIndex < messageHistoryIndex &&
+                    toolResponsesMap.get(toolRequest.id) == undefined
+                  }
+                  toolRequest={toolRequest}
+                  toolResponse={toolResponsesMap.get(toolRequest.id)}
+                  notifications={toolCallNotifications.get(toolRequest.id)}
+                  isStreamingMessage={isStreaming}
+                />
+              </div>
+            ))}
+            <div className="text-xs text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
+              {!isStreaming && timestamp}
+            </div>
+          </div>
+        )}
+
+        {hasToolConfirmation && (
+          <ToolCallConfirmation
+            isCancelledMessage={messageIndex == messageHistoryIndex - 1}
+            isClicked={messageIndex < messageHistoryIndex}
+            toolConfirmationId={toolConfirmationContent.id}
+            toolName={toolConfirmationContent.toolName}
+          />
+        )}
+      </div>
+
+      {/* TODO(alexhancock): Re-enable link previews once styled well again */}
+      {/* eslint-disable-next-line no-constant-binary-expression */}
+      {false && urls.length > 0 && (
+        <div className="flex flex-wrap mt-[16px]">
+          {urls.map((url, index) => (
+            <LinkPreview key={index} url={url} />
+          ))}
+        </div>
+      )}
+
+      {/* enable or disable prompts here */}
+      {/* NOTE from alexhancock on 1/14/2025 - disabling again temporarily due to non-determinism in when the forms show up */}
+      {/* eslint-disable-next-line no-constant-binary-expression */}
+      {false && metadata && (
+        <div className="flex mt-[16px]">
+          <GooseResponseForm message={displayText} metadata={metadata || null} append={append} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/desktop/src/components/ToolCallChain.tsx
+++ b/ui/desktop/src/components/ToolCallChain.tsx
@@ -7,7 +7,7 @@ interface ToolCallChainProps {
   messages: Message[];
   chainIndices: number[];
   toolCallNotifications: Map<string, NotificationEvent[]>;
-  toolResponsesMap: Map<string, any>;
+  toolResponsesMap: Map<string, import("../types/message").ToolResponseMessageContent>;
   messageHistoryIndex: number;
   isStreaming?: boolean;
 }

--- a/ui/desktop/src/components/ToolCallChain.tsx
+++ b/ui/desktop/src/components/ToolCallChain.tsx
@@ -1,0 +1,63 @@
+import { formatMessageTimestamp } from '../utils/timeUtils';
+import { Message, getToolRequests } from '../types/message';
+import { NotificationEvent } from '../hooks/useMessageStream';
+import ToolCallWithResponse from './ToolCallWithResponse';
+
+interface ToolCallChainProps {
+  messages: Message[];
+  chainIndices: number[];
+  toolCallNotifications: Map<string, NotificationEvent[]>;
+  toolResponsesMap: Map<string, any>;
+  messageHistoryIndex: number;
+  isStreaming?: boolean;
+}
+
+/**
+ * Component that renders a chain of consecutive tool call messages with a single timestamp
+ */
+export default function ToolCallChain({
+  messages,
+  chainIndices,
+  toolCallNotifications,
+  toolResponsesMap,
+  messageHistoryIndex,
+  isStreaming = false
+}: ToolCallChainProps) {
+  // Get the timestamp from the last message in the chain
+  const lastMessageIndex = chainIndices[chainIndices.length - 1];
+  const lastMessage = messages[lastMessageIndex];
+  const timestamp = lastMessage ? formatMessageTimestamp(lastMessage.created) : '';
+
+  return (
+    <div className="relative flex flex-col w-full">
+      {/* Render each message's tool calls in the chain */}
+      {chainIndices.map((messageIndex) => {
+        const message = messages[messageIndex];
+        const toolRequests = getToolRequests(message);
+
+        return toolRequests.map((toolRequest) => (
+          <div 
+            key={toolRequest.id} 
+            className="goose-message-tool pb-2"
+          >
+            <ToolCallWithResponse
+              isCancelledMessage={
+                messageIndex < messageHistoryIndex &&
+                toolResponsesMap.get(toolRequest.id) == undefined
+              }
+              toolRequest={toolRequest}
+              toolResponse={toolResponsesMap.get(toolRequest.id)}
+              notifications={toolCallNotifications.get(toolRequest.id)}
+              isStreamingMessage={isStreaming}
+            />
+          </div>
+        ));
+      })}
+      
+      {/* Single timestamp for the entire chain */}
+      <div className="text-xs text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
+        {!isStreaming && timestamp}
+      </div>
+    </div>
+  );
+}

--- a/ui/desktop/src/components/ToolCallStatusIndicator.tsx
+++ b/ui/desktop/src/components/ToolCallStatusIndicator.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import { cn } from '../utils';
+
+export type ToolCallStatus = 'pending' | 'loading' | 'success' | 'error';
+
+interface ToolCallStatusIndicatorProps {
+  status: ToolCallStatus;
+  className?: string;
+}
+
+export const ToolCallStatusIndicator: React.FC<ToolCallStatusIndicatorProps> = ({
+  status,
+  className,
+}) => {
+  const getStatusStyles = () => {
+    switch (status) {
+      case 'success':
+        return 'bg-green-500';
+      case 'error':
+        return 'bg-red-500';
+      case 'loading':
+        return 'bg-yellow-500 animate-pulse';
+      case 'pending':
+      default:
+        return 'bg-gray-400';
+    }
+  };
+
+  return (
+    <div
+      className={cn(
+        'absolute -top-0.5 -right-0.5 w-2 h-2 rounded-full border border-background-default',
+        getStatusStyles(),
+        className
+      )}
+      aria-label={`Tool status: ${status}`}
+    />
+  );
+};
+
+/**
+ * Wrapper component that adds a status indicator to a tool icon
+ */
+interface ToolIconWithStatusProps {
+  ToolIcon: React.ComponentType<{ className?: string }>;
+  status: ToolCallStatus;
+  className?: string;
+}
+
+export const ToolIconWithStatus: React.FC<ToolIconWithStatusProps> = ({
+  ToolIcon,
+  status,
+  className,
+}) => {
+  return (
+    <div className={cn('relative inline-block', className)}>
+      <ToolIcon className="w-3 h-3 flex-shrink-0" />
+      <ToolCallStatusIndicator status={status} />
+    </div>
+  );
+};

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -6,9 +6,9 @@ import { ToolCallArguments, ToolCallArgumentValue } from './ToolCallArguments';
 import MarkdownContent from './MarkdownContent';
 import { Content, ToolRequestMessageContent, ToolResponseMessageContent } from '../types/message';
 import { cn, snakeToTitleCase } from '../utils';
-import Dot, { LoadingStatus } from './ui/Dot';
+import { LoadingStatus } from './ui/Dot';
 import { NotificationEvent } from '../hooks/useMessageStream';
-import { ChevronRight, FlaskConical, LoaderCircle } from 'lucide-react';
+import { ChevronRight, FlaskConical } from 'lucide-react';
 import { TooltipWrapper } from './settings/providers/subcomponents/buttons/TooltipWrapper';
 import MCPUIResourceRenderer from './MCPUIResourceRenderer';
 

--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -1,3 +1,5 @@
+import { ToolIconWithStatus, ToolCallStatus } from './ToolCallStatusIndicator';
+import { getToolCallIcon } from '../utils/toolIconMapping';
 import React, { useEffect, useRef, useState } from 'react';
 import { Button } from './ui/button';
 import { ToolCallArguments, ToolCallArgumentValue } from './ToolCallArguments';
@@ -439,36 +441,44 @@ function ToolCallView({
     // Fallback tool name formatting
     return snakeToTitleCase(toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2));
   };
+  // Map LoadingStatus to ToolCallStatus
+  const getToolCallStatus = (loadingStatus: LoadingStatus): ToolCallStatus => {
+    switch (loadingStatus) {
+      case 'success':
+        return 'success';
+      case 'error':
+        return 'error';
+      case 'loading':
+        return 'loading';
+      default:
+        return 'pending';
+    }
+  };
+
+  const toolCallStatus = getToolCallStatus(loadingStatus);
 
   const toolLabel = (
-    <span className={cn('ml-2', extensionTooltip && 'cursor-pointer hover:opacity-80')}>
-      {getToolLabelContent()}
+    <span className={cn('ml-2 flex items-center gap-2', extensionTooltip && 'cursor-pointer hover:opacity-80')}>
+      <ToolIconWithStatus
+        ToolIcon={getToolCallIcon(toolCall.name)}
+        status={toolCallStatus}
+      />
+      <span>{getToolLabelContent()}</span>
     </span>
   );
-
   return (
     <ToolCallExpandable
       isStartExpanded={isRenderingProgress}
       isForceExpand={isShouldExpand}
       label={
-        <>
-          <div className="w-2 flex items-center justify-center">
-            {loadingStatus === 'loading' ? (
-              <LoaderCircle className="animate-spin text-text-muted" size={3} />
-            ) : (
-              <Dot size={2} loadingStatus={loadingStatus} />
-            )}
-          </div>
-          {extensionTooltip ? (
-            <TooltipWrapper tooltipContent={extensionTooltip} side="top" align="start">
-              {toolLabel}
-            </TooltipWrapper>
-          ) : (
-            toolLabel
-          )}
-        </>
-      }
-    >
+        extensionTooltip ? (
+          <TooltipWrapper tooltipContent={extensionTooltip} side="top" align="start">
+            {toolLabel}
+          </TooltipWrapper>
+        ) : (
+          toolLabel
+        )
+      }    >
       {/* Tool Details */}
       {isToolDetails && (
         <div className="border-t border-borderSubtle">

--- a/ui/desktop/src/components/icons/toolcalls/Archive.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Archive.tsx
@@ -1,0 +1,17 @@
+export const Archive = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="#1E1E20"/>
+    <path d="M1.375 6.1875H9.625V8.25C9.625 8.6297 9.3172 8.9375 8.9375 8.9375H2.0625C1.6828 8.9375 1.375 8.6297 1.375 8.25V6.1875Z" fill="#DBD7CE"/>
+    <path d="M1.375 6.1875H9.625V7.5625H1.375V6.1875Z" fill="#434343"/>
+    <path d="M1.375 4.8125H9.625V6.1875H1.375V4.8125Z" fill="white"/>
+    <path d="M1.375 3.4375H9.625V4.8125H1.375V3.4375Z" fill="#616161"/>
+    <path d="M1.375 2.75C1.375 2.3703 1.6828 2.0625 2.0625 2.0625H8.9375C9.3172 2.0625 9.625 2.3703 9.625 2.75V3.4375H1.375V2.75Z" fill="#9F9F9F"/>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Brain.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Brain.tsx
@@ -1,0 +1,20 @@
+export const Brain = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="#3E3E3E"/>
+    <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_782)"/>
+    <path d="M5.5 2.0625L1.375 5.5L5.5 8.9375L9.625 5.5L5.5 2.0625Z" fill="#E74786"/>
+    <defs>
+      <linearGradient id="paint0_linear_6313_782" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop/>
+        <stop offset="1" stopColor="#323232"/>
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Camera.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Camera.tsx
@@ -1,0 +1,20 @@
+export const Camera = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_741)"/>
+    <path d="M1.375 3.4375C1.375 3.0578 1.6828 2.75 2.0625 2.75H8.9375C9.3172 2.75 9.625 3.0578 9.625 3.4375V7.5625C9.625 7.9422 9.3172 8.25 8.9375 8.25H2.0625C1.6828 8.25 1.375 7.9422 1.375 7.5625V3.4375Z" fill="#2F2F31"/>
+    <path d="M6.53125 5.5C6.53125 6.06954 6.06954 6.53125 5.5 6.53125C4.93046 6.53125 4.46875 6.06954 4.46875 5.5C4.46875 4.93046 4.93046 4.46875 5.5 4.46875C6.06954 4.46875 6.53125 4.93046 6.53125 5.5Z" fill="white"/>
+    <defs>
+      <linearGradient id="paint0_linear_6313_741" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#E2E3F7"/>
+        <stop offset="1" stopColor="#978E8F"/>
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Code2.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Code2.tsx
@@ -1,0 +1,13 @@
+export const Code2 = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="#1C1C1E"/>
+    <rect x="2" y="5" width="7" height="1" rx="0.5" fill="#19FF4F"/>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Eye.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Eye.tsx
@@ -1,0 +1,20 @@
+export const Eye = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_805)"/>
+    <path d="M1.375 5.5C1.375 4.36091 2.29841 3.4375 3.4375 3.4375H7.5625C8.70159 3.4375 9.625 4.36091 9.625 5.5V5.5C9.625 6.63909 8.70159 7.5625 7.5625 7.5625H3.4375C2.29841 7.5625 1.375 6.63909 1.375 5.5V5.5Z" fill="white"/>
+    <path d="M6.53125 5.5C6.53125 6.06954 6.06954 6.53125 5.5 6.53125C4.93046 6.53125 4.46875 6.06954 4.46875 5.5C4.46875 4.93046 4.93046 4.46875 5.5 4.46875C6.06954 4.46875 6.53125 4.93046 6.53125 5.5Z" fill="black"/>
+    <defs>
+      <linearGradient id="paint0_linear_6313_805" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#00A2FF"/>
+        <stop offset="1" stopColor="#5A6DFF"/>
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/FileEdit.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/FileEdit.tsx
@@ -1,0 +1,20 @@
+export const FileEdit = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_755)"/>
+    <path d="M8.96875 2.03125L8.96875 4.78125L2.09375 4.78125L2.09375 3.40625C2.09375 2.64686 2.70936 2.03125 3.46875 2.03125L8.96875 2.03125Z" fill="white"/>
+    <path d="M5.03125 6.03125L5.03125 9.03125L2.03125 9.03125L2.03125 7.53125C2.03125 6.70282 2.29988 6.03125 2.63125 6.03125L5.03125 6.03125Z" fill="white"/>
+    <defs>
+      <linearGradient id="paint0_linear_6313_755" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop/>
+        <stop offset="1" stopColor="#383838"/>
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/FilePlus.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/FilePlus.tsx
@@ -1,0 +1,20 @@
+export const FilePlus = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_774)"/>
+    <rect x="2" y="5" width="7" height="1" rx="0.5" fill="white"/>
+    <rect x="6" y="2" width="7" height="1" rx="0.5" transform="rotate(90 6 2)" fill="white"/>
+    <defs>
+      <linearGradient id="paint0_linear_6313_774" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#FF9A00"/>
+        <stop offset="1" stopColor="#FFC800"/>
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/FileText.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/FileText.tsx
@@ -1,0 +1,19 @@
+export const FileText = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_764)"/>
+    <path fillRule="evenodd" clipRule="evenodd" d="M8.73614 2.26386C9.00462 2.53235 9.00462 2.96765 8.73614 3.23614L3.23614 8.73614C2.96765 9.00462 2.53235 9.00462 2.26386 8.73614C1.99538 8.46765 1.99538 8.03235 2.26386 7.76386L7.76386 2.26386C8.03235 1.99538 8.46765 1.99538 8.73614 2.26386Z" fill="white"/>
+    <defs>
+      <linearGradient id="paint0_linear_6313_764" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#FFB645"/>
+        <stop offset="1" stopColor="#FF8735"/>
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Globe.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Globe.tsx
@@ -1,0 +1,24 @@
+export const Globe = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <g clipPath="url(#clip0_6313_720)">
+      <rect width="11" height="11" rx="2" fill="white"/>
+      <path d="M10.3125 5.5C10.3125 8.15787 8.15787 10.3125 5.5 10.3125C2.84213 10.3125 0.6875 8.15787 0.6875 5.5C0.6875 2.84213 2.84213 0.6875 5.5 0.6875C8.15787 0.6875 10.3125 2.84213 10.3125 5.5Z" fill="url(#paint0_linear_6313_720)"/>
+    </g>
+    <defs>
+      <linearGradient id="paint0_linear_6313_720" x1="5.5" y1="0.6875" x2="5.5" y2="10.3125" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#00CAF7"/>
+        <stop offset="1" stopColor="#0B54DE"/>
+      </linearGradient>
+      <clipPath id="clip0_6313_720">
+        <rect width="11" height="11" rx="2" fill="white"/>
+      </clipPath>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Harddrive.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Harddrive.tsx
@@ -1,0 +1,13 @@
+export const Harddrive = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="#1E1E20"/>
+    <path d="M5 3.5C5 4.32843 4.32843 5 3.5 5C2.67157 5 2 4.32843 2 3.5C2 2.67157 2.67157 2 3.5 2C4.32843 2 5 2.67157 5 3.5Z" fill="white"/>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Monitor.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Monitor.tsx
@@ -1,0 +1,13 @@
+export const Monitor = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="white"/>
+    <path d="M9.625 5.5C9.625 7.77817 7.77817 9.625 5.5 9.625C3.22183 9.625 1.375 7.77817 1.375 5.5C1.375 3.22183 3.22183 1.375 5.5 1.375C7.77817 1.375 9.625 3.22183 9.625 5.5Z" fill="#E60023"/>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Numbers.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Numbers.tsx
@@ -1,0 +1,21 @@
+export const Numbers = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_717)"/>
+    <path d="M4.8125 3.4375C4.8125 3.0578 5.1203 2.75 5.5 2.75C5.8797 2.75 6.1875 3.0578 6.1875 3.4375V7.5625C6.1875 7.9422 5.8797 8.25 5.5 8.25C5.1203 8.25 4.8125 7.9422 4.8125 7.5625V3.4375Z" fill="white"/>
+    <path d="M2.0625 6.1875C2.0625 5.8078 2.3703 5.5 2.75 5.5C3.1297 5.5 3.4375 5.8078 3.4375 6.1875V7.5625C3.4375 7.9422 3.1297 8.25 2.75 8.25C2.3703 8.25 2.0625 7.9422 2.0625 7.5625V6.1875Z" fill="white"/>
+    <path d="M8.25 4.125C7.8703 4.125 7.5625 4.4328 7.5625 4.8125V7.5625C7.5625 7.9422 7.8703 8.25 8.25 8.25C8.6297 8.25 8.9375 7.9422 8.9375 7.5625V4.8125C8.9375 4.4328 8.6297 4.125 8.25 4.125Z" fill="white"/>
+    <defs>
+      <linearGradient id="paint0_linear_6313_717" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#73FA80"/>
+        <stop offset="1" stopColor="#00D648"/>
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Save.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Save.tsx
@@ -1,0 +1,13 @@
+export const Save = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="#C32361"/>
+    <path d="M5.5 2.0625L1.375 5.5L5.5 8.9375L9.625 5.5L5.5 2.0625Z" fill="#E74786"/>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Search.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Search.tsx
@@ -1,0 +1,19 @@
+export const Search = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_760)"/>
+    <path d="M7.5625 5.5C7.5625 6.63909 6.63909 7.5625 5.5 7.5625C4.36091 7.5625 3.4375 6.63909 3.4375 5.5C3.4375 4.36091 4.36091 3.4375 5.5 3.4375C6.63909 3.4375 7.5625 4.36091 7.5625 5.5Z" fill="#2D2D2E"/>
+    <defs>
+      <linearGradient id="paint0_linear_6313_760" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#D2D5DA"/>
+        <stop offset="1" stopColor="#8B8E95"/>
+      </linearGradient>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Settings.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Settings.tsx
@@ -1,0 +1,25 @@
+export const Settings = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <g clipPath="url(#clip0_6313_731)">
+      <rect width="11" height="11" rx="2" fill="url(#paint0_linear_6313_731)"/>
+      <path fillRule="evenodd" clipRule="evenodd" d="M5.5 8.9375C7.39848 8.9375 8.9375 7.39848 8.9375 5.5C8.9375 3.60152 7.39848 2.0625 5.5 2.0625C3.60152 2.0625 2.0625 3.60152 2.0625 5.5C2.0625 7.39848 3.60152 8.9375 5.5 8.9375ZM5.5 10.3125C8.15787 10.3125 10.3125 8.15787 10.3125 5.5C10.3125 2.84213 8.15787 0.6875 5.5 0.6875C2.84213 0.6875 0.6875 2.84213 0.6875 5.5C0.6875 8.15787 2.84213 10.3125 5.5 10.3125Z" fill="#2D2D2E"/>
+      <path d="M7.5625 5.5C7.5625 6.63909 6.63909 7.5625 5.5 7.5625C4.36091 7.5625 3.4375 6.63909 3.4375 5.5C3.4375 4.36091 4.36091 3.4375 5.5 3.4375C6.63909 3.4375 7.5625 4.36091 7.5625 5.5Z" fill="#2D2D2E"/>
+    </g>
+    <defs>
+      <linearGradient id="paint0_linear_6313_731" x1="5.5" y1="0" x2="5.5" y2="11" gradientUnits="userSpaceOnUse">
+        <stop stopColor="#D2D5DA"/>
+        <stop offset="1" stopColor="#8B8E95"/>
+      </linearGradient>
+      <clipPath id="clip0_6313_731">
+        <rect width="11" height="11" rx="2" fill="white"/>
+      </clipPath>
+    </defs>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Terminal.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Terminal.tsx
@@ -1,0 +1,13 @@
+export const Terminal = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="#1C1C1E"/>
+    <path d="M2 3L2 2L6 2L6 3L2 3Z" fill="#19FF4F"/>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/Tool.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/Tool.tsx
@@ -1,0 +1,13 @@
+export const Tool = ({ className }: { className?: string }) => (
+  <svg 
+    width="11" 
+    height="11" 
+    viewBox="0 0 11 11" 
+    fill="none" 
+    xmlns="http://www.w3.org/2000/svg"
+    className={className}
+  >
+    <rect width="11" height="11" rx="2" fill="#1E1E20"/>
+    <rect x="2" y="5" width="7" height="1" rx="0.5" fill="white"/>
+  </svg>
+);

--- a/ui/desktop/src/components/icons/toolcalls/index.tsx
+++ b/ui/desktop/src/components/icons/toolcalls/index.tsx
@@ -1,0 +1,17 @@
+export { Archive } from './Archive';
+export { Brain } from './Brain';
+export { Camera } from './Camera';
+export { Code2 } from './Code2';
+export { Eye } from './Eye';
+export { FileEdit } from './FileEdit';
+export { FilePlus } from './FilePlus';
+export { FileText } from './FileText';
+export { Globe } from './Globe';
+export { Harddrive } from './Harddrive';
+export { Monitor } from './Monitor';
+export { Numbers } from './Numbers';
+export { Save } from './Save';
+export { Search } from './Search';
+export { Settings } from './Settings';
+export { Terminal } from './Terminal';
+export { Tool } from './Tool';

--- a/ui/desktop/src/utils/githubUpdater.ts
+++ b/ui/desktop/src/utils/githubUpdater.ts
@@ -165,7 +165,7 @@ export class GitHubUpdater {
       const chunks: Uint8Array[] = [];
       let downloadedSize = 0;
 
-      while (true) { // eslint-disable-line no-constant-condition
+      while (true) {
         const { done, value } = await reader.read();
         if (done) break;
 

--- a/ui/desktop/src/utils/githubUpdater.ts
+++ b/ui/desktop/src/utils/githubUpdater.ts
@@ -165,7 +165,7 @@ export class GitHubUpdater {
       const chunks: Uint8Array[] = [];
       let downloadedSize = 0;
 
-      while (true) {
+      while (true) { // eslint-disable-line no-constant-condition
         const { done, value } = await reader.read();
         if (done) break;
 

--- a/ui/desktop/src/utils/toolCallChaining.ts
+++ b/ui/desktop/src/utils/toolCallChaining.ts
@@ -1,0 +1,87 @@
+import { Message, getToolRequests, getTextContent, getToolResponses } from '../types/message';
+
+/**
+ * Enhanced function to detect tool call chains including mixed content messages
+ * @param messages - Array of all messages
+ * @returns Array of message indices that should be chained together
+ */
+export function identifyConsecutiveToolCalls(messages: Message[]): number[][] {
+  const chains: number[][] = [];
+  let currentChain: number[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const toolRequests = getToolRequests(message);
+    const toolResponses = getToolResponses(message);
+    const textContent = getTextContent(message);
+    const hasText = textContent.trim().length > 0;
+
+    // Skip tool response messages - they don't break chains
+    if (toolResponses.length > 0 && toolRequests.length === 0) {
+      continue;
+    }
+
+    // This message has tool calls
+    if (toolRequests.length > 0) {
+      if (hasText) {
+        // Message with text + tools - start a new chain or add to existing
+        if (currentChain.length > 0) {
+          // End current chain and start new one
+          if (currentChain.length > 1) {
+            chains.push([...currentChain]);
+          }
+        }
+        // Start new chain with this mixed content message
+        currentChain = [i];
+      } else {
+        // Pure tool call message - add to chain
+        currentChain.push(i);
+      }
+    } else if (hasText) {
+      // Pure text message - end current chain
+      if (currentChain.length > 1) {
+        chains.push([...currentChain]);
+      }
+      currentChain = [];
+    } else {
+      // Empty or other content - end current chain
+      if (currentChain.length > 1) {
+        chains.push([...currentChain]);
+      }
+      currentChain = [];
+    }
+  }
+
+  // Don't forget the last chain
+  if (currentChain.length > 1) {
+    chains.push(currentChain);
+  }
+
+  return chains;
+}
+
+/**
+ * Check if a message at given index should be hidden (part of chain but not first)
+ * @param messageIndex - Index of the message to check
+ * @param chains - Array of chains (arrays of message indices)
+ * @returns True if message should be hidden
+ */
+export function shouldHideMessage(messageIndex: number, chains: number[][]): boolean {
+  for (const chain of chains) {
+    if (chain.includes(messageIndex)) {
+      // Hide if it's in a chain but not the first message
+      return chain[0] !== messageIndex;
+    }
+  }
+  return false;
+}
+
+/**
+ * Get the chain that contains the given message index
+ * @param messageIndex - Index of the message
+ * @param chains - Array of chains
+ * @returns The chain containing this message, or null
+ */
+export function getChainForMessage(messageIndex: number, chains: number[][]): number[] | null {
+  return chains.find(chain => chain.includes(messageIndex)) || null;
+}

--- a/ui/desktop/src/utils/toolIconMapping.tsx
+++ b/ui/desktop/src/utils/toolIconMapping.tsx
@@ -9,7 +9,7 @@ import {
   FilePlus,
   FileText,
   Globe,
-  Harddrive,
+
   Monitor,
   Numbers,
   Save,

--- a/ui/desktop/src/utils/toolIconMapping.tsx
+++ b/ui/desktop/src/utils/toolIconMapping.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import {
+  Archive,
+  Brain,
+  Camera,
+  Code2,
+  Eye,
+  FileEdit,
+  FilePlus,
+  FileText,
+  Globe,
+  Harddrive,
+  Monitor,
+  Numbers,
+  Save,
+  Search,
+  Settings,
+  Terminal,
+  Tool,
+} from '../components/icons/toolcalls';
+
+export type ToolIconProps = {
+  className?: string;
+};
+
+/**
+ * Maps tool names to their corresponding icon components
+ * @param toolName - The name of the tool (extracted from toolCall.name)
+ * @returns React component for the tool icon
+ */
+export const getToolIcon = (toolName: string): React.ComponentType<ToolIconProps> => {
+  switch (toolName) {
+    // Developer Extension Tools
+    case 'text_editor':
+      return FileEdit;
+    case 'shell':
+      return Terminal;
+
+    // Memory Extension Tools  
+    case 'remember_memory':
+      return Save;
+    case 'retrieve_memories':
+      return Brain;
+
+    // Computer Controller Extension Tools
+    case 'automation_script':
+      return Settings;
+    case 'computer_control':
+      return Monitor;
+    case 'web_scrape':
+      return Globe;
+    case 'screen_capture':
+      return Camera;
+    case 'pdf_tool':
+      return FileText;
+    case 'docx_tool':
+      return FileText;
+    case 'xlsx_tool':
+      return Numbers;
+    case 'cache':
+      return Archive;
+
+    // File Operations
+    case 'search':
+      return Search;
+    case 'read':
+      return Eye;
+    case 'create_file':
+      return FilePlus;
+    case 'update_file':
+      return FileEdit;
+
+    // Google Workspace Tools (if still supported)
+    case 'sheets_tool':
+      return Numbers;
+    case 'docs_tool':
+      return FileText;
+
+    // Special Tools
+    case 'final_output':
+      return Tool; // Could be a checkmark icon if we had one
+
+    // Default fallback for unknown tools
+    default:
+      return Tool;
+  }
+};
+
+/**
+ * Maps extension names to their corresponding icon components
+ * @param extensionName - The name of the extension
+ * @returns React component for the extension icon
+ */
+export const getExtensionIcon = (extensionName: string): React.ComponentType<ToolIconProps> => {
+  switch (extensionName) {
+    case 'developer':
+      return Code2;
+    case 'memory':
+      return Brain;
+    case 'computercontroller':
+      return Monitor;
+    default:
+      return Tool;
+  }
+};
+
+/**
+ * Helper function to extract tool name from full tool call name
+ * @param toolCallName - Full tool call name (e.g., "developer__text_editor")
+ * @returns Extracted tool name (e.g., "text_editor")
+ */
+export const extractToolName = (toolCallName: string): string => {
+  return toolCallName.substring(toolCallName.lastIndexOf('__') + 2);
+};
+
+/**
+ * Helper function to extract extension name from full tool call name
+ * @param toolCallName - Full tool call name (e.g., "developer__text_editor")
+ * @returns Extracted extension name (e.g., "developer")
+ */
+export const extractExtensionName = (toolCallName: string): string => {
+  const lastIndex = toolCallName.lastIndexOf('__');
+  return lastIndex === -1 ? '' : toolCallName.substring(0, lastIndex);
+};
+
+/**
+ * Main function to get the appropriate icon for a tool call
+ * @param toolCallName - Full tool call name (e.g., "developer__text_editor")
+ * @param useExtensionIcon - Whether to use extension icon instead of tool icon
+ * @returns React component for the icon
+ */
+export const getToolCallIcon = (
+  toolCallName: string, 
+  useExtensionIcon: boolean = false
+): React.ComponentType<ToolIconProps> => {
+  if (useExtensionIcon) {
+    const extensionName = extractExtensionName(toolCallName);
+    return getExtensionIcon(extensionName);
+  }
+  
+  const toolName = extractToolName(toolCallName);
+  return getToolIcon(toolName);
+};

--- a/ui/desktop/tests/e2e/app.spec.ts
+++ b/ui/desktop/tests/e2e/app.spec.ts
@@ -100,7 +100,7 @@ async function selectProvider(mainWindow: any, provider: Provider) {
     const root = document.getElementById('root');
     return root && root.children.length > 0;
   });
-  await mainWindow.waitForTimeout(2000);
+  await mainWindow.waitForTimeout(10000);
 
   // Take a screenshot before proceeding
   await mainWindow.screenshot({ path: `test-results/before-provider-${provider.name.toLowerCase()}-check.png` });
@@ -155,7 +155,7 @@ async function selectProvider(mainWindow: any, provider: Provider) {
 
   // Wait for chat interface to appear
   const chatTextareaAfterClick = await mainWindow.waitForSelector('[data-testid="chat-input"]',
-    { timeout: 2000 });
+    { timeout: 10000 });
   expect(await chatTextareaAfterClick.isVisible()).toBe(true);
 
   // Take screenshot of chat interface


### PR DESCRIPTION
- Add 17 custom tool call icon components (Terminal, FileEdit, Globe, etc.)
- Create comprehensive tool-to-icon mapping system
- Implement status indicator overlay system (success/error/loading/pending)
- Replace old green dot status with integrated icon+status display
- Remove redundant LoaderCircle and Dot components from tool calls
- Maintain all existing functionality (tooltips, expansion, etc.)

Visual improvements:
- Each tool call now shows specific icon (11x11px matching design system)
- Status indicators: green (success), red (error), yellow pulsing (loading), gray (pending)
- Cleaner layout with single status indicator per tool
- Better visual hierarchy and user experience

Files added:
- ui/desktop/src/components/icons/toolcalls/ (17 icon components)
- ui/desktop/src/utils/toolIconMapping.tsx (mapping logic)
- ui/desktop/src/components/ToolCallStatusIndicator.tsx (status system)

Files modified:
- ui/desktop/src/components/ToolCallWithResponse.tsx (integration)

<img width="1724" height="1186" alt="Screenshot 2025-08-21 at 12 33 43 PM" src="https://github.com/user-attachments/assets/43e37907-f920-4800-9b56-172dda7dd90b" />

