### PR TITLE
docs: July and August 2025 Community All-Stars Update

### DIFF
--- a/documentation/src/pages/community/data/august-2025.json
+++ b/documentation/src/pages/community/data/august-2025.json
@@ -1,0 +1,65 @@
+{
+  "month": "August 2025",
+  "communityStars": [
+    {
+      "name": "Abhijay007",
+      "handle": "Abhijay007"
+    },
+    {
+      "name": "johnlanda",
+      "handle": "johnlanda"
+    },
+    {
+      "name": "Developerayo",
+      "handle": "Developerayo"
+    },
+    {
+      "name": "cgwalters",
+      "handle": "cgwalters"
+    },
+    {
+      "name": "par5ul1",
+      "handle": "par5ul1"
+    }
+  ],
+  "teamStars": [
+    {
+      "name": "lifeizhou-ap",
+      "handle": "lifeizhou-ap"
+    },
+    {
+      "name": "tlongwell-block",
+      "handle": "tlongwell-block"
+    },
+    {
+      "name": "GaryZhous",
+      "handle": "GaryZhous"
+    },
+    {
+      "name": "aharvard",
+      "handle": "aharvard"
+    },
+    {
+      "name": "tiensi",
+      "handle": "tiensi"
+    }
+  ],
+  "leaderboard": [
+    { "handle": "lifeizhou-ap", "rank": 1, "medal": "🥇" },
+    { "handle": "Abhijay007", "rank": 2, "medal": "🥈" },
+    { "handle": "johnlanda", "rank": 3, "medal": "🥉" },
+    { "handle": "Developerayo", "rank": 4 },
+    { "handle": "cgwalters", "rank": 5 },
+    { "handle": "tlongwell-block", "rank": 6 },
+    { "handle": "par5ul1", "rank": 7 },
+    { "handle": "GaryZhous", "rank": 8 },
+    { "handle": "aharvard", "rank": 9 },
+    { "handle": "ayax79", "rank": 10 },
+    { "handle": "codefromthecrypt", "rank": 11 },
+    { "handle": "tiensi", "rank": 12 },
+    { "handle": "shellz-n-stuff", "rank": 13 },
+    { "handle": "JJSwigut", "rank": 14 },
+    { "handle": "exitcode0", "rank": 15 },
+    { "handle": "inmzhang", "rank": 16 }
+  ]
+}

--- a/documentation/src/pages/community/data/config.json
+++ b/documentation/src/pages/community/data/config.json
@@ -15,6 +15,16 @@
       "display": "June 2025",
       "file": "june-2025.json"
     }
+    {
+      "id": "july-2025",
+      "display": "July 2025",
+      "file": "july-2025.json"
+    }
+    {
+      "id": "august-2025",
+      "display": "August 2025",
+      "file": "august-2025.json"
+    }
   ],
-  "defaultMonth": "june-2025"
+  "defaultMonth": "august-2025"
 }

--- a/documentation/src/pages/community/data/config.json
+++ b/documentation/src/pages/community/data/config.json
@@ -14,12 +14,12 @@
       "id": "june-2025",
       "display": "June 2025",
       "file": "june-2025.json"
-    }
+    },
     {
       "id": "july-2025",
       "display": "July 2025",
       "file": "july-2025.json"
-    }
+    },
     {
       "id": "august-2025",
       "display": "August 2025",

--- a/documentation/src/pages/community/data/july-2025.json
+++ b/documentation/src/pages/community/data/july-2025.json
@@ -1,0 +1,70 @@
+{
+  "month": "July 2025",
+  "communityStars": [
+    {
+      "name": "The-Best-Codes",
+      "handle": "The-Best-Codes"
+    },
+    {
+      "name": "rolznz",
+      "handle": "rolznz"
+    },
+    {
+      "name": "toyamagu-2021",
+      "handle": "toyamagu-2021"
+    },
+    {
+      "name": "dcieslak19973",
+      "handle": "dcieslak19973"
+    },
+    {
+      "name": "shelajev",
+      "handle": "shelajev"
+    }
+  ],
+  "teamStars": [
+    {
+      "name": "cloud-on-prem",
+      "handle": "cloud-on-prem"
+    },
+    {
+      "name": "jsibbison-square",
+      "handle": "jsibbison-square"
+    },
+    {
+      "name": "glenn-sq",
+      "handle": "glenn-sq"
+    },
+    {
+      "name": "aharvard",
+      "handle": "aharvard"
+    },
+    {
+      "name": "chaitanyarahalkar",
+      "handle": "chaitanyarahalkar"
+    }
+  ],
+  "leaderboard": [
+    { "handle": "The-Best-Codes", "rank": 1, "medal": "🥇" },
+    { "handle": "cloud-on-prem", "rank": 2, "medal": "🥈" },
+    { "handle": "jsibbison-square", "rank": 3, "medal": "🥉" },
+    { "handle": "glenn-sq", "rank": 4 },
+    { "handle": "aharvard", "rank": 5 },
+    { "handle": "rolznz", "rank": 6 },
+    { "handle": "toyamagu-2021", "rank": 7 },
+    { "handle": "dcieslak19973", "rank": 8 },
+    { "handle": "shelajev", "rank": 9 },
+    { "handle": "necaris", "rank": 10 },
+    { "handle": "Jay4242", "rank": 11 },
+    { "handle": "Developerayo", "rank": 12 },
+    { "handle": "uddhav", "rank": 13 },
+    { "handle": "mr-brobot", "rank": 14 },
+    { "handle": "sfc-gh-twhite", "rank": 15 },
+    { "handle": "GaryZhous", "rank": 16 },
+    { "handle": "chaitanyarahalkar", "rank": 17 },
+    { "handle": "simonsickle", "rank": 18 },
+    { "handle": "LordMelkor", "rank": 19 },
+    { "handle": "cgwalters", "rank": 20 },
+    { "handle": "alexrrouse", "rank": 21 }
+  ]
+}

--- a/documentation/src/pages/community/index.tsx
+++ b/documentation/src/pages/community/index.tsx
@@ -9,12 +9,16 @@ import communityConfig from "./data/config.json";
 import april2025Data from "./data/april-2025.json";
 import may2025Data from "./data/may-2025.json";
 import june2025Data from "./data/june-2025.json";
+import july2025Data from "./data/july-2025.json";
+import august2025Data from "./data/august-2025.json";
 
 // Create a data map for easy access
 const communityDataMap = {
   "april-2025": april2025Data,
   "may-2025": may2025Data,
   "june-2025": june2025Data,
+  "july-2025": july2025Data,
+  "august-2025": august2025Data,
 };
 
 function UpcomingEventsSection() {


### PR DESCRIPTION
# July and August 2025 Community Spotlight
Each month, to create a new spotlight for a given month, I just have to submit a month-year.json file, and set that given month to default on the [community landing page](https://block.github.io/goose/community). This PR pushes a new spotlight for July and August 2025.

## Background
Previously, I worked with goose to build a community landing page. This was carefully reviewed by both Rizel and Anthony to formatting choices and everything.

## Reference
For reference, the list of all contributors to the block/goose project are pulled from GitHub, and are then analyzed and populated into the following lists:

1. Community Stars - This list consists of the top 5 contributors from the external community
2. Team Stars - This list consists the top 5 contributors from the internal community, aka the goose team and any contributors from Block!
3. Monthly Leaderboard - This lists consists of all contributors for the month, both internal and external members.

<img width="2208" height="1720" alt="image" src="https://github.com/user-attachments/assets/57c8a7bc-9fc3-4910-b495-6b4b936100a5" />
