### PR TITLE
fix: path is duplicated on tool calls causing them to fail (#4658)

### DIFF
--- a/crates/goose-mcp/src/developer/text_editor.rs
+++ b/crates/goose-mcp/src/developer/text_editor.rs
@@ -188,22 +188,16 @@ fn generate_summary(results: &DiffResults, is_single_file: bool, base_path: &Pat
     ]
 }
 
-/// Adjusts the base directory to handle overlapping paths between base_dir and file_path
 fn adjust_base_dir_for_overlap(base_dir: &Path, file_path: &Path) -> PathBuf {
-    // Find the overlapping path: longest suffix of base_dir that is prefix of file_path
     let base_components: Vec<_> = base_dir.components().collect();
     let file_components: Vec<_> = file_path.components().collect();
 
-    // Find the maximum k where base_components[(len-k)..] == file_components[0..k]
-    let mut max_k = 0;
-    for k in 1..=(base_components.len().min(file_components.len())) {
-        if &file_components[0..k] == &base_components[(base_components.len() - k)..] {
-            max_k = k;
-        }
-    }
+    let min_len = base_components.len().min(file_components.len());
+    let max_k = (1..=min_len)
+        .rfind(|&k| file_components[0..k] == base_components[base_components.len() - k..])
+        .unwrap_or(0);
 
     if max_k > 0 {
-        // Remove the last max_k components from base_dir
         let adjusted_components = base_components[..base_components.len() - max_k].to_vec();
         PathBuf::from_iter(adjusted_components)
     } else {


### PR DESCRIPTION
There is an issue opened 

https://github.com/block/goose/issues/4658
Path is duplicated on tool calls causing them to fail

What happens is when LLM calls text_editor in diff mode it passes
path: /a/b/c/base/src/file.go
in diff there is path: base/src/file.go

Inside mpatch they are merged and produce
path: /a/b/c/base/src/base/src/file.go

This path doesn't exist and tool fails.

Maybe it's an error from LLM side, that it calls tool incorrectly. But I tried several and it's a common issue. 

So I propose to remove overlapping part from base_dir before sending to mpatch. I tested fix in Linux and it works good.