### PR TITLE
feat(releases): set up a workflow for nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,98 @@
+# This workflow is for nightly releases, automatically triggered at midnight US Eastern
+name: Nightly Build
+
+on:
+  schedule:
+    # Run at midnight US Eastern (0500 UTC)
+    - cron: '0 5 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  prepare-version:
+    name: Prepare Version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - name: Generate a nightly version
+        id: set-version
+        run: |
+          # Extract the version from Cargo.toml and add nightly tag with date
+          VERSION=$(grep '^version\s*=' Cargo.toml | head -n 1 | cut -d\" -f2)
+          DATE=$(date -u +%Y%m%d)
+          VERSION="${VERSION}-nightly.${DATE}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+  build-cli:
+    needs: [prepare-version]
+    uses: ./.github/workflows/build-cli.yml
+    with:
+      version: ${{ needs.prepare-version.outputs.version }}
+
+  install-script:
+    name: Upload Install Script
+    runs-on: ubuntu-latest
+    needs: [build-cli]
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
+        with:
+          name: download_cli.sh
+          path: download_cli.sh
+
+  bundle-desktop:
+    needs: [prepare-version]
+    uses: ./.github/workflows/bundle-desktop.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      version: ${{ needs.prepare-version.outputs.version }}
+      signing: false
+
+  bundle-desktop-linux:
+    needs: [prepare-version]
+    uses: ./.github/workflows/bundle-desktop-linux.yml
+    with:
+      version: ${{ needs.prepare-version.outputs.version }}
+
+  bundle-desktop-windows:
+    needs: [prepare-version]
+    uses: ./.github/workflows/bundle-desktop-windows.yml
+    with:
+      version: ${{ needs.prepare-version.outputs.version }}
+      signing: false
+
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    needs: [build-cli, install-script, bundle-desktop, bundle-desktop-linux, bundle-desktop-windows]
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
+        with:
+          merge-multiple: true
+
+      # Create/update the nightly release
+      - name: Release nightly
+        uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # pin@v1
+        with:
+          tag: nightly
+          name: Nightly
+          token: ${{ secrets.GITHUB_TOKEN }}
+          artifacts: |
+            goose-*.tar.bz2
+            goose-*.zip
+            Goose*.zip
+            *.deb
+            *.rpm
+            download_cli.sh
+          allowUpdates: true
+          omitBody: true
+          omitPrereleaseDuringUpdate: true


### PR DESCRIPTION
Step one of having nightly releases. This sets up a new workflow for nightly releases of goose. These won't be signed yet.

Followups:

* Figure out signing keys that will work for nightly builds and update `with.signing` to be `true`
* Set up https://www.electronjs.org/docs/latest/tutorial/updates#using-cloud-object-storage-serverless as a deliver channel
* Add UI to settings to enable the user to opt into nightly builds