### PR TITLE
Run the conversation fixer over messages for recipe create

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1489,6 +1489,14 @@ impl Agent {
         tracing::debug!("Retrieved {} tools for recipe creation", tools.len());
 
         messages.push(Message::user().with_text(recipe_prompt));
+
+        let (messages, issues) = fix_conversation(messages);
+        if !issues.is_empty() {
+            issues
+                .iter()
+                .for_each(|issue| tracing::warn!(recipe.conversation.issue = issue));
+        }
+
         tracing::debug!(
             "Added recipe prompt to messages, total messages: {}",
             messages.len()


### PR DESCRIPTION
We've seen orphaned tool requests in the wild causing the create-recipe flow to fail. We should figure out why that happens, but given that we'll be moving the source of truth to the session file and away from the frontend state at some point it seems better to invest our efforts in tracking down any issues there.