### PR TITLE
fix: Missing final structured output should provide guidance to model

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1308,6 +1308,7 @@ impl Agent {
                             let message = Message::user().with_text(FINAL_OUTPUT_CONTINUATION_MESSAGE);
                             messages_to_add.push(message.clone());
                             yield AgentEvent::Message(message);
+                            messages.extend(messages_to_add);
                             continue
                         } else {
                             let message = Message::assistant().with_text(final_output_tool.final_output.clone().unwrap());

--- a/crates/goose/src/agents/final_output_tool.rs
+++ b/crates/goose/src/agents/final_output_tool.rs
@@ -38,17 +38,17 @@ impl FinalOutputTool {
 
     pub fn tool(&self) -> Tool {
         let instructions = formatdoc! {r#"
-            This tool collects the final output for a user and provides validation for structured JSON final output against a predefined schema.
+            The final_output tool collects the final output for the user and provides validation for structured JSON final output against a predefined schema.
 
-            This tool MUST be used for the final output to the user.
+            This final_output tool MUST be called with the final output for the user.
             
             Purpose:
-            - Collects the final output for a user
+            - Collects the final output for the user
             - Ensures that final outputs conform to the expected JSON structure
             - Provides clear validation feedback when outputs don't match the schema
             
             Usage:
-            - Call the `final_output` tool with your JSON final output
+            - Call the `final_output` tool with your JSON final output passed as the argument.
             
             The expected JSON schema format is:
 
@@ -83,8 +83,8 @@ impl FinalOutputTool {
         formatdoc! {r#"
             # Final Output Instructions
 
-            You MUST use the `final_output` tool to collect the final output for a user.
-            The final output MUST be a valid JSON object that matches the following expected schema:
+            You MUST use the `final_output` tool to collect the final output for the user rather than providing the output directly in your response.
+            The final output MUST be a valid JSON object that is provided to the `final_output` tool when called and it must match the following schema:
 
             {}
 


### PR DESCRIPTION
## Scenario
When using structured output in a recipe and the agent completes its reply without calling the final_output tool. The agent will immediately be triggered to try again until it does call the final_output tool.

## Problem
When this scenario occurs we create a user message telling the agent to call the final_output tool. This is yielded from the agent loop so users see it. However the problem was that this message was not being added to the messages vector, therefore the agent never saw this correctional guidance.

This can result in the agent repeating its mistake multiple times or taking entirely different trajectories rather than immediately fixing itself and calling the final_output tool on the next turn.

## Fix
Append the correction message to messages vector so agent loop sees it on next turn.

I've also updated the tool prompt a little but cannot tell if has helped.

## Steps to reproduce
Non deterministic.

I've found o3 model with a recipe that tells it to output markdown manages to make it not do the tool call maybe 25% of the time which is enough to demonstrate the issue. Attached the recipe, you should notice it fixing itself on the next turn.

[output_fail.txt](https://github.com/user-attachments/files/22362664/output_fail.txt)
