### PR TITLE
Catch errors in node main

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1675,7 +1675,7 @@ const registerGlobalHotkey = (accelerator: string) => {
   }
 };
 
-app.whenReady().then(async () => {
+async function appMain() {
   // Ensure Windows shims are available before any MCP processes are spawned
   await ensureWinShims();
 
@@ -2144,6 +2144,15 @@ app.whenReady().then(async () => {
       return false;
     }
   });
+}
+
+app.whenReady().then(async () => {
+  try {
+    await appMain();
+  } catch (error) {
+    dialog.showErrorBox('Goose Error', `Failed to create main window: ${error}`);
+    app.quit();
+  }
 });
 
 async function getAllowList(): Promise<string[]> {


### PR DESCRIPTION
If we can't create the BrowswerWindow for whatever reason, the app just doesn't open a window and sits there in your system tray. Instead, we can catch and show a message like this (if I bundle the app without a goosed, for example):

<img width="271" height="352" alt="Screenshot 2025-09-12 at 3 25 10 PM" src="https://github.com/user-attachments/assets/66151607-eff6-4b57-a651-b8569ba8a686" />
