### PR TITLE
fix: recipe deeplink "+" characters and folder change

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1066,6 +1066,7 @@ function parseRecipeDeeplink(url: string): string | undefined {
   const parsedUrl = new URL(url);
   let recipeDeeplink = parsedUrl.searchParams.get('config');
   if (recipeDeeplink && !url.includes(recipeDeeplink)) {
+    // URLSearchParams decodes + as space, which can break encoded configs
     // Parse raw query to preserve "+" characters in values like config
     const search = parsedUrl.search || '';
     // parse recipe deeplink from search params


### PR DESCRIPTION
## Pull Request Description
1. Deep links with "+" characters where failing due to the url decoding logic. This PR fixes that issue by grabbing the deep link directly from the url if the decoded deeplink doesn't match

before:
```
[Main] Received open-url event: goose://recipe?config=...WNpcGU+YC5cbiA
...
[Main] Creating window with recipe loading state for deeplink: ...WNpcGU YC5cbi // "+" is replaced by " " space
```

after:
```
[Main] Received open-url event: goose://recipe?config=...WNpcGU+YC5cbiA
...
[Main] Creating window with recipe loading state for deeplink: ...WNpcGU+YC5cbi
```

2. Preserve deeplink if folder is changed

Behavior before:
Open deeplink -> new window opens -> realize folder is wrong so change folder -> new window opens -> need to click deeplink again -> new window with recipe and correct folder

New behavior:
Open deeplink -> new window opens -> realize folder is wrong so change folder -> new window with recipe and correct folder