### PR TITLE
Fix gpt-5 input context limit

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -17,7 +17,7 @@ pub enum ConfigError {
 static MODEL_SPECIFIC_LIMITS: Lazy<Vec<(&'static str, usize)>> = Lazy::new(|| {
     vec![
         // openai
-        ("gpt-5", 272_000),
+        ("gpt-5", 400_000),
         ("gpt-4-turbo", 128_000),
         ("gpt-4.1", 1_000_000),
         ("gpt-4-1", 1_000_000),


### PR DESCRIPTION
Update gpt-5 context limit from 272,000 to 400,000 tokens to match OpenAI's official documentation.

Fixes #4509

## Changes
- Updated the  constant in  to set gpt-5's context limit to 400,000 tokens
- This aligns with the official OpenAI documentation: https://platform.openai.com/docs/models/gpt-5

## Testing
- Ran existing unit tests to ensure the change doesn't break functionality
- The test  passes successfully