### PR TITLE
Add MOIM (Minus One Info Message) for automatic context injection (TODO list and current time)

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -62,9 +62,7 @@ use super::model_selector::autopilot::AutoPilot;
 use super::platform_tools;
 use super::tool_execution::{ToolCallResult, CHAT_MODE_TOOL_SKIPPED_RESPONSE, DECLINED_RESPONSE};
 use crate::agents::subagent_task_config::TaskConfig;
-use crate::agents::todo_tools::{
-    todo_read_tool, todo_write_tool, TODO_READ_TOOL_NAME, TODO_WRITE_TOOL_NAME,
-};
+use crate::agents::todo_tools::{todo_write_tool, TODO_WRITE_TOOL_NAME};
 use crate::conversation::message::{Message, ToolRequest};
 
 const DEFAULT_MAX_TURNS: u32 = 1000;
@@ -504,27 +502,6 @@ impl Agent {
                 "Frontend tool execution required".to_string(),
                 None,
             )))
-        } else if tool_call.name == TODO_READ_TOOL_NAME {
-            // Handle task planner read tool
-            let session_file_path = if let Some(session_config) = session {
-                session::storage::get_path(session_config.id.clone()).ok()
-            } else {
-                None
-            };
-
-            let todo_content = if let Some(path) = session_file_path {
-                session::storage::read_metadata(&path)
-                    .ok()
-                    .and_then(|m| {
-                        session::TodoState::from_extension_data(&m.extension_data)
-                            .map(|state| state.content)
-                    })
-                    .unwrap_or_default()
-            } else {
-                String::new()
-            };
-
-            ToolCallResult::from(Ok(vec![Content::text(todo_content)]))
         } else if tool_call.name == TODO_WRITE_TOOL_NAME {
             // Handle task planner write tool
             let content = tool_call
@@ -825,8 +802,8 @@ impl Agent {
                 platform_tools::manage_schedule_tool(),
             ]);
 
-            // Add task planner tools
-            prefixed_tools.extend([todo_read_tool(), todo_write_tool()]);
+            // Add task planner tool (write only, read happens via MOIM)
+            prefixed_tools.push(todo_write_tool());
 
             // Dynamic task tool
             prefixed_tools.push(create_dynamic_task_tool());
@@ -1118,6 +1095,7 @@ impl Agent {
                     messages.messages(),
                     &tools,
                     &toolshim_tools,
+                    &session,
                 ).await?;
 
                 let mut added_message = false;
@@ -1767,13 +1745,11 @@ mod tests {
     async fn test_todo_tools_integration() -> Result<()> {
         let agent = Agent::new();
 
-        // Test that task planner tools are listed
+        // Test that task planner tool is listed (write only, read happens via MOIM)
         let tools = agent.list_tools(None).await;
 
-        let todo_read = tools.iter().find(|tool| tool.name == TODO_READ_TOOL_NAME);
         let todo_write = tools.iter().find(|tool| tool.name == TODO_WRITE_TOOL_NAME);
 
-        assert!(todo_read.is_some(), "TODO read tool should be present");
         assert!(todo_write.is_some(), "TODO write tool should be present");
         Ok(())
     }

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -6,6 +6,7 @@ pub mod extension_manager;
 pub mod final_output_tool;
 mod large_response_handler;
 pub mod model_selector;
+mod moim;
 pub mod platform_tools;
 pub mod prompt_manager;
 pub mod recipe_tools;

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -6,7 +6,7 @@ pub mod extension_manager;
 pub mod final_output_tool;
 mod large_response_handler;
 pub mod model_selector;
-mod moim;
+pub mod moim;
 pub mod platform_tools;
 pub mod prompt_manager;
 pub mod recipe_tools;

--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -1,0 +1,160 @@
+use crate::agents::types::SessionConfig;
+use crate::conversation::message::Message;
+use crate::conversation::Conversation;
+use crate::session::extension_data::ExtensionState;
+use crate::session::{self, TodoState};
+use chrono::Local;
+
+async fn build_moim_content(session: &Option<SessionConfig>) -> Option<String> {
+    let timestamp = Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
+    let mut content = format!("Current date and time: {}\n", timestamp);
+
+    if let Some(todo_content) = get_todo_context(session).await {
+        content.push_str("\nCurrent tasks and notes:\n");
+        content.push_str(&todo_content);
+        content.push('\n');
+    }
+
+    Some(content)
+}
+
+pub async fn inject_moim_if_enabled(
+    messages_for_provider: Conversation,
+    session: &Option<SessionConfig>,
+) -> Conversation {
+    // Check if MOIM is enabled
+    let moim_enabled = crate::config::Config::global()
+        .get_param::<bool>("goose_moim_enabled")
+        .unwrap_or(true);
+
+    if !moim_enabled {
+        return messages_for_provider;
+    }
+
+    if let Some(moim_content) = build_moim_content(session).await {
+        let mut msgs = messages_for_provider.messages().to_vec();
+
+        if !msgs.is_empty() {
+            let moim_msg = Message::user().with_text(moim_content);
+
+            // Insert at position -1 (before last message)
+            // This ensures MOIM appears just before the latest user query
+            let insert_pos = msgs.len().saturating_sub(1);
+            msgs.insert(insert_pos, moim_msg);
+        }
+
+        Conversation::new_unvalidated(msgs)
+    } else {
+        messages_for_provider
+    }
+}
+
+async fn get_todo_context(session: &Option<SessionConfig>) -> Option<String> {
+    let session_config = session.as_ref()?;
+
+    match session::storage::get_path(session_config.id.clone()) {
+        Ok(path) => match session::storage::read_metadata(&path) {
+            Ok(metadata) => TodoState::from_extension_data(&metadata.extension_data)
+                .map(|state| state.content)
+                .filter(|content| !content.trim().is_empty()),
+            Err(e) => {
+                tracing::debug!("Could not read session metadata for MOIM: {}", e);
+                None
+            }
+        },
+        Err(e) => {
+            tracing::debug!("Could not get session path for MOIM: {}", e);
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::conversation::message::Message;
+    use crate::conversation::Conversation;
+
+    #[tokio::test]
+    async fn test_inject_moim_preserves_messages() {
+        // Create a conversation with multiple messages
+        let messages = vec![
+            Message::user().with_text("First message"),
+            Message::assistant().with_text("First response"),
+            Message::user().with_text("Second message"),
+        ];
+        let conversation = Conversation::new_unvalidated(messages.clone());
+
+        // Inject MOIM (with no session, so only timestamp)
+        let result = inject_moim_if_enabled(conversation, &None).await;
+
+        // Should have one more message (the MOIM)
+        assert_eq!(result.len(), messages.len() + 1);
+
+        // Original messages should still be present
+        assert_eq!(result.messages()[0].as_concat_text(), "First message");
+        assert_eq!(result.messages()[1].as_concat_text(), "First response");
+
+        // MOIM should be at position -1 (before last user message)
+        let moim_msg = &result.messages()[2];
+        assert!(moim_msg.as_concat_text().contains("Current date and time:"));
+
+        // Last message should be the original last message
+        assert_eq!(result.messages()[3].as_concat_text(), "Second message");
+    }
+
+    #[tokio::test]
+    async fn test_inject_moim_empty_conversation() {
+        // Empty conversation
+        let conversation = Conversation::empty();
+
+        // Inject MOIM
+        let result = inject_moim_if_enabled(conversation, &None).await;
+
+        // Should still be empty (no place to inject)
+        assert_eq!(result.len(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_inject_moim_single_message() {
+        // Single message conversation
+        let messages = vec![Message::user().with_text("Only message")];
+        let conversation = Conversation::new_unvalidated(messages.clone());
+
+        // Inject MOIM
+        let result = inject_moim_if_enabled(conversation, &None).await;
+
+        // Should have MOIM before the single message
+        assert_eq!(result.len(), 2);
+
+        // MOIM should be first
+        let moim_msg = &result.messages()[0];
+        assert!(moim_msg.as_concat_text().contains("Current date and time:"));
+
+        // Original message should be last
+        assert_eq!(result.messages()[1].as_concat_text(), "Only message");
+    }
+
+    #[tokio::test]
+    async fn test_moim_disabled_no_injection() {
+        // Temporarily set MOIM to disabled
+        std::env::set_var("GOOSE_MOIM_ENABLED", "false");
+
+        let messages = vec![
+            Message::user().with_text("Test message"),
+            Message::assistant().with_text("Test response"),
+        ];
+        let conversation = Conversation::new_unvalidated(messages.clone());
+
+        // Try to inject MOIM
+        let result = inject_moim_if_enabled(conversation, &None).await;
+
+        // Should be unchanged
+        assert_eq!(result.len(), messages.len());
+        assert_eq!(result.messages()[0].as_concat_text(), "Test message");
+        assert_eq!(result.messages()[1].as_concat_text(), "Test response");
+
+        // Clean up
+        std::env::remove_var("GOOSE_MOIM_ENABLED");
+    }
+}

--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -33,10 +33,12 @@ pub async fn inject_moim_if_enabled(
 
     if let Some(moim_content) = build_moim_content(session).await {
         let mut msgs = messages_for_provider.messages().to_vec();
+        let moim_msg = Message::user().with_text(moim_content);
 
-        if !msgs.is_empty() {
-            let moim_msg = Message::user().with_text(moim_content);
-
+        if msgs.is_empty() {
+            // If conversation is empty, just add the MOIM
+            msgs.push(moim_msg);
+        } else {
             // Insert at position -1 (before last message)
             // This ensures MOIM appears just before the latest user query
             let insert_pos = msgs.len().saturating_sub(1);
@@ -66,95 +68,5 @@ async fn get_todo_context(session: &Option<SessionConfig>) -> Option<String> {
             tracing::debug!("Could not get session path for MOIM: {}", e);
             None
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::conversation::message::Message;
-    use crate::conversation::Conversation;
-
-    #[tokio::test]
-    async fn test_inject_moim_preserves_messages() {
-        // Create a conversation with multiple messages
-        let messages = vec![
-            Message::user().with_text("First message"),
-            Message::assistant().with_text("First response"),
-            Message::user().with_text("Second message"),
-        ];
-        let conversation = Conversation::new_unvalidated(messages.clone());
-
-        // Inject MOIM (with no session, so only timestamp)
-        let result = inject_moim_if_enabled(conversation, &None).await;
-
-        // Should have one more message (the MOIM)
-        assert_eq!(result.len(), messages.len() + 1);
-
-        // Original messages should still be present
-        assert_eq!(result.messages()[0].as_concat_text(), "First message");
-        assert_eq!(result.messages()[1].as_concat_text(), "First response");
-
-        // MOIM should be at position -1 (before last user message)
-        let moim_msg = &result.messages()[2];
-        assert!(moim_msg.as_concat_text().contains("Current date and time:"));
-
-        // Last message should be the original last message
-        assert_eq!(result.messages()[3].as_concat_text(), "Second message");
-    }
-
-    #[tokio::test]
-    async fn test_inject_moim_empty_conversation() {
-        // Empty conversation
-        let conversation = Conversation::empty();
-
-        // Inject MOIM
-        let result = inject_moim_if_enabled(conversation, &None).await;
-
-        // Should still be empty (no place to inject)
-        assert_eq!(result.len(), 0);
-    }
-
-    #[tokio::test]
-    async fn test_inject_moim_single_message() {
-        // Single message conversation
-        let messages = vec![Message::user().with_text("Only message")];
-        let conversation = Conversation::new_unvalidated(messages.clone());
-
-        // Inject MOIM
-        let result = inject_moim_if_enabled(conversation, &None).await;
-
-        // Should have MOIM before the single message
-        assert_eq!(result.len(), 2);
-
-        // MOIM should be first
-        let moim_msg = &result.messages()[0];
-        assert!(moim_msg.as_concat_text().contains("Current date and time:"));
-
-        // Original message should be last
-        assert_eq!(result.messages()[1].as_concat_text(), "Only message");
-    }
-
-    #[tokio::test]
-    async fn test_moim_disabled_no_injection() {
-        // Temporarily set MOIM to disabled
-        std::env::set_var("GOOSE_MOIM_ENABLED", "false");
-
-        let messages = vec![
-            Message::user().with_text("Test message"),
-            Message::assistant().with_text("Test response"),
-        ];
-        let conversation = Conversation::new_unvalidated(messages.clone());
-
-        // Try to inject MOIM
-        let result = inject_moim_if_enabled(conversation, &None).await;
-
-        // Should be unchanged
-        assert_eq!(result.len(), messages.len());
-        assert_eq!(result.messages()[0].as_concat_text(), "Test message");
-        assert_eq!(result.messages()[1].as_concat_text(), "Test response");
-
-        // Clean up
-        std::env::remove_var("GOOSE_MOIM_ENABLED");
     }
 }

--- a/crates/goose/src/agents/prompt_manager.rs
+++ b/crates/goose/src/agents/prompt_manager.rs
@@ -1,4 +1,3 @@
-use chrono::Utc;
 use serde_json::Value;
 use std::collections::HashMap;
 
@@ -10,7 +9,6 @@ use crate::{config::Config, prompt_template, utils::sanitize_unicode_tags};
 pub struct PromptManager {
     system_prompt_override: Option<String>,
     system_prompt_extras: Vec<String>,
-    current_date_timestamp: String,
 }
 
 impl Default for PromptManager {
@@ -24,8 +22,6 @@ impl PromptManager {
         PromptManager {
             system_prompt_override: None,
             system_prompt_extras: Vec::new(),
-            // Use the fixed current date time so that prompt cache can be used.
-            current_date_timestamp: Utc::now().format("%Y-%m-%d %H:%M:%S").to_string(),
         }
     }
 
@@ -101,11 +97,6 @@ impl PromptManager {
                 Value::String(llm_search_tool_prompt()),
             );
         }
-
-        context.insert(
-            "current_date_time",
-            Value::String(self.current_date_timestamp.clone()),
-        );
 
         // Add the suggestion about disabling extensions if flag is true
         context.insert(

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -146,7 +146,8 @@ impl Agent {
         };
 
         // Inject MOIM (timestamp + TODO content) if enabled
-        let messages_for_provider = super::moim::inject_moim_if_enabled(messages_for_provider, session).await;
+        let messages_for_provider =
+            super::moim::inject_moim_if_enabled(messages_for_provider, session).await;
 
         // Clone owned data to move into the async stream
         let system_prompt = system_prompt.to_owned();

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -134,6 +134,7 @@ impl Agent {
         messages: &[Message],
         tools: &[Tool],
         toolshim_tools: &[Tool],
+        session: &Option<crate::agents::types::SessionConfig>,
     ) -> Result<MessageStream, ProviderError> {
         let config = provider.get_model_config();
 
@@ -143,6 +144,9 @@ impl Agent {
         } else {
             Conversation::new_unvalidated(messages.to_vec())
         };
+
+        // Inject MOIM (timestamp + TODO content) if enabled
+        let messages_for_provider = super::moim::inject_moim_if_enabled(messages_for_provider, session).await;
 
         // Clone owned data to move into the async stream
         let system_prompt = system_prompt.to_owned();

--- a/crates/goose/src/agents/todo_tools.rs
+++ b/crates/goose/src/agents/todo_tools.rs
@@ -2,45 +2,8 @@ use indoc::indoc;
 use rmcp::model::{Tool, ToolAnnotations};
 use rmcp::object;
 
-/// Tool name constant for reading task planner content
-pub const TODO_READ_TOOL_NAME: &str = "todo__read";
-
 /// Tool name constant for writing task planner content
 pub const TODO_WRITE_TOOL_NAME: &str = "todo__write";
-
-/// Creates a tool for reading task planner content.
-///
-/// This tool reads the entire task planner file content as a string.
-/// It is marked as read-only and safe to use repeatedly.
-///
-/// # Returns
-/// A configured `Tool` instance for reading task planner content
-pub fn todo_read_tool() -> Tool {
-    Tool::new(
-        TODO_READ_TOOL_NAME.to_string(),
-        indoc! {r#"
-            Read the entire TODO file content.
-
-            This tool reads the complete TODO file and returns its content as a string.
-            Use this to view current tasks, notes, and any other information stored in the TODO file.
-
-            The tool will return an error if the TODO file doesn't exist or cannot be read.
-        "#}
-        .to_string(),
-        object!({
-            "type": "object",
-            "required": [],
-            "properties": {}
-        }),
-    )
-    .annotate(ToolAnnotations {
-        title: Some("Read TODO content".to_string()),
-        read_only_hint: Some(true),
-        destructive_hint: Some(false),
-        idempotent_hint: Some(true),
-        open_world_hint: Some(false),
-    })
-}
 
 /// Creates a tool for writing task planner content.
 ///
@@ -53,16 +16,9 @@ pub fn todo_write_tool() -> Tool {
     Tool::new(
         TODO_WRITE_TOOL_NAME.to_string(),
         indoc! {r#"
-            Write or overwrite the entire TODO file content.
-
-            This tool replaces the complete TODO file content with the provided string.
-            Use this to update tasks, add new items, or reorganize the TODO file.
-
-            WARNING: This operation completely replaces the file content. Make sure to include
-            all content you want to keep, not just the changes.
-
-            The tool will create the TODO file if it doesn't exist, or overwrite it if it does.
-            Returns an error if the file cannot be written due to permissions or other I/O issues.
+            Update your task list, notes, or any information you want to track.
+            This content will be automatically available in your context for future turns.
+            This tool overwrites the entire existing todo list.
         "#}
         .to_string(),
         object!({
@@ -88,32 +44,6 @@ pub fn todo_write_tool() -> Tool {
 #[cfg(test)]
 mod unit_tests {
     use super::*;
-
-    #[test]
-    fn test_todo_read_tool_creation() {
-        let tool = todo_read_tool();
-
-        // Verify tool name
-        assert_eq!(tool.name, TODO_READ_TOOL_NAME);
-
-        // Verify description exists and is not empty
-        assert!(tool.description.is_some());
-        let description = tool.description.as_ref().unwrap();
-        assert!(!description.is_empty());
-
-        // Verify input schema
-        let schema = &tool.input_schema;
-        assert_eq!(schema["type"], "object");
-        assert_eq!(schema["required"].as_array().unwrap().len(), 0);
-
-        // Verify annotations
-        let annotations = tool.annotations.as_ref().unwrap();
-        assert_eq!(annotations.title, Some("Read TODO content".to_string()));
-        assert_eq!(annotations.read_only_hint, Some(true));
-        assert_eq!(annotations.destructive_hint, Some(false));
-        assert_eq!(annotations.idempotent_hint, Some(true));
-        assert_eq!(annotations.open_world_hint, Some(false));
-    }
 
     #[test]
     fn test_todo_write_tool_creation() {
@@ -151,10 +81,8 @@ mod unit_tests {
 
     #[test]
     fn test_tool_name_constants() {
-        // Verify the constants follow the naming pattern
-        assert!(TODO_READ_TOOL_NAME.starts_with("todo__"));
+        // Verify the constant follows the naming pattern
         assert!(TODO_WRITE_TOOL_NAME.starts_with("todo__"));
-        assert_eq!(TODO_READ_TOOL_NAME, "todo__read");
         assert_eq!(TODO_WRITE_TOOL_NAME, "todo__write");
     }
 }

--- a/crates/goose/src/prompts/subagent_system.md
+++ b/crates/goose/src/prompts/subagent_system.md
@@ -1,4 +1,4 @@
-You are a specialized subagent within the Goose AI framework, created by Block. You were spawned by the main Goose agent to handle a specific task efficiently. The current date is {{current_date_time}}.
+You are a specialized subagent within the Goose AI framework, created by Block. You were spawned by the main Goose agent to handle a specific task efficiently.
 
 # Your Role
 You are an autonomous subagent with these characteristics:

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -39,7 +39,7 @@ No extensions are defined. You should let the user know that they should add ext
 # Task Management
 
 - Use `todo__write` for tasks with 2+ steps, multiple files/components, or uncertain scope
-- Your written TODO content is automatically available in your context
+- TODO content you've written is automatically available in your context
 - Workflow — Start: write checklist | During: update progress | End: verify all complete
 - Warning — `todo__write` overwrites entirely; include all content you want to keep
 - Keep items short, specific, action-oriented

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -1,7 +1,5 @@
 You are a general-purpose AI agent called Goose, created by Block, the parent company of Square, CashApp, and Tidal. Goose is being developed as an open-source software project.
 
-The current date is {{current_date_time}}.
-
 Goose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o, claude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).
 These models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10 months prior to the current date.
 
@@ -40,11 +38,12 @@ No extensions are defined. You should let the user know that they should add ext
 
 # Task Management
 
-- Use `todo__read` and `todo__write` for tasks with 2+ steps, multiple files/components, or uncertain scope
-- Workflow — Start: read → write checklist | During: read → update progress | End: verify all complete
-- Warning — `todo__write` overwrites entirely; always `todo__read` first (skipping is an error)
+- Use `todo__write` for tasks with 2+ steps, multiple files/components, or uncertain scope
+- Your written TODO content is automatically available in your context
+- Workflow — Start: write checklist | During: update progress | End: verify all complete
+- Warning — `todo__write` overwrites entirely; include all content you want to keep
 - Keep items short, specific, action-oriented
-- Not using the todo tools for complex tasks is an error
+- Not using the todo tool for complex tasks is an error
 
 Template:
 ```markdown

--- a/crates/goose/src/prompts/system_gpt_4.1.md
+++ b/crates/goose/src/prompts/system_gpt_4.1.md
@@ -1,6 +1,6 @@
 You are a general-purpose AI agent called Goose, created by Block, the parent company of Square, CashApp, and Tidal. Goose is being developed as an open-source software project.
 
-IMPORTANT INSTRUCTIONS: 
+IMPORTANT INSTRUCTIONS:
 
 Please keep going until the user's query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved.
 
@@ -11,15 +11,11 @@ CRITICAL: The str_replace command in the text_editor tool (when available) shoul
 The user may direct or imply that you are to take actions, in this case, it is important to note the following guidelines:
 
 * If you are directed to complete a task, you should see it through.
-* Your thinking should be thorough and so it's fine if it's very long. You can think step by step before and after each action you decide to take. 
+* Your thinking should be thorough and so it's fine if it's very long. You can think step by step before and after each action you decide to take.
 * Only terminate your turn when you are sure that the problem is solved. Go through the problem step by step, and make sure to verify that your changes are correct. NEVER end your turn without having solved the problem, and when you say you are going to make a tool call, make sure you ACTUALLY make the tool call, instead of ending your turn.
 * You MUST plan extensively before each function call, and reflect extensively on the outcomes of the previous function calls. DO NOT do this entire process by making function calls only, as this can impair your ability to solve the problem and think insightfully.
 * Take your time and think through every step - remember to check your solution rigorously and watch out for boundary cases, especially with the changes you made. Your solution must be perfect. If not, continue working on it. When you are validating solutions with tools, it is important to iterate until you get success
 * Do not stop and ask the user for confirmation for actions you should be taking to achieve the outcomes directed and with tools available.
-
-
-
-The current date is {{current_date_time}}.
 
 Goose uses LLM providers with tool calling capability.
 Your model may have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10 months prior to the current date.

--- a/crates/goose/tests/moim_tests.rs
+++ b/crates/goose/tests/moim_tests.rs
@@ -1,0 +1,109 @@
+use goose::agents::moim;
+use goose::conversation::message::Message;
+use goose::conversation::Conversation;
+
+#[tokio::test]
+async fn test_inject_moim_preserves_messages() {
+    // Create a conversation with multiple messages
+    let messages = vec![
+        Message::user().with_text("First message"),
+        Message::assistant().with_text("First response"),
+        Message::user().with_text("Second message"),
+    ];
+    let conversation = Conversation::new_unvalidated(messages.clone());
+
+    // Inject MOIM (with no session, so only timestamp)
+    let result = moim::inject_moim_if_enabled(conversation, &None).await;
+
+    // Should have one more message (the MOIM with timestamp)
+    assert_eq!(result.len(), messages.len() + 1);
+
+    // Original messages should still be present
+    assert_eq!(result.messages()[0].as_concat_text(), "First message");
+    assert_eq!(result.messages()[1].as_concat_text(), "First response");
+
+    // MOIM should be at position -1 (before last user message)
+    let moim_msg = &result.messages()[2];
+    assert!(moim_msg.as_concat_text().contains("Current date and time:"));
+
+    // Last message should be the original last message
+    assert_eq!(result.messages()[3].as_concat_text(), "Second message");
+}
+
+#[tokio::test]
+async fn test_inject_moim_empty_conversation() {
+    // Empty conversation
+    let conversation = Conversation::empty();
+
+    // Inject MOIM
+    let result = moim::inject_moim_if_enabled(conversation, &None).await;
+
+    // Should have one message now (the MOIM with timestamp)
+    assert_eq!(result.len(), 1);
+
+    // Should contain timestamp
+    assert!(result.messages()[0]
+        .as_concat_text()
+        .contains("Current date and time:"));
+}
+
+#[tokio::test]
+async fn test_inject_moim_single_message() {
+    // Single message conversation
+    let messages = vec![Message::user().with_text("Only message")];
+    let conversation = Conversation::new_unvalidated(messages.clone());
+
+    // Inject MOIM
+    let result = moim::inject_moim_if_enabled(conversation, &None).await;
+
+    // Should have MOIM before the single message
+    assert_eq!(result.len(), 2);
+
+    // MOIM should be first
+    let moim_msg = &result.messages()[0];
+    assert!(moim_msg.as_concat_text().contains("Current date and time:"));
+
+    // Original message should be last
+    assert_eq!(result.messages()[1].as_concat_text(), "Only message");
+}
+
+#[tokio::test]
+async fn test_moim_disabled_no_injection() {
+    // Temporarily set MOIM to disabled
+    // Note: Config uses uppercase for env vars
+    std::env::set_var("GOOSE_MOIM_ENABLED", "false");
+
+    let messages = vec![
+        Message::user().with_text("Test message"),
+        Message::assistant().with_text("Test response"),
+    ];
+    let conversation = Conversation::new_unvalidated(messages.clone());
+
+    // Try to inject MOIM
+    let result = moim::inject_moim_if_enabled(conversation, &None).await;
+
+    // Should be unchanged when disabled
+    assert_eq!(result.len(), messages.len());
+    assert_eq!(result.messages()[0].as_concat_text(), "Test message");
+    assert_eq!(result.messages()[1].as_concat_text(), "Test response");
+
+    // Clean up
+    std::env::remove_var("GOOSE_MOIM_ENABLED");
+}
+
+#[tokio::test]
+async fn test_moim_always_includes_timestamp() {
+    // Even without session or TODO content, MOIM should include timestamp
+    let messages = vec![Message::user().with_text("Test")];
+    let conversation = Conversation::new_unvalidated(messages);
+
+    let result = moim::inject_moim_if_enabled(conversation, &None).await;
+
+    // Should have MOIM with timestamp
+    assert_eq!(result.len(), 2);
+    let moim_content = result.messages()[0].as_concat_text();
+    assert!(moim_content.contains("Current date and time:"));
+    // Should have format like "2025-09-25 18:19:30"
+    assert!(moim_content.contains("202")); // Year
+    assert!(moim_content.contains(":")); // Time separator
+}

--- a/crates/goose/tests/moim_tests.rs
+++ b/crates/goose/tests/moim_tests.rs
@@ -1,6 +1,8 @@
 use goose::agents::moim;
 use goose::conversation::message::Message;
 use goose::conversation::Conversation;
+use mcp_core::ToolCall;
+use rmcp::model::Content;
 use serial_test::serial;
 
 #[tokio::test]
@@ -23,7 +25,7 @@ async fn test_inject_moim_preserves_messages() {
     assert_eq!(result.messages()[0].as_concat_text(), "First message");
     assert_eq!(result.messages()[1].as_concat_text(), "First response");
 
-    // MOIM should be at position -1 (before last user message)
+    // MOIM should be inserted at a safe position (before last user message)
     let moim_msg = &result.messages()[2];
     assert!(moim_msg.as_concat_text().contains("Current date and time:"));
 
@@ -37,6 +39,7 @@ async fn test_inject_moim_empty_conversation() {
 
     let result = moim::inject_moim_if_enabled(conversation, &None).await;
 
+    // Empty conversation gets MOIM added
     assert_eq!(result.len(), 1);
 
     // Should contain timestamp
@@ -88,4 +91,146 @@ async fn test_moim_disabled_no_injection() {
 
     // Clean up
     std::env::remove_var("GOOSE_MOIM_ENABLED");
+}
+
+#[tokio::test]
+async fn test_moim_respects_tool_pairs() {
+    // Create a conversation with tool call/response pairs
+    let tool_call = Ok(ToolCall::new(
+        "test_tool",
+        serde_json::json!({"param": "value"}),
+    ));
+    let tool_result = Ok(vec![Content::text("Tool executed successfully")]);
+
+    let messages = vec![
+        Message::user().with_text("Please use the tool"),
+        Message::assistant()
+            .with_text("I'll use the tool for you")
+            .with_tool_request("tool1", tool_call),
+        Message::user().with_tool_response("tool1", tool_result),
+        Message::assistant().with_text("The tool has been executed"),
+        Message::user().with_text("Thank you"),
+    ];
+
+    let conversation = Conversation::new_unvalidated(messages.clone());
+
+    let result = moim::inject_moim_if_enabled(conversation, &None).await;
+
+    // Should have one more message (the MOIM)
+    assert_eq!(result.len(), messages.len() + 1);
+
+    // Verify tool call and response are still adjacent
+    let msgs = result.messages();
+    for i in 0..msgs.len() - 1 {
+        if msgs[i].is_tool_call() {
+            // The next message should be the tool response (not MOIM)
+            assert!(
+                msgs[i + 1].is_tool_response()
+                    || !msgs[i + 1]
+                        .as_concat_text()
+                        .contains("Current date and time:"),
+                "MOIM should not be inserted between tool call and response"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_find_safe_insertion_point_empty() {
+    let messages = vec![];
+    assert_eq!(goose::agents::moim::find_safe_insertion_point(&messages), 0);
+}
+
+#[test]
+fn test_find_safe_insertion_point_single_message() {
+    let messages = vec![Message::user().with_text("Hello")];
+    // Single message, should insert before it
+    assert_eq!(goose::agents::moim::find_safe_insertion_point(&messages), 0);
+}
+
+#[test]
+fn test_find_safe_insertion_point_no_tools() {
+    let messages = vec![
+        Message::user().with_text("Hello"),
+        Message::assistant().with_text("Hi there"),
+        Message::user().with_text("How are you?"),
+    ];
+    // Should insert before the last message
+    assert_eq!(goose::agents::moim::find_safe_insertion_point(&messages), 2);
+}
+
+#[test]
+fn test_find_safe_insertion_point_with_tool_pair() {
+    let tool_call = Ok(ToolCall::new("test_tool", serde_json::json!({})));
+    let tool_result = Ok(vec![Content::text("Result")]);
+
+    let messages = vec![
+        Message::user().with_text("Do something"),
+        Message::assistant().with_tool_request("tool1", tool_call),
+        Message::user().with_tool_response("tool1", tool_result),
+        Message::assistant().with_text("Done"),
+        Message::user().with_text("Thanks"),
+    ];
+
+    // Should insert before "Thanks" (index 4), the last message
+    assert_eq!(goose::agents::moim::find_safe_insertion_point(&messages), 4);
+}
+
+#[test]
+fn test_find_safe_insertion_point_ending_with_tool_response() {
+    let tool_call = Ok(ToolCall::new("test_tool", serde_json::json!({})));
+    let tool_result = Ok(vec![Content::text("Result")]);
+
+    let messages = vec![
+        Message::user().with_text("Do something"),
+        Message::assistant().with_tool_request("tool1", tool_call),
+        Message::user().with_tool_response("tool1", tool_result),
+    ];
+
+    // Last message is a tool response that pairs with previous tool call
+    // Should insert before the tool call instead (index 1)
+    assert_eq!(goose::agents::moim::find_safe_insertion_point(&messages), 1);
+}
+
+#[test]
+fn test_find_safe_insertion_point_mixed_content() {
+    let messages = vec![
+        Message::user().with_text("Start"),
+        Message::assistant().with_text("OK"),
+        Message::user()
+            .with_text("Here's an image")
+            .with_image("data", "image/png"),
+        Message::assistant().with_text("I see the image"),
+        Message::user().with_text("What do you think?"),
+    ];
+
+    // Should insert before the last message regardless of content
+    assert_eq!(goose::agents::moim::find_safe_insertion_point(&messages), 4);
+}
+
+#[test]
+fn test_find_safe_insertion_point_no_text_only_user_messages() {
+    let tool_result = Ok(vec![Content::text("Result")]);
+    let messages = vec![
+        Message::assistant().with_text("Hello"),
+        Message::user().with_tool_response("tool1", tool_result),
+    ];
+
+    // Should insert before the tool response, but since previous is not a tool call,
+    // it's safe to insert at position 1
+    assert_eq!(goose::agents::moim::find_safe_insertion_point(&messages), 1);
+}
+
+#[test]
+fn test_find_safe_insertion_point_tool_response_only() {
+    let tool_result = Ok(vec![Content::text("Result")]);
+    let messages = vec![
+        Message::user().with_text("Start"),
+        Message::assistant().with_text("Let me help"),
+        Message::user().with_tool_response("tool1", tool_result),
+    ];
+
+    // Last message is a tool response but previous is not a tool call
+    // Safe to insert at position 2
+    assert_eq!(goose::agents::moim::find_safe_insertion_point(&messages), 2);
 }


### PR DESCRIPTION
Implements ephemeral context injection at the provider boundary to automatically include timestamp and TODO content in LLM context without modifying conversation history.

**Problem**

Previously, accessing TODO content required explicit `todo__read` tool calls, cluttering conversation history and consuming tokens. Timestamps were injected via template variables in system prompts, creating inconsistency across different prompt variants and preventing effective prompt caching.

**Solution**

MOIM (Minus One Info Message) injects a synthetic user message at approximately position -1 during provider calls. This message contains:
- Current timestamp (always)
- TODO content from session metadata (when available)

The injection happens in `reply_parts.rs` at the provider boundary, ensuring the message is never persisted to storage or returned in conversation history.

**Architecture Benefits**

- Zero changes to core data structures (`Message`, `Conversation`)
- No persistence layer modifications  
- Clean module boundaries
- No impact on existing sessions or conversation replay

**Testing**

Comprehensive test coverage in `crates/goose/tests/moim_tests.rs` with proper test isolation using `serial_test` for tests that modify environment variables.

**Migration**

- Removed `todo__read` tool (breaking change for recipes using it)
- Updated `todo__write` description to reflect automatic availability
- System prompts now receive timestamp via MOIM instead of template variables