### PR TITLE
fix chat button alignment and spacing for attachments

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1325,7 +1325,7 @@ export default function ChatInput({
         </div>
 
         {/* Inline action buttons on the right */}
-        <div className="flex items-center gap-1 px-2 relative">
+        <div className="flex items-center gap-1 px-2 relative self-center">
           {/* Microphone button - show only if dictation is enabled */}
           {dictationSettings?.enabled && (
             <>
@@ -1472,7 +1472,7 @@ export default function ChatInput({
 
       {/* Combined files and images preview */}
       {(pastedImages.length > 0 || allDroppedFiles.length > 0) && (
-        <div className="flex flex-wrap gap-2 p-2 border-t border-borderSubtle">
+        <div className="flex flex-wrap gap-2 p-4 mt-2 border-t border-borderSubtle">
           {/* Render pasted images first */}
           {pastedImages.map((img) => (
             <div key={img.id} className="relative group w-20 h-20">


### PR DESCRIPTION
## Pull Request Description
fix chat button alignment and spacing for attachments

before:
<img width="819" height="166" alt="Screenshot 2025-09-24 at 8 56 52 AM" src="https://github.com/user-attachments/assets/41c1d2d1-ab83-49d5-a4ef-25b38147e4af" />

after:
<img width="818" height="188" alt="Screenshot 2025-09-24 at 9 03 16 AM" src="https://github.com/user-attachments/assets/082f0dd8-4b9e-42ee-8f75-8e8e6c25a65d" />

