### PR TITLE
fix: need to send errors to appropriate stream

### DIFF
--- a/crates/goose-cli/src/logging.rs
+++ b/crates/goose-cli/src/logging.rs
@@ -106,6 +106,7 @@ fn setup_logging_internal(
 
             // Create console logging layer for development - INFO and above only
             let console_layer = fmt::layer()
+                .with_writer(std::io::stderr)
                 .with_target(true)
                 .with_level(true)
                 .with_ansi(true)


### PR DESCRIPTION
before this the dev MCP server would exit whene running in CLI. 

it will now look like this: 

<img width="811" height="212" alt="image" src="https://github.com/user-attachments/assets/a0e84ea4-39c0-43f9-a32d-a73a37dbf0ae" />


which stops it from terminating (still not ideal though