### PR TITLE
shave and code split

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -6,7 +6,7 @@ import type { View } from '../utils/navigationUtils';
 import Stop from './ui/Stop';
 import { Attach, Send, Close, Microphone } from './icons';
 import { ChatState } from '../types/chatState';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { LocalMessageStorage } from '../utils/localMessageStorage';
 import { Message } from '../types/message';
 import { DirSwitcher } from './bottom_menu/DirSwitcher';

--- a/ui/desktop/src/components/CodeBlock.tsx
+++ b/ui/desktop/src/components/CodeBlock.tsx
@@ -1,0 +1,79 @@
+import { useEffect, useRef, useState } from 'react';
+import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
+import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+import { Check, Copy } from './icons';
+import React from 'react';
+
+const CodeBlock = React.memo(function CodeBlock({
+  language,
+  children,
+}: {
+  language: string;
+  children: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<number | null>(null);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(children);
+      setCopied(true);
+
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+
+      timeoutRef.current = window.setTimeout(() => setCopied(false), 2000);
+    } catch (err) {
+      console.error('Failed to copy text: ', err);
+    }
+  };
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <div className="relative group w-full">
+      <button
+        onClick={handleCopy}
+        className="absolute right-2 bottom-2 p-1.5 rounded-lg bg-gray-700/50 text-gray-300 font-sans text-sm
+                 opacity-0 group-hover:opacity-100 transition-opacity duration-200
+                 hover:bg-gray-600/50 hover:text-gray-100 z-10"
+        title="Copy code"
+      >
+        {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+      </button>
+      <div className="w-full overflow-x-auto">
+        <SyntaxHighlighter
+          style={oneDark}
+          language={language}
+          PreTag="div"
+          customStyle={{
+            margin: 0,
+            width: '100%',
+            maxWidth: '100%',
+          }}
+          codeTagProps={{
+            style: {
+              whiteSpace: 'pre-wrap',
+              wordBreak: 'break-all',
+              overflowWrap: 'break-word',
+              fontFamily: 'var(--font-mono)',
+            },
+          }}
+          wrapLines={false}
+          lineProps={undefined}
+        >
+          {children}
+        </SyntaxHighlighter>
+      </div>
+    </div>
+  );
+});
+
+export default CodeBlock;

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -15,17 +15,33 @@ interface MarkdownContentProps {
   className?: string;
 }
 
-const SimpleCodeBlock = React.forwardRef(function SimpleCodeBlock({
-  ref,
+const LightweightCodeBlock = function LightweightCodeBlock({
   children,
-  ...props
-}: CodeProps) {
+}: {
+  children: React.ReactNode;
+}) {
   return (
-    <code ref={ref} {...props} className="break-all bg-inline-code whitespace-pre-wrap font-sans">
-      {children}
-    </code>
+    // This mimics the code block from react-syntax-highlighter, but without the actual highlighting,
+    // just so we have a fallback that isn't too jarringly different while the highlighter lazy-loads
+    <div
+      style={{
+        background: 'rgb(40, 44, 52)',
+        color: 'rgb(171, 178, 191)',
+        whiteSpace: 'pre',
+        lineHeight: 1.5,
+        tabSize: 2,
+        padding: '1em',
+        margin: '0px',
+        overflow: 'auto',
+        borderRadius: '0.3em',
+      }}
+    >
+      <code className="break-all whitespace-pre-wrap" style={{ fontFamily: 'monospace' }}>
+        {children}
+      </code>
+    </div>
   );
-});
+};
 
 const MarkdownCode = memo(
   React.forwardRef(function MarkdownCode(
@@ -34,19 +50,13 @@ const MarkdownCode = memo(
   ) {
     const match = /language-(\w+)/.exec(className || '');
     return !inline && match ? (
-      <Suspense
-        fallback={
-          <SimpleCodeBlock ref={ref} {...props}>
-            {children}
-          </SimpleCodeBlock>
-        }
-      >
+      <Suspense fallback={<LightweightCodeBlock>{children}</LightweightCodeBlock>}>
         <CodeBlock language={match[1]}>{String(children).replace(/\n$/, '')}</CodeBlock>
       </Suspense>
     ) : (
-      <SimpleCodeBlock ref={ref} {...props}>
+      <code ref={ref} {...props} className="break-all bg-inline-code whitespace-pre-wrap font-mono">
         {children}
-      </SimpleCodeBlock>
+      </code>
     );
   })
 );

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -1,11 +1,10 @@
-import React, { useState, useEffect, useRef, memo, useMemo } from 'react';
+import React, { useState, useEffect, memo, lazy, Suspense } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
-import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
-import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
-import { Check, Copy } from './icons';
 import { wrapHTMLInCodeBlock } from '../utils/htmlSecurity';
+
+const CodeBlock = lazy(() => import('./CodeBlock'));
 
 interface CodeProps extends React.ClassAttributes<HTMLElement>, React.HTMLAttributes<HTMLElement> {
   inline?: boolean;
@@ -16,91 +15,15 @@ interface MarkdownContentProps {
   className?: string;
 }
 
-// Memoized CodeBlock component to prevent re-rendering when props haven't changed
-const CodeBlock = memo(function CodeBlock({
-  language,
+const SimpleCodeBlock = React.forwardRef(function SimpleCodeBlock({
+  ref,
   children,
-}: {
-  language: string;
-  children: string;
-}) {
-  const [copied, setCopied] = useState(false);
-  const timeoutRef = useRef<number | null>(null);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(children);
-      setCopied(true);
-
-      if (timeoutRef.current) {
-        window.clearTimeout(timeoutRef.current);
-      }
-
-      timeoutRef.current = window.setTimeout(() => setCopied(false), 2000);
-    } catch (err) {
-      console.error('Failed to copy text: ', err);
-    }
-  };
-
-  useEffect(() => {
-    return () => {
-      if (timeoutRef.current) {
-        window.clearTimeout(timeoutRef.current);
-      }
-    };
-  }, []);
-
-  // Memoize the SyntaxHighlighter component to prevent re-rendering
-  // Only re-render if language or children change
-  const memoizedSyntaxHighlighter = useMemo(() => {
-    // For very large code blocks, consider truncating or lazy loading
-    const isLargeCodeBlock = children.length > 10000; // 10KB threshold
-
-    if (isLargeCodeBlock) {
-      console.log(`Large code block detected (${children.length} chars), consider optimization`);
-    }
-
-    return (
-      <SyntaxHighlighter
-        style={oneDark}
-        language={language}
-        PreTag="div"
-        customStyle={{
-          margin: 0,
-          width: '100%',
-          maxWidth: '100%',
-        }}
-        codeTagProps={{
-          style: {
-            whiteSpace: 'pre-wrap',
-            wordBreak: 'break-all',
-            overflowWrap: 'break-word',
-            fontFamily: 'var(--font-sans)',
-          },
-        }}
-        // Performance optimizations for SyntaxHighlighter
-        showLineNumbers={false} // Disable line numbers for better performance
-        wrapLines={false} // Disable line wrapping for better performance
-        lineProps={undefined} // Don't add extra props to each line
-      >
-        {children}
-      </SyntaxHighlighter>
-    );
-  }, [language, children]);
-
+  ...props
+}: CodeProps) {
   return (
-    <div className="relative group w-full">
-      <button
-        onClick={handleCopy}
-        className="absolute right-2 bottom-2 p-1.5 rounded-lg bg-gray-700/50 text-gray-300 font-sans text-sm
-                 opacity-0 group-hover:opacity-100 transition-opacity duration-200
-                 hover:bg-gray-600/50 hover:text-gray-100 z-10"
-        title="Copy code"
-      >
-        {copied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
-      </button>
-      <div className="w-full overflow-x-auto">{memoizedSyntaxHighlighter}</div>
-    </div>
+    <code ref={ref} {...props} className="break-all bg-inline-code whitespace-pre-wrap font-sans">
+      {children}
+    </code>
   );
 });
 
@@ -111,11 +34,19 @@ const MarkdownCode = memo(
   ) {
     const match = /language-(\w+)/.exec(className || '');
     return !inline && match ? (
-      <CodeBlock language={match[1]}>{String(children).replace(/\n$/, '')}</CodeBlock>
+      <Suspense
+        fallback={
+          <SimpleCodeBlock ref={ref} {...props}>
+            {children}
+          </SimpleCodeBlock>
+        }
+      >
+        <CodeBlock language={match[1]}>{String(children).replace(/\n$/, '')}</CodeBlock>
+      </Suspense>
     ) : (
-      <code ref={ref} {...props} className="break-all bg-inline-code whitespace-pre-wrap font-sans">
+      <SimpleCodeBlock ref={ref} {...props}>
         {children}
-      </code>
+      </SimpleCodeBlock>
     );
   })
 );

--- a/ui/desktop/src/components/conversation/SearchBar.tsx
+++ b/ui/desktop/src/components/conversation/SearchBar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef, KeyboardEvent } from 'react';
 import { Search as SearchIcon } from 'lucide-react';
 import { ArrowDown, ArrowUp, Close } from '../icons';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import { Button } from '../ui/button';
 
 /**

--- a/ui/desktop/src/components/conversation/SearchView.tsx
+++ b/ui/desktop/src/components/conversation/SearchView.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, PropsWithChildren, useCallback, useRef } from 'react';
 import SearchBar from './SearchBar';
 import { SearchHighlighter } from '../../utils/searchHighlighter';
-import { debounce } from 'lodash';
+import debounce from 'lodash/debounce';
 import '../../styles/search.css';
 
 /**


### PR DESCRIPTION
removes 99% of lodash we don't use, and splits 1mb of syntax highlighting to a separate artifact with lazy loading.

this didn't turn out to be the big gain I'd hoped for but it does make the page load slightly snappier