### PR TITLE
remove localstorage getconfig fallbacks

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -657,56 +657,6 @@ const createChat = async (
     menu.popup();
   });
 
-  // Store config in localStorage for future windows
-  const windowConfig = {
-    ...appConfig, // Use the potentially updated appConfig here as well
-    GOOSE_PORT: port, // Ensure this specific window's config gets the correct port
-    GOOSE_WORKING_DIR: working_dir,
-    REQUEST_DIR: dir,
-    GOOSE_BASE_URL_SHARE: sharingUrl,
-    recipe: recipe,
-  };
-
-  // We need to wait for the window to load before we can access localStorage
-  mainWindow.webContents.on('did-finish-load', () => {
-    const configStr = JSON.stringify(windowConfig).replace(/'/g, "\\'");
-    mainWindow.webContents
-      .executeJavaScript(
-        `
-      (function() {
-        function setConfig() {
-          try {
-            if (document.readyState === 'complete' && window.localStorage) {
-              localStorage.setItem('gooseConfig', '${configStr}');
-              return true;
-            }
-          } catch (e) {
-            console.warn('[Renderer] localStorage access failed:', e);
-          }
-          return false;
-        }
-
-        // If document is already complete, try immediately
-        if (document.readyState === 'complete') {
-          if (!setConfig()) {
-            console.error('[Renderer] Failed to set localStorage config despite document being ready');
-          }
-        } else {
-          // Wait for document to be fully ready
-          document.addEventListener('DOMContentLoaded', () => {
-            if (!setConfig()) {
-              console.error('[Renderer] Failed to set localStorage config after DOMContentLoaded');
-            }
-          });
-        }
-      })();
-    `
-      )
-      .catch((error) => {
-        console.error('Failed to execute localStorage script:', error);
-      });
-  });
-
   // Handle new window creation for links
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
     // Open all links in external browser
@@ -811,31 +761,8 @@ const createChat = async (
             decodedRecipe.isScheduledExecution = true;
           }
 
-          // Update the window config with the decoded recipe
-          const updatedConfig = {
-            ...windowConfig,
-            recipe: decodedRecipe,
-          };
-
           // Send the decoded recipe to the renderer process
           mainWindow.webContents.send('recipe-decoded', decodedRecipe);
-
-          // Update localStorage with the decoded recipe
-          const configStr = JSON.stringify(updatedConfig).replace(/'/g, "\\'");
-          mainWindow.webContents
-            .executeJavaScript(
-              `
-            try {
-              localStorage.setItem('gooseConfig', '${configStr}');
-              console.log('[Renderer] Recipe decoded and config updated');
-            } catch (e) {
-              console.error('[Renderer] Failed to update config with decoded recipe:', e);
-            }
-          `
-            )
-            .catch((error) => {
-              console.error('[Main] Failed to update localStorage with decoded recipe:', error);
-            });
         } else {
           console.error('[Main] Failed to decode recipe from deeplink');
           // Send error to renderer

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -124,18 +124,10 @@ const electronAPI: ElectronAPI = {
   platform: process.platform,
   reactReady: () => ipcRenderer.send('react-ready'),
   getConfig: () => {
-    // Add fallback to localStorage if config from preload is empty or missing
     if (!config || Object.keys(config).length === 0) {
-      try {
-        if (window.localStorage) {
-          const storedConfig = localStorage.getItem('gooseConfig');
-          if (storedConfig) {
-            return JSON.parse(storedConfig);
-          }
-        }
-      } catch (e) {
-        console.warn('Failed to parse stored config from localStorage:', e);
-      }
+      console.warn(
+        'No config provided by main process. This may indicate an initialization issue.'
+      );
     }
     return config;
   },


### PR DESCRIPTION
## Pull Request Description
remove localstorage getconfig fallbacks since they aren't needed
- Configuration is now passed entirely through process.argv in webPreferences.additionalArguments
- No need for localStorage fallback - the main process provides complete config

Verified things are loading locally and in the bundle.

