### PR TITLE
fix: Don't count recipe explain or render as recipe usage

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -964,15 +964,6 @@ pub async fn cli() -> Result<()> {
                             })
                             .unwrap_or_else(|| "unknown".to_string());
 
-                    tracing::info!(
-                        counter.goose.recipe_runs = 1,
-                        recipe_name = %recipe_display_name,
-                        recipe_version = %recipe_version,
-                        session_type = "recipe",
-                        interface = "cli",
-                        "Recipe execution started"
-                    );
-
                     if explain {
                         explain_recipe(&recipe_name, params)?;
                         return Ok(());
@@ -984,6 +975,16 @@ pub async fn cli() -> Result<()> {
                         }
                         return Ok(());
                     }
+
+                    tracing::info!(
+                        counter.goose.recipe_runs = 1,
+                        recipe_name = %recipe_display_name,
+                        recipe_version = %recipe_version,
+                        session_type = "recipe",
+                        interface = "cli",
+                        "Recipe execution started"
+                    );
+
                     let (input_config, recipe_info) =
                         extract_recipe_info_from_cli(recipe_name, params, additional_sub_recipes)?;
                     (input_config, Some(recipe_info))


### PR DESCRIPTION
When collecting recipe usage metrics from the cli we were including render and explain usages. We should only count 'run' usage, not much difference but more correct given we want to know how many recipes are run rather than the other aspects.