### PR TITLE
feat(acp): upgrade agent-client-protocol + improve tool experience

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,12 +30,13 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.1.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b91e5ec3ce05e8effb2a7a3b7b1a587daa6699b9f98bbde6a35e44b8c6c773a"
+checksum = "cc2526e80463b9742afed4829aedd6ae5632d6db778c6cc1fecb80c960c3521b"
 dependencies = [
  "anyhow",
  "async-broadcast",
+ "async-trait",
  "futures",
  "log",
  "parking_lot",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -22,7 +22,7 @@ mcp-client = { path = "../mcp-client" }
 mcp-server = { path = "../mcp-server" }
 mcp-core = { path = "../mcp-core" }
 rmcp = { workspace = true }
-agent-client-protocol = "0.1.1"
+agent-client-protocol = "0.4.0"
 clap = { version = "4.4", features = ["derive"] }
 cliclack = "0.3.5"
 console = "0.15.8"


### PR DESCRIPTION
Improves the acp command a bit by...

* Upgrading the agent-client-protocol crate dep
* Make content from tool results accessible via acp
* Refactoring is mainly to align with the new crate

Screenshot from running in zed

<img width="839" height="1103" alt="Screenshot 2025-09-19 at 3 32 06 PM" src="https://github.com/user-attachments/assets/6ce8b2ca-9bd7-4515-8f5f-3643fadbe3c7" />

Can do another followup to make tool names more human-friendly and useful

Helpful config to run goose from source (on any local branch) from zed:

```
# ~/.config/zed/settings.json
{
  "theme": "One Dark",
  "agent_servers": {
    "goose": {
      "command": "cargo",
      "args": [
        "+nightly",
        "-Z",
        "unstable-options",
        "-C",
        "/PATH/TO/GOOSE/REPO",
        "run",
        "--bin",
        "goose",
        "acp"
      ],
      "env": {}
    }
  }
}

```
