### PR TITLE
Add Synthetic (https://synthetic.new) as a provider

### DIFF
--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -21,6 +21,7 @@ use super::{
     provider_registry::ProviderRegistry,
     sagemaker_tgi::SageMakerTgiProvider,
     snowflake::SnowflakeProvider,
+    synthetic::SyntheticProvider,
     tetrate::TetrateProvider,
     venice::VeniceProvider,
     xai::XaiProvider,
@@ -58,6 +59,7 @@ static REGISTRY: Lazy<RwLock<ProviderRegistry>> = Lazy::new(|| {
         registry.register::<OpenRouterProvider, _>(OpenRouterProvider::from_env);
         registry.register::<SageMakerTgiProvider, _>(SageMakerTgiProvider::from_env);
         registry.register::<SnowflakeProvider, _>(SnowflakeProvider::from_env);
+        registry.register::<SyntheticProvider, _>(SyntheticProvider::from_env);
         registry.register::<TetrateProvider, _>(TetrateProvider::from_env);
         registry.register::<VeniceProvider, _>(VeniceProvider::from_env);
         registry.register::<XaiProvider, _>(XaiProvider::from_env);

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -28,6 +28,7 @@ pub mod provider_registry;
 mod retry;
 pub mod sagemaker_tgi;
 pub mod snowflake;
+pub mod synthetic;
 pub mod testprovider;
 pub mod tetrate;
 pub mod toolshim;

--- a/crates/goose/src/providers/synthetic.rs
+++ b/crates/goose/src/providers/synthetic.rs
@@ -1,0 +1,165 @@
+use super::api_client::{ApiClient, AuthMethod};
+use super::errors::ProviderError;
+use super::retry::ProviderRetry;
+use super::utils::{get_model, handle_response_openai_compat};
+use crate::conversation::message::Message;
+use crate::impl_provider_default;
+use crate::model::ModelConfig;
+use crate::providers::base::{ConfigKey, Provider, ProviderMetadata, ProviderUsage, Usage};
+use crate::providers::formats::openai::{create_request, get_usage, response_to_message};
+use anyhow::Result;
+use async_trait::async_trait;
+use rmcp::model::Tool;
+use serde_json::Value;
+
+pub const SYNTHETIC_API_HOST: &str = "https://api.synthetic.new";
+pub const SYNTHETIC_DEFAULT_MODEL: &str = "hf:zai-org/GLM-4.5";
+pub const SYNTHETIC_KNOWN_MODELS: &[&str] = &[
+    // This will be populated dynamically from the API, but provide some defaults
+    "hf:zai-org/GLM-4.5",
+    "hf:moonshotai/Kimi-K2-Instruct-0905",
+    "hf:deepseek-ai/DeepSeek-V3-0324",
+    "hf:deepseek-ai/DeepSeek-R1-0528",
+];
+
+// TODO(billy@syntheticlab.co): Update this when developer API docs are launched.
+pub const SYNTHETIC_DOC_URL: &str = "https://synthetic.new";
+
+#[derive(serde::Serialize)]
+pub struct SyntheticProvider {
+    #[serde(skip)]
+    api_client: ApiClient,
+    model: ModelConfig,
+}
+
+impl_provider_default!(SyntheticProvider);
+
+impl SyntheticProvider {
+    pub fn from_env(model: ModelConfig) -> Result<Self> {
+        let config = crate::config::Config::global();
+        let api_key: String = config.get_secret("SYNTHETIC_API_KEY")?;
+        let host: String = config
+            .get_param("SYNTHETIC_HOST")
+            .unwrap_or_else(|_| SYNTHETIC_API_HOST.to_string());
+
+        let auth = AuthMethod::BearerToken(api_key);
+        let api_client = ApiClient::new(host, auth)?;
+
+        Ok(Self { api_client, model })
+    }
+
+    async fn post(&self, payload: Value) -> Result<Value, ProviderError> {
+        let response = self
+            .api_client
+            .response_post("openai/v1/chat/completions", &payload)
+            .await?;
+        handle_response_openai_compat(response).await
+    }
+}
+
+#[async_trait]
+impl Provider for SyntheticProvider {
+    fn metadata() -> ProviderMetadata {
+        ProviderMetadata::new(
+            "synthetic",
+            "Synthetic",
+            "Unified provider for popular open weight models.",
+            SYNTHETIC_DEFAULT_MODEL,
+            SYNTHETIC_KNOWN_MODELS.to_vec(),
+            SYNTHETIC_DOC_URL,
+            vec![
+                ConfigKey::new("SYNTHETIC_API_KEY", true, true, None),
+                ConfigKey::new("SYNTHETIC_HOST", false, false, Some(SYNTHETIC_API_HOST)),
+            ],
+        )
+    }
+
+    fn get_model_config(&self) -> ModelConfig {
+        self.model.clone()
+    }
+
+    #[tracing::instrument(
+        skip(self, model_config, system, messages, tools),
+        fields(model_config, input, output, input_tokens, output_tokens, total_tokens)
+    )]
+    async fn complete_with_model(
+        &self,
+        model_config: &ModelConfig,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+    ) -> Result<(Message, ProviderUsage), ProviderError> {
+        let payload = create_request(
+            model_config,
+            system,
+            messages,
+            tools,
+            &super::utils::ImageFormat::OpenAi,
+        )?;
+
+        let response = self.with_retry(|| self.post(payload.clone())).await?;
+
+        let message = response_to_message(&response)?;
+        let usage = response.get("usage").map(get_usage).unwrap_or_else(|| {
+            tracing::debug!("Failed to get usage data");
+            Usage::default()
+        });
+        let response_model = get_model(&response);
+        super::utils::emit_debug_trace(model_config, &payload, &response, &usage);
+        Ok((message, ProviderUsage::new(response_model, usage)))
+    }
+
+    /// Fetch supported models from Synthetic API
+    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
+        let response = self
+            .api_client
+            .request("openai/v1/models")
+            .header("Content-Type", "application/json")?
+            .response_get()
+            .await?;
+        let response = handle_response_openai_compat(response).await?;
+
+        let data = response
+            .get("data")
+            .and_then(|v| v.as_array())
+            .ok_or_else(|| {
+                ProviderError::UsageError("Missing or invalid `data` field in response".into())
+            })?;
+
+        let mut model_names: Vec<String> = data
+            .iter()
+            .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(String::from))
+            .collect();
+        model_names.sort();
+        Ok(Some(model_names))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_synthetic_provider_metadata() {
+        let metadata = SyntheticProvider::metadata();
+        assert_eq!(metadata.name, "synthetic");
+        assert_eq!(metadata.display_name, "Synthetic");
+        assert!(metadata.description.contains("OpenAI compatible"));
+        assert_eq!(metadata.default_model, SYNTHETIC_DEFAULT_MODEL);
+        assert!(metadata.config_keys.len() >= 2);
+
+        // Check that API key is required and secret
+        let api_key_config = metadata.config_keys.iter()
+            .find(|k| k.name == "SYNTHETIC_API_KEY")
+            .expect("SYNTHETIC_API_KEY should be in config");
+        assert!(api_key_config.required);
+        assert!(api_key_config.secret);
+
+        // Check that host has default value
+        let host_config = metadata.config_keys.iter()
+            .find(|k| k.name == "SYNTHETIC_HOST")
+            .expect("SYNTHETIC_HOST should be in config");
+        assert!(!host_config.required);
+        assert_eq!(host_config.default, Some(SYNTHETIC_API_HOST.to_string()));
+    }
+}

--- a/crates/goose/src/providers/synthetic.rs
+++ b/crates/goose/src/providers/synthetic.rs
@@ -140,30 +140,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_synthetic_provider_metadata() {
+    fn test_metadata_structure() {
         let metadata = SyntheticProvider::metadata();
-        assert_eq!(metadata.name, "synthetic");
-        assert_eq!(metadata.display_name, "Synthetic");
-        assert!(metadata.description.contains("OpenAI compatible"));
-        assert_eq!(metadata.default_model, SYNTHETIC_DEFAULT_MODEL);
-        assert!(metadata.config_keys.len() >= 2);
 
-        // Check that API key is required and secret
-        let api_key_config = metadata
-            .config_keys
-            .iter()
-            .find(|k| k.name == "SYNTHETIC_API_KEY")
-            .expect("SYNTHETIC_API_KEY should be in config");
-        assert!(api_key_config.required);
-        assert!(api_key_config.secret);
+        assert_eq!(metadata.default_model, "hf:zai-org/GLM-4.5");
+        assert!(!metadata.known_models.is_empty());
 
-        // Check that host has default value
-        let host_config = metadata
-            .config_keys
-            .iter()
-            .find(|k| k.name == "SYNTHETIC_HOST")
-            .expect("SYNTHETIC_HOST should be in config");
-        assert!(!host_config.required);
-        assert_eq!(host_config.default, Some(SYNTHETIC_API_HOST.to_string()));
+        assert_eq!(metadata.config_keys.len(), 2);
+        assert_eq!(metadata.config_keys[0].name, "SYNTHETIC_API_KEY");
+        assert_eq!(metadata.config_keys[1].name, "SYNTHETIC_HOST");
     }
 }

--- a/crates/goose/src/providers/synthetic.rs
+++ b/crates/goose/src/providers/synthetic.rs
@@ -149,14 +149,18 @@ mod tests {
         assert!(metadata.config_keys.len() >= 2);
 
         // Check that API key is required and secret
-        let api_key_config = metadata.config_keys.iter()
+        let api_key_config = metadata
+            .config_keys
+            .iter()
             .find(|k| k.name == "SYNTHETIC_API_KEY")
             .expect("SYNTHETIC_API_KEY should be in config");
         assert!(api_key_config.required);
         assert!(api_key_config.secret);
 
         // Check that host has default value
-        let host_config = metadata.config_keys.iter()
+        let host_config = metadata
+            .config_keys
+            .iter()
             .find(|k| k.name == "SYNTHETIC_HOST")
             .expect("SYNTHETIC_HOST should be in config");
         assert!(!host_config.required);


### PR DESCRIPTION
## Pull Request Description

Thanks for building goose, it looks like a neat LLM frontend!

I'm the cofounder of [Synthetic](https://synthetic.new). A few of our users wanted to try to use goose but reported having issues setting up Synthetic as a custom provider. I also wasn't able to get it to work, so proposing this PR to add us as a native provider.

Tested with `cargo check` and verified running locally, both via CLI and MacOS UI:

<img width="1124" height="1066" alt="CleanShot 2025-09-15 at 17 13 50@2x" src="https://github.com/user-attachments/assets/3c0fde1e-5caa-4a48-85c0-3e759796fb50" />
<img width="2018" height="836" alt="CleanShot 2025-09-15 at 17 20 47@2x" src="https://github.com/user-attachments/assets/36ec8f50-12ad-4e13-b644-2ba103131d02" />


<img width="1780" height="1192" alt="CleanShot 2025-09-15 at 18 07 05@2x" src="https://github.com/user-attachments/assets/48164e2b-0909-46a7-92c6-a6b70b3127a0" />
<img width="1060" height="1078" alt="CleanShot 2025-09-15 at 18 07 50@2x" src="https://github.com/user-attachments/assets/99405888-db17-4c14-8ecc-08872ff229f1" />
<img width="1970" height="952" alt="CleanShot 2025-09-15 at 18 08 12@2x" src="https://github.com/user-attachments/assets/b6aa049d-e31b-4fec-92cb-5715758fbc25" />
