### PR TITLE
fix: docker build include valid string prior to sha

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -41,7 +41,7 @@ jobs:
           tags: |
             # For main branch: latest, main, and sha
             type=ref,event=branch
-            type=sha,prefix={{branch}}-
+            type=sha,prefix=sha-
             type=raw,value=latest,enable={{is_default_branch}}
             # For tags: v1.2.3 -> 1.2.3, 1.2, 1, latest (if not pre-release)
             type=semver,pattern={{version}}


### PR DESCRIPTION
I noticed failing docker builds when the trigger is a tag

https://github.com/block/goose/actions/runs/17649096320/job/50154994435?pr=4577

### Issue

The problematic line of the action config was:

```yaml
type=sha,prefix={{branch}}-
```

When this action runs on a tag (like `v1.8.0`), the `{{branch}}` variable is empty, resulting in a tag that starts with just a hyphen: `ghcr.io/block/goose:-881a71a`. This is an invalid Docker tag format.

### Solution

Updated the workflow to use a fixed prefix:

```yaml
type=sha,prefix=sha-
```

This change ensures that SHA-based tags will always have a valid format like `ghcr.io/block/goose:sha-881a71a` regardless of whether the workflow is triggered by a branch push or a tag