### PR TITLE
Add missing library for fedora/rhel/centos docs

### DIFF
--- a/BUILDING_LINUX.md
+++ b/BUILDING_LINUX.md
@@ -19,7 +19,7 @@ sudo pacman -S --needed dpkg fakeroot base-devel
 
 **Fedora/RHEL/CentOS:**
 ```bash
-sudo dnf install dpkg-dev fakeroot gcc gcc-c++ make
+sudo dnf install dpkg-dev fakeroot gcc gcc-c++ make libxcb-devel
 ```
 
 **openSUSE:**


### PR DESCRIPTION
## Pull Request Description

The libxcb-devel package is missing for building under fedora systems.

