### PR TITLE
Fix : Google AI schema validation by adding missing array items fields

### DIFF
--- a/crates/goose/src/agents/recipe_tools/dynamic_task_tools.rs
+++ b/crates/goose/src/agents/recipe_tools/dynamic_task_tools.rs
@@ -43,13 +43,25 @@ pub fn create_dynamic_task_tool() -> Tool {
                             // Optional - auto-generated if not provided
                             "title": {"type": "string"},
                             "description": {"type": "string"},
-                            "extensions": {"type": "array"},
+                            "extensions": {
+                                "type": "array",
+                                "items": {"type": "object"}
+                            },
                             "settings": {"type": "object"},
-                            "parameters": {"type": "array"},
+                            "parameters": {
+                                "type": "array",
+                                "items": {"type": "object"}
+                            },
                             "response": {"type": "object"},
                             "retry": {"type": "object"},
-                            "context": {"type": "array"},
-                            "activities": {"type": "array"},
+                            "context": {
+                                "type": "array",
+                                "items": {"type": "string"}
+                            },
+                            "activities": {
+                                "type": "array",
+                                "items": {"type": "string"}
+                            },
                             "return_last_only": {
                                 "type": "boolean",
                                 "description": "If true, return only the last message from the subagent (default: false, returns full conversation)"


### PR DESCRIPTION
related: https://github.com/block/goose/issues/3770

**Pull Request Description**

This PR fixes Google AI API schema validation errors by adding missing items specifications to array properties in the dynamic task tool schema. The Google AI API was rejecting requests with 400 Bad Request errors due to incomplete JSON Schema definitions.

**Changes Made**

- Added items field specifications to four array properties in `dynamic_task_tools.rs`:

   - `extensions`: defined as array of objects
   - `parameters`: defined as array of objects
   - `context`: defined as array of strings
   - `activities`: defined as array of strings
   
- Ensures proper JSON Schema compliance across all AI providers
- Fixes Google AI integration while maintaining compatibility with existing providers

**Preview of error** : 

![pythonRecipe](https://github.com/user-attachments/assets/2dbe1202-4794-494e-90c2-0b646c098791)

