### PR TITLE
fix(nix): add nixpkgs missing for existing build process & useful in dev process

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -93,9 +93,15 @@
             cargo-watch
             cargo-edit
             clippy
+            gemini-cli # potentially useful during dev/testing
+            go_1_25 # 'just' run-ui (temporal-service)
+            just # used in dev/test
+            nodejs_24 # 'just' run-ui
+            ripgrep
             rustfmt
             xorg.libxcb
             dbus
+            yarn # 'just' install-deps
           ]);
           
           shellHook = ''


### PR DESCRIPTION


## Pull Request Description

A flake.nix seems recently added to the repo. As a self contained unit, it is currently missing software necessary as part of the existing goose dev/build environment. In the absence of information why they are deliberately absent, it appears to make sense to add that software, particularly as it all appears to already exist in nixpkgs.

I've additionally added `gemini-cli`. This isn't a requirement for the existing documented build process, however 
a) it is useful to developers working with that ecosystem
b) doesn't appear to pollute the dev/build environment in any harmful way
c) potentially supports more deterministic outcomes

---


