### PR TITLE
feat(cli): add GOOSE_DEBUG environment variable support

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -395,11 +395,13 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
             }
         });
 
+    let debug_mode = session_config.debug || config.get_param("GOOSE_DEBUG").unwrap_or(false);
+
     // Create new session
     let mut session = CliSession::new(
         Arc::try_unwrap(agent_ptr).unwrap_or_else(|_| panic!("There should be no more references")),
         session_id.clone(),
-        session_config.debug,
+        debug_mode,
         session_config.scheduled_job_id.clone(),
         session_config.max_turns,
         edit_mode,


### PR DESCRIPTION
Add support for GOOSE_DEBUG environment variable to enable debug mode without requiring the --debug CLI flag. Follows existing precedence pattern where CLI flags take priority over environment variables.

- CLI --debug flag overrides GOOSE_DEBUG env var
- GOOSE_DEBUG=true shows full tool parameters without truncation
- Defaults to false if neither CLI flag nor env var is set
- Uses same config.get_param() pattern as GOOSE_PROVIDER/GOOSE_MODEL

