### PR TITLE
fix: pricing integration test

### DIFF
--- a/crates/goose/tests/pricing_integration_test.rs
+++ b/crates/goose/tests/pricing_integration_test.rs
@@ -21,7 +21,7 @@ async fn test_pricing_cache_performance() {
         ("anthropic", "claude-sonnet-4"),
         ("openai", "gpt-4o"),
         ("openai", "gpt-4o-mini"),
-        ("google", "gemini-flash-1.5"),
+        ("google", "gemini-2.5-flash"),
         ("anthropic", "claude-opus-4"),
     ];
 


### PR DESCRIPTION
The real fix here is that we should not have a test that breaks when an external API changes. If we want to keep this text around we should mock the API