### PR TITLE
fix: url path trailing slash for custom-providers

### DIFF
--- a/crates/goose/src/providers/api_client.rs
+++ b/crates/goose/src/providers/api_client.rs
@@ -297,8 +297,14 @@ impl ApiClient {
 
     fn build_url(&self, path: &str) -> Result<url::Url> {
         use url::Url;
-        let base_url =
+        let mut base_url =
             Url::parse(&self.host).map_err(|e| anyhow::anyhow!("Invalid base URL: {}", e))?;
+
+        if !base_url.path().is_empty() && base_url.path() != "/" && !base_url.path().ends_with('/')
+        {
+            base_url.set_path(&format!("{}/", base_url.path()));
+        }
+
         base_url
             .join(path)
             .map_err(|e| anyhow::anyhow!("Failed to construct URL: {}", e))

--- a/crates/goose/src/providers/api_client.rs
+++ b/crates/goose/src/providers/api_client.rs
@@ -300,9 +300,9 @@ impl ApiClient {
         let mut base_url =
             Url::parse(&self.host).map_err(|e| anyhow::anyhow!("Invalid base URL: {}", e))?;
 
-        if !base_url.path().is_empty() && base_url.path() != "/" && !base_url.path().ends_with('/')
-        {
-            base_url.set_path(&format!("{}/", base_url.path()));
+        let base_path = base_url.path();
+        if !base_path.is_empty() && base_path != "/" && !base_path.ends_with('/') {
+            base_url.set_path(&format!("{}/", base_path));
         }
 
         base_url


### PR DESCRIPTION
Fixes: https://github.com/block/goose/issues/3777#issuecomment-3223671268

```
~/.config/goose/custom_providers/custom_bigm_-_glm.json

{
  "name": "custom_bigm_-_glm",
  "engine": "anthropic",
  "display_name": "BIGM - GLM",
  "description": "Custom BIGM - GLM provider",
  "api_key_env": "CUSTOM_BIGM_-_GLM_API_KEY",
  "base_url": "https://open.bigmodel.cn/api/anthropic/v1/messages",
  "models": [
    {
      "name": "glm-4.5",
      "context_limit": 128000,
      "input_token_cost": null,
      "output_token_cost": null,
      "currency": null,
      "supports_cache_control": null
    },
    {
      "name": "glm-45.-air",
      "context_limit": 128000,
      "input_token_cost": null,
      "output_token_cost": null,
      "currency": null,
      "supports_cache_control": null
    }
  ],
  "headers": null,
  "timeout_seconds": null,
  "supports_streaming": true
}
% goose session
starting session | provider: custom_bigm_-_glm model: glm-4.5
    logging to /Users/cyue/.local/share/goose/sessions/20250826_183556.jsonl
    working directory: /ws/AiWorks/goose-poc

Goose is running! Enter your instructions, or try asking what goose can do.

Context: ○○○○○○○○○○ 0% (0/128000 tokens)
( O)> hi
  2025-08-26T10:35:57.785345Z  WARN goose::providers::utils: Provider request failed with status: 404 Not Found. Payload: Some(Object {"detail": String("Not Found")}). Returning error: RequestFailed("Request failed with status: 404 Not Found")
    at crates/goose/src/providers/utils.rs:110

  2025-08-26T10:35:57.785432Z ERROR goose::session::storage: Failed to generate session description: Request failed: Request failed with status: 404 Not Found
    at crates/goose/src/session/storage.rs:1299
update: added a trailing / to real base url so "base_url": "https://open.bigmodel.cn/api/anthropic/" does work now ...
```