### PR TITLE
docs: update View/Edit Recipe menu item name

### DIFF
--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -191,7 +191,7 @@ You can turn your current Goose session into a reusable recipe that includes the
   <TabItem value="ui" label="Goose Desktop" default>
 
    1. While in the session that's using the recipe, click the <Bot className="inline" size={16} /> button at the bottom of the app 
-   2. Click `View recipe` 
+   2. Click `View/Edit Recipe` 
    3. Edit any of the following:
       - Title
       - Description
@@ -199,7 +199,7 @@ You can turn your current Goose session into a reusable recipe that includes the
       - Initial prompt
       - Activities
   4. When you're finished, you can:
-      - Copy the recipe link to share the recipe with others or [open it from the link](#use-recipe)
+      - Copy the recipe link to share the recipe with others
       - Click `Save Recipe` to [save the recipe](/docs/guides/recipes/storing-recipes) locally
       - Click `Create Schedule` to [schedule the recipe](#schedule-recipe)
 
@@ -461,7 +461,7 @@ You can turn your current Goose session into a reusable recipe that includes the
     To copy the recipe URL:
     1. [Open the recipe](#use-recipe)
     2. Click the <Bot className="inline" size={16} /> button at the bottom of the app 
-    3. Click `View recipe`
+    3. Click `View/Edit Recipe`
     4. Scroll down and copy the link
 
     When someone clicks the URL, it will open Goose Desktop with your recipe configuration. They can also use your recipe URL to [import a recipe](/docs/guides/recipes/storing-recipes#storing-recipes) into their Recipe Library.


### PR DESCRIPTION
This PR updates the "View/Edit Recipe" menu item name to sync with UI changes.

Documentation updates:
- `documentation/docs/guides/recipes/session-recipes.md`: Update name in Edit and Share steps