### PR TITLE
fix: improve oneDark theme for comment contrast and readability

### DIFF
--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -4,6 +4,25 @@ import remarkGfm from 'remark-gfm';
 import remarkBreaks from 'remark-breaks';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { oneDark } from 'react-syntax-highlighter/dist/esm/styles/prism';
+// Improved oneDark theme for better comment contrast and readability
+const customOneDarkTheme = {
+  ...oneDark,
+  'code[class*="language-"]': {
+    ...oneDark['code[class*="language-"]'],
+    color: '#e6e6e6',
+    fontSize: '14px',
+  },
+  'pre[class*="language-"]': {
+    ...oneDark['pre[class*="language-"]'],
+    color: '#e6e6e6',
+    fontSize: '14px',
+  },
+  comment: { ...oneDark.comment, color: '#a0a0a0', fontStyle: 'italic' },
+  prolog: { ...oneDark.prolog, color: '#a0a0a0' },
+  doctype: { ...oneDark.doctype, color: '#a0a0a0' },
+  cdata: { ...oneDark.cdata, color: '#a0a0a0' },
+};
+
 import { Check, Copy } from './icons';
 import { wrapHTMLInCodeBlock } from '../utils/htmlSecurity';
 
@@ -62,7 +81,7 @@ const CodeBlock = memo(function CodeBlock({
 
     return (
       <SyntaxHighlighter
-        style={oneDark}
+        style={customOneDarkTheme}
         language={language}
         PreTag="div"
         customStyle={{
@@ -76,6 +95,7 @@ const CodeBlock = memo(function CodeBlock({
             wordBreak: 'break-all',
             overflowWrap: 'break-word',
             fontFamily: 'var(--font-sans)',
+            fontSize: '14px',
           },
         }}
         // Performance optimizations for SyntaxHighlighter


### PR DESCRIPTION
closes: #4618 

## Pull Request Description

This PR aims to improve the code comments contrast and font size in markdown 

**Changes Made:** 

- Increase code block font size to 14px
- Improve the contrast of comments for both modes
- Add a custom syntax highlighter theme for better visibility

**Preview :** 

| Before Contrast | After Contrast |
|---------------|--------------|
| <img width="475" height="247" alt="beforeContrast" src="https://github.com/user-attachments/assets/bfc26348-7907-4c59-98a2-df9c4ddf945b" /> | <img width="562" height="303" alt="afterContrast" src="https://github.com/user-attachments/assets/0f3e3632-c9fa-468c-a96c-0362cf5b095e" /> |

