### PR TITLE
docs: nested goosehints

### DIFF
--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -22,18 +22,19 @@ import { FolderKey } from 'lucide-react';
   ></iframe>
 </details>
 
+A good time to consider adding a `.goosehints` file is when you find yourself repeating prompts, or providing the same kind of instructions multiple times. It's also a great way to provide a lot of context which might be better suited in a file.
+
+This guide will walk you through creating and using `.goosehints` files to streamline your workflow with custom instructions and context.
+
 :::info Developer extension required
 To make use of the hints file, you need to have the `Developer` extension [enabled](/docs/getting-started/using-extensions).
-
 :::
 
-This guide will walk you through creating and using your `.goosehints` file to streamline your workflow with custom instructions and context.
-
-## Creating your hints file
+## Creating Your Hints File
 
 Goose supports two types of hint files:
 - **Global hints file** - These hints will apply to all your sessions with Goose, regardless of directory.
-- **Local hints file** -  These hints will only apply when working in a specific directory.
+- **Local hints files** -  These hints will only apply when working in a specific directory or directory hierarchy.
 
 You can use both global and local hints at the same time. When both exist, Goose will consider both your global preferences and project-specific requirements. If the instructions in your local hints file conflict with your global preferences, Goose will prioritize the local hints.
 
@@ -47,7 +48,7 @@ You can use other agent rule files with Goose by using the [`CONTEXT_FILE_NAMES`
     #### Global hints file
     1. Create a `.goosehints` file in `~/.config/goose`.
 
-     #### Local hints file
+    #### Local hints file
 
     1. Change the directory to where you'd like to set up the file. You can do this by clicking the directory path on the bottom of the Goose window.
     2. Click the <FolderKey size={16} /> icon on the bottom right of the Goose window.
@@ -58,35 +59,32 @@ You can use other agent rule files with Goose by using the [`CONTEXT_FILE_NAMES`
     If a `.goosehints` file already exists in the given directory, you can edit or add to it from this screen.
 
     :::tip
-    You may have to scroll or adjust the screen size to fully see the Save and Cancel buttons.
+    You may have to scroll or adjust the screen size to fully see the `Save` and `Cancel` buttons.
     :::
 
     </TabItem>
     <TabItem value="manual" label="Manual">
     
     - **Global hints file** - Create a `.goosehints` file in `~/.config/goose`.
-    - **Local hints file** -  Create a `.goosehints` file at the root of the directory you'd like it applied to.
+    - **Local hints file** -  Create a `.goosehints` file at the root of your project and/or in any directory in the hierarchy.
 
     </TabItem>
 </Tabs>
 
-
-
 The `.goosehints` file can include any instructions or contextual details relevant to your projects.
 
-A good time to consider adding a `.goosehints` file is when you find yourself repeating prompts, or providing the same kind of instructions multiple times. It's also a great way to provide a lot of context which might be better suited in a file.
+## Setting Up Hints
+
+The `.goosehints` file supports natural language. Write clear, specific instructions using direct language that Goose can easily understand and follow. Include relevant context about your project and workflow preferences, and prioritize your most important guidelines first.
 
 Goosehints are loaded at the start of your session and become part of the system prompt sent with every request. This means the content of `.goosehints` contributes to token usage, so keeping it concise can save both cost and processing time.
 
-## Setting up hints
-
-The `.goosehints` file supports natural language.
-
-### Example global `.goosehints` file
+### Example Global `.goosehints` File
 
 ```
 Always use TypeScript for new Next.js projects.
 
+@coding-standards.md
 Follow the [Google Style Guide](https://google.github.io/styleguide/pyguide.html) for Python code.
 
 Run unit tests before committing any changes.
@@ -94,7 +92,7 @@ Run unit tests before committing any changes.
 Prefer functional programming patterns where applicable.
 ```
 
-### Example local `.goosehints` file
+### Example Local `.goosehints` File
 
 ```
 This is a simple example JavaScript web application that uses the Express.js framework. View [Express documentation](https://expressjs.com/) for extended guidance.
@@ -106,7 +104,87 @@ Make sure to confirm all changes with me before applying.
 Run tests with `npm run test` ideally after each change.
 ```
 
-## Common use cases
+### Nested `.goosehints` Files
+
+Goose supports hierarchical local hints in  git repositories. All `.goosehints` files from your current directory up to the root directory are automatically loaded and combined. If you're not working in a git repository, Goose only loads the `.goosehints` file from the current directory.
+
+As a best practice, `.goosehints` at each level should only include hints relevant to that scope:
+- **Root level**: Include project-wide standards, build processes, and general guidelines
+- **Module/feature level**: Add specific requirements for that area of the codebase
+- **Directory level**: Include very specific context like local testing procedures or component patterns
+
+**Example Project Structure:**
+```sh
+my-project/
+├── .git/
+├── .goosehints              # Project-wide hints
+├── frontend/
+│   ├── .goosehints          # Frontend-specific hints
+│   └── components/
+│       ├── .goosehints      # Component-specific hints
+│       └── Button.tsx
+└── backend/
+    ├── .goosehints          # Backend-specific hints
+    └── api/
+        └── routes.py
+```
+
+When working in `frontend/components/` in this example project, Goose loads hints from directories higher up the hierarchy in the following order:
+1. <details>
+     <summary>`my-project/.goosehints` (project root)</summary>
+        ```
+        This is a React + TypeScript project using Vite.
+
+        @README.md
+        @docs/development-setup.md
+
+        Always run tests before committing: `npm test`
+        Use conventional commits for all changes.
+        ```
+   </details>
+2. <details>
+     <summary>`frontend/.goosehints`</summary>
+        ```
+        This frontend uses React 18 with TypeScript and Tailwind CSS.
+
+        @package.json
+        @docs/frontend-architecture.md
+
+        ## Development Standards
+        - Use functional components with hooks (no class components)
+        - Implement proper TypeScript interfaces for all props
+        - Follow the component structure: /components/ComponentName/index.tsx
+        - Use Tailwind classes instead of custom CSS when possible
+
+        ## Testing Requirements  
+        - Write unit tests for all components using React Testing Library
+        - Test files should be co-located: ComponentName.test.tsx
+        - Run `npm run test:frontend` before committing changes
+
+        ## State Management
+        - Use React Query for server state
+        - Use Zustand for client state management
+        - Avoid prop drilling - lift state appropriately
+
+        Always confirm UI changes with design team before implementation.
+        ```
+   </details> 
+3. <details>
+     <summary>`frontend/components/.goosehints` (current directory)</summary>
+        ```
+        Components in this directory use our design system.
+
+        @docs/component-api.md
+
+        All components must:
+        - Export a default component
+        - Include TypeScript props interface
+        - Have corresponding .test.tsx file
+        - Follow naming convention: PascalCase
+        ```
+   </details>
+
+## Common Use Cases
 Here are some ways people have used hints to provide additional context to Goose:
 
 - **Decision-Making**: Specify if Goose should autonomously make changes or confirm actions with you first.
@@ -122,9 +200,9 @@ Include core documentation (like API schemas or coding standards) with @-mention
 
 Like prompts, this is not an extensive list to shape your `.goosehints` file. You can include as much context as you need.
 
-## Best practices
+## Best Practices
 
-- **Keep file updated**: Regularly update the `.goosehints` file to reflect any changes in project protocols or priorities.
+- **Keep files updated**: Regularly update the `.goosehints` files to reflect any changes in project protocols or priorities.
 - **Be concise**: Make sure the content is straightforward and to the point, ensuring Goose can quickly parse and act on the information.
 - **Start small**: Create a small set of clear, specific hints and gradually expand them based on your needs. This makes it easier to understand how Goose interprets and applies your instructions.
 - **Reference other files**: Point Goose to relevant files like /docs/style.md or /scripts/validation.js to reduce repetition and keep instructions lightweight.


### PR DESCRIPTION
This PR documents support for nested local goosehints.

Documentation updates:
- `documentation/docs/guides/using-goosehints.md`:
  - Add "Nested `.goosehints` Files" section
  - Move content around and extend "Setting Up Hints" intro for better context
  - Title case headings for consistency with most topics