### PR TITLE
docs: fix broken links in Docker tutorial

### DIFF
--- a/documentation/docs/tutorials/goose-in-docker.md
+++ b/documentation/docs/tutorials/goose-in-docker.md
@@ -12,7 +12,7 @@ You can build Goose from the source file within a Docker container. This approac
 
 To begin, you will need to modify the `Dockerfile` and `docker-compose.yml` files to suit your requirements. Some changes you might consider include:
 
-- **Required:** Setting your API key, provider, and model in the `docker-compose.yml` file as environment variables because the keyring settings do not work on Ubuntu in Docker. This example uses the Google API key and its corresponding settings, but you can [find your own list of API keys](https://github.com/block/goose/blob/main/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx) and the [corresponding settings](https://github.com/block/goose/blob/main/ui/desktop/src/components/settings/models/hardcoded_stuff.tsx).
+- **Required:** Setting your API key, provider, and model in the `docker-compose.yml` file as environment variables because the keyring settings do not work on Ubuntu in Docker. This example uses the Google API key and its corresponding settings, but you can [find your own list of supported providers and their API keys](https://github.com/block/goose/blob/main/ui/desktop/src/components/settings/providers/ProviderRegistry.tsx) in the provider registry.
 
 - **Optional:** Changing the base image to a different Linux distribution in the `Dockerfile`. This example uses Ubuntu, but you can switch to another distribution such as CentOS, Fedora, or Alpine.
 


### PR DESCRIPTION
## Problem

The Docker tutorial documentation contained broken links to `hardcoded_stuff.tsx` which was removed in commit a89fa18502 (PR #2744). These links were returning 404 errors when users tried to access them.

## Solution

Updated the broken links to point to the current `ProviderRegistry.tsx` file, which contains the same provider and API key information that users need for Docker configuration.

## Changes

- Fixed broken GitHub links in `documentation/docs/tutorials/goose-in-docker.md`
- Updated link text to be more descriptive
- Verified new link works and points to correct provider registry

## Before/After

**Before:** 
- Link to non-existent `hardcoded_stuff.tsx` (404 error)

**After:**
- Link to current `ProviderRegistry.tsx` (working link with same information)

This ensures users can actually access the provider and API key information they need when setting up Goose in Docker.