### PR TITLE
chore: fix nightly builds to have tags

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -70,10 +70,12 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: [build-cli, install-script, bundle-desktop, bundle-desktop-linux, bundle-desktop-windows]
+    needs: [prepare-version, build-cli, install-script, bundle-desktop, bundle-desktop-linux, bundle-desktop-windows]
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+
       - name: Download all artifacts
         uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
         with:
@@ -83,8 +85,8 @@ jobs:
       - name: Release nightly
         uses: ncipollo/release-action@440c8c1cb0ed28b9f43e4d1d670870f059653174 # pin@v1
         with:
-          tag: nightly
-          name: Nightly
+          tag: ${{ needs.prepare-version.outputs.version }}
+          name: "Nightly ${{ needs.prepare-version.outputs.version }}"
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
             goose-*.tar.bz2
@@ -95,4 +97,5 @@ jobs:
             download_cli.sh
           allowUpdates: true
           omitBody: true
-          omitPrereleaseDuringUpdate: true
+          prerelease: true
+          makeLatest: false


### PR DESCRIPTION
Should resolve these issues that occur during each nightly build action

```
Error 422: Validation Failed: {"resource":"Release","code":"custom","field":"pre_receive","message":"pre_receive Repository rule violations found\n\nCannot create ref due to creations being restricted.\n\n"}, {"resource":"Release","code":"custom","message":"Published releases must have a valid tag"}
```

Example https://github.com/block/goose/actions/runs/17603712251/job/50011373654