### PR TITLE
remove only-pr-labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -94,6 +94,3 @@ jobs:
           
           # Order to process PRs (oldest first is more fair)
           ascending: true
-          
-          # Only process PRs (not issues)
-          only-pr-labels: true


### PR DESCRIPTION
## Pull Request Description

When only-pr-labels is used, the stale action will only consider pull requests that contain all of the specified labels for its staleness checks.