### PR TITLE
Add .goosehints file to enforce lowercase branding in documentation

### DIFF
--- a/documentation/.goosehints
+++ b/documentation/.goosehints
@@ -7,7 +7,7 @@
 - ✅ Correct: "goose", "using goose", "goose provides"
 - ❌ Incorrect: "Goose", "using Goose", "Goose provides"
 
-This is a legal requirement and brand guideline that must be strictly followed.
+This is a brand guideline that must be strictly followed.
 
 ## Context
 

--- a/documentation/.goosehints
+++ b/documentation/.goosehints
@@ -18,4 +18,4 @@ This rule applies to:
 - Configuration files with user-facing text
 - Any other documentation content
 
-When editing or creating content in this documentation directory, always ensure "goose" uses a lowercase "g" unless it's the first word of a sentence.
+When editing or creating content in this documentation directory, always ensure "goose" uses a lowercase "g".

--- a/documentation/.goosehints
+++ b/documentation/.goosehints
@@ -1,0 +1,21 @@
+# Documentation Style Guide
+
+## Brand Guidelines
+
+**IMPORTANT**: The product name "goose" should ALWAYS be written in lowercase "g" in all documentation, blog posts, and any content within this documentation directory.
+
+- ✅ Correct: "goose", "using goose", "goose provides"
+- ❌ Incorrect: "Goose", "using Goose", "Goose provides"
+
+This is a legal requirement and brand guideline that must be strictly followed.
+
+## Context
+
+This rule applies to:
+- All markdown files in `/docs/`
+- All blog posts in `/blog/`
+- README files
+- Configuration files with user-facing text
+- Any other documentation content
+
+When editing or creating content in this documentation directory, always ensure "goose" uses a lowercase "g" unless it's the first word of a sentence.


### PR DESCRIPTION
- Ensures goose is always written with lowercase 'g' in docs and blog
- brand guideline compliance
- Provides clear examples for correct usage

