### PR TITLE
docs: update built-in extensions list and fix link

### DIFF
--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -666,4 +666,4 @@ goose session --with-streamable-http-extension "https://example.com/streamable"
 
 Goose extensions are implemented with MCP, a standard protocol that allows AI models and agents to securely connect with local or remote resources. Learn how to build your own [extension as an MCP server](https://modelcontextprotocol.io/quickstart/server).
 
-[extensions-directory]: https://block.github.io/goose/extensions/
+[extensions-directory]: /extensions

--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -27,6 +27,7 @@ Here are the built-in extensions:
 - [Computer Controller](/docs/mcp/computer-controller-mcp): Provides general computer control tools for webscraping, file caching, and automations.
 - [Memory](/docs/mcp/memory-mcp): Teaches Goose to remember your preferences as you use it.
 - [Tutorial](/docs/mcp/tutorial-mcp): Provides interactive tutorials for learning about Goose.
+- [Auto Visualiser](/docs/mcp/autovisualiser-mcp): Automatically generates graphical data visualizations in conversations.
 
 
 #### Toggling Built-in Extensions

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -110,7 +110,7 @@ Let's begin 🚀
 
 ## Configure Provider
 
-Goose works with [supported LLM providers][providers] that give Goose the AI intelligence it needs to understand your requests. On first use, you'll be prompted to configure your preferred provider.
+Goose works with [supported LLM providers](/docs/getting-started/providers) that give Goose the AI intelligence it needs to understand your requests. On first use, you'll be prompted to configure your preferred provider.
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="Goose Desktop" default>
@@ -182,14 +182,14 @@ Goose will create a plan and then get right to work on implementing it. Once don
 
 ## Enable an Extension
 
-While you're able to manually navigate to your working directory and open the HTML file in a browser, wouldn't it be better if Goose did that for you? Let's give Goose the ability to open a web browser by enabling the `Computer Controller` extension.
+While you're able to manually navigate to your working directory and open the HTML file in a browser, wouldn't it be better if Goose did that for you? Let's give Goose the ability to open a web browser by enabling the [`Computer Controller` extension](/docs/mcp/computer-controller-mcp).
 
 <Tabs groupId="interface">
 
     <TabItem value="ui" label="Goose Desktop" default>
         1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
         2. Click `Extensions` in the sidebar menu.
-        3. Toggle the `Computer Controller` extension to enable it. This [extension](https://block.github.io/goose/v1/extensions/detail/nondeveloper) enables webscraping, file caching, and automations.
+        3. Toggle the `Computer Controller` extension to enable it. This extension enables webscraping, file caching, and automations.
         4. Return to your session to continue.
         5. Now that Goose has browser capabilities, let's ask it to launch your game in a browser:
     </TabItem>
@@ -199,7 +199,7 @@ While you're able to manually navigate to your working directory and open the HT
         ```sh
         goose configure
         ```
-        3. Choose `Add Extension` > `Built-in Extension` > `Computer Controller`, and set the timeout to 300s. This [extension](/docs/mcp/computer-controller-mcp) enables webscraping, file caching, and automations.
+        3. Choose `Add Extension` > `Built-in Extension` > `Computer Controller`, and set the timeout to 300s. This extension enables webscraping, file caching, and automations.
         ```
         ┌   goose-configure
         │
@@ -236,20 +236,7 @@ Go ahead and play your game, I know you want to 😂 ... good luck!
 Congrats, you've successfully used Goose to develop a web app! 🎉
 
 Here are some ideas for next steps:
-* Continue your session with Goose and it improve your game (styling, functionality, etc).
-* Browse other available [extensions][extensions-guide] and install more to enhance Goose's functionality even further.
+* Continue your session with Goose and improve your game (styling, functionality, etc).
+* Browse other available [extensions](/goose/extensions) and install more to enhance Goose's functionality even further.
 * Provide Goose with a [set of hints](/docs/guides/using-goosehints) to use within your sessions.
 
-
-
-
-[handling-rate-limits]: /docs/guides/handling-llm-rate-limits-with-goose
-[openai-key]: https://platform.openai.com/api-keys
-[getting-started]: /docs/category/getting-started
-[providers]: /docs/getting-started/providers
-[managing-sessions]: /docs/guides/sessions/session-management
-[contributing]: https://github.com/block/goose/blob/main/CONTRIBUTING.md
-[quick-tips]: /docs/guides/tips
-[extensions-guide]: /docs/getting-started/using-extensions
-[cli]: /docs/guides/goose-cli-commands
-[MCP]: https://www.anthropic.com/news/model-context-protocol

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -237,6 +237,6 @@ Congrats, you've successfully used Goose to develop a web app! 🎉
 
 Here are some ideas for next steps:
 * Continue your session with Goose and improve your game (styling, functionality, etc).
-* Browse other available [extensions](/goose/extensions) and install more to enhance Goose's functionality even further.
+* Browse other available [extensions](https://block.github.io/goose/extensions/) and install more to enhance Goose's functionality even further.
 * Provide Goose with a [set of hints](/docs/guides/using-goosehints) to use within your sessions.
 

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -237,6 +237,6 @@ Congrats, you've successfully used Goose to develop a web app! 🎉
 
 Here are some ideas for next steps:
 * Continue your session with Goose and improve your game (styling, functionality, etc).
-* Browse other available [extensions](https://block.github.io/goose/extensions/) and install more to enhance Goose's functionality even further.
+* Browse other available [extensions](/extensions) and install more to enhance Goose's functionality even further.
 * Provide Goose with a [set of hints](/docs/guides/using-goosehints) to use within your sessions.
 

--- a/documentation/docs/troubleshooting.md
+++ b/documentation/docs/troubleshooting.md
@@ -377,4 +377,4 @@ If you have questions, run into issues, or just need to brainstorm ideas join th
 [discord]: https://discord.gg/block-opensource
 [goosehints]: /docs/guides/using-goosehints
 [configure-llm-provider]: /docs/getting-started/providers
-[extensions-directory]: https://block.github.io/goose/extensions/
+[extensions-directory]: /extensions

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -111,6 +111,10 @@ const config: Config = {
             to: '/extensions'
           },
           {
+            from: '/v1/extensions/detail/nondeveloper',
+            to: '/docs/mcp/computer-controller-mcp'
+          },
+          {
             from: '/docs/guides/managing-goose-sessions',
             to: '/docs/guides/sessions/session-management'
           },


### PR DESCRIPTION
This PR updates the list of built-in extensions and updates links.

Documentation updates:
- `documentation/docs/getting-started/using-extensions.md`:
  - Add Auto Visualiser as a built-in extension
- `documentation/docs/quickstart.md`:
  - Replace broken v1 link
  - Remove reference links (mostly unused) for consistency
  - Change "Browse extensions" link target
- `documentation/docusaurus.config.ts`: 
  - Add redirect
