### PR TITLE
Change microphone entitlement to audio-input

### DIFF
--- a/ui/desktop/entitlements.plist
+++ b/ui/desktop/entitlements.plist
@@ -24,7 +24,7 @@
     <true/>
     <key>com.apple.security.device.camera</key>
     <true/>
-    <key>com.apple.security.device.microphone</key>
+    <key>com.apple.security.device.audio-input</key>
     <true/>
   </dict>
 </plist>


### PR DESCRIPTION

## Pull Request Description
From Gemini:
```
com.apple.security.device.microphone is a sandbox entitlement used by sandboxed macOS applications to request access to the built-in microphone. In contrast, com.apple.security.device.audio-input is a hardened runtime entitlement for apps built with the hardened runtime, which grants access to audio input via Core Audio. A sandboxed and hardened app requires both entitlements to access audio input. 
```
And indeed changing to audio-input fixed access to microphone in a test build

