### PR TITLE
Add visual indicator while recipe loads

### DIFF
--- a/ui/desktop/src/utils/appInitialization.ts
+++ b/ui/desktop/src/utils/appInitialization.ts
@@ -145,7 +145,7 @@ const initializeForRecipe = async ({
 
   const loadingToastId = toastService.loading({
     title: `Loading recipe: ${recipeConfig.title}`,
-    msg: 'Setting up extensions and environment...',
+    msg: 'Setting up environment...',
   });
 
   await initConfig();


### PR DESCRIPTION
Add a toast loading indicator during recipe loading phase to provide visual feedback.

- Toast notification appears immediately when recipe starts loading
- Success toast confirms when recipe is ready