### PR TITLE
chore(mcp): convert memory mcp server to use the rust sdk for mcp

### DIFF
--- a/crates/goose-mcp/src/lib.rs
+++ b/crates/goose-mcp/src/lib.rs
@@ -16,5 +16,5 @@ pub mod tutorial;
 pub use autovisualiser::AutoVisualiserRouter;
 pub use computercontroller::ComputerControllerRouter;
 pub use developer::rmcp_developer::DeveloperServer;
-pub use memory::MemoryRouter;
+pub use memory::MemoryServer;
 pub use tutorial::TutorialServer;

--- a/crates/goose-server/src/commands/mcp.rs
+++ b/crates/goose-server/src/commands/mcp.rs
@@ -1,6 +1,6 @@
 use anyhow::{anyhow, Result};
 use goose_mcp::{
-    AutoVisualiserRouter, ComputerControllerRouter, DeveloperServer, MemoryRouter, TutorialServer,
+    AutoVisualiserRouter, ComputerControllerRouter, DeveloperServer, MemoryServer, TutorialServer,
 };
 use mcp_server::router::RouterService;
 use mcp_server::{BoundedService, ByteTransport, Server};
@@ -55,10 +55,17 @@ pub async fn run(name: &str) -> Result<()> {
         return Ok(());
     }
 
+    if name == "memory" {
+        let service = MemoryServer::new().serve(stdio()).await.inspect_err(|e| {
+            tracing::error!("serving error: {:?}", e);
+        })?;
+        service.waiting().await?;
+        return Ok(());
+    }
+
     // Handle old MCP-based servers
     let router: Option<Box<dyn BoundedService>> = match name {
         "computercontroller" => Some(Box::new(RouterService(ComputerControllerRouter::new()))),
-        "memory" => Some(Box::new(RouterService(MemoryRouter::new()))),
         _ => None,
     };
 


### PR DESCRIPTION
- Server three of the change originally in https://github.com/block/goose/pull/4488
- Converts memory to only use the rust sdk for mcp, and not our internal mcp-server crate
- Verified all the input schemas and tool descriptions are the exact same as before