### PR TITLE
adding brand guidelines to AGENTS.md

### DIFF
--- a/documentation/AGENTS.md
+++ b/documentation/AGENTS.md
@@ -1,0 +1,21 @@
+# Documentation Style Guide
+
+## Brand Guidelines
+
+**IMPORTANT**: The product name "goose" should ALWAYS be written in lowercase "g" in all documentation, blog posts, and any content within this documentation directory.
+
+- ✅ Correct: "goose", "using goose", "goose provides"
+- ❌ Incorrect: "Goose", "using Goose", "Goose provides"
+
+This is a brand guideline that must be strictly followed.
+
+## Context
+
+This rule applies to:
+- All markdown files in `/docs/`
+- All blog posts in `/blog/`
+- README files
+- Configuration files with user-facing text
+- Any other documentation content
+
+When editing or creating content in this documentation directory, always ensure "goose" uses a lowercase "g".


### PR DESCRIPTION
This pull request adds a documentation style guide to clarify brand guidelines for referring to the product name "goose." The guide emphasizes always using a lowercase "g" in all documentation and related content.

Documentation guidelines:

* Added a new section to `AGENTS.md` specifying that "goose" must always be written with a lowercase "g" across all documentation, blog posts, READMEs, and user-facing configuration files.
* Outlined the contexts in which this rule applies to ensure consistent brand representation.