### PR TITLE
docs: new recipe warning

### DIFF
--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -234,14 +234,16 @@ You can turn your current Goose session into a reusable recipe that includes the
          3. Find your recipe in the Recipe Library
          4. Click `Use` next to the recipe you want to open
 
-  2. If the recipe contains parameters, enter your values in the `Recipe Parameters` dialog and click `Start Recipe`.
+  2. The first time you run a recipe, a warning dialog displays the recipe's title, description, and instructions for you to review. If you trust the recipe, click `Trust and Execute` to continue. You won't be prompted again for the same recipe unless it changes.
+
+  3. If the recipe contains parameters, enter your values in the `Recipe Parameters` dialog and click `Start Recipe`.
   
      Parameters are dynamic values used in the recipe:
 
      - **Required parameters** are marked with red asterisks (*)
      - **Optional parameters** show default values that can be changed
 
-  3. To run the recipe, click an activity bubble or send the prompt.
+  4. To run the recipe, click an activity bubble or send the prompt.
 
   :::info Parameter Creation In Goose CLI Only
   You can enter parameter values to use in a recipe, but you cannot add parameters to a recipe in Goose Desktop. Parameters can only be defined in recipes created via the CLI.

--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -234,7 +234,7 @@ You can turn your current Goose session into a reusable recipe that includes the
          3. Find your recipe in the Recipe Library
          4. Click `Use` next to the recipe you want to open
 
-  2. The first time you run a recipe, a warning dialog displays the recipe's title, description, and instructions for you to review. If you trust the recipe, click `Trust and Execute` to continue. You won't be prompted again for the same recipe unless it changes.
+  2. The first time you run a recipe, a warning dialog displays the recipe's title, description, and instructions for you to review. If you trust the recipe content, click `Trust and Execute` to continue. You won't be prompted again for the same recipe unless it changes.
 
   3. If the recipe contains parameters, enter your values in the `Recipe Parameters` dialog and click `Start Recipe`.
   

--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -104,6 +104,13 @@ For detailed steps on updating your LLM provider, refer to the [Installation][in
 
 ---
 
+### New Recipe Warning
+
+The first time you run a given recipe in Goose Desktop, you'll see a `New Recipe Warning` dialog that allows you to review the recipe's title, description, and instructions. If you trust the recipe, click `Trust and Execute` to continue. You won't be prompted again for the same recipe unless it changes.
+
+This warning helps protect against inadvertently executing potentially harmful recipe code.
+
+---
 ### Uninstall Goose or Remove Cached Data
 
 You may need to uninstall Goose or clear existing data before re-installing. Goose stores data in a few places. Secrets, such as API keys, are stored exclusively in the system keychain.


### PR DESCRIPTION
This PR documents the "New Recipe Warning" model that runs each time a new/modified recipe is opened in Goose Desktop.

Documentation updates:
- `documentation/docs/guides/recipes/session-recipes.md`: 
  - Add as step in "Use Recipe" section
- `documentation/docs/troubleshooting.md`:
  - Add "New Recipe Warning" section
