### PR TITLE
feat: implement tool call chaining for consecutive tool calls

### DIFF
--- a/ui/desktop/src/components/GooseMessage.tsx.backup
+++ b/ui/desktop/src/components/GooseMessage.tsx.backup
@@ -1,13 +1,12 @@
 import { useEffect, useMemo, useRef } from 'react';
 import LinkPreview from './LinkPreview';
 import ImagePreview from './ImagePreview';
+import GooseResponseForm from './GooseResponseForm';
 import { extractUrls } from '../utils/urlUtils';
 import { extractImagePaths, removeImagePathsFromText } from '../utils/imageUtils';
 import { formatMessageTimestamp } from '../utils/timeUtils';
 import MarkdownContent from './MarkdownContent';
 import ToolCallWithResponse from './ToolCallWithResponse';
-import ToolCallChain from './ToolCallChain';
-import { identifyConsecutiveToolCalls, shouldHideMessage, getChainForMessage } from '../utils/toolCallChaining';
 import {
   Message,
   getTextContent,
@@ -36,21 +35,39 @@ interface GooseMessageProps {
 export default function GooseMessage({
   messageHistoryIndex,
   message,
+  metadata,
   messages,
-  metadata: _metadata,
   toolCallNotifications,
-  append: _append,
+  append,
   appendMessage,
   isStreaming = false,
 }: GooseMessageProps) {
-  const contentRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement | null>(null);
+  // Track which tool confirmations we've already handled to prevent infinite loops
   const handledToolConfirmations = useRef<Set<string>>(new Set());
 
-  // Extract image paths from the message content
-  const imagePaths = extractImagePaths(getTextContent(message));
+  // Extract text content from the message
+  let textContent = getTextContent(message);
 
-  // Get text content without Chain of Thought
-  const textWithoutCot = getTextContent(message);
+  // Utility to split Chain-of-Thought (CoT) from the visible assistant response.
+  // If the text contains a <think>...</think> block, everything inside is treated as the
+  // CoT and removed from the user-visible text.
+  const splitChainOfThought = (text: string): { visibleText: string; cotText: string | null } => {
+    const regex = /<think>([\s\S]*?)<\/think>/i;
+    const match = text.match(regex);
+    if (!match) {
+      return { visibleText: text, cotText: null };
+    }
+
+    const cotRaw = match[1].trim();
+    const visible = text.replace(match[0], '').trim();
+    return { visibleText: visible, cotText: cotRaw.length > 0 ? cotRaw : null };
+  };
+
+  const { visibleText: textWithoutCot, cotText } = splitChainOfThought(textContent);
+
+  // Extract image paths from the visible part of the message (exclude CoT)
+  const imagePaths = extractImagePaths(textWithoutCot);
 
   // Remove image paths from text for display
   const displayText =
@@ -62,25 +79,11 @@ export default function GooseMessage({
   // Get tool requests from the message
   const toolRequests = getToolRequests(message);
 
-  // Identify tool call chains - only when not streaming to avoid flickering
-  const toolCallChains = useMemo(() => {
-    if (isStreaming) return [];
-    return identifyConsecutiveToolCalls(messages);
-  }, [messages, isStreaming]);
-
-  // Get current message index
-  const messageIndex = messages.findIndex((msg) => msg.id === message.id);
-
-  // Check if this message should be hidden (part of chain but not first)
-  const shouldHide = !isStreaming && shouldHideMessage(messageIndex, toolCallChains);
-  
-  // Get the chain this message belongs to
-  const messageChain = getChainForMessage(messageIndex, toolCallChains);
-
   // Extract URLs under a few conditions
   // 1. The message is purely text
   // 2. The link wasn't also present in the previous message
   // 3. The message contains the explicit http:// or https:// protocol at the beginning
+  const messageIndex = messages?.findIndex((msg) => msg.id === message.id);
   const previousMessage = messageIndex > 0 ? messages[messageIndex - 1] : null;
   const previousUrls = previousMessage ? extractUrls(getTextContent(previousMessage)) : [];
   const urls = toolRequests.length === 0 ? extractUrls(displayText, previousUrls) : [];
@@ -129,10 +132,7 @@ export default function GooseMessage({
         handledToolConfirmations.current.add(toolConfirmationContent.id);
 
         appendMessage(
-          createToolErrorResponseMessage(
-            toolConfirmationContent.id,
-            'Tool execution was cancelled or interrupted.'
-          )
+          createToolErrorResponseMessage(toolConfirmationContent.id, 'The tool call is cancelled.')
         );
       }
     }
@@ -145,34 +145,33 @@ export default function GooseMessage({
     appendMessage,
   ]);
 
-  // If this message should be hidden (part of chain but not first), don't render it
-  if (shouldHide) {
-    return null;
-  }
-
   return (
-    <div className="group relative w-full">
-      <div className="flex flex-col items-start w-full">
+    <div className="goose-message flex w-[90%] justify-start min-w-0">
+      <div className="flex flex-col w-full min-w-0">
+        {/* Chain-of-Thought (hidden by default) */}
+        {cotText && (
+          <details className="bg-bgSubtle border border-borderSubtle rounded p-2 mb-2">
+            <summary className="cursor-pointer text-sm text-textSubtle select-none">
+              Show thinking
+            </summary>
+            <div className="mt-2">
+              <MarkdownContent content={cotText} />
+            </div>
+          </details>
+        )}
+
+        {/* Visible assistant response */}
         {displayText && (
-          <div className="flex flex-col w-full">
-            <div ref={contentRef} className="w-full">
-              <MarkdownContent content={displayText} />
+          <div className="flex flex-col group">
+            <div className={`goose-message-content py-2`}>
+              <div ref={contentRef}>{<MarkdownContent content={displayText} />}</div>
             </div>
 
-            {/* Image previews */}
+            {/* Render images if any */}
             {imagePaths.length > 0 && (
-              <div className="mt-4">
+              <div className="flex flex-wrap gap-2 mt-2 mb-2">
                 {imagePaths.map((imagePath, index) => (
-                  <ImagePreview key={index} src={imagePath} />
-                ))}
-              </div>
-            )}
-
-            {/* URLs */}
-            {urls.length > 0 && (
-              <div className="mt-4">
-                {urls.map((url, index) => (
-                  <LinkPreview key={index} url={url} />
+                  <ImagePreview key={index} src={imagePath} alt={`Image ${index + 1}`} />
                 ))}
               </div>
             )}
@@ -195,42 +194,27 @@ export default function GooseMessage({
           </div>
         )}
 
-        {/* Tool calls - either as chain or individual */}
         {toolRequests.length > 0 && (
-          <>
-            {messageChain && messageChain[0] === messageIndex ? (
-              // This is the first message in a chain - render the entire chain
-              <ToolCallChain
-                messages={messages}
-                chainIndices={messageChain}
-                toolCallNotifications={toolCallNotifications}
-                toolResponsesMap={toolResponsesMap}
-                messageHistoryIndex={messageHistoryIndex}
-                isStreaming={isStreaming}
-              />
-            ) : !messageChain ? (
-              // This message is not part of any chain - render individual tool calls
-              <div className="relative flex flex-col w-full">
-                {toolRequests.map((toolRequest) => (
-                  <div className={`goose-message-tool pb-2`} key={toolRequest.id}>
-                    <ToolCallWithResponse
-                      isCancelledMessage={
-                        messageIndex < messageHistoryIndex &&
-                        toolResponsesMap.get(toolRequest.id) == undefined
-                      }
-                      toolRequest={toolRequest}
-                      toolResponse={toolResponsesMap.get(toolRequest.id)}
-                      notifications={toolCallNotifications.get(toolRequest.id)}
-                      isStreamingMessage={isStreaming}
-                    />
-                  </div>
-                ))}
-                <div className="text-xs text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
-                  {!isStreaming && timestamp}
-                </div>
+          <div className="relative flex flex-col w-full">
+            {toolRequests.map((toolRequest) => (
+              <div className={`goose-message-tool pb-2`} key={toolRequest.id}>
+                <ToolCallWithResponse
+                  // If the message is resumed and not matched tool response, it means the tool is broken or cancelled.
+                  isCancelledMessage={
+                    messageIndex < messageHistoryIndex &&
+                    toolResponsesMap.get(toolRequest.id) == undefined
+                  }
+                  toolRequest={toolRequest}
+                  toolResponse={toolResponsesMap.get(toolRequest.id)}
+                  notifications={toolCallNotifications.get(toolRequest.id)}
+                  isStreamingMessage={isStreaming}
+                />
               </div>
-            ) : null}
-          </>
+            ))}
+            <div className="text-xs text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
+              {!isStreaming && timestamp}
+            </div>
+          </div>
         )}
 
         {hasToolConfirmation && (
@@ -242,6 +226,25 @@ export default function GooseMessage({
           />
         )}
       </div>
+
+      {/* TODO(alexhancock): Re-enable link previews once styled well again */}
+      {/* eslint-disable-next-line no-constant-binary-expression */}
+      {false && urls.length > 0 && (
+        <div className="flex flex-wrap mt-[16px]">
+          {urls.map((url, index) => (
+            <LinkPreview key={index} url={url} />
+          ))}
+        </div>
+      )}
+
+      {/* enable or disable prompts here */}
+      {/* NOTE from alexhancock on 1/14/2025 - disabling again temporarily due to non-determinism in when the forms show up */}
+      {/* eslint-disable-next-line no-constant-binary-expression */}
+      {false && metadata && (
+        <div className="flex mt-[16px]">
+          <GooseResponseForm message={displayText} metadata={metadata || null} append={append} />
+        </div>
+      )}
     </div>
   );
 }

--- a/ui/desktop/src/components/ToolCallChain.tsx
+++ b/ui/desktop/src/components/ToolCallChain.tsx
@@ -1,0 +1,63 @@
+import { formatMessageTimestamp } from '../utils/timeUtils';
+import { Message, getToolRequests } from '../types/message';
+import { NotificationEvent } from '../hooks/useMessageStream';
+import ToolCallWithResponse from './ToolCallWithResponse';
+
+interface ToolCallChainProps {
+  messages: Message[];
+  chainIndices: number[];
+  toolCallNotifications: Map<string, NotificationEvent[]>;
+  toolResponsesMap: Map<string, any>;
+  messageHistoryIndex: number;
+  isStreaming?: boolean;
+}
+
+/**
+ * Component that renders a chain of consecutive tool call messages with a single timestamp
+ */
+export default function ToolCallChain({
+  messages,
+  chainIndices,
+  toolCallNotifications,
+  toolResponsesMap,
+  messageHistoryIndex,
+  isStreaming = false
+}: ToolCallChainProps) {
+  // Get the timestamp from the last message in the chain
+  const lastMessageIndex = chainIndices[chainIndices.length - 1];
+  const lastMessage = messages[lastMessageIndex];
+  const timestamp = lastMessage ? formatMessageTimestamp(lastMessage.created) : '';
+
+  return (
+    <div className="relative flex flex-col w-full">
+      {/* Render each message's tool calls in the chain */}
+      {chainIndices.map((messageIndex) => {
+        const message = messages[messageIndex];
+        const toolRequests = getToolRequests(message);
+
+        return toolRequests.map((toolRequest) => (
+          <div 
+            key={toolRequest.id} 
+            className="goose-message-tool pb-2"
+          >
+            <ToolCallWithResponse
+              isCancelledMessage={
+                messageIndex < messageHistoryIndex &&
+                toolResponsesMap.get(toolRequest.id) == undefined
+              }
+              toolRequest={toolRequest}
+              toolResponse={toolResponsesMap.get(toolRequest.id)}
+              notifications={toolCallNotifications.get(toolRequest.id)}
+              isStreamingMessage={isStreaming}
+            />
+          </div>
+        ));
+      })}
+      
+      {/* Single timestamp for the entire chain */}
+      <div className="text-xs text-text-muted pt-1 transition-all duration-200 group-hover:-translate-y-4 group-hover:opacity-0">
+        {!isStreaming && timestamp}
+      </div>
+    </div>
+  );
+}

--- a/ui/desktop/src/utils/toolCallChaining.ts
+++ b/ui/desktop/src/utils/toolCallChaining.ts
@@ -1,0 +1,77 @@
+import { Message, getToolRequests, getTextContent, getToolResponses } from '../types/message';
+
+/**
+ * Simple function to detect consecutive tool call messages that should be chained
+ * @param messages - Array of all messages
+ * @returns Array of message indices that should be chained together
+ */
+export function identifyConsecutiveToolCalls(messages: Message[]): number[][] {
+  const chains: number[][] = [];
+  let currentChain: number[] = [];
+
+  for (let i = 0; i < messages.length; i++) {
+    const message = messages[i];
+    const toolRequests = getToolRequests(message);
+    const toolResponses = getToolResponses(message);
+    const textContent = getTextContent(message);
+    const hasText = textContent.trim().length > 0;
+
+    // Skip tool response messages - they don't break chains
+    if (toolResponses.length > 0 && toolRequests.length === 0) {
+      continue;
+    }
+
+    // This message has tool calls
+    if (toolRequests.length > 0) {
+      // If it also has text content, end any current chain and don't start a new one
+      if (hasText) {
+        if (currentChain.length > 1) {
+          chains.push([...currentChain]);
+        }
+        currentChain = [];
+      } else {
+        // Pure tool call message - add to chain
+        currentChain.push(i);
+      }
+    } else {
+      // No tool calls and not a tool response - end current chain if it has multiple messages
+      if (currentChain.length > 1) {
+        chains.push([...currentChain]);
+      }
+      currentChain = [];
+    }
+  }
+
+  // Don't forget the last chain
+  if (currentChain.length > 1) {
+    chains.push(currentChain);
+  }
+
+  return chains;
+}
+
+/**
+ * Check if a message at given index should be hidden (part of chain but not first)
+ * @param messageIndex - Index of the message to check
+ * @param chains - Array of chains (arrays of message indices)
+ * @returns True if message should be hidden
+ */
+export function shouldHideMessage(messageIndex: number, chains: number[][]): boolean {
+  for (const chain of chains) {
+    if (chain.includes(messageIndex)) {
+      // Hide if it's in a chain but not the first message
+      return chain[0] !== messageIndex;
+    }
+  }
+  return false;
+}
+
+/**
+ * Get the chain that contains the given message index
+ * @param messageIndex - Index of the message
+ * @param chains - Array of chains
+ * @returns The chain containing this message, or null
+ */
+export function getChainForMessage(messageIndex: number, chains: number[][]): number[] | null {
+  return chains.find(chain => chain.includes(messageIndex)) || null;
+}


### PR DESCRIPTION
- Add tool call chaining logic to group consecutive tool-only messages
- Create ToolCallChain component to render chained tool calls with single timestamp
- Skip tool response messages when detecting chains to avoid breaking sequences
- Hide intermediate messages in chains, show only first message with all tool calls
- Disable chaining during streaming to prevent flickering
- Maintain all existing functionality (status indicators, expansion, notifications)

Visual improvements:
- Multiple consecutive tool calls now show as a single grouped section
- Single timestamp displayed for the entire chain instead of individual timestamps
- Reduces visual clutter when LLM makes multiple tool calls in sequence
- Preserves individual display for mixed content (text + tool calls)

Files added:
- ui/desktop/src/utils/toolCallChaining.ts (chain detection logic)
- ui/desktop/src/components/ToolCallChain.tsx (chain rendering component)

Files modified:
- ui/desktop/src/components/GooseMessage.tsx (integrated chaining logic)