### PR TITLE
chore: fix all warnings in test compilation

### DIFF
--- a/crates/goose-server/src/routes/audio.rs
+++ b/crates/goose-server/src/routes/audio.rs
@@ -391,7 +391,6 @@ pub fn routes(state: Arc<AppState>) -> Router {
 mod tests {
     use super::*;
     use axum::{body::Body, http::Request};
-    use serde_json::json;
     use tower::ServiceExt;
 
     #[tokio::test(flavor = "multi_thread")]
@@ -424,7 +423,6 @@ mod tests {
         let state = AppState::new().await.unwrap();
         let app = routes(state);
 
-        let large_data = "a".repeat(30 * 1024 * 1024); // 30MB
         let request = Request::builder()
             .uri("/audio/transcribe")
             .method("POST")

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -557,58 +557,15 @@ pub fn routes(state: Arc<AppState>) -> Router {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use goose::conversation::message::Message;
-    use goose::{
-        model::ModelConfig,
-        providers::{
-            base::{Provider, ProviderUsage, Usage},
-            errors::ProviderError,
-        },
-    };
-
-    #[derive(Clone)]
-    struct MockProvider {
-        model_config: ModelConfig,
-    }
-
-    #[async_trait::async_trait]
-    impl Provider for MockProvider {
-        fn metadata() -> goose::providers::base::ProviderMetadata {
-            goose::providers::base::ProviderMetadata::empty()
-        }
-
-        async fn complete_with_model(
-            &self,
-            _model_config: &ModelConfig,
-            _system: &str,
-            _messages: &[Message],
-            _tools: &[rmcp::model::Tool],
-        ) -> anyhow::Result<(Message, ProviderUsage), ProviderError> {
-            Ok((
-                Message::assistant().with_text("Mock response"),
-                ProviderUsage::new("mock".to_string(), Usage::default()),
-            ))
-        }
-
-        fn get_model_config(&self) -> ModelConfig {
-            self.model_config.clone()
-        }
-    }
 
     mod integration_tests {
         use super::*;
         use axum::{body::Body, http::Request};
         use goose::conversation::message::Message;
-        use serde_json::json;
         use tower::ServiceExt;
 
         #[tokio::test(flavor = "multi_thread")]
         async fn test_reply_endpoint() {
-            let mock_model_config = ModelConfig::new("test-model").unwrap();
-            let mock_provider = MockProvider {
-                model_config: mock_model_config,
-            };
-
             let state = AppState::new().await.unwrap();
 
             let app = routes(state);

--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -30,11 +30,6 @@ use crate::model::ModelConfig;
 use anyhow::Result;
 use once_cell::sync::Lazy;
 
-#[cfg(test)]
-use super::errors::ProviderError;
-#[cfg(test)]
-use rmcp::model::Tool;
-
 const DEFAULT_LEAD_TURNS: usize = 3;
 const DEFAULT_FAILURE_THRESHOLD: usize = 2;
 const DEFAULT_FALLBACK_TURNS: usize = 2;
@@ -174,62 +169,7 @@ fn create_worker_model_config(default_model: &ModelConfig) -> Result<ModelConfig
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::conversation::message::{Message, MessageContent};
-    use crate::providers::base::{ProviderMetadata, ProviderUsage, Usage};
-    use chrono::Utc;
-    use rmcp::model::{AnnotateAble, RawTextContent, Role};
     use std::env;
-
-    #[derive(Clone)]
-    struct MockTestProvider {
-        name: String,
-        model_config: ModelConfig,
-    }
-
-    #[async_trait::async_trait]
-    impl Provider for MockTestProvider {
-        fn metadata() -> ProviderMetadata {
-            ProviderMetadata::new(
-                "mock_test",
-                "Mock Test Provider",
-                "A mock provider for testing",
-                "mock-model",
-                vec!["mock-model"],
-                "",
-                vec![],
-            )
-        }
-
-        fn get_model_config(&self) -> ModelConfig {
-            self.model_config.clone()
-        }
-
-        async fn complete_with_model(
-            &self,
-            _model_config: &ModelConfig,
-            _system: &str,
-            _messages: &[Message],
-            _tools: &[Tool],
-        ) -> Result<(Message, ProviderUsage), ProviderError> {
-            Ok((
-                Message::new(
-                    Role::Assistant,
-                    Utc::now().timestamp(),
-                    vec![MessageContent::Text(
-                        RawTextContent {
-                            text: format!(
-                                "Response from {} with model {}",
-                                self.name, self.model_config.model_name
-                            ),
-                            meta: None,
-                        }
-                        .no_annotation(),
-                    )],
-                ),
-                ProviderUsage::new(self.model_config.model_name.clone(), Usage::default()),
-            ))
-        }
-    }
 
     struct EnvVarGuard {
         vars: Vec<(String, Option<String>)>,

--- a/crates/goose/src/tool_inspection.rs
+++ b/crates/goose/src/tool_inspection.rs
@@ -274,30 +274,6 @@ mod tests {
     use mcp_core::ToolCall;
     use serde_json::json;
 
-    struct MockInspector {
-        name: &'static str,
-        results: Vec<InspectionResult>,
-    }
-
-    #[async_trait]
-    impl ToolInspector for MockInspector {
-        fn name(&self) -> &'static str {
-            self.name
-        }
-
-        fn as_any(&self) -> &dyn std::any::Any {
-            self
-        }
-
-        async fn inspect(
-            &self,
-            _tool_requests: &[ToolRequest],
-            _messages: &[Message],
-        ) -> Result<Vec<InspectionResult>> {
-            Ok(self.results.clone())
-        }
-    }
-
     #[test]
     fn test_apply_inspection_results() {
         let tool_request = ToolRequest {

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -235,6 +235,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_agent_with_anthropic() -> Result<()> {
+        run_test_with_config(TestConfig {
+            provider_type: ProviderType::Anthropic,
+            model: "claude-sonnet-4",
+            context_window: 200_000,
+        })
+        .await
+    }
+
+    #[tokio::test]
     async fn test_agent_with_azure() -> Result<()> {
         run_test_with_config(TestConfig {
             provider_type: ProviderType::Azure,
@@ -540,9 +550,7 @@ mod schedule_tool_tests {
 mod final_output_tool_tests {
     use super::*;
     use futures::stream;
-    use goose::agents::final_output_tool::{
-        FINAL_OUTPUT_CONTINUATION_MESSAGE, FINAL_OUTPUT_TOOL_NAME,
-    };
+    use goose::agents::final_output_tool::FINAL_OUTPUT_TOOL_NAME;
     use goose::conversation::Conversation;
     use goose::providers::base::MessageStream;
     use goose::recipe::Response;


### PR DESCRIPTION
Removing unused code, and adding test cases where there was unused code that should have been used