### PR TITLE
[Security] Implement Security Option for Handling Tool-Call Chains

### DIFF
--- a/crates/goose/src/security/mod.rs
+++ b/crates/goose/src/security/mod.rs
@@ -105,7 +105,7 @@ impl SecurityManager {
                     .await?;
 
                 // Get threshold from config - only flag things above threshold
-                let config_threshold = scanner.get_threshold_from_config();
+                let config_threshold = scanner.get_confidence_threshold_from_config();
 
                 if analysis_result.is_malicious && analysis_result.confidence > config_threshold {
                     // Generate a unique finding ID based on normalized tool call content


### PR DESCRIPTION
## Pull Request Description
One of the key attacks against Goose is MCP poisoning. Using the response data from an MCP to trigger a non-expected tool-call that performs an unintended action.

Whilst we absolutely don't want to remove the utility of the agent autonomously deciding to call a chain of tools, users should be able to configure security profiles in their config to prevent certain tools being called as a "secondary tool" without user input.

This PR introduces such functionality

## Implementation Detail
The general approach is to intercept tool-calls and perform a message look back to see what tools have been called since prior invocation. Specifically, the method is as follows:
1. Check for config of tools to protect (if null skip the check)
2. Check if the current tool-call exists in the list of protected tools (if null skip)
3. Collect a list of tool calls between the tool we're about to invoke and the last user message (if 0 skip)
4. If the last called tool is this tool skip
5. If the last called tool is another tool raise a security alert.


## Testing

<img width="477" height="82" alt="Screenshot 2025-09-22 at 5 23 24 pm" src="https://github.com/user-attachments/assets/3e2f8ac6-c1fa-4c73-a521-50a800938046" />

- Config File Setup

<img width="1357" height="553" alt="Screenshot 2025-09-22 at 5 25 32 pm" src="https://github.com/user-attachments/assets/ecbf40f8-6d49-47c6-8613-2c0fb71e16e1" />

- Base Case Running a Normal MCP + The developer__shell mcp - Part 1

<img width="1227" height="161" alt="Screenshot 2025-09-22 at 5 26 01 pm" src="https://github.com/user-attachments/assets/bf9c2c66-f1dc-47d6-a6ac-0a0eb8f756c8" />

- Base Case Running a Normal MCP + The developer__shell mcp - Part 2

<img width="729" height="311" alt="Screenshot 2025-09-22 at 5 24 50 pm" src="https://github.com/user-attachments/assets/30f40e1b-9e5b-457f-a2eb-d4c7441b2c9a" />

- Secondary Case running two instances of developer shell