### PR TITLE
Extensions loading indicator on desktop launch

### DIFF
--- a/ui/desktop/src/components/settings/extensions/extension-manager.test.ts
+++ b/ui/desktop/src/components/settings/extensions/extension-manager.test.ts
@@ -96,6 +96,19 @@ describe('Extension Manager', () => {
       expect(mockAddToConfig).not.toHaveBeenCalled();
     });
 
+    it('should successfully add extension on startup with custom toast options', async () => {
+      mockAddToAgent.mockResolvedValue({} as Response);
+
+      await addToAgentOnStartup({
+        addToConfig: mockAddToConfig,
+        extensionConfig: mockExtensionConfig,
+        toastOptions: { silent: false },
+      });
+
+      expect(mockAddToAgent).toHaveBeenCalledWith(mockExtensionConfig, { silent: false });
+      expect(mockAddToConfig).not.toHaveBeenCalled();
+    });
+
     it('should retry on 428 errors', async () => {
       const error428 = new Error('428 Precondition Required');
       mockAddToAgent

--- a/ui/desktop/src/components/settings/extensions/extension-manager.ts
+++ b/ui/desktop/src/components/settings/extensions/extension-manager.ts
@@ -86,6 +86,7 @@ export async function activateExtension({
 interface AddToAgentOnStartupProps {
   addToConfig: (name: string, extensionConfig: ExtensionConfig, enabled: boolean) => Promise<void>;
   extensionConfig: ExtensionConfig;
+  toastOptions?: ToastServiceOptions;
 }
 
 /**
@@ -94,9 +95,10 @@ interface AddToAgentOnStartupProps {
 export async function addToAgentOnStartup({
   addToConfig,
   extensionConfig,
+  toastOptions = { silent: true },
 }: AddToAgentOnStartupProps): Promise<void> {
   try {
-    await retryWithBackoff(() => addToAgent(extensionConfig, { silent: true }), {
+    await retryWithBackoff(() => addToAgent(extensionConfig, toastOptions), {
       retries: 3,
       delayMs: 1000,
       shouldRetry: (error: ExtensionError) =>

--- a/ui/desktop/src/utils/providerUtils.ts
+++ b/ui/desktop/src/utils/providerUtils.ts
@@ -187,7 +187,11 @@ export const initializeSystem = async (
       const extensionName = extensionConfig.name;
 
       try {
-        await addToAgentOnStartup({ addToConfig: options.addExtension!, extensionConfig });
+        await addToAgentOnStartup({
+          addToConfig: options.addExtension!,
+          extensionConfig,
+          toastOptions: { silent: false },
+        });
       } catch (error) {
         console.error(`Failed to load extension ${extensionName}:`, error);
       }


### PR DESCRIPTION
Currently, when the Goose Desktop application starts up, extensions are loaded silently in the background during the initialization phase. Users have no visual feedback about which extensions are being loaded, their loading status, or if any failures occur during this phase.

This implements toast loading indicators that show during application startup to provide visual feedback.