### PR TITLE
chore(mcp): convert tutorial mcp server to use the rust sdk for mcp

### DIFF
--- a/crates/goose-mcp/src/lib.rs
+++ b/crates/goose-mcp/src/lib.rs
@@ -11,10 +11,10 @@ pub mod autovisualiser;
 pub mod computercontroller;
 pub mod developer;
 mod memory;
-mod tutorial;
+pub mod tutorial;
 
 pub use autovisualiser::AutoVisualiserRouter;
 pub use computercontroller::ComputerControllerRouter;
 pub use developer::rmcp_developer::DeveloperServer;
 pub use memory::MemoryRouter;
-pub use tutorial::TutorialRouter;
+pub use tutorial::TutorialServer;

--- a/crates/goose-server/src/commands/mcp.rs
+++ b/crates/goose-server/src/commands/mcp.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use goose_mcp::{
-    AutoVisualiserRouter, ComputerControllerRouter, DeveloperServer, MemoryRouter, TutorialRouter,
+    AutoVisualiserRouter, ComputerControllerRouter, DeveloperServer, MemoryRouter, TutorialServer,
 };
 use mcp_server::router::RouterService;
 use mcp_server::{BoundedService, ByteTransport, Server};
@@ -18,6 +18,7 @@ pub async fn run(name: &str) -> Result<()> {
 
     tracing::info!("Starting MCP server");
 
+    // Handle RMCP-based servers
     if name == "developer" {
         let service = DeveloperServer::new()
             .serve(stdio())
@@ -42,10 +43,22 @@ pub async fn run(name: &str) -> Result<()> {
         return Ok(());
     }
 
+    if name == "tutorial" {
+        let service = TutorialServer::new()
+            .serve(stdio())
+            .await
+            .inspect_err(|e| {
+                tracing::error!("serving error: {:?}", e);
+            })?;
+
+        service.waiting().await?;
+        return Ok(());
+    }
+
+    // Handle old MCP-based servers
     let router: Option<Box<dyn BoundedService>> = match name {
         "computercontroller" => Some(Box::new(RouterService(ComputerControllerRouter::new()))),
         "memory" => Some(Box::new(RouterService(MemoryRouter::new()))),
-        "tutorial" => Some(Box::new(RouterService(TutorialRouter::new()))),
         _ => None,
     };
 


### PR DESCRIPTION
- Server two of the change originally in https://github.com/block/goose/pull/4488
- Converts tutorial to only use the rust sdk for mcp, and not our internal mcp-server crate
- Verified all the input schemas and tool descriptions are the exact same as before