### PR TITLE
chore(mcp): convert autovisualiser to use the rust sdk for mcp

### DIFF
--- a/crates/goose-cli/src/commands/mcp.rs
+++ b/crates/goose-cli/src/commands/mcp.rs
@@ -40,9 +40,20 @@ pub async fn run_server(name: &str) -> Result<()> {
         return Ok(());
     }
 
+    if name == "autovisualiser" {
+        let service = AutoVisualiserRouter::new()
+            .serve(stdio())
+            .await
+            .inspect_err(|e| {
+                tracing::error!("serving error: {:?}", e);
+            })?;
+
+        service.waiting().await?;
+        return Ok(());
+    }
+
     let router: Option<Box<dyn BoundedService>> = match name {
         "computercontroller" => Some(Box::new(RouterService(ComputerControllerRouter::new()))),
-        "autovisualiser" => Some(Box::new(RouterService(AutoVisualiserRouter::new()))),
         "memory" => Some(Box::new(RouterService(MemoryRouter::new()))),
         "tutorial" => Some(Box::new(RouterService(TutorialRouter::new()))),
         _ => None,

--- a/crates/goose-server/src/commands/mcp.rs
+++ b/crates/goose-server/src/commands/mcp.rs
@@ -29,9 +29,21 @@ pub async fn run(name: &str) -> Result<()> {
         service.waiting().await?;
         return Ok(());
     }
+
+    if name == "autovisualiser" {
+        let service = AutoVisualiserRouter::new()
+            .serve(stdio())
+            .await
+            .inspect_err(|e| {
+                tracing::error!("serving error: {:?}", e);
+            })?;
+
+        service.waiting().await?;
+        return Ok(());
+    }
+
     let router: Option<Box<dyn BoundedService>> = match name {
         "computercontroller" => Some(Box::new(RouterService(ComputerControllerRouter::new()))),
-        "autovisualiser" => Some(Box::new(RouterService(AutoVisualiserRouter::new()))),
         "memory" => Some(Box::new(RouterService(MemoryRouter::new()))),
         "tutorial" => Some(Box::new(RouterService(TutorialRouter::new()))),
         _ => None,


### PR DESCRIPTION
* Server one of the change originally in https://github.com/block/goose/pull/4488
* Converts `autovisualiser` to only use the rust sdk for mcp, and not our internal `mcp-server` crate
* Verified all the input schemas and tool descriptions are the exact same as before, and it works well locally