### PR TITLE
adding Vercel MCP

### DIFF
--- a/documentation/docs/mcp/vercel-mcp.md
+++ b/documentation/docs/mcp/vercel-mcp.md
@@ -17,6 +17,7 @@ This tutorial covers how to add the [Vercel MCP Server](https://vercel.com/docs/
 Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run installation commands, which use `npx`.
 :::
 
+:::tip TLDR
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
   [Launch the installer](goose://extension?url=https%3A%2F%2Fmcp.vercel.com&type=streamable_http&id=vercel&name=Vercel&description=Access%20deployments%2C%20manage%20projects%2C%20and%20more%20with%20Vercel%E2%80%99s%20official%20MCP%20server)
@@ -27,7 +28,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     ```
   </TabItem>
 </Tabs>
-
+:::
 
 ## Configuration
 


### PR DESCRIPTION
 **New documentation for Vercel MCP Server extension:**

* Adds a comprehensive guide (`documentation/docs/mcp/vercel-mcp.md`) on how to add and configure the Vercel MCP Server as a Goose extension, including both UI and CLI installation methods, authentication steps, and example usage scenarios.
* Provides a sample workflow and output illustrating how users can retrieve and display Vercel project statuses and deployment details within Goose, along with recommendations and best practices.