### PR TITLE
Fix #4612: Return non-zero exit code when CLI session ends with error

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1196,6 +1196,7 @@ pub async fn cli() -> Result<()> {
                 .await;
                 if let Err(e) = session.interactive(None).await {
                     eprintln!("Session ended with error: {}", e);
+                    std::process::exit(1);
                 }
                 Ok(())
             };


### PR DESCRIPTION
## Summary
This PR fixes the CLI to properly return a non-zero exit code (1) when a session ends with an error, allowing scripts and CI/CD pipelines to detect failures.

## Problem
When the goose CLI encounters an error during a session (such as an invalid temperature parameter), it prints the error message to stderr but still exits with code 0. This makes it impossible for automated scripts to detect when goose has failed.

## Solution
Added `std::process::exit(1)` after printing the error message when a session fails. This ensures the process exits with a non-zero status code that scripts can detect.

## Changes
- Modified `crates/goose-cli/src/cli.rs` to call `std::process::exit(1)` when `session.interactive()` returns an error

## Testing
- Built the project with `cargo build --package goose-cli`
- Ran existing tests with `cargo test --package goose-cli`
- Verified clippy passes with no warnings
- Manual testing confirms:
  - Normal sessions still exit with code 0
  - Error conditions now exit with code 1

## Example
Before this fix:
```bash
$ GOOSE_TEMPERATURE="0.3" goose <<< "hey"
Session ended with error: ...
$ echo $?
0  # Wrong - should be non-zero
```

After this fix:
```bash
$ GOOSE_TEMPERATURE="0.3" goose <<< "hey"
Session ended with error: ...
$ echo $?
1  # Correct - non-zero exit code indicates failure
```

Fixes #4612