### PR TITLE
Fix local (working directory) recipes storage

### DIFF
--- a/ui/desktop/src/recipe/recipeStorage.ts
+++ b/ui/desktop/src/recipe/recipeStorage.ts
@@ -34,7 +34,13 @@ function parseLastModified(val: string | Date): Date {
  * Get the storage directory path for recipes
  */
 export function getStorageDirectory(isGlobal: boolean): string {
-  return isGlobal ? '~/.config/goose/recipes' : '.goose/recipes';
+  if (isGlobal) {
+    return '~/.config/goose/recipes';
+  } else {
+    // For directory recipes, build absolute path using working directory
+    const workingDir = window.appConfig.get('GOOSE_WORKING_DIR') as string;
+    return `${workingDir}/.goose/recipes`;
+  }
 }
 
 /**


### PR DESCRIPTION
Fixes https://github.com/block/goose/issues/4452

Changed `getStorageDirectory()` to use `window.appConfig.get('GOOSE_WORKING_DIR')` for building absolute paths instead of relative `.goose/recipes` paths, ensuring directory recipes are saved to the user's actual working directory rather than the Electron main process directory.