### PR TITLE
fix focus ring under form submits

### DIFF
--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -120,7 +120,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
             <h2 className="text-xl font-bold text-textProminent mb-6">Recipe Parameters</h2>
           </div>
           <div className="flex-1 overflow-y-auto px-8">
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit} className="space-y-4 mb-4">
               {parameters.map((param) => (
                 <div key={param.key}>
                   <label className="block text-md font-medium text-textStandard mb-2">


### PR DESCRIPTION
quick fix to stop form submit area overlapping recipe form input focus ring

Before:
<img width="543" height="311" alt="Screenshot 2025-08-25 at 2 32 44 PM" src="https://github.com/user-attachments/assets/acfa08ac-161c-4206-89af-aa590594cd15" />

After:
<img width="554" height="320" alt="Screenshot 2025-08-25 at 2 33 53 PM" src="https://github.com/user-attachments/assets/e4d31735-d220-483a-b87d-cbff5287c3ec" />
