### PR TITLE
improve auto scroll to bottom + detection

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -276,18 +276,11 @@ function BaseChatContent({
   }, []);
 
   // Auto-scroll when messages are loaded (for session resuming)
-  useEffect(() => {
-    if (messages.length > 0 && !loadingChat) {
-      const scrollTimeout = setTimeout(() => {
-        if (scrollRef.current?.scrollToBottom) {
-          scrollRef.current.scrollToBottom();
-        }
-      }, 500); // delay to ensure content is fully loaded
-
-      return () => clearTimeout(scrollTimeout);
+  const handleRenderingComplete = React.useCallback(() => {
+    if (scrollRef.current?.scrollToBottom) {
+      scrollRef.current.scrollToBottom();
     }
-    return;
-  }, [messages.length, loadingChat]);
+  }, []);
 
   // Handle submit
   const handleSubmit = (e: React.FormEvent) => {
@@ -419,6 +412,7 @@ function BaseChatContent({
                       isUserMessage={isUserMessage}
                       isStreamingMessage={chatState !== ChatState.Idle}
                       onMessageUpdate={onMessageUpdate}
+                      onRenderingComplete={handleRenderingComplete}
                     />
                   ) : (
                     // Render messages with SearchView wrapper when search is enabled
@@ -435,6 +429,7 @@ function BaseChatContent({
                         isUserMessage={isUserMessage}
                         isStreamingMessage={chatState !== ChatState.Idle}
                         onMessageUpdate={onMessageUpdate}
+                        onRenderingComplete={handleRenderingComplete}
                       />
                     </SearchView>
                   )}


### PR DESCRIPTION
## Pull Request Description
During chat the window is not auto scrolling to the bottom after an agent response. This adds detection if the user is near the bottom of scroll and debouncing with timeouts to avoid jumpiness.

Also fixes the window not auto scrolling to the bottom when resuming sessions
