### PR TITLE
fix: modifies openai request logic for reasoning models (#4221)

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -606,10 +606,13 @@ pub fn create_request(
         ));
     }
 
-    let is_ox_model =
-        model_config.model_name.starts_with("o") || model_config.model_name.starts_with("gpt-5");
+    let is_ox_model = model_config.model_name.starts_with("o1")
+        || model_config.model_name.starts_with("o2")
+        || model_config.model_name.starts_with("o3")
+        || model_config.model_name.starts_with("o4")
+        || model_config.model_name.starts_with("gpt-5");
 
-    // Only extract reasoning effort for O1/O3 models
+    // Only extract reasoning effort for O-series models
     let (model_name, reasoning_effort) = if is_ox_model {
         let parts: Vec<&str> = model_config.model_name.split('-').collect();
         let last_part = parts.last().unwrap();


### PR DESCRIPTION
This is a first take at fixing the issue described in #4221 where the logic used in the litellm provider to create the requests is the same as the openai format, which has significant bias towards openai models. I've modified the name-based parsing to use more specific schemes, calling out o{1..4} instead of just "o" as the starting char. 