### PR TITLE
fix: dictation provider dropdown getting cut off

### DIFF
--- a/ui/desktop/src/components/settings/dictation/VoiceDictationToggle.tsx
+++ b/ui/desktop/src/components/settings/dictation/VoiceDictationToggle.tsx
@@ -66,18 +66,13 @@ export const VoiceDictationToggle = () => {
         </div>
       </div>
 
-      <div 
-        className={`overflow-hidden transition-all duration-300 ease-in-out ${
-          settings.enabled 
-            ? 'max-h-96 opacity-100 mt-2' 
-            : 'max-h-0 opacity-0 mt-0'
+      <div
+        className={`overflow-visible transition-all duration-300 ease-in-out ${
+          settings.enabled ? 'max-h-96 opacity-100 mt-2' : 'max-h-0 opacity-0 mt-0'
         }`}
       >
         <div className="space-y-3 pb-2">
-          <ProviderSelector 
-            settings={settings}
-            onProviderChange={handleProviderChange}
-          />
+          <ProviderSelector settings={settings} onProviderChange={handleProviderChange} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
Closes: #4657  

## Pull Request Description  

This PR fixes the issue where the **Dictation Provider** dropdown was being cut off/clipped when opened, showing only partial options.  

The root cause was the parent container in `VoiceDictationToggle.tsx` having `overflow-hidden`, which clipped the absolutely positioned dropdown.  

**Changes Made**  

- Updated the container `div` from `overflow-hidden` to `overflow-visible` for proper rendering.  

**Preview**  

![dictationProvider](https://github.com/user-attachments/assets/48adc2f6-0083-4d57-b5ef-ea0deae05b8a)  
