### PR TITLE
feat: add grok-code-fast-1 support for xAI provider

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -58,10 +58,12 @@ static MODEL_SPECIFIC_LIMITS: Lazy<Vec<(&'static str, usize)>> = Lazy::new(|| {
         ("qwen2-70b", 262_144),
         ("qwen2", 128_000),
         ("qwen3-32b", 131_072),
+        // xai
+        ("grok-4", 256_000),
+        ("grok-code-fast-1", 256_000),
+        ("grok", 131_072),
         // other
         ("kimi-k2", 131_072),
-        ("grok-4", 256_000),
-        ("grok", 131_072),
     ]
 });
 

--- a/crates/goose/src/providers/xai.rs
+++ b/crates/goose/src/providers/xai.rs
@@ -15,6 +15,7 @@ use serde_json::Value;
 pub const XAI_API_HOST: &str = "https://api.x.ai/v1";
 pub const XAI_DEFAULT_MODEL: &str = "grok-3";
 pub const XAI_KNOWN_MODELS: &[&str] = &[
+    "grok-code-fast-1",
     "grok-4-0709",
     "grok-3",
     "grok-3-fast",

--- a/crates/goose/src/providers/xai.rs
+++ b/crates/goose/src/providers/xai.rs
@@ -13,7 +13,7 @@ use rmcp::model::Tool;
 use serde_json::Value;
 
 pub const XAI_API_HOST: &str = "https://api.x.ai/v1";
-pub const XAI_DEFAULT_MODEL: &str = "grok-3";
+pub const XAI_DEFAULT_MODEL: &str = "grok-code-fast-1";
 pub const XAI_KNOWN_MODELS: &[&str] = &[
     "grok-code-fast-1",
     "grok-4-0709",


### PR DESCRIPTION
## Pull Request Description

Added support for xAI's grok-code-fast-1 model, which is cost-effective, fast, and particularly good at writing code with a 256K context window.

### Changes
- Added `grok-code-fast-1` to `XAI_KNOWN_MODELS` array
- Set `grok-code-fast-1` as the default xAI model

### Related Issue
Closes #4386

### Technical Notes
https://openrouter.ai/x-ai/grok-code-fast-1

### Testing
- [x] Verified grok-code-fast-1 is properly recognized by the xAI provider
- [x] Confirmed it's correctly set as the default model

---

<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved & merged -->
**Email**: 