### PR TITLE
docs: new multi-model section with autopilot topic

### DIFF
--- a/documentation/docs/experimental/index.md
+++ b/documentation/docs/experimental/index.md
@@ -9,11 +9,11 @@ import styles from '@site/src/components/Card/styles.module.css';
 
 <h1 className={styles.pageTitle}>Experimental</h1>
 <p className={styles.pageDescription}>
-  Goose is an open source project that is constantly being improved and expanded upon. These experimental features and projects are still in development and may not be fully stable or ready for production use, but they showcase exciting possibilities for the future of AI automation.
+  goose is an open source project that is constantly being improved and expanded upon. These experimental features and projects are still in development and may not be fully stable or ready for production use, but they showcase exciting possibilities for the future of AI automation.
 </p>
 
 :::note
-The list of experimental features may change as Goose development progresses. Some features may be promoted to stable features, while others might be modified or removed. This section will be updated with specific experimental features as they become available.
+The list of experimental features may change as goose development progresses. Some features may be promoted to stable features, while others might be modified or removed. This section will be updated with specific experimental features as they become available.
 :::
 
 <div className={styles.categorySection}>
@@ -30,14 +30,19 @@ The list of experimental features may change as Goose development progresses. So
       link="/docs/experimental/ollama"
     />
     <Card 
-      title="Goose Mobile"
+      title="goose Mobile"
       description="An experimental Android automation app that acts as an open agent running on your phone, providing maximal automation of everyday tasks."
       link="/docs/experimental/goose-mobile"
     />
     <Card 
       title="VS Code Extension"
-      description="An experimental extension enabling Goose to work within VS Code."
+      description="An experimental extension enabling goose to work within VS Code."
       link="/docs/experimental/vs-code-extension"
+    />
+    <Card 
+      title="Automatic Multi-Model Switching"
+      description="Intelligent, context-aware switching between models based on conversation content, complexity, and tool usage patterns."
+      link="/docs/guides/multi-model/autopilot"
     />
   </div>
 </div>
@@ -51,13 +56,13 @@ The list of experimental features may change as Goose development progresses. So
       link="/blog/2025/04/11/finetuning-toolshim"
     />
     <Card 
-      title="AI, But Make It Local With Goose and Ollama"
-      description="Learn how to integrate Goose with Ollama for a fully local AI experience, including structured outputs and tool calling capabilities."
+      title="AI, But Make It Local With goose and Ollama"
+      description="Learn how to integrate goose with Ollama for a fully local AI experience, including structured outputs and tool calling capabilities."
       link="/blog/2025/03/14/goose-ollama"
     />
     <Card 
-      title="Community-Inspired Benchmarking: The Goose Vibe Check"
-      description="See how open source AI models measure up in our first Goose agent benchmark tests, including toolshim performance analysis."
+      title="Community-Inspired Benchmarking: The goose Vibe Check"
+      description="See how open source AI models measure up in our first goose agent benchmark tests, including toolshim performance analysis."
       link="/blog/2025/03/31/goose-benchmark"
     />
   </div>

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -10,7 +10,7 @@ import { ModelSelectionTip } from '@site/src/components/ModelSelectionTip';
 
 # Supported LLM Providers
 
-Goose is compatible with a wide range of LLM providers, allowing you to choose and integrate your preferred model.
+goose is compatible with a wide range of LLM providers, allowing you to choose and integrate your preferred model.
 
 :::tip Model Selection
 <ModelSelectionTip/>
@@ -33,8 +33,8 @@ Goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [Groq](https://groq.com/)                                                   | High-performance inference hardware and tools for LLMs.                                                                                                                                                                   | `GROQ_API_KEY`                                                                                                                                                                      |
 | [LiteLLM](https://docs.litellm.ai/docs/) | LiteLLM proxy supporting multiple models with automatic prompt caching and unified API access. | `LITELLM_HOST`, `LITELLM_BASE_PATH` (optional), `LITELLM_API_KEY` (optional), `LITELLM_CUSTOM_HEADERS` (optional), `LITELLM_TIMEOUT` (optional) |
 | [Ollama](https://ollama.com/)                                               | Local model runner supporting Qwen, Llama, DeepSeek, and other open-source models. **Because this provider runs locally, you must first [download and run a model](#local-llms).**  | `OLLAMA_HOST`                                                                                                                                                                       |
-| [Ramalama](https://ramalama.ai/)                                            | Local model using native [OCI](https://opencontainers.org/) container runtimes, [CNCF](https://www.cncf.io/) tools, and supporting models as OCI artifacts. Ramalama API an compatible alternative to Ollama and can be used with the Goose Ollama provider. Supports Qwen, Llama, DeepSeek, and other open-source models. **Because this provider runs locally, you must first [download and run a model](#local-llms).**  | `OLLAMA_HOST`                                                                                                                                                                       |
-| [OpenAI](https://platform.openai.com/api-keys)                              | Provides gpt-4o, o1, and other advanced language models. Also supports OpenAI-compatible endpoints (e.g., self-hosted LLaMA, vLLM, KServe). **o1-mini and o1-preview are not supported because Goose uses tool calling.** | `OPENAI_API_KEY`, `OPENAI_HOST` (optional), `OPENAI_ORGANIZATION` (optional), `OPENAI_PROJECT` (optional), `OPENAI_CUSTOM_HEADERS` (optional)                                       |
+| [Ramalama](https://ramalama.ai/)                                            | Local model using native [OCI](https://opencontainers.org/) container runtimes, [CNCF](https://www.cncf.io/) tools, and supporting models as OCI artifacts. Ramalama API an compatible alternative to Ollama and can be used with the goose Ollama provider. Supports Qwen, Llama, DeepSeek, and other open-source models. **Because this provider runs locally, you must first [download and run a model](#local-llms).**  | `OLLAMA_HOST`                                                                                                                                                                       |
+| [OpenAI](https://platform.openai.com/api-keys)                              | Provides gpt-4o, o1, and other advanced language models. Also supports OpenAI-compatible endpoints (e.g., self-hosted LLaMA, vLLM, KServe). **o1-mini and o1-preview are not supported because goose uses tool calling.** | `OPENAI_API_KEY`, `OPENAI_HOST` (optional), `OPENAI_ORGANIZATION` (optional), `OPENAI_PROJECT` (optional), `OPENAI_CUSTOM_HEADERS` (optional)                                       |
 | [OpenRouter](https://openrouter.ai/)                                        | API gateway for unified access to various models with features like rate-limiting management.                                                                                                                             | `OPENROUTER_API_KEY`                                                                                                                                                                |
 | [Snowflake](https://docs.snowflake.com/user-guide/snowflake-cortex/aisql#choosing-a-model) | Access the latest models using Snowflake Cortex services, including Claude models. **Requires a Snowflake account and programmatic access token (PAT)**.                                                     | `SNOWFLAKE_HOST`, `SNOWFLAKE_TOKEN`                                                                                                                                                                 |
 | [Tetrate Agent Router Service](https://router.tetrate.ai)                   | Unified API gateway for AI models including Claude, Gemini, GPT, open-weight models, and others. Supports PKCE authentication flow for secure API key generation.                                                                                | `TETRATE_API_KEY`, `TETRATE_HOST` (optional)                                                                                                                                        |
@@ -43,7 +43,7 @@ Goose is compatible with a wide range of LLM providers, allowing you to choose a
 
 ## CLI Providers
 
-Goose also supports special "pass-through" providers that work with existing CLI tools, allowing you to use your subscriptions instead of paying per token:
+goose also supports special "pass-through" providers that work with existing CLI tools, allowing you to use your subscriptions instead of paying per token:
 
 | Provider                                                                    | Description                                                                                                                                                                                                               | Requirements                                                                                                                                                                          |
 |-----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -58,10 +58,10 @@ CLI providers are cost-effective alternatives that use your existing subscriptio
    
 ## Configure Provider
 
-To configure your chosen provider or see available options, visit the `Models` tab in the Goose Desktop or run `goose configure` in the CLI.
+To configure your chosen provider or see available options, visit the `Models` tab in the goose desktop or run `goose configure` in the CLI.
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose desktop" default>
   **To update your LLM provider and API key:** 
   1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
   2. Click the `Settings` button on the sidebar
@@ -89,7 +89,7 @@ To configure your chosen provider or see available options, visit the `Models` t
   3. Click the `Models` tab
   4. Click `Reset Provider and Model` to clear your current settings and return to the welcome screen
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     1. Run the following command: 
 
     ```sh
@@ -163,7 +163,7 @@ To configure your chosen provider or see available options, visit the `Models` t
 
 ## Using Custom OpenAI Endpoints
 
-Goose supports using custom OpenAI-compatible endpoints, which is particularly useful for:
+goose supports using custom OpenAI-compatible endpoints, which is particularly useful for:
 - Self-hosted LLMs (e.g., LLaMA, Mistral) using vLLM or KServe
 - Private OpenAI-compatible API servers
 - Enterprise deployments requiring data governance and security compliance
@@ -220,7 +220,7 @@ Goose supports using custom OpenAI-compatible endpoints, which is particularly u
 ### Setup Instructions
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose desktop" default>
     1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
     2. Click the `Settings` button on the sidebar
     3. Click the `Models` tab
@@ -233,7 +233,7 @@ Goose supports using custom OpenAI-compatible endpoints, which is particularly u
        - Project (for resource management)
     7. Click `Submit`
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     1. Run `goose configure`
     2. Select `Configure Providers`
     3. Choose `OpenAI` as the provider
@@ -249,19 +249,19 @@ Goose supports using custom OpenAI-compatible endpoints, which is particularly u
 For enterprise deployments, you can pre-configure these values using environment variables or configuration files to ensure consistent governance across your organization.
 :::
 
-## Using Goose for Free
+## Using goose for Free
 
-Goose is a free and open source AI agent that you can start using right away, but not all supported [LLM Providers][providers] provide a free tier. 
+goose is a free and open source AI agent that you can start using right away, but not all supported [LLM Providers][providers] provide a free tier. 
 
 Below, we outline a couple of free options and how to get started with them.
 
 :::warning Limitations
-These free options are a great way to get started with Goose and explore its capabilities. However, you may need to upgrade your LLM for better performance.
+These free options are a great way to get started with goose and explore its capabilities. However, you may need to upgrade your LLM for better performance.
 :::
 
 
 ### Groq
-Groq provides free access to open source models with high-speed inference. To use Groq with Goose, you need an API key from [Groq Console](https://console.groq.com/keys).
+Groq provides free access to open source models with high-speed inference. To use Groq with goose, you need an API key from [Groq Console](https://console.groq.com/keys).
 
 Groq offers several open source models that support tool calling:
 - **moonshotai/kimi-k2-instruct** - Mixture-of-Experts model with 1 trillion parameters, optimized for agentic intelligence and tool use
@@ -269,10 +269,10 @@ Groq offers several open source models that support tool calling:
 - **gemma2-9b-it** - Google's Gemma 2 model with instruction tuning
 - **llama-3.3-70b-versatile** - Meta's Llama 3.3 model for versatile applications
 
-To set up Groq with Goose, follow these steps:
+To set up Groq with goose, follow these steps:
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose desktop" default>
   **To update your LLM provider and API key:** 
 
     1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
@@ -283,7 +283,7 @@ To set up Groq with Goose, follow these steps:
     6. Click `Configure`, enter your API key, and click `Submit`.
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     1. Run: 
     ```sh
     goose configure
@@ -296,12 +296,12 @@ To set up Groq with Goose, follow these steps:
 </Tabs>
 
 ### Google Gemini
-Google Gemini provides a free tier. To start using the Gemini API with Goose, you need an API Key from [Google AI studio](https://aistudio.google.com/app/apikey).
+Google Gemini provides a free tier. To start using the Gemini API with goose, you need an API Key from [Google AI studio](https://aistudio.google.com/app/apikey).
 
-To set up Google Gemini with Goose, follow these steps:
+To set up Google Gemini with goose, follow these steps:
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose desktop" default>
   **To update your LLM provider and API key:** 
 
     1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar.
@@ -312,7 +312,7 @@ To set up Google Gemini with Goose, follow these steps:
     6. Click `Configure`, enter your API key, and click `Submit`.
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     1. Run: 
     ```sh
     goose configure
@@ -347,10 +347,10 @@ To set up Google Gemini with Goose, follow these steps:
 
 ### Local LLMs
 
-Goose is a local AI agent, and by using a local LLM, you keep your data private, maintain full control over your environment, and can work entirely offline without relying on cloud access. However, please note that local LLMs require a bit more set up before you can use one of them with Goose.
+goose is a local AI agent, and by using a local LLM, you keep your data private, maintain full control over your environment, and can work entirely offline without relying on cloud access. However, please note that local LLMs require a bit more set up before you can use one of them with goose.
 
 :::warning Limited Support for models without tool calling
-Goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all Goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions).
+goose extensively uses tool calling, so models without it can only do chat completion. If using models without tool calling, all goose [extensions must be disabled](/docs/getting-started/using-extensions#enablingdisabling-extensions).
 :::
 
 Here are some local providers we support:
@@ -362,7 +362,7 @@ Here are some local providers we support:
         1. [Download Ramalama](https://github.com/containers/ramalama?tab=readme-ov-file#install).
         2. In a terminal, run any Ollama [model supporting tool-calling](https://ollama.com/search?c=tools) or [GGUF format HuggingFace Model](https://huggingface.co/search/full-text?q=%22tools+support%22+%2B+%22gguf%22&type=model):
 
-          The `--runtime-args="--jinja"` flag is required for Ramalama to work with the Goose Ollama provider.
+          The `--runtime-args="--jinja"` flag is required for Ramalama to work with the goose Ollama provider.
 
           Example:
 
@@ -370,7 +370,7 @@ Here are some local providers we support:
           ramalama serve --runtime-args="--jinja" ollama://qwen2.5
           ```
 
-          3. In a separate terminal window, configure with Goose:
+          3. In a separate terminal window, configure with goose:
 
           ```sh
           goose configure
@@ -388,7 +388,7 @@ Here are some local providers we support:
           └
           ```
 
-          5. Choose `Ollama` as the model provider since Ramalama is API compatible and can use the Goose Ollama provider
+          5. Choose `Ollama` as the model provider since Ramalama is API compatible and can use the goose Ollama provider
 
           ```
           ┌   goose-configure
@@ -451,12 +451,12 @@ Here are some local providers we support:
           ```
 
           :::tip Context Length
-          If you notice that Goose is having trouble using extensions or is ignoring [.goosehints](/docs/guides/using-goosehints), it is likely that the model's default context length of 2048 tokens is too low. Use `ramalama serve` to set the `--ctx-size, -c` option to a [higher value](https://github.com/containers/ramalama/blob/main/docs/ramalama-serve.1.md#--ctx-size--c).
+          If you notice that goose is having trouble using extensions or is ignoring [.goosehints](/docs/guides/using-goosehints), it is likely that the model's default context length of 2048 tokens is too low. Use `ramalama serve` to set the `--ctx-size, -c` option to a [higher value](https://github.com/containers/ramalama/blob/main/docs/ramalama-serve.1.md#--ctx-size--c).
           :::
 
       </TabItem>
       <TabItem value="deepseek" label="DeepSeek-R1">
-        The native `DeepSeek-r1` model doesn't support tool calling, however, we have a [custom model](https://ollama.com/michaelneale/deepseek-r1-goose) you can use with Goose. 
+        The native `DeepSeek-r1` model doesn't support tool calling, however, we have a [custom model](https://ollama.com/michaelneale/deepseek-r1-goose) you can use with goose. 
 
         :::warning
         Note that this is a 70B model size and requires a powerful device to run smoothly.
@@ -470,7 +470,7 @@ Here are some local providers we support:
         ollama run michaelneale/deepseek-r1-goose
         ```
 
-        3. In a separate terminal window, configure with Goose:
+        3. In a separate terminal window, configure with goose:
 
         ```sh
         goose configure
@@ -555,7 +555,7 @@ Here are some local providers we support:
           ollama run qwen2.5
           ```
 
-        3. In a separate terminal window, configure with Goose:
+        3. In a separate terminal window, configure with goose:
 
           ```sh
           goose configure
@@ -638,7 +638,7 @@ Here are some local providers we support:
         ```
 
         :::tip Context Length
-        If you notice that Goose is having trouble using extensions or is ignoring [.goosehints](/docs/guides/using-goosehints), it is likely that the model's default context length of 4096 tokens is too low. Set the `OLLAMA_CONTEXT_LENGTH` environment variable to a [higher value](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size).
+        If you notice that goose is having trouble using extensions or is ignoring [.goosehints](/docs/guides/using-goosehints), it is likely that the model's default context length of 4096 tokens is too low. Set the `OLLAMA_CONTEXT_LENGTH` environment variable to a [higher value](https://github.com/ollama/ollama/blob/main/docs/faq.md#how-can-i-specify-the-context-window-size).
         :::
         
       </TabItem>
@@ -655,7 +655,7 @@ Here are some local providers we support:
     docker model pull hf.co/unsloth/gemma-3n-e4b-it-gguf:q6_k
     ```
 
-    4. Configure Goose to use Docker Model Runner, using the OpenAI API compatible endpoint: 
+    4. Configure goose to use Docker Model Runner, using the OpenAI API compatible endpoint: 
 
     ```sh
     goose configure
@@ -718,7 +718,7 @@ Here are some local providers we support:
 
     Docker model runner uses `/engines/llama.cpp/v1/chat/completions` for the base path.
 
-    9. Finally configure the model available in Docker Model Runner to be used by Goose: `hf.co/unsloth/gemma-3n-e4b-it-gguf:q6_k`
+    9. Finally configure the model available in Docker Model Runner to be used by goose: `hf.co/unsloth/gemma-3n-e4b-it-gguf:q6_k`
 
     ```
     │
@@ -735,7 +735,7 @@ Here are some local providers we support:
 
 ## Azure OpenAI Credential Chain
 
-Goose supports two authentication methods for Azure OpenAI:
+goose supports two authentication methods for Azure OpenAI:
 
 1. **API Key Authentication** - Uses the `AZURE_OPENAI_API_KEY` for direct authentication
 2. **Azure Credential Chain** - Uses Azure CLI credentials automatically without requiring an API key
@@ -747,9 +747,17 @@ To use the Azure Credential Chain:
 
 This method simplifies authentication and enhances security for enterprise environments.
 
+## Multi-Model Configuration
+
+Beyond single-model setups, goose supports [multi-model configurations](/docs/guides/multi-model/) that can use different models and providers for specialized tasks:
+
+- **AutoPilot** - Intelligent, context-aware switching between specialized models based on conversation content and complexity
+- **Lead/Worker Model** - Automatic switching between a lead model for initial turns and a worker model for execution tasks
+- **Planning Mode** - Manual planning phase using a dedicated model to create detailed project breakdowns before execution
+
 ---
 
-If you have any questions or need help with a specific provider, feel free to reach out to us on [Discord](https://discord.gg/block-opensource) or on the [Goose repo](https://github.com/block/goose).
+If you have any questions or need help with a specific provider, feel free to reach out to us on [Discord](https://discord.gg/block-opensource) or on the [goose repo](https://github.com/block/goose).
 
 
 [providers]: /docs/getting-started/providers

--- a/documentation/docs/guides/config-file.md
+++ b/documentation/docs/guides/config-file.md
@@ -6,7 +6,7 @@ sidebar_label: Configuration File
 
 # Configuration File
 
-Goose uses a YAML configuration file to manage settings and extensions. This file is located at:
+goose uses a YAML configuration file to manage settings and extensions. This file is located at:
 
 * macOS/Linux: `~/.config/goose/config.yaml`
 * Windows: `%APPDATA%\Block\goose\config\config.yaml`
@@ -26,7 +26,7 @@ The following settings can be configured at the root level of your config.yaml f
 | `GOOSE_MAX_TURNS` | [Maximum number of turns](/docs/guides/sessions/smart-context-management#maximum-turns) allowed without user input | Integer (e.g., 10, 50, 100) | 1000 | No |
 | `GOOSE_LEAD_PROVIDER` | Provider for lead model in [lead/worker mode](/docs/guides/environment-variables#leadworker-model-configuration) | Same as `GOOSE_PROVIDER` options | Falls back to `GOOSE_PROVIDER` | No |
 | `GOOSE_LEAD_MODEL` | Lead model for lead/worker mode | Model name | None | No |
-| `GOOSE_PLANNER_PROVIDER` | Provider for [planning mode](/docs/guides/creating-plans) | Same as `GOOSE_PROVIDER` options | Falls back to `GOOSE_PROVIDER` | No |
+| `GOOSE_PLANNER_PROVIDER` | Provider for [planning mode](/docs/guides/multi-model/creating-plans) | Same as `GOOSE_PROVIDER` options | Falls back to `GOOSE_PROVIDER` | No |
 | `GOOSE_PLANNER_MODEL` | Model for planning mode | Model name | Falls back to `GOOSE_MODEL` | No |
 | `GOOSE_TOOLSHIM` | Enable tool interpretation | true/false | false | No |
 | `GOOSE_TOOLSHIM_OLLAMA_MODEL` | Model for tool interpretation | Model name (e.g., "llama3.2") | System default | No |
@@ -35,7 +35,11 @@ The following settings can be configured at the root level of your config.yaml f
 | `GOOSE_CLI_SHOW_COST` | Show estimated cost for token use in the CLI | true/false | false | No |
 | `GOOSE_ALLOWLIST` | URL for allowed extensions | Valid URL | None | No |
 | `GOOSE_RECIPE_GITHUB_REPO` | GitHub repository for recipes | Format: "org/repo" | None | No |
-| `GOOSE_AUTO_COMPACT_THRESHOLD` | Set the percentage threshold at which Goose [automatically summarizes your session](/docs/guides/sessions/smart-context-management#automatic-compaction). | Float between 0.0 and 1.0 (disabled at 0.0)| 0.8 | No |
+| `GOOSE_AUTO_COMPACT_THRESHOLD` | Set the percentage threshold at which goose [automatically summarizes your session](/docs/guides/sessions/smart-context-management#automatic-compaction). | Float between 0.0 and 1.0 (disabled at 0.0)| 0.8 | No |
+
+:::info Automatic Multi-Model Configuration
+The experimental [AutoPilot](/docs/guides/multi-model/autopilot) feature provides intelligent, context-aware model switching. Configure models for different roles using the `x-advanced-models` setting.
+:::
 
 ## Experimental Features
 
@@ -96,7 +100,7 @@ Extensions are configured under the `extensions` key. Each extension can have th
 ```yaml
 extensions:
   extension_name:
-    bundled: true/false        # Whether it's included with Goose
+    bundled: true/false        # Whether it's included with goose
     display_name: "Name"       # Human-readable name (optional)
     enabled: true/false        # Whether the extension is active
     name: "extension_name"     # Internal name
@@ -127,7 +131,7 @@ Settings are applied in the following order of precedence:
 
 ## Updating Configuration
 
-Changes to the config file require restarting Goose to take effect. You can verify your current configuration using:
+Changes to the config file require restarting goose to take effect. You can verify your current configuration using:
 
 ```bash
 goose info -v
@@ -137,6 +141,6 @@ This will show all active settings and their current values.
 
 ## See Also
 
-- [Environment Variables](./environment-variables.md) - For environment variable configuration
-- [Using Extensions](/docs/getting-started/using-extensions.md) - For more details on extension configuration
-- [Creating Plans](./creating-plans.md) - For information about planning mode configuration
+- **[Multi-Model Configuration](/docs/guides/multi-model/)** - For multiple model-selection strategies
+- **[Environment Variables](./environment-variables.md)** - For environment variable configuration
+- **[Using Extensions](/docs/getting-started/using-extensions.md)** - For more details on extension configuration

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -4,7 +4,7 @@ title: Environment Variables
 sidebar_label: Environment Variables
 ---
 
-Goose supports various environment variables that allow you to customize its behavior. This guide provides a comprehensive list of available environment variables grouped by their functionality.
+goose supports various environment variables that allow you to customize its behavior. This guide provides a comprehensive list of available environment variables grouped by their functionality.
 
 ## Model Configuration
 
@@ -12,7 +12,7 @@ These variables control the [language models](/docs/getting-started/providers) a
 
 ### Basic Provider Configuration
 
-These are the minimum required variables to get started with Goose.
+These are the minimum required variables to get started with goose.
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
@@ -52,6 +52,10 @@ export GOOSE_PROVIDER__API_KEY="your-api-key-here"
 
 These variables configure a [lead/worker model pattern](/docs/tutorials/lead-worker) where a powerful lead model handles initial planning and complex reasoning, then switches to a faster/cheaper worker model for execution. The switch happens automatically based on your settings.
 
+:::info Automatic Multi-Model Switching
+The experimental [AutoPilot](/docs/guides/multi-model/autopilot) feature provides intelligent, context-aware model switching. Configure models for different roles using the `x-advanced-models` setting.
+:::
+
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
 | `GOOSE_LEAD_MODEL` | **Required to enable lead mode.** Name of the lead model | Model name (e.g., "gpt-4o", "claude-sonnet-4-20250514") | None |
@@ -66,7 +70,7 @@ A _turn_ is one complete prompt-response interaction. Here's how it works with t
 - Fallback to the lead model if the worker model struggles for 2 consecutive turns
 - Use the lead model for 2 turns and then switch back to the worker model
 
-The lead model and worker model names are displayed at the start of the Goose CLI session. If you don't export a `GOOSE_MODEL` for your session, the worker model defaults to the `GOOSE_MODEL` in your [configuration file](/docs/guides/config-file).
+The lead model and worker model names are displayed at the start of the goose CLI session. If you don't export a `GOOSE_MODEL` for your session, the worker model defaults to the `GOOSE_MODEL` in your [configuration file](/docs/guides/config-file).
 
 **Examples**
 
@@ -84,7 +88,7 @@ export GOOSE_LEAD_FALLBACK_TURNS=2
 
 ### Planning Mode Configuration
 
-These variables control Goose's [planning functionality](/docs/guides/creating-plans).
+These variables control goose's [planning functionality](/docs/guides/multi-model/creating-plans).
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
@@ -142,19 +146,19 @@ export DATABRICKS_MAX_RETRY_INTERVAL_MS=60000        # cap the maximum retry del
 
 ## Session Management
 
-These variables control how Goose manages conversation sessions and context.
+These variables control how goose manages conversation sessions and context.
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
-| `GOOSE_CONTEXT_STRATEGY` | Controls how Goose handles context limit exceeded situations | "summarize", "truncate", "clear", "prompt" | "prompt" (interactive), "summarize" (headless) |
+| `GOOSE_CONTEXT_STRATEGY` | Controls how goose handles context limit exceeded situations | "summarize", "truncate", "clear", "prompt" | "prompt" (interactive), "summarize" (headless) |
 | `GOOSE_MAX_TURNS` | [Maximum number of turns](/docs/guides/sessions/smart-context-management#maximum-turns) allowed without user input | Integer (e.g., 10, 50, 100) | 1000 |
 | `CONTEXT_FILE_NAMES` | Specifies custom filenames for [hint/context files](/docs/guides/using-goosehints#custom-context-files) | JSON array of strings (e.g., `["CLAUDE.md", ".goosehints"]`) | `[".goosehints"]` |
 | `GOOSE_CLI_THEME` | [Theme](/docs/guides/goose-cli-commands#themes) for CLI response  markdown | "light", "dark", "ansi" | "dark" |
-| `GOOSE_SCHEDULER_TYPE` | Controls which scheduler Goose uses for [scheduled recipes](/docs/guides/recipes/session-recipes.md#schedule-recipe) | "legacy" or "temporal" | "legacy" (Goose's built-in cron scheduler) | 
+| `GOOSE_SCHEDULER_TYPE` | Controls which scheduler goose uses for [scheduled recipes](/docs/guides/recipes/session-recipes.md#schedule-recipe) | "legacy" or "temporal" | "legacy" (goose's built-in cron scheduler) | 
 | `GOOSE_TEMPORAL_BIN` | Optional custom path to your Temporal binary | /path/to/temporal-service | None |
 | `GOOSE_RANDOM_THINKING_MESSAGES` | Controls whether to show amusing random messages during processing | "true", "false" | "true" |
 | `GOOSE_CLI_SHOW_COST` | Toggles display of model cost estimates in CLI output | "true", "1" (case insensitive) to enable | false |
-| `GOOSE_AUTO_COMPACT_THRESHOLD` | Set the percentage threshold at which Goose [automatically summarizes your session](/docs/guides/sessions/smart-context-management#automatic-compaction). | Float between 0.0 and 1.0 (disabled at 0.0) | 0.8 |
+| `GOOSE_AUTO_COMPACT_THRESHOLD` | Set the percentage threshold at which goose [automatically summarizes your session](/docs/guides/sessions/smart-context-management#automatic-compaction). | Float between 0.0 and 1.0 (disabled at 0.0) | 0.8 |
 
 **Examples**
 
@@ -198,14 +202,14 @@ export GOOSE_AUTO_COMPACT_THRESHOLD=0.6
 
 ### Model Context Limit Overrides
 
-These variables allow you to override the default context window size (token limit) for your models. This is particularly useful when using [LiteLLM proxies](https://docs.litellm.ai/docs/providers/litellm_proxy) or custom models that don't match Goose's predefined model patterns.
+These variables allow you to override the default context window size (token limit) for your models. This is particularly useful when using [LiteLLM proxies](https://docs.litellm.ai/docs/providers/litellm_proxy) or custom models that don't match goose's predefined model patterns.
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
 | `GOOSE_CONTEXT_LIMIT` | Override context limit for the main model | Integer (number of tokens) | Model-specific default or 128,000 |
 | `GOOSE_LEAD_CONTEXT_LIMIT` | Override context limit for the lead model in [lead/worker mode](/docs/tutorials/lead-worker) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 | `GOOSE_WORKER_CONTEXT_LIMIT` | Override context limit for the worker model in lead/worker mode | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
-| `GOOSE_PLANNER_CONTEXT_LIMIT` | Override context limit for the [planner model](/docs/guides/creating-plans) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
+| `GOOSE_PLANNER_CONTEXT_LIMIT` | Override context limit for the [planner model](/docs/guides/multi-model/creating-plans) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 
 **Examples**
 
@@ -225,11 +229,11 @@ For more details and examples, see [Model Context Limit Overrides](/docs/guides/
 
 ## Tool Configuration
 
-These variables control how Goose handles [tool execution](/docs/guides/goose-permissions) and [tool management](/docs/guides/managing-tools/).
+These variables control how goose handles [tool execution](/docs/guides/goose-permissions) and [tool management](/docs/guides/managing-tools/).
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
-| `GOOSE_MODE` | Controls how Goose handles tool execution | "auto", "approve", "chat", "smart_approve" | "smart_approve" |
+| `GOOSE_MODE` | Controls how goose handles tool execution | "auto", "approve", "chat", "smart_approve" | "smart_approve" |
 | `GOOSE_ENABLE_ROUTER` | Enables [intelligent tool selection strategy](/docs/guides/managing-tools/tool-router) | "true", "false" | "false" |
 | `GOOSE_TOOLSHIM` | Enables/disables tool call interpretation | "1", "true" (case insensitive) to enable | false |
 | `GOOSE_TOOLSHIM_OLLAMA_MODEL` | Specifies the model for [tool call interpretation](/docs/experimental/ollama) | Model name (e.g. llama3.2, qwen2.5) | System default |
@@ -327,28 +331,28 @@ export ALPHA_FEATURES=true
 ALPHA_FEATURES=true goose session
 ```
 
-## Variables Controlled by Goose
+## Variables Controlled by goose
 
-These variables are automatically set by Goose during command execution.
+These variables are automatically set by goose during command execution.
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
-| `GOOSE_TERMINAL` | Indicates that a command is being executed by Goose, enables customizing shell behavior | "1" when set | Unset |
+| `GOOSE_TERMINAL` | Indicates that a command is being executed by goose, enables customizing shell behavior | "1" when set | Unset |
 
 ### Customizing Shell Behavior
 
-Sometimes you want Goose to use different commands or have different shell behavior than your normal terminal usage. For example, you might want Goose to use a different tool, or prevent Goose from running long-running development servers that could hang the AI agent. This is most useful when using Goose CLI, where shell commands are executed directly in your terminal environment.
+Sometimes you want goose to use different commands or have different shell behavior than your normal terminal usage. For example, you might want goose to use a different tool, or prevent goose from running long-running development servers that could hang the AI agent. This is most useful when using goose CLI, where shell commands are executed directly in your terminal environment.
 
 **How it works:**
-1. When Goose runs commands, `GOOSE_TERMINAL` is automatically set to "1"
-2. Your shell configuration can detect this and direct Goose to change its default behavior while keeping your normal terminal usage unchanged
+1. When goose runs commands, `GOOSE_TERMINAL` is automatically set to "1"
+2. Your shell configuration can detect this and direct goose to change its default behavior while keeping your normal terminal usage unchanged
 
 **Example:**
 
 ```bash
 # In your ~/.bashrc or ~/.zshrc
 
-# Guide Goose toward better tool choices
+# Guide goose toward better tool choices
 if [[ -n "$GOOSE_TERMINAL" ]]; then
   alias find="echo 'Use rg instead: rg --files | rg <pattern> for filenames, or rg <pattern> for content search'"
 fi
@@ -358,6 +362,6 @@ fi
 
 - Environment variables take precedence over configuration files.
 - For security-sensitive variables (like API keys), consider using the system keyring instead of environment variables.
-- Some variables may require restarting Goose to take effect.
-- When using the planning mode, if planner-specific variables are not set, Goose will fall back to the main model configuration.
+- Some variables may require restarting goose to take effect.
+- When using the planning mode, if planner-specific variables are not set, goose will fall back to the main model configuration.
 

--- a/documentation/docs/guides/multi-model/_category_.json
+++ b/documentation/docs/guides/multi-model/_category_.json
@@ -1,0 +1,5 @@
+{
+  "label": "Multi-Model Config",
+  "position": 20,
+  "description": "Configure multiple models and providers for model-switching strategies."
+}

--- a/documentation/docs/guides/multi-model/autopilot.md
+++ b/documentation/docs/guides/multi-model/autopilot.md
@@ -1,0 +1,127 @@
+---
+sidebar_position: 1
+title: Automatic Multi-Model Switching
+sidebar_label: Automatic Model Switching
+---
+
+The AutoPilot feature enables intelligent, context-aware switching between different models. You simply work naturally with goose, and AutoPilot chooses the right model based on conversation content, complexity, tool usage patterns, and other triggers.
+
+:::warning Experimental Feature
+AutoPilot is an experimental feature. Behavior and configuration may change in future releases.
+:::
+
+## How AutoPilot Works
+
+After you configure which models to use for different roles, AutoPilot handles the rest. During your sessions, it automatically switches to the most appropriate model for your current task&mdash;whether you need specialized coding help, complex reasoning, or just want a second opinion.
+
+**For example:**
+- When you ask to "debug this error," AutoPilot switches to a model optimized for debugging
+- When you request "analyze the performance implications," it switches to a model better suited for complex reasoning  
+- When you're doing repetitive coding tasks, it uses a cost-effective model, but escalates to a more powerful one when it encounters failures
+
+Switching happens automatically based on:
+- The terminology used in your requests ("debug", "analyze", "implement")
+- How complex the task appears to be
+- Whether previous attempts have failed and need a different approach
+- How much autonomous work has been happening without your input
+
+When AutoPilot switches to a specialized model, it stays with that model for a configured number of <abbr title="A turn is one complete prompt-response interaction between goose and the LLM" style={{ textUnderlineOffset: "3px" }}>turns</abbr> before evaluating whether to switch back to the base model or to a different specialized model based on the new context.
+
+:::info
+You can use `goose session --debug` in goose CLI to see when AutoPilot switches models. Note that each switch applies the provider's rate limits and pricing.
+::: 
+
+## Configuration
+
+Add the `x-advanced-models` section to your [`config.yaml`](/docs/guides/config-file) file and map your model preferences to [predefined](#predefined-roles) or custom roles. 
+
+The `provider`, `model` and `role` parameters are required.
+
+```yaml
+# Base provider and model (always available)
+GOOSE_PROVIDER: "anthropic"
+GOOSE_MODEL: "claude-sonnet-4-20250514"
+
+# AutoPilot models
+x-advanced-models:
+- provider: openai
+  model: o1-preview
+  role: deep-thinker
+- provider: openai
+  model: gpt-4o
+  role: debugger
+- provider: anthropic
+  model: claude-opus-4-20250805
+  role: reviewer
+```
+
+**Migrate From Lead/Worker Model**
+
+This example shows how you can reproduce [lead model](/docs/tutorials/lead-worker) behavior using `x-advanced-models`.
+
+```yaml
+# Before: Defined lead model using environment variables
+# GOOSE_LEAD_PROVIDER=openai
+# GOOSE_LEAD_MODEL=o1-preview
+
+# After: AutoPilot equivalent
+GOOSE_PROVIDER: "anthropic"
+GOOSE_MODEL: "claude-sonnet-4-20250514"  # Base is used as the worker model
+
+x-advanced-models:
+- provider: openai
+  model: o1-preview
+  role: lead  # Use the predefined lead role (or define a custom role)
+```
+
+### Predefined Roles
+
+AutoPilot includes a set of predefined roles defined in [`premade_roles.yaml`](https://github.com/block/goose/blob/main/crates/goose/src/agents/model_selector/premade_roles.yaml) that goose is aware of by default. Examples include:
+
+- **deep-thinker**: Activates for complex reasoning tasks
+- **debugger**: Switches in for error resolution
+- **reviewer**: Monitors after extensive tool usage
+- **coder**: Handles code implementation tasks
+- **mathematician**: Processes mathematical computations
+
+### Custom Roles
+
+You can create custom roles with specific triggers by defining them in your `config.yaml` file:
+
+```yaml
+x-advanced-models:
+- provider: openai
+  model: gpt-4o
+  role: custom-debugger
+  rules:
+    triggers:
+      keywords: ["bug", "broken", "failing", "crash"]
+      consecutive_failures: 1
+    active_turns: 5
+    priority: 15
+```
+
+<details>
+<summary>Custom Role Configuration Fields</summary>
+
+**Rule Configuration:**
+| Parameter | Description | Values |
+|-----------|-------------|---------|
+| `triggers` | Conditions that activate the role | Object (see parameters below) |
+| `active_turns` | Number of turns the rule stays active once triggered | Integer (default: 5) |
+| `priority` | Selection priority when multiple roles match | Integer (higher wins, default: 0) |
+
+**Trigger Parameters:**
+
+| Parameter | Description | Values |
+|-----------|-------------|---------|
+| `keywords` | Words that activate the role | Array of strings |
+| `match_type` | How to match keywords | "any", "all" |
+| `complexity_threshold` | Minimum complexity level | "low", "medium", "high" |
+| `consecutive_failures` | Failures in sequence | Integer |
+| `first_turn` | Trigger on conversation start | Boolean |
+| `source` | Message source filter | "human", "machine", "any" |
+
+The previous table includes several common rule trigger parameters. For the complete list, see the `TriggerRules` struct in [`autopilot.rs`](https://github.com/block/goose/blob/main/crates/goose/src/agents/model_selector/autopilot.rs).
+
+</details>

--- a/documentation/docs/guides/multi-model/creating-plans.md
+++ b/documentation/docs/guides/multi-model/creating-plans.md
@@ -13,40 +13,42 @@ Starting a project without a clear plan is like building a house without a bluep
 * Wasted time and effort
 * Projects that grow too big
 
-A good plan keeps everyone on track and helps measure progress. That's why the Goose CLI includes the `/plan` prompt completion command to help break down your projects into clear, manageable steps.
+A good plan keeps everyone on track and helps measure progress. That's why the goose CLI includes the `/plan` prompt completion command to help break down your projects into clear, manageable steps.
  
-:::tip Plans in the Goose Desktop
-The Goose Desktop doesn't have a `plan` keyword. If you want Goose Desktop to create a plan for you, you need to use a prompt like:
+:::tip Plans in the goose desktop
+The goose desktop doesn't have a `plan` keyword. If you want goose desktop to create a plan for you, you need to use a prompt like:
 
 ```
-"Hey Goose, can you create a plan to convert my CLI project into a locally hosted web page that gives me input fields for each CLI command I can run? Please don't start the actual work"
+"Hey goose, can you create a plan to convert my CLI project into a locally hosted web page that gives me input fields for each CLI command I can run? Please don't start the actual work"
 ```
-Unless you ask Goose to "create a plan", it might just start into the project work. 
+Unless you ask goose to "create a plan", it might just start into the project work. 
 :::
 
-The Goose CLI's plan mode is interactive, asking clarifying questions to understand your project before creating a plan. If you can provide thoughtful and informative answers to those questions, Goose can generate a really useul and actionable plan.
+The goose CLI's plan mode is interactive, asking clarifying questions to understand your project before creating a plan. If you can provide thoughtful and informative answers to those questions, goose can generate a really useful and actionable plan.
 
 ## Set your planner provider and model
 In some workflows, it can be helpful to use one LLM for planning and a different one for execution. For example, GPT-4.1 tends to excel at strategic planning and breaking down complex tasks into clear, logical steps. On the other hand, Claude Sonnet 3.5 is particularly strong at writing clean, efficient code and following instructions precisely. By using GPT-4.1 to plan and Claude to execute, you can play to the strengths of both models and get better results overall.
 
-The Goose CLI plan mode uses two configuration values:
+The goose CLI plan mode uses two configuration values:
 
 - `GOOSE_PLANNER_PROVIDER`: Which provider to use for planning
 - `GOOSE_PLANNER_MODEL`: Which model to use for planning
 
-:::tip Use Lead/Worker Mode For Automatic Model Switching
-[Lead/worker mode](/docs/guides/environment-variables#leadworker-model-configuration) is an alternative to plan mode. It allows you to configure a powerful lead model for initial planning and reasoning before automatically switching to a faster and/or cheaper worker model for execution. Both modes help you achieve optimal results by balancing model capabilities with cost and speed.
+:::tip Multi-Model Alternatives to Plan Mode
+goose also supports two options for automatic model switching that help balance model capabilities with cost and speed:
+- **[Lead/Worker mode](/docs/guides/environment-variables#leadworker-model-configuration)**: Turn-based switching between two models
+- **[AutoPilot](/docs/guides/multi-model/autopilot)**: Context-aware switching between multiple models
 :::
 
-### Set Goose planner environment variables
+### Set goose planner environment variables
 You might add these lines to your bash shell config file (.bashrc) to add the planner environment variables:
 ```bash
 export GOOSE_PLANNER_PROVIDER=<my-chosen-provider>
 export GOOSE_PLANNER_MODEL=<my-chosen-model>
 ```
-After you save your changes to the config file, you need to re-start your Goose session so that Goose can use the variables.
+After you save your changes to the config file, you need to re-start your goose session so that goose can use the variables.
 
-If these aren't set, Goose will use your default provider and model settings. You might want to set different planning models if you find certain models are better at breaking down tasks into clear steps. However, your default model configuration is usually sufficient.
+If these aren't set, goose will use your default provider and model settings. You might want to set different planning models if you find certain models are better at breaking down tasks into clear steps. However, your default model configuration is usually sufficient.
 
 To verify that the planner provider is set, input the following terminal command:
 
@@ -76,10 +78,10 @@ Goose Configuration:
  If either `GOOSE_PLANNER_PROVIDER` or `GOOSE_PLANNER_MODEL` are not set, `GOOSE_PROVIDER` and `GOOSE_MODEL`are used to build your plan.  
 
 ## Describe your project
-While Goose can handle complex project descriptions, it works best with clear, concise ones. Focus on stating your project's purpose and desired outcomes. If these aren't clear, Goose will ask clarifying questions until it fully understands your goals. 
+While goose can handle complex project descriptions, it works best with clear, concise ones. Focus on stating your project's purpose and desired outcomes. If these aren't clear, goose will ask clarifying questions until it fully understands your goals. 
 
 ## A simple construction plan example
-Goose can produce good plans for relatively simple projects such as the home construction example:
+goose can produce good plans for relatively simple projects such as the home construction example:
 
 ```bash
 ( O)> /plan
@@ -141,7 +143,7 @@ Given that no extensions are currently available for more specific tools or data
 * Search for available extensions using the <function=platform__search_available_extensions>{}</function>
 
 ```
-The home construction plan remains high-level because Goose's current models specialize in technology and software development rather than construction. This is why projects like our first example—building a web application—receive more detailed planning and specific guidance.
+The home construction plan remains high-level because goose's current models specialize in technology and software development rather than construction. This is why projects like our first example—building a web application—receive more detailed planning and specific guidance.
 
 ### Create a separate plan for plan sub-steps
 Let's return to the home construction example. While the plan includes hiring an architect, this high-level step needs more detail – such as what type of architect to hire and how to navigate the selection process.
@@ -149,7 +151,7 @@ Let's return to the home construction example. While the plan includes hiring an
 ```
 - **Architectural Design**: Hire an architect to design the house, ensuring it meets your space requirements and is energy efficient. Consider factors like natural lighting, insulation, and window placement.
 ```
-If you exit plan mode while reviewing your construction plan, you can always resume it to continue working with Goose. 
+If you exit plan mode while reviewing your construction plan, you can always resume it to continue working with goose. 
 
 ```
 ( O)> /plan hire an architect
@@ -170,12 +172,12 @@ Entering plan mode. You can provide instructions to create a plan and then act o
 10. How involved do you want to be in the design process?
 ```
 
-After gathering information through clarifying questions, Goose creates a detailed plan for hiring an architect. This sub-plan integrates with the larger home construction project, with steps that reflect and support the overall construction context.
+After gathering information through clarifying questions, goose creates a detailed plan for hiring an architect. This sub-plan integrates with the larger home construction project, with steps that reflect and support the overall construction context.
 
 ## A development project example
-In this example, a developer has written a CLI in Python that interacts with the Contentful CMS to let a user search for strings and replace them with new strings. As a website, the search/replace feature would be more usable and also allow for a larger set of features. The developer is using the Goose CLI to plan the conversion project.
+In this example, a developer has written a CLI in Python that interacts with the Contentful CMS to let a user search for strings and replace them with new strings. As a website, the search/replace feature would be more usable and also allow for a larger set of features. The developer is using the goose CLI to plan the conversion project.
 
-If Goose believes the project can be completed in many different ways and using a wide variety of components, it will ask you a clarifying question for each of these decision points. For example, if you start a plan like this:
+If goose believes the project can be completed in many different ways and using a wide variety of components, it will ask you a clarifying question for each of these decision points. For example, if you start a plan like this:
 
 ```bash 
 ( O)> /plan
@@ -184,10 +186,10 @@ Entering plan mode. You can provide instructions to create a plan and then act o
 
 ( O)> Convert the CLI built by search_replace_routes.py into a web page
 ```
-Goose parses your project description, consults with the LLM mode you've configured, and then if it needs more information, starts a round of clarifying questions.
+goose parses your project description, consults with the LLM mode you've configured, and then if it needs more information, starts a round of clarifying questions.
 
 ## Clarifying questions
-Converting a Python CLI into a website seems simple enough but Goose will have questions about things like styling, authentication, features, technology stack, and more. You might see questions like this:
+Converting a Python CLI into a website seems simple enough but goose will have questions about things like styling, authentication, features, technology stack, and more. You might see questions like this:
 
 ```bash
 1. Should the application support any keyboard shortcuts for common actions?
@@ -205,14 +207,14 @@ You can answer the questions one at a time or you can batch your answers:
 
 
 :::tip
-When Goose requests a project artifact like source code during plan mode, you'll need to paste the content directly into the chat. Simply copying the file contents and prefixing it with a brief description like 'Here's the requested code:' is sufficient. Note that providing just a file path won't work in plan mode.
+When goose requests a project artifact like source code during plan mode, you'll need to paste the content directly into the chat. Simply copying the file contents and prefixing it with a brief description like 'Here's the requested code:' is sufficient. Note that providing just a file path won't work in plan mode.
 :::
 
-When answering multiple questions, number your responses to match each question. For example, instead of answering with a simple 'no' or 'don't remember', provide context like '2. Do not store my preferences.' This helps Goose track which questions have been answered and prevents repeated questions.
+When answering multiple questions, number your responses to match each question. For example, instead of answering with a simple 'no' or 'don't remember', provide context like '2. Do not store my preferences.' This helps goose track which questions have been answered and prevents repeated questions.
 
-In complex projects like converting a CLI to a website, Goose may ask multiple rounds of clarifying questions. Each round typically stems from new information in your previous answers or when additional details are needed about specific aspects of your project.
+In complex projects like converting a CLI to a website, goose may ask multiple rounds of clarifying questions. Each round typically stems from new information in your previous answers or when additional details are needed about specific aspects of your project.
 
-If you've answered _all_ of Gooses questions and it has no more questions, Goose will generate the plan. Other times, you might think Goose will never run out of questions. If you want your plan and don't want to answer more questions, you can simply ask for a "generic" plan:
+If you've answered _all_ of gooses questions and it has no more questions, goose will generate the plan. Other times, you might think goose will never run out of questions. If you want your plan and don't want to answer more questions, you can simply ask for a "generic" plan:
 
 ```bash
 I still need some critical information to create a comprehensive plan:
@@ -226,7 +228,7 @@ I still need some critical information to create a comprehensive plan:
 Without this information, I can only provide a generic plan that might not accurately capture your requirements.
 ( O)> please provde a generic plan
 ```
-While Goose creates a standardized plan format, it customizes the content based on your answers. Goose can generate the code needed to implement the steps of the plan it produces. You should review the plan and any code that it generates before ending plan mode (`/endplan`) and asking Goose to implement the plan. 
+While goose creates a standardized plan format, it customizes the content based on your answers. goose can generate the code needed to implement the steps of the plan it produces. You should review the plan and any code that it generates before ending plan mode (`/endplan`) and asking goose to implement the plan. 
 
 Below is a sample plan for this project, with the generated website code omitted for brevity:
 
@@ -297,7 +299,7 @@ This plan provides a comprehensive framework for converting your CLI script to a
 
 
 ## Basic usage
-You need to have an active Goose session before you can put the CLI into plan mode. If you are going to dedicate a session to creating a plan, you should give your new session a name as in the following example:
+You need to have an active goose session before you can put the CLI into plan mode. If you are going to dedicate a session to creating a plan, you should give your new session a name as in the following example:
 
 ```bash
 ~ goose session -n web-project-plan -r
@@ -312,7 +314,7 @@ To enter planning mode, type `/plan`.  Optionally, you can append your plan desc
 ( O)> /plan  Build a four bedroom house
 ```
 
- Plan mode in the CLI is a special interaction mode where Goose helps break down tasks into manageable steps.  If you want to close the plan mode and return to the active session, type `/endplan`.
+ Plan mode in the CLI is a special interaction mode where goose helps break down tasks into manageable steps.  If you want to close the plan mode and return to the active session, type `/endplan`.
 
 ```bash
 ( O)> /endplan

--- a/documentation/docs/guides/multi-model/index.mdx
+++ b/documentation/docs/guides/multi-model/index.mdx
@@ -1,0 +1,58 @@
+---
+title: Multi-Model Configuration
+hide_title: true
+description: Approaches for configuring model-switching behavior to optimize for cost, performance, and results.
+---
+
+import Card from '@site/src/components/Card';
+import styles from '@site/src/components/Card/styles.module.css';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<h1 className={styles.pageTitle}>Multi-Model Configuration</h1>
+<p className={styles.pageDescription}>
+  goose supports several approaches for using different models within a single session, allowing you to optimize for cost, performance, and task specialization. Strategies range from manual or turn-based model selection to dynamic, context-aware switching.
+</p>
+
+<div className={styles.categorySection}>
+  <h2 className={styles.categoryTitle}>📚 Documentation & Guides</h2>
+  <div className={styles.cardGrid}>
+    <Card 
+      title="Automatic Multi-Model Switching"
+      description="Intelligent switching between models based on conversation content, complexity, and tool usage patterns."
+      link="/docs/guides/multi-model/autopilot"
+    />
+    <Card 
+      title="Lead/Worker Multi-Model Setup"
+      description="Automatic switching between models using a lead model for initial turns and a worker model for execution."
+      link="/docs/tutorials/lead-worker"
+    />
+    <Card 
+      title="Creating Plans Before Working"
+      description="Manual planning mode that uses a dedicated model to break complex projects into detailed, actionable steps."
+      link="/docs/guides/multi-model/creating-plans"
+    />
+    <Card 
+      title="Planning Complex Tasks"
+      description="Uses the Plan feature to transform a complex devcontainer setup into a systematic, executable roadmap."
+      link="/docs/tutorials/plan-feature-devcontainer-setup"
+    />
+  </div>
+</div>
+
+<div className={styles.categorySection}>
+  <h2 className={styles.categoryTitle}>📝 Featured Blog Posts</h2>
+  <div className={styles.cardGrid}>
+    <Card
+      title="Treating LLMs Like Tools in a Toolbox: A Multi-Model Approach to Smarter AI Agents"
+      description="LLMs are specialized tools, and multi-model approaches create smarter, more efficient AI agents."
+      link="/blog/2025/06/16/multi-model-in-goose"
+    />
+    <Card
+      title="LLM Tag Team: Who Plans, Who Executes?"
+      description="Learn how lead/worker model configuration creates an effective AI tag team, with one model for planning and another for execution."
+      link="/blog/2025/08/11/llm-tag-team-lead-worker-model"
+    />
+  </div>
+</div>
+

--- a/documentation/docs/guides/sessions/smart-context-management.md
+++ b/documentation/docs/guides/sessions/smart-context-management.md
@@ -9,24 +9,24 @@ import TabItem from '@theme/TabItem';
 import { ScrollText } from 'lucide-react';
 import { PanelLeft } from 'lucide-react';
 
-When working with [Large Language Models (LLMs)](/docs/getting-started/providers), there are limits to how much conversation history they can process at once. Goose provides smart context management features to help handle context and conversation limits so you can maintain productive sessions. Here are some key concepts:
+When working with [Large Language Models (LLMs)](/docs/getting-started/providers), there are limits to how much conversation history they can process at once. goose provides smart context management features to help handle context and conversation limits so you can maintain productive sessions. Here are some key concepts:
 
 - **Context Length**: The amount of conversation history the LLM can consider, also referred to as the context window
 - **Context Limit**: The maximum number of tokens the model can process
-- **Context Management**: How Goose handles conversations approaching these limits
-- **Turn**: One complete prompt-response interaction between Goose and the LLM
+- **Context Management**: How goose handles conversations approaching these limits
+- **Turn**: One complete prompt-response interaction between goose and the LLM
 
-## How Goose Manages Context
-Goose uses a two-tiered approach to context management:
+## How goose Manages Context
+goose uses a two-tiered approach to context management:
 
 1. **Auto-Compaction**: Proactively summarizes conversation when approaching token limits
 2. **Context Strategies**: Backup strategy used if the context limit is still exceeded after auto-compaction
 
-This layered approach lets Goose handle token and context limits gracefully.
+This layered approach lets goose handle token and context limits gracefully.
 
 ## Automatic Compaction
-Goose automatically compacts (summarizes) older parts of your conversation when approaching token limits, allowing you to maintain long-running sessions without manual intervention. 
-Auto-compaction is triggered by default when you reach 80% of the token limit in Goose Desktop and the Goose CLI.
+goose automatically compacts (summarizes) older parts of your conversation when approaching token limits, allowing you to maintain long-running sessions without manual intervention. 
+Auto-compaction is triggered by default when you reach 80% of the token limit in goose desktop and the goose CLI.
 
 Control the auto-compaction behavior with the `GOOSE_AUTO_COMPACT_THRESHOLD` [environment variable](/docs/guides/environment-variables.md#session-management). 
 Disable this feature by setting the value to `0.0`.
@@ -37,27 +37,27 @@ export GOOSE_AUTO_COMPACT_THRESHOLD=0.6
 ```
 
 When you reach the auto-compaction threshold:
-  1. Goose will automatically start compacting the conversation to make room.
+  1. goose will automatically start compacting the conversation to make room.
   2. Once complete, you'll see a confirmation message that the conversation was compacted and summarized.
-  3. Continue the session. Your previous conversation remains visible, but only the compacted conversion is included in the active context for Goose.
+  3. Continue the session. Your previous conversation remains visible, but only the compacted conversion is included in the active context for goose.
 
 ### Manual Compaction
 You can also trigger compaction manually before reaching context or token limits:
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose desktop" default>
 
   1. Point to the token usage indicator dot next to the model name at the bottom of the app
   2. Click <ScrollText className="inline" size={16} /> `Compact now` in the context window that appears
   3. Once complete, you'll see a confirmation message that the conversation was compacted and summarized.
-  4. Continue the session. Your previous conversation remains visible, but only the compacted conversion is included in the active context for Goose.
+  4. Continue the session. Your previous conversation remains visible, but only the compacted conversion is included in the active context for goose.
 
   :::info 
   You must send at least one message in the chat before the `Compact now` button is enabled. 
   :::
 
 </TabItem>
-<TabItem value="cli" label="Goose CLI" default>
+<TabItem value="cli" label="goose CLI" default>
 
 To proactively trigger summarization before reaching context limits, use the `/summarize` command:
 
@@ -76,7 +76,7 @@ Key information has been preserved while reducing context length.
 
 ## Context Limit Strategies
 
-When auto-compaction is disabled, or if a conversation still exceeds the context limit, Goose offers different ways to handle it:
+When auto-compaction is disabled, or if a conversation still exceeds the context limit, goose offers different ways to handle it:
 
 | Feature | Description | Best For | Availability | Impact |
 |---------|-------------|-----------|-----------|---------|
@@ -86,12 +86,12 @@ When auto-compaction is disabled, or if a conversation still exceeds the context
 | **Prompt** | Asks user to choose from the above options | Control over each decision in interactive sessions | CLI only | Depends on choice made |
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose desktop" default>
 
-Goose Desktop exclusively uses summarization by compacting the conversation to manage context, preserving key information while reducing size.
+goose desktop exclusively uses summarization by compacting the conversation to manage context, preserving key information while reducing size.
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
 The CLI supports all context limit strategies: `summarize`, `truncate`, `clear`, and `prompt`. 
 
@@ -99,7 +99,7 @@ The default behavior depends on the mode you're running in:
 - **Interactive mode**: Prompts user to choose (equivalent to `prompt`)
 - **Headless mode** (`goose run`): Automatically summarizes (equivalent to `summarize`)
 
-You can configure how Goose handles context limits by setting the `GOOSE_CONTEXT_STRATEGY` environment variable:
+You can configure how goose handles context limits by setting the `GOOSE_CONTEXT_STRATEGY` environment variable:
 
 ```bash
 # Set automatic strategy (choose one)
@@ -127,10 +127,10 @@ final_summary: [A summary of your conversation will appear here]
 
 Context maxed out
 --------------------------------------------------
-Goose summarized messages for you.
+goose summarized messages for you.
 ```
 
-**With `GOOSE_CONTEXT_STRATEGY` configured**, Goose will automatically apply your chosen strategy:
+**With `GOOSE_CONTEXT_STRATEGY` configured**, goose will automatically apply your chosen strategy:
 
 ```sh
 # Example with GOOSE_CONTEXT_STRATEGY=summarize
@@ -151,7 +151,7 @@ Context maxed out - automatically cleared session.
 </Tabs>
 
 ## Maximum Turns
-The `Max Turns` limit is the maximum number of consecutive turns that Goose can take without user input (default: 1000). When the limit is reached, Goose stops and prompts: "I've reached the maximum number of actions I can do without user input. Would you like me to continue?" If the user answers in the affirmative, Goose continues until the limit is reached and then prompts again.
+The `Max Turns` limit is the maximum number of consecutive turns that goose can take without user input (default: 1000). When the limit is reached, goose stops and prompts: "I've reached the maximum number of actions I can do without user input. Would you like me to continue?" If the user answers in the affirmative, goose continues until the limit is reached and then prompts again.
 
 This feature gives you control over agent autonomy and prevents infinite loops and runaway behavior, which could have significant cost consequences or damaging impact in production environments. Use it for:
 
@@ -162,7 +162,7 @@ This feature gives you control over agent autonomy and prevents infinite loops a
 This setting is stored as the `GOOSE_MAX_TURNS` environment variable in your [config.yaml file](/docs/guides/config-file). You can configure it using the Desktop app or CLI.
 
 <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose desktop" default>
 
       1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
       2. Click the `Settings` button on the sidebar
@@ -170,7 +170,7 @@ This setting is stored as the `GOOSE_MAX_TURNS` environment variable in your [co
       4. Scroll to `Conversation Limits` and enter a value for `Max Turns`
         
     </TabItem>
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
 
       1. Run the `configuration` command:
       ```sh
@@ -245,15 +245,15 @@ The appropriate max turns value depends on your use case and comfort level with 
 
 - **5-10 turns**: Good for exploratory tasks, debugging, or when you want frequent check-ins. For example, "analyze this codebase and suggest improvements" where you want to review each step
 - **25-50 turns**: Effective for well-defined tasks with moderate complexity, such as "refactor this module to use the new API" or "set up a basic CI/CD pipeline"
-- **100+ turns**: More suitable for complex, multi-step automation where you trust Goose to work independently, like "migrate this entire project from React 16 to React 18" or "implement comprehensive test coverage for this service"
+- **100+ turns**: More suitable for complex, multi-step automation where you trust goose to work independently, like "migrate this entire project from React 16 to React 18" or "implement comprehensive test coverage for this service"
 
-Remember that even simple-seeming tasks often require multiple turns. For example, asking Goose to "fix the failing tests" might involve analyzing test output (1 turn), identifying the root cause (1 turn), making code changes (1 turn), and verifying the fix (1 turn).
+Remember that even simple-seeming tasks often require multiple turns. For example, asking goose to "fix the failing tests" might involve analyzing test output (1 turn), identifying the root cause (1 turn), making code changes (1 turn), and verifying the fix (1 turn).
 
 ## Token Usage
-After sending your first message, Goose Desktop and Goose CLI display token usage.
+After sending your first message, goose desktop and goose CLI display token usage.
 
 <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose desktop" default>
     The Desktop displays a colored circle next to the model name at the bottom of the session window. The color provides a visual indicator of your token usage for the session. 
       - **Green**: Normal usage - Plenty of context space available
       - **Orange**: Warning state - Approaching limit (80% of capacity)
@@ -266,7 +266,7 @@ After sending your first message, Goose Desktop and Goose CLI display token usag
       - A progress bar showing your current token usage
         
     </TabItem>
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
     The CLI displays a context label above each command prompt, showing:
       - A visual indicator using dots (●○) and colors to represent your token usage:
         - **Green**: Below 50% usage
@@ -280,14 +280,14 @@ After sending your first message, Goose Desktop and Goose CLI display token usag
 
 ## Model Context Limit Overrides
 
-Context limits are automatically detected based on your model name, but Goose provides settings to override the default limits:
+Context limits are automatically detected based on your model name, but goose provides settings to override the default limits:
 
 | Model | Description | Best For | Setting |
 |-------|-------------|----------|---------|
 | **Main** | Set context limit for the main model (also serves as fallback for other models) | LiteLLM proxies, custom models with non-standard names | `GOOSE_CONTEXT_LIMIT` |
 | **Lead** | Set larger context for planning in [lead/worker mode](/docs/tutorials/lead-worker) | Complex planning tasks requiring more context | `GOOSE_LEAD_CONTEXT_LIMIT` |
 | **Worker** | Set smaller context for execution in lead/worker mode | Cost optimization during execution phase | `GOOSE_WORKER_CONTEXT_LIMIT` |
-| **Planner** | Set context for [planner models](/docs/guides/creating-plans) | Large planning tasks requiring extensive context | `GOOSE_PLANNER_CONTEXT_LIMIT` |
+| **Planner** | Set context for [planner models](/docs/guides/multi-model/creating-plans) | Large planning tasks requiring extensive context | `GOOSE_PLANNER_CONTEXT_LIMIT` |
 
 :::info
 This setting only affects the displayed token usage and progress indicators. Actual context management is handled by your LLM, so you may experience more or less usage than the limit you set, regardless of what the display shows.
@@ -295,12 +295,12 @@ This setting only affects the displayed token usage and progress indicators. Act
 
 This feature is particularly useful with:
 
-- **LiteLLM Proxy Models**: When using LiteLLM with custom model names that don't match Goose's patterns
+- **LiteLLM Proxy Models**: When using LiteLLM with custom model names that don't match goose's patterns
 - **Enterprise Deployments**: Custom model deployments with non-standard naming  
 - **Fine-tuned Models**: Custom models with different context limits than their base versions
 - **Development/Testing**: Temporarily adjusting context limits for testing purposes
 
-Goose resolves context limits with the following precedence (highest to lowest):
+goose resolves context limits with the following precedence (highest to lowest):
 
 1. Explicit context_limit in model configuration (if set programmatically)
 2. Specific environment variable (e.g., `GOOSE_LEAD_CONTEXT_LIMIT`)
@@ -311,12 +311,12 @@ Goose resolves context limits with the following precedence (highest to lowest):
 **Configuration**
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose desktop" default>
 
-     Model context limit overrides are not yet available in the Goose Desktop app.
+     Model context limit overrides are not yet available in the goose desktop app.
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
     Context limit overrides only work as [environment variables](/docs/guides/environment-variables#model-context-limit-overrides), not in the config file.
 
@@ -361,21 +361,21 @@ export GOOSE_PLANNER_CONTEXT_LIMIT=1000000
 Display real-time estimated costs of your session.
 
 <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose desktop" default>
 To manage live cost tracking:
   1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
   2. Click the `Settings` button on the sidebar
   3. Click the `App` tab 
   4. Toggle `Cost Tracking` on/off
 
-The session cost is shown at the bottom of the Goose window and updates dynamically as tokens are consumed. Hover over the cost to see a detailed breakdown of token usage. If multiple models are used in the session, this includes a cost breakdown by model. Ollama and local deployments always show a cost of $0.00.
+The session cost is shown at the bottom of the goose window and updates dynamically as tokens are consumed. Hover over the cost to see a detailed breakdown of token usage. If multiple models are used in the session, this includes a cost breakdown by model. Ollama and local deployments always show a cost of $0.00.
 
 Pricing data is regularly fetched from the OpenRouter API and cached locally. The `Advanced settings` tab shows when the data was last updated and allows you to refresh. 
 
 These costs are estimates only, and not connected to your actual provider bill. The cost shown is an approximation based on token counts and public pricing data.
 </TabItem>
-    <TabItem value="cli" label="Goose CLI">
-    Show estimated cost in the Goose CLI by setting the `GOOSE_CLI_SHOW_COST` [environment variable](/docs/guides/environment-variables.md#session-management) or including it in the [configuration file](/docs/guides/config-file.md).
+    <TabItem value="cli" label="goose CLI">
+    Show estimated cost in the goose CLI by setting the `GOOSE_CLI_SHOW_COST` [environment variable](/docs/guides/environment-variables.md#session-management) or including it in the [configuration file](/docs/guides/config-file.md).
 
   ```
   # Set environment variable

--- a/documentation/docs/tutorials/lead-worker.md
+++ b/documentation/docs/tutorials/lead-worker.md
@@ -7,15 +7,19 @@ import TabItem from '@theme/TabItem';
 
 # Lead/Worker Multi-Model Setup
 
-Goose supports a lead/worker model configuration that lets you pair two different AI models - one that's great at thinking and another that's fast at doing. This setup tackles a major pain point: premium models are powerful but expensive, while cheaper models are faster but can struggle with complex tasks. With lead/worker mode, you get the best of both worlds.
+goose supports a lead/worker model configuration that lets you pair two different AI models - one that's great at thinking and another that's fast at doing. This setup tackles a major pain point: premium models are powerful but expensive, while cheaper models are faster but can struggle with complex tasks. With lead/worker mode, you get the best of both worlds.
 
-The lead/worker model is a smart hand-off system. The "lead" model (think: GPT-4 or Claude Opus) kicks things off, handling the early planning and big picture reasoning. Once the direction is set, Goose hands the task over to the "worker" model (like GPT-4o-mini or Claude Sonnet) to carry out the steps.
+The lead/worker model is a smart hand-off system. The "lead" model (think: GPT-4 or Claude Opus) kicks things off, handling the early planning and big picture reasoning. Once the direction is set, goose hands the task over to the "worker" model (like GPT-4o-mini or Claude Sonnet) to carry out the steps.
 
-If things go sideways (e.g. the worker model gets confused or keeps making mistakes), Goose notices and automatically pulls the lead model back in to recover. Once things are back on track, the worker takes over again.
+If things go sideways (e.g. the worker model gets confused or keeps making mistakes), goose notices and automatically pulls the lead model back in to recover. Once things are back on track, the worker takes over again.
+
+:::tip Consider AutoPilot for Advanced Model Switching
+[AutoPilot](/docs/guides/multi-model/autopilot) supports turn-based switching and also offers intelligent context-aware switching between multiple models.
+:::
 
 ## Turn-Based System
 
-A **turn** is one full interaction - your prompt and the model's response. Goose switches models based on turns:
+A **turn** is one full interaction - your prompt and the model's response. goose switches models based on turns:
 
 - **Initial turns** (default: 3) go to the lead model
 - **Subsequent turns** use the worker model
@@ -25,7 +29,7 @@ A **turn** is one full interaction - your prompt and the model's response. Goose
 
 ## Quick Example
 
-You might configure Goose like this:
+You might configure goose like this:
 
 ```bash
 export GOOSE_LEAD_MODEL="gpt-4o"          # strong reasoning
@@ -33,29 +37,29 @@ export GOOSE_MODEL="gpt-4o-mini"          # fast execution
 export GOOSE_PROVIDER="openai"
 ```
 
-Goose will start with `gpt-4o` for the first three turns, then hand off to `gpt-4o-mini`. If the worker gets tripped up twice in a row, Goose temporarily switches back to the lead model for two fallback turns before trying the worker again.
+goose will start with `gpt-4o` for the first three turns, then hand off to `gpt-4o-mini`. If the worker gets tripped up twice in a row, goose temporarily switches back to the lead model for two fallback turns before trying the worker again.
 
 ## Configuration
 
 :::tip
-Ensure you have [added the LLMs to Goose](/docs/getting-started/providers)
+Ensure you have [added the LLMs to goose](/docs/getting-started/providers)
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
-   1. Click the model name at the bottom of the Goose Desktop window
+  <TabItem value="ui" label="goose desktop" default>
+   1. Click the model name at the bottom of the goose desktop window
    2. Click **Lead/Worker Settings**
    3. Check the box to **Enable lead/worker mode**
    4. Select your **Lead Model** and **Worker Model** from the dropdown menus
    5. (Optional) Change the default number of **initial lead turns**, the **failure threshold** before switching back to the leavd model, or the number of **fallback turns** to use the lead model during fallback
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     The only required configuration is setting the `GOOSE_LEAD_MODEL` [environment variable](/docs/guides/environment-variables#leadworker-model-configuration):
 
     ```bash
     export GOOSE_LEAD_MODEL="gpt-4o"
     ```
-    That's it. Goose treats your regular `GOOSE_MODEL` as the worker model by default.
+    That's it. goose treats your regular `GOOSE_MODEL` as the worker model by default.
 
     For more control, you can also set these optional environment variables:
 
@@ -71,13 +75,13 @@ Ensure you have [added the LLMs to Goose](/docs/getting-started/providers)
 
 ## What Counts as a Failure?
 
-Goose is smart about detecting actual task failures, not just API errors. The fallback kicks in when the worker:
+goose is smart about detecting actual task failures, not just API errors. The fallback kicks in when the worker:
 
 - Generates broken code (syntax errors, tool failures, missing files)
 - Hits permission issues
 - Gets corrected by the user ("that's wrong", "try again", etc.)
 
-Technical hiccups like timeouts, authentication issues, or service downtime don't trigger fallback mode. Goose retries those quietly.
+Technical hiccups like timeouts, authentication issues, or service downtime don't trigger fallback mode. goose retries those quietly.
 
 ## Reasons to Use Lead/Worker
 
@@ -91,7 +95,7 @@ Technical hiccups like timeouts, authentication issues, or service downtime don'
 If you're just getting started, the default settings will work fine. But here's how to tune things:
 
 - Bump up `GOOSE_LEAD_TURNS` to 5–7 for heavier planning upfront
-- Lower `GOOSE_LEAD_FAILURE_THRESHOLD` to 1 if you want Goose to correct issues quickly
+- Lower `GOOSE_LEAD_FAILURE_THRESHOLD` to 1 if you want goose to correct issues quickly
 - Choose a fast, lightweight worker model (Claude Haiku, GPT-4o-mini) for day-to-day tasks
 
 For debugging, you can see model switching behavior by turning on this log:
@@ -101,7 +105,7 @@ export RUST_LOG=goose::providers::lead_worker=info
 ```
 
 ## Planning Mode Compatibility
-The lead/worker model is an automatic alternative to the [Goose CLI's `/plan` command](/docs/guides/creating-plans.md). You can assign separate models to use as the lead/worker and planning models. For example:
+The lead/worker model is an automatic alternative to the [goose CLI's `/plan` command](/docs/guides/multi-model/creating-plans). You can assign separate models to use as the lead/worker and planning models. For example:
 
 ```bash
 export GOOSE_PROVIDER="openai"

--- a/documentation/docs/tutorials/plan-feature-devcontainer-setup.md
+++ b/documentation/docs/tutorials/plan-feature-devcontainer-setup.md
@@ -1,6 +1,6 @@
 ---
 title: "Planning Complex Tasks"
-description: "Learn how to use Goose's Plan feature to break down complex tasks into manageable, executable steps."
+description: "Learn how to use goose's Plan feature to break down complex tasks into manageable, executable steps."
 ---
 
 # Planning Complex Tasks
@@ -8,15 +8,15 @@ description: "Learn how to use Goose's Plan feature to break down complex tasks 
 *Transform overwhelming tasks into systematic, step-by-step execution plans*
 
 
-Using Goose for large, complex tasks can feel overwhelming, especially when you're unsure of exactly how you want to approach it in advance. I experienced this when I needed to set up a complex development environment for an [API course](https://github.com/LinkedInLearning/java-automated-api-testing-with-rest-assured-5989068) I published. Between Docker configurations, database initialization, devcontainer setup, and GitHub Codespaces integration, there are dozens of moving pieces that need to work together perfectly. One missing configuration or incorrect dependency can derail the entire process.
+Using goose for large, complex tasks can feel overwhelming, especially when you're unsure of exactly how you want to approach it in advance. I experienced this when I needed to set up a complex development environment for an [API course](https://github.com/LinkedInLearning/java-automated-api-testing-with-rest-assured-5989068) I published. Between Docker configurations, database initialization, devcontainer setup, and GitHub Codespaces integration, there are dozens of moving pieces that need to work together perfectly. One missing configuration or incorrect dependency can derail the entire process.
 
-This tutorial shows you how to use Goose's [Plan feature](/docs/guides/creating-plans) to transform a complex devcontainer setup into a systematic, executable roadmap. You'll learn how to brainstorm with Goose, refine your requirements, and let Goose create both a detailed plan and implementation checklist.
+This tutorial shows you how to use goose's [Plan feature](/docs/guides/multi-model/creating-plans) to transform a complex devcontainer setup into a systematic, executable roadmap. You'll learn how to brainstorm with goose, refine your requirements, and let goose create both a detailed plan and implementation checklist.
 
 ## What You'll Learn
 
 By the end of this tutorial, you'll understand how to:
 
-- Use Goose's Plan feature to break down complex technical projects
+- Use goose's Plan feature to break down complex technical projects
 - Brainstorm and refine requirements through AI-assisted conversation
 - Transform high-level goals into detailed, executable steps
 - Create comprehensive checklists for validation and quality assurance
@@ -37,23 +37,23 @@ This involves coordinating multiple technologies: Docker, MySQL, PHP, Java, devc
 
 ## Step 1: Initial Brainstorming Session
 
-Let's start by having a brainstorming conversation with Goose to clarify our requirements.
+Let's start by having a brainstorming conversation with goose to clarify our requirements.
 
 :::info Planning in Desktop vs CLI
-The Goose Desktop doesn't have a `/plan` keyword like the CLI. In Desktop, you need to explicitly ask Goose to create a plan:
+The goose desktop doesn't have a `/plan` keyword like the CLI. In Desktop, you need to explicitly ask goose to create a plan:
 
 ```
-"Hey Goose, can you create a plan to set up my GitHub repo for Codespaces with automatic Docker startup? Please don't start the actual work yet."
+"Hey goose, can you create a plan to set up my GitHub repo for Codespaces with automatic Docker startup? Please don't start the actual work yet."
 ```
 
-In the CLI, you can enter plan mode with `/plan` and Goose will ask clarifying questions before generating the plan. Unless you specifically ask Goose Desktop to "create a plan", it might jump straight into implementation.
+In the CLI, you can enter plan mode with `/plan` and goose will ask clarifying questions before generating the plan. Unless you specifically ask goose desktop to "create a plan", it might jump straight into implementation.
 :::
 
 ### Starting the Conversation
 
 **You:** _"I need help setting up a GitHub repository for automated API testing. Students should be able to open it in GitHub Codespaces and immediately start writing tests without any manual setup. Can you help me think through what's needed?"_
 
-**Goose:** _"I'd be happy to help you design this automated setup! Let me ask some clarifying questions to understand your requirements better:_
+**goose:** _"I'd be happy to help you design this automated setup! Let me ask some clarifying questions to understand your requirements better:_
 
 1. What type of API are you working with? (REST, GraphQL, etc.)
 2. What testing framework do you want students to use?
@@ -65,7 +65,7 @@ In the CLI, you can enter plan mode with `/plan` and Goose will ask clarifying q
 
 **You:** _"It's a REST API built in PHP that students will test using Rest Assured in Java. They need a real MySQL database with actual test data so they can practice realistic scenarios. The API has endpoints for managing products and categories in an e-commerce system."_
 
-**Goose:** _"Perfect! That gives me a clear picture. A few more questions to ensure we design this correctly:_
+**goose:** _"Perfect! That gives me a clear picture. A few more questions to ensure we design this correctly:_
 
 1. Do you already have the PHP API code, or do we need to create it?
 2. What version of Java should the environment support?
@@ -77,7 +77,7 @@ In the CLI, you can enter plan mode with `/plan` and Goose will ask clarifying q
 
 ## Step 2: Creating the Detailed Plan
 
-Now that we've clarified the requirements, let's ask Goose to create a comprehensive plan.
+Now that we've clarified the requirements, let's ask goose to create a comprehensive plan.
 
 ### Requesting the Plan
 
@@ -85,7 +85,7 @@ Now that we've clarified the requirements, let's ask Goose to create a comprehen
 
 ### The Generated Plan
 
-Goose will generate a comprehensive plan similar to this:
+goose will generate a comprehensive plan similar to this:
 
 <details>
   <summary>GitHub Codespaces API Testing Environment Setup Plan</summary>
@@ -295,15 +295,15 @@ Create a GitHub repository that automatically provisions a complete development 
 
 ## Step 3: Detailed Implementation Planning
 
-Now let's ask Goose to create the specific implementation prompt that will guide the execution.
+Now let's ask goose to create the specific implementation prompt that will guide the execution.
 
 ### Creating the Implementation Prompt
 
-**You:**  _"This plan looks comprehensive! Can you now create a detailed implementation prompt that I can use to execute this plan? I want something specific enough that Goose can follow it step-by-step without needing additional clarification."_
+**You:**  _"This plan looks comprehensive! Can you now create a detailed implementation prompt that I can use to execute this plan? I want something specific enough that goose can follow it step-by-step without needing additional clarification."_
 
 ### The Implementation Prompt
 
-Goose will generate a detailed prompt like this:
+goose will generate a detailed prompt like this:
 
 <details>
     <summary>Detailed Prompt</summary>
@@ -370,11 +370,11 @@ With our detailed plan and implementation prompt ready, we can now execute the s
 
 **You:** _"Perfect! Now let's implement this plan. Here's the detailed prompt we created: [paste the implementation prompt]"_
 
-Goose will now work through each step of the plan, creating the necessary files and configurations.
+goose will now work through each step of the plan, creating the necessary files and configurations.
 
 ### Monitoring Progress
 
-As Goose implements the plan, you can verify each deliverable against the checklist we created:
+As goose implements the plan, you can verify each deliverable against the checklist we created:
 
 1. **File Creation**: Check that each required file is created in the correct location
 2. **Configuration Accuracy**: Verify that configurations match the specifications
@@ -408,11 +408,11 @@ If issues arise during implementation or testing, use the plan as a reference to
 - **Permission Problems**: Update Dockerfile with proper permissions
 - **Configuration Errors**: Verify environment variables and connection strings
 
-## Best Practices for Planning with Goose
+## Best Practices
 
 1. Start with brainstorming. Don't jump straight to asking for a plan. Have a conversation to clarify requirements and explore options.
 2. Be specific about deliverables. Ask for concrete deliverables, file names, and validation criteria for each step.
-3. Ask Goose to identify potential issues and provide mitigation strategies.
+3. Ask goose to identify potential issues and provide mitigation strategies.
 4. Generate detailed implementation prompts that can guide execution without additional clarification.
 5. Include specific ways to verify that each step worked correctly.
 
@@ -424,7 +424,7 @@ For very complex projects, break the plan into phases and tackle them incrementa
 **You:** _"This plan is quite comprehensive. Can you break it into smaller phases that I can implement and test independently?"_
 
 ### Dependency Mapping
-Ask Goose to identify dependencies between tasks:
+Ask goose to identify dependencies between tasks:
 
 **You:** _"Which of these tasks can be done in parallel, and which have dependencies on other tasks?"_
 
@@ -435,7 +435,7 @@ Explore different implementation strategies:
 
 ## Conclusion
 
-Goose's Plan feature transforms complex technical challenges from overwhelming problems into systematic, executable roadmaps. By following this tutorial's approach:
+goose's Plan feature transforms complex technical challenges from overwhelming problems into systematic, executable roadmaps. By following this tutorial's approach:
 
 1. **Brainstorm** to clarify requirements and explore options
 2. **Plan** to break down complexity into manageable steps
@@ -445,13 +445,13 @@ Goose's Plan feature transforms complex technical challenges from overwhelming p
 
 You can tackle any complex development environment setup with confidence, knowing that you have a clear path forward and specific criteria for success.
 
-The key is treating Goose as a planning partner, not just a code generator. Give it the full context of what you're trying to achieve, and let it help you think through the complexity before diving into implementation.
+The key is treating goose as a planning partner, not just a code generator. Give it the full context of what you're trying to achieve, and let it help you think through the complexity before diving into implementation.
 
 ## Next Steps
 
 - Try this approach with your own complex setup challenges
 - Experiment with different types of planning prompts
-- Share your planning successes with the [Goose community](https://discord.gg/block-opensource)
+- Share your planning successes with the [goose community](https://discord.gg/block-opensource)
 - Explore how planning integrates with [Lead/Worker mode](/docs/tutorials/lead-worker) or [Subagents](/docs/experimental/subagents) for even more sophisticated workflows
 
 Remember, the goal is to get the right approach, in the right order, with the right safeguards. That's what makes the difference between a quick fix and a robust, maintainable solution.

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -150,6 +150,10 @@ const config: Config = {
             from: '/docs/guides/goose-in-docker',
             to: '/docs/tutorials/goose-in-docker'
           },
+          {
+            from: '/docs/guides/creating-plans',
+            to: '/docs/guides/multi-model/creating-plans'
+          },
           // MCP tutorial redirects - moved from /docs/tutorials/ to /docs/mcp/
           {
             from: '/docs/tutorials/agentql-mcp',


### PR DESCRIPTION
This PR documents AutoPilot multi-model switching support. Changed "Goose" to "goose" in all touched files (except where CLI output still uses "Goose").

Documentation updates:
- `documentation/docs/guides/multi-model/autopilot.md`: 
  - New topic
- `documentation/docs/guides/multi-model/index.mdx` and `documentation/docs/guides/multi-model/_category_.json`: 
  - New multi-model landing page
- `documentation/docs/guides/multi-model/creating-plans.md`:
  - Move from /guides to /multi-model
  - Revise multi-model alternatives tip

Add links to multi-model section or AutoPilot topic:
- `documentation/docs/tutorials/lead-worker.md`
- `documentation/docs/guides/environment-variables.md`: 
- `documentation/docs/guides/config-file.md`
- `documentation/docs/guides/multi-model/creating-plans.md`

Update links to relocated /plan topic:
- `documentation/docs/experimental/index.md`
- `documentation/docs/getting-started/providers.md`
- `documentation/docs/guides/config-file.md`
- `documentation/docs/guides/sessions/smart-context-management.md`
- `documentation/docs/tutorials/plan-feature-devcontainer-setup.md`