### PR TITLE
feat: add commit command for AI-generated commits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2701,6 +2701,7 @@ dependencies = [
  "goose-mcp",
  "http 1.2.0",
  "indicatif",
+ "indoc",
  "is-terminal",
  "jsonschema",
  "nix 0.30.1",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -58,6 +58,7 @@ tokio-util = { version = "0.7.15", features = ["compat"] }
 is-terminal = "0.4.16"
 anstream = "0.6.18"
 url = "2.5.7"
+indoc = "2.0.5"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose-cli/src/commands/commit.rs
+++ b/crates/goose-cli/src/commands/commit.rs
@@ -1,0 +1,109 @@
+use anyhow::Result;
+use indoc::indoc;
+
+use crate::session::{build_session, SessionBuilderConfig};
+
+/// Configuration for the commit command
+pub struct CommitConfig {
+    pub staged_only: bool,
+    pub debug: bool,
+    pub max_tool_repetitions: Option<u32>,
+    pub max_turns: Option<u32>,
+    pub extensions: Vec<String>,
+    pub remote_extensions: Vec<String>,
+    pub streamable_http_extensions: Vec<String>,
+    pub builtins: Vec<String>,
+    pub provider: Option<String>,
+    pub model: Option<String>,
+}
+
+/// Handle the commit command - review changes and create an AI-generated commit
+pub async fn handle_commit(config: CommitConfig) -> Result<()> {
+    let CommitConfig {
+        staged_only,
+        debug,
+        max_tool_repetitions,
+        max_turns,
+        extensions,
+        remote_extensions,
+        streamable_http_extensions,
+        builtins,
+        provider,
+        model,
+    } = config;
+    // Build the commit analysis prompt
+    let commit_prompt = if staged_only {
+        indoc! {r#"
+            Review this git repository and create a commit for the staged changes.
+
+            Please follow these steps:
+            1. Use `git status` to see what files are staged for commit
+            2. Use `git diff --staged` to review the staged changes in detail
+            3. Use `git log --oneline -10` to review the last 10 commits for context
+            4. If any of those recent commits seem relevant to the current changes, use `git show <commit-hash>` to review them in detail
+            5. Based on your analysis, create a commit using `git commit` with a well-written conventional commit message that:
+               - Follows the conventional commits format (e.g., "feat:", "fix:", "docs:", etc.)
+               - Has a concise subject line (50 chars or less)
+               - Includes a detailed body if the changes are complex
+               - References any related issues if applicable
+
+            After the commit is created, you can continue to interact with me for any follow-up actions.
+        "#}
+    } else {
+        indoc! {r#"
+            Review this git repository and create a commit for all uncommitted changes.
+
+            Please follow these steps:
+            1. Use `git status` to see what files have changed (both staged and unstaged)
+            2. Use `git diff` to review unstaged changes
+            3. Use `git diff --staged` to review staged changes (if any)
+            4. Use `git log --oneline -10` to review the last 10 commits for context
+            5. If any of those recent commits seem relevant to the current changes, use `git show <commit-hash>` to review them in detail
+            6. Use `git add -A` to stage all changes
+            7. Based on your analysis, create a commit using `git commit` with a well-written conventional commit message that:
+               - Follows the conventional commits format (e.g., "feat:", "fix:", "docs:", etc.)
+               - Has a concise subject line (50 chars or less)
+               - Includes a detailed body if the changes are complex
+               - References any related issues if applicable
+
+            After the commit is created, you can continue to interact with me for any follow-up actions.
+        "#}
+    };
+
+    tracing::info!(
+        counter.goose.commit_sessions = 1,
+        staged_only,
+        "Commit session started"
+    );
+
+    // Build the session with interactive mode enabled
+    let mut session = build_session(SessionBuilderConfig {
+        session_id: None,
+        resume: false,
+        no_session: false,
+        extensions,
+        remote_extensions,
+        streamable_http_extensions,
+        builtins,
+        extensions_override: None,
+        additional_system_prompt: None,
+        settings: None,
+        provider,
+        model,
+        debug,
+        max_tool_repetitions,
+        max_turns,
+        scheduled_job_id: None,
+        interactive: true, // Always interactive for commit command
+        quiet: false,
+        sub_recipes: None,
+        final_output_response: None,
+        retry_config: None,
+    })
+    .await;
+
+    // Start interactive session with the commit prompt as initial input
+    session.interactive(Some(commit_prompt.to_string())).await?;
+
+    Ok(())
+}

--- a/crates/goose-cli/src/commands/mod.rs
+++ b/crates/goose-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 pub mod acp;
 pub mod bench;
+pub mod commit;
 pub mod configure;
 pub mod info;
 pub mod project;


### PR DESCRIPTION
## Pull Request Description

Add new 'goose commit' command that analyzes git changes and generates conventional commit messages using an interactive AI session.

The command supports both staged and unstaged changes, with options to review git history for context. It integrates seamlessly with goose's existing session infrastructure and supports all standard CLI options.

Implementation details:
- Add CommitConfig struct to encapsulate command parameters
- Add handle_commit() function in commands/commit.rs
- Add Command::Commit variant to CLI enum with comprehensive options
- Add indoc dependency (2.0.5) for cleaner multi-line strings
- Use --staged-only flag to commit only staged changes
- Support standard goose options: extensions, provider, model, debug, etc.