### PR TITLE
feat(cli): add `path` & `limit` to `session list` command

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -128,7 +128,7 @@ enum SessionCommand {
             long = "limit",
             help = "Limit the number of results",
         )]
-        limit: Option<u32>,
+        limit: Option<usize>,
     },
     #[command(about = "Remove sessions. Runs interactively if no ID or regex is provided.")]
     Remove {
@@ -198,7 +198,7 @@ enum SchedulerCommand {
         id: String,
         /// Maximum number of sessions to return
         #[arg(long, help = "Maximum number of sessions to return")]
-        limit: Option<u32>,
+        limit: Option<usize>,
     },
     /// Run a scheduled job immediately
     #[command(about = "Run a scheduled job immediately")]

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -98,9 +98,6 @@ fn parse_key_val(s: &str) -> Result<(String, String), String> {
 enum SessionCommand {
     #[command(about = "List all available sessions")]
     List {
-        #[arg(short, long, help = "List all available sessions")]
-        verbose: bool,
-
         #[arg(
             short,
             long,
@@ -118,10 +115,10 @@ enum SessionCommand {
 
         #[arg(
             short = 'p',
-            long = "path",
+            long = "working_dir",
             help = "Filter sessions by working directory"
         )]
-        path: Option<PathBuf>,
+        working_dir: Option<PathBuf>,
 
         #[arg(short = 'l', long = "limit", help = "Limit the number of results")]
         limit: Option<usize>,
@@ -192,11 +189,9 @@ enum SchedulerCommand {
         /// ID of the schedule
         #[arg(long, help = "ID of the schedule")] // Explicitly make it --id
         id: String,
-        /// Maximum number of sessions to return
         #[arg(long, help = "Maximum number of sessions to return")]
         limit: Option<usize>,
     },
-    /// Run a scheduled job immediately
     #[command(about = "Run a scheduled job immediately")]
     RunNow {
         /// ID of the schedule to run
@@ -801,13 +796,12 @@ pub async fn cli() -> Result<()> {
         }) => {
             return match command {
                 Some(SessionCommand::List {
-                    verbose,
                     format,
                     ascending,
-                    path,
+                    working_dir,
                     limit,
                 }) => {
-                    handle_session_list(verbose, format, ascending, path, limit).await?;
+                    handle_session_list(format, ascending, working_dir, limit).await?;
                     Ok(())
                 }
                 Some(SessionCommand::Remove { id, regex }) => {

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -115,6 +115,20 @@ enum SessionCommand {
             long_help = "Sort sessions by date in ascending order (oldest first). Default is descending order (newest first)."
         )]
         ascending: bool,
+
+        #[arg(
+            short = 'p',
+            long = "path",
+            help = "Filter sessions by working directory",
+        )]
+        path: Option<PathBuf>,
+
+        #[arg(
+            short = 'l',
+            long = "limit",
+            help = "Limit the number of results",
+        )]
+        limit: Option<u32>,
     },
     #[command(about = "Remove sessions. Runs interactively if no ID or regex is provided.")]
     Remove {
@@ -794,8 +808,10 @@ pub async fn cli() -> Result<()> {
                     verbose,
                     format,
                     ascending,
+                    path,
+                    limit,
                 }) => {
-                    handle_session_list(verbose, format, ascending).await?;
+                    handle_session_list(verbose, format, ascending, path, limit).await?;
                     Ok(())
                 }
                 Some(SessionCommand::Remove { id, regex }) => {

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -119,15 +119,11 @@ enum SessionCommand {
         #[arg(
             short = 'p',
             long = "path",
-            help = "Filter sessions by working directory",
+            help = "Filter sessions by working directory"
         )]
         path: Option<PathBuf>,
 
-        #[arg(
-            short = 'l',
-            long = "limit",
-            help = "Limit the number of results",
-        )]
+        #[arg(short = 'l', long = "limit", help = "Limit the number of results")]
         limit: Option<usize>,
     },
     #[command(about = "Remove sessions. Runs interactively if no ID or regex is provided.")]

--- a/crates/goose-cli/src/commands/schedule.rs
+++ b/crates/goose-cli/src/commands/schedule.rs
@@ -203,14 +203,14 @@ pub async fn handle_schedule_remove(id: String) -> Result<()> {
     }
 }
 
-pub async fn handle_schedule_sessions(id: String, limit: Option<u32>) -> Result<()> {
+pub async fn handle_schedule_sessions(id: String, limit: Option<usize>) -> Result<()> {
     let scheduler_storage_path =
         get_default_scheduler_storage_path().context("Failed to get scheduler storage path")?;
     let scheduler = SchedulerFactory::create(scheduler_storage_path)
         .await
         .context("Failed to initialize scheduler")?;
 
-    match scheduler.sessions(&id, limit.unwrap_or(50) as usize).await {
+    match scheduler.sessions(&id, limit.unwrap_or(50)).await {
         Ok(sessions) => {
             if sessions.is_empty() {
                 println!("No sessions found for schedule ID '{}'.", id);

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -115,15 +115,14 @@ pub async fn handle_session_remove(id: Option<String>, regex_string: Option<Stri
 }
 
 pub async fn handle_session_list(
-    verbose: bool,
     format: String,
     ascending: bool,
-    path: Option<PathBuf>,
+    working_dir: Option<PathBuf>,
     limit: Option<usize>,
 ) -> Result<()> {
     let mut sessions = SessionManager::list_sessions().await?;
 
-    if let Some(ref pat) = path {
+    if let Some(ref pat) = working_dir {
         let pat_lower = pat.to_string_lossy().to_lowercase();
         sessions.retain(|s| {
             s.working_dir
@@ -159,11 +158,7 @@ pub async fn handle_session_list(
                     "{} - {} - {}",
                     session.id, session.description, session.updated_at
                 );
-                if verbose {
-                    println!("  {}", output);
-                } else {
-                    println!("{}", output);
-                }
+                println!("{}", output);
             }
         }
     }

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -114,7 +114,7 @@ pub async fn handle_session_remove(id: Option<String>, regex_string: Option<Stri
     remove_sessions(matched_sessions).await
 }
 
-pub async fn handle_session_list(verbose: bool, format: String, ascending: bool, path: Option<PathBuf>, limit: Option<u32>) -> Result<()> {
+pub async fn handle_session_list(verbose: bool, format: String, ascending: bool, path: Option<PathBuf>, limit: Option<usize>) -> Result<()> {
     let mut sessions = SessionManager::list_sessions().await?;
 
     if let Some(ref pat) = path {
@@ -134,7 +134,7 @@ pub async fn handle_session_list(verbose: bool, format: String, ascending: bool,
     }
 
     if let Some(n) = limit {
-        sessions.truncate(n as usize);
+        sessions.truncate(n);
     }
 
     match format.as_str() {

--- a/crates/goose-cli/src/commands/session.rs
+++ b/crates/goose-cli/src/commands/session.rs
@@ -114,7 +114,13 @@ pub async fn handle_session_remove(id: Option<String>, regex_string: Option<Stri
     remove_sessions(matched_sessions).await
 }
 
-pub async fn handle_session_list(verbose: bool, format: String, ascending: bool, path: Option<PathBuf>, limit: Option<usize>) -> Result<()> {
+pub async fn handle_session_list(
+    verbose: bool,
+    format: String,
+    ascending: bool,
+    path: Option<PathBuf>,
+    limit: Option<usize>,
+) -> Result<()> {
     let mut sessions = SessionManager::list_sessions().await?;
 
     if let Some(ref pat) = path {


### PR DESCRIPTION
adds `-p/--path` and `-l/--limit` to `goose session list` command

## Pull Request Description

<!-- Describe your changes here -->

---

<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved & merged -->
**Email**: 
