### PR TITLE
Add Tetrate Agent Router Service to Provider Registry

### DIFF
--- a/ui/desktop/src/components/settings/providers/ProviderRegistry.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderRegistry.tsx
@@ -253,4 +253,24 @@ export const PROVIDER_REGISTRY: ProviderRegistry[] = [
       ],
     },
   },
+  {
+    name: 'Tetrate Agent Router Service',
+    details: {
+      id: 'tetrate_agent_router_service',
+      name: 'Tetrate Agent Router Service',
+      description:
+        'Unified router for AI models including Claude, Gemini, GPT, and open-weight models',
+      parameters: [
+        {
+          name: 'TETRATE_API_KEY',
+          is_secret: true,
+        },
+        {
+          name: 'TETRATE_HOST',
+          is_secret: false,
+          default: 'https://api.router.tetrate.ai',
+        },
+      ],
+    },
+  },
 ];


### PR DESCRIPTION
Adds Tetrate Agent Router Service to the provider registry for folks who want to configure manually. Note that only users going through the PKCE flow will get the promotional credit at the moment, however. 