### PR TITLE
docs: remove subagents from experimental

### DIFF
--- a/documentation/blog/2025-07-21-orchestrating-subagents/index.md
+++ b/documentation/blog/2025-07-21-orchestrating-subagents/index.md
@@ -36,7 +36,7 @@ I decided to create a digital resource that teaches foundational concepts like A
 
 ## Meet the Subagents
 
-[Subagents](/docs/experimental/subagents) are individual AI instances that take on specific tasks. Each one runs in its own session, which helps preserve the main context window and keeps your primary Goose conversation uncluttered and focused on high-level orchestration. I think of subagents as temporary teammates. Goose assigns each subagent a job and deallocates it when the work is complete.
+[Subagents](/docs/guides/subagents) are individual AI instances that take on specific tasks. Each one runs in its own session, which helps preserve the main context window and keeps your primary Goose conversation uncluttered and focused on high-level orchestration. I think of subagents as temporary teammates. Goose assigns each subagent a job and deallocates it when the work is complete.
 
 For this project, I turned my subagents into an on-demand dev squad, and I assigned them the following roles:
 
@@ -58,7 +58,7 @@ export GOOSE_ALPHA_FEATURES=true
 
 ## Instructing My Team
 
-There are a few ways to create subagents in Goose. You can use natural language prompts, define them through [recipes](/docs/guides/recipes/), or even spin up [external subagents](/docs/experimental/subagents/#external-subagents) like Codex or Claude Code.
+There are a few ways to create subagents in Goose. You can use natural language prompts, define them through [recipes](/docs/guides/recipes/), or even spin up [external subagents](/docs/guides/subagents/#external-subagents) like Codex or Claude Code.
 
 I took the natural language prompt approach because it felt convenient to directly configure a subagent through one prompt. Here’s the prompt I used:
   
@@ -173,7 +173,7 @@ What will you build with subagents?
 
 [Download Goose](/)
 
-[Learn about subagents](/docs/experimental/subagents)
+[Learn about subagents](/docs/guides/subagents)
 
 <head>
   <meta property="og:title" content="Orchestrating 6 Subagents to Build a Collaborative API Playground for Kids" />

--- a/documentation/blog/2025-07-28-ai-to-ai/index.md
+++ b/documentation/blog/2025-07-28-ai-to-ai/index.md
@@ -406,7 +406,7 @@ Angie's Diner shows exceptional performance with premium order values and strong
 </details>
 
 
-What a fun experiment! This gave me a better understanding of how agent-to-agent and [subagent](/docs/experimental/subagents) workflows may work behind the scenes. Makes you wonder, what else could happen when AIs start talking to each other without us?
+What a fun experiment! This gave me a better understanding of how agent-to-agent and [subagent](/docs/guides/subagents) workflows may work behind the scenes. Makes you wonder, what else could happen when AIs start talking to each other without us?
 
 ---
 

--- a/documentation/blog/2025-08-13-pulse-mcp-automates-recipe/index.md
+++ b/documentation/blog/2025-08-13-pulse-mcp-automates-recipe/index.md
@@ -21,7 +21,7 @@ Every week, the PulseMCP team faced the same time-consuming workflow: sourcing r
 
 ## The Solution: Why Sequential Beats Monolithic
 
-Instead of building one massive "do-everything" agent (which inevitably fails on complex tasks), PulseMCP broke their workflow into six distinct phases. Each phase gets handled by focused [recipes](/docs/guides/recipes/session-recipes), [subrecipes](/docs/guides/recipes/subrecipes) and [subagents](/docs/experimental/subagents) with clear inputs, outputs, and a single job.
+Instead of building one massive "do-everything" agent (which inevitably fails on complex tasks), PulseMCP broke their workflow into six distinct phases. Each phase gets handled by focused [recipes](/docs/guides/recipes/session-recipes), [subrecipes](/docs/guides/recipes/subrecipes) and [subagents](/docs/guides/subagents) with clear inputs, outputs, and a single job.
 
 This approach has three main benefits: debugging becomes easier when agents have single responsibilities, results become more predictable with clear handoffs between stages, and humans stay in control of the editorial process while automating the tedious work.
 

--- a/documentation/blog/2025-08-14-agent-coordination-patterns/index.md
+++ b/documentation/blog/2025-08-14-agent-coordination-patterns/index.md
@@ -36,7 +36,7 @@ Think lone developer grinding through the ticket.
 
 ## The Subagent Setup: Orchestrator With a Crew
 
-With [subagents](/docs/experimental/subagents), you still have one "main" agent, but instead of doing everything, it plays tech lead and delegates pieces of the work to other specialized agents.
+With [subagents](/docs/guides/subagents), you still have one "main" agent, but instead of doing everything, it plays tech lead and delegates pieces of the work to other specialized agents.
 
 The main agent says:
 

--- a/documentation/blog/2025-08-18-understanding-context-windows/index.md
+++ b/documentation/blog/2025-08-18-understanding-context-windows/index.md
@@ -81,7 +81,7 @@ The [Memory extension](https://block.github.io/goose/docs/mcp/memory-mcp) stores
 
 **5. Subagents**
 
-[Subagents](https://block.github.io/goose/docs/experimental/subagents) handle specific tasks in their own isolated sessions. This prevents your main conversation from getting cluttered with implementation details and tool outputs. You delegate work to subagents and only see the final results, keeping your primary context window clean and focused.
+[Subagents](https://block.github.io/goose/docs/guides/subagents) handle specific tasks in their own isolated sessions. This prevents your main conversation from getting cluttered with implementation details and tool outputs. You delegate work to subagents and only see the final results, keeping your primary context window clean and focused.
 
 **6. Short sessions**
 

--- a/documentation/blog/2025-09-26-subagents-vs-subrecipes/index.md
+++ b/documentation/blog/2025-09-26-subagents-vs-subrecipes/index.md
@@ -7,7 +7,7 @@ authors:
 
 ![Subagents vs Subrecipes](subrecipes-vs-subagents.png)
 
-When you're working on complex projects with goose, you'll often need to break work into multiple tasks and run them with AI agents. Goose gives you two powerful ways to do this: [subagents](/docs/experimental/subagents/) and [subrecipes](/docs/tutorials/subrecipes-in-parallel/). Both can run multiple AI instances in parallel, but they work  differently. Picking which one to use can be confusing, so we're going to guide you to a decision.
+When you're working on complex projects with goose, you'll often need to break work into multiple tasks and run them with AI agents. Goose gives you two powerful ways to do this: [subagents](/docs/guides/subagents/) and [subrecipes](/docs/tutorials/subrecipes-in-parallel/). Both can run multiple AI instances in parallel, but they work  differently. Picking which one to use can be confusing, so we're going to guide you to a decision.
 
 I've been using both approaches, and the choice between them depends on what you're trying to accomplish. Let me break down when to use each method and show you real examples.
 

--- a/documentation/docs/experimental/index.md
+++ b/documentation/docs/experimental/index.md
@@ -19,11 +19,6 @@ The list of experimental features may change as Goose development progresses. So
 <div className={styles.categorySection}>
   <h2 className={styles.categoryTitle}>🧪 Experimental Features</h2>
   <div className={styles.cardGrid}>
-      <Card 
-      title="Subagents"
-      description="Independent instances that execute tasks while keeping your main conversation clean and focused. Run tasks sequentially or in parallel with process isolation and context preservation."
-      link="/docs/experimental/subagents"
-    />
     <Card 
       title="Ollama Tool Shim"
       description="Enable tool calling capabilities for language models that don't natively support tool calling (like DeepSeek) using an experimental local interpreter model setup."
@@ -43,6 +38,11 @@ The list of experimental features may change as Goose development progresses. So
       title="Automatic Multi-Model Switching"
       description="Intelligent, context-aware switching between models based on conversation content, complexity, and tool usage patterns."
       link="/docs/guides/multi-model/autopilot"
+    />
+    <Card 
+      title="Using goose in ACP Clients"
+      description="Interact with goose natively in ACP-compatible clients like Zed."
+      link="/docs/guides/acp-clients"
     />
   </div>
 </div>

--- a/documentation/docs/guides/acp-clients.md
+++ b/documentation/docs/guides/acp-clients.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 25
+sidebar_position: 105
 title: Using Goose in ACP Clients
 sidebar_label: Goose in ACP Clients
 ---

--- a/documentation/docs/guides/allowlist.md
+++ b/documentation/docs/guides/allowlist.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 19
+sidebar_position: 90
 title: Goose Extension Allowlist
 sidebar_label: Extension Allowlist
 ---

--- a/documentation/docs/guides/cli-providers.md
+++ b/documentation/docs/guides/cli-providers.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 45
 title: CLI Providers
 sidebar_label: CLI Providers
 description: Use Claude Code, Cursor Agent, or Gemini CLI subscriptions in Goose

--- a/documentation/docs/guides/config-file.md
+++ b/documentation/docs/guides/config-file.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 85
 title: Configuration File
 sidebar_label: Configuration File
 ---
@@ -47,7 +47,7 @@ These settings enable experimental features that are in active development. Thes
 
 | Setting | Purpose | Values | Default | Required |
 |---------|---------|---------|---------|-----------|
-| `ALPHA_FEATURES` | Enables experimental alpha features like [subagents](/docs/experimental/subagents) | true/false | false | No |
+| `ALPHA_FEATURES` | Enables access to experimental alpha features&mdash;check the feature docs to see if this flag is required | true/false | false | No |
 
 Additional [environment variables](/docs/guides/environment-variables) may also be supported in config.yaml.
 

--- a/documentation/docs/guides/enhanced-code-editing.md
+++ b/documentation/docs/guides/enhanced-code-editing.md
@@ -2,6 +2,7 @@
 title: Enhanced Code Editing with AI Models
 sidebar_label: Enhanced Code Editing
 description: Use AI models to intelligently apply code changes
+sidebar_position: 110
 ---
 
 The [Developer extension](/docs/mcp/developer-mcp) supports using AI models for enhanced code editing through the `str_replace` command. When configured, it intelligently applies code changes using an AI model instead of simple string replacement.

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 20
+sidebar_position: 95
 title: Environment Variables
 sidebar_label: Environment Variables
 ---
@@ -319,7 +319,7 @@ These variables enable experimental features that are in active development. The
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
-| `ALPHA_FEATURES` | Enables experimental alpha features like [subagents](/docs/experimental/subagents) | "true", "1" (case insensitive) to enable | false |
+| `ALPHA_FEATURES` | Enables experimental alpha features&mdash;check the feature docs to see if this flag is required | "true", "1" (case insensitive) to enable | false |
 
 **Examples**
 

--- a/documentation/docs/guides/file-management.md
+++ b/documentation/docs/guides/file-management.md
@@ -1,6 +1,6 @@
 ---
 title: File Access and Management
-sidebar_position: 10
+sidebar_position: 70
 sidebar_label: File Management
 description: Efficiently find and reference files in Goose Desktop and follow best practices for safe file operations
 ---

--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 35
 title: CLI Commands
 sidebar_label: CLI Commands
 toc_max_heading_level: 4

--- a/documentation/docs/guides/goose-permissions.md
+++ b/documentation/docs/guides/goose-permissions.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 25
 title: Goose Permission Modes
 sidebar_label: Goose Permissions
 ---

--- a/documentation/docs/guides/handling-llm-rate-limits-with-goose.md
+++ b/documentation/docs/guides/handling-llm-rate-limits-with-goose.md
@@ -1,7 +1,7 @@
 ---
 title: Set LLM Rate Limits
 sidebar_label: LLM Rate Limits
-sidebar_position: 9
+sidebar_position: 60
 ---
 
 import Tabs from '@theme/Tabs';

--- a/documentation/docs/guides/interactive-chat/_category_.json
+++ b/documentation/docs/guides/interactive-chat/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Rich Interactive Chat",
-  "position": 8,
+  "position": 55,
   "link": {
     "type": "doc",
     "id": "guides/interactive-chat/index"

--- a/documentation/docs/guides/logs.md
+++ b/documentation/docs/guides/logs.md
@@ -1,7 +1,7 @@
 ---
 title: Goose Logging System
 sidebar_label: Logging System
-sidebar_position: 9
+sidebar_position: 65
 ---
 
 

--- a/documentation/docs/guides/managing-projects.md
+++ b/documentation/docs/guides/managing-projects.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 15
 title: Managing Projects
 sidebar_label: Managing Projects
 ---

--- a/documentation/docs/guides/managing-tools/_category_.json
+++ b/documentation/docs/guides/managing-tools/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Managing Tools",
-  "position": 4,
+  "position": 15,
   "link": {
     "type": "doc",
     "id": "guides/managing-tools/index"

--- a/documentation/docs/guides/multi-model/_category_.json
+++ b/documentation/docs/guides/multi-model/_category_.json
@@ -1,5 +1,5 @@
 {
   "label": "Multi-Model Config",
-  "position": 20,
+  "position": 100,
   "description": "Configure multiple models and providers for model-switching strategies."
 }

--- a/documentation/docs/guides/recipes/_category_.json
+++ b/documentation/docs/guides/recipes/_category_.json
@@ -1,6 +1,6 @@
 {
   "label": "Recipes",
-  "position": 2,
+  "position": 5,
   "link": {
     "type": "doc",
     "id": "guides/recipes/index"

--- a/documentation/docs/guides/running-tasks.md
+++ b/documentation/docs/guides/running-tasks.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 75
 title: Running Tasks
 sidebar_label: Run Tasks
 ---

--- a/documentation/docs/guides/subagents.md
+++ b/documentation/docs/guides/subagents.md
@@ -1,18 +1,14 @@
 ---
 title: Subagents
-sidebar_position: 1
+sidebar_position: 50
 sidebar_label: Subagents
 ---
 
 Subagents are independent instances that execute tasks while keeping your main conversation clean and focused. They bring process isolation and context preservation by offloading work to separate instances. Think of them as temporary assistants that handle specific jobs without cluttering your chat with tool execution details.
 
-:::warning
-Subagents are an experimental feature in active development. Behavior and configuration may change in future releases.
-:::
-
 ## How to Use Subagents
 
-To use subagents, ask Goose to delegate tasks using natural language. Goose automatically decides when to spawn subagents and handles their lifecycle. You can:
+To use subagents, ask goose to delegate tasks using natural language. goose automatically decides when to spawn subagents and handles their lifecycle. You can:
 
 1. **Request specialized help**: "Use a code reviewer to analyze this function for security issues"
 2. **Reference specific recipes**: "Use the 'security-auditor' recipe to scan this endpoint"  
@@ -29,20 +25,6 @@ You can run multiple subagents sequentially or in parallel.
 :::info
 If a subagent fails or times out (5-minute default), you will receive no output from that subagent. For parallel execution, if any subagent fails, you get results only from the successful ones.
 :::
-
-
-## Prerequisites
-To use subagents, you need to enable alpha features first. You can do this by setting an [environment variable](/docs/guides/environment-variables#experimental-features) or adding it to your [config file](/docs/guides/config-file#experimental-features):
-
-**Environment Variable:**
-```bash
-export ALPHA_FEATURES=true
-```
-
-**Config File** (`~/.config/goose/config.yaml`):
-```yaml
-ALPHA_FEATURES: true
-```
 
 ## Internal Subagents
 

--- a/documentation/docs/guides/subagents.md
+++ b/documentation/docs/guides/subagents.md
@@ -8,7 +8,7 @@ Subagents are independent instances that execute tasks while keeping your main c
 
 ## How to Use Subagents
 
-To use subagents, ask goose to delegate tasks using natural language. goose automatically decides when to spawn subagents and handles their lifecycle. You can:
+To use subagents, ask Goose to delegate tasks using natural language. Goose automatically decides when to spawn subagents and handles their lifecycle. You can:
 
 1. **Request specialized help**: "Use a code reviewer to analyze this function for security issues"
 2. **Reference specific recipes**: "Use the 'security-auditor' recipe to scan this endpoint"  

--- a/documentation/docs/guides/tips.md
+++ b/documentation/docs/guides/tips.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Goose Tips
-sidebar_position: 6
+sidebar_position: 30
 sidebar_label: Quick Tips
 description: Best practices for working with Goose
 ---

--- a/documentation/docs/guides/updating-goose.md
+++ b/documentation/docs/guides/updating-goose.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 5
+sidebar_position: 20
 title: Updating Goose
 sidebar_label: Updating Goose
 ---

--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -1,6 +1,6 @@
 ---
 title: Providing Hints to Goose
-sidebar_position: 7
+sidebar_position: 40
 sidebar_label: Using Goosehints
 ---
 

--- a/documentation/docs/guides/using-gooseignore.md
+++ b/documentation/docs/guides/using-gooseignore.md
@@ -1,7 +1,7 @@
 ---
 title: Prevent Goose from Accessing Files
 sidebar_label: Using Gooseignore
-sidebar_position: 14
+sidebar_position: 80
 ---
 
 

--- a/documentation/docs/tutorials/plan-feature-devcontainer-setup.md
+++ b/documentation/docs/tutorials/plan-feature-devcontainer-setup.md
@@ -452,6 +452,6 @@ The key is treating Goose as a planning partner, not just a code generator. Give
 - Try this approach with your own complex setup challenges
 - Experiment with different types of planning prompts
 - Share your planning successes with the [Goose community](https://discord.gg/block-opensource)
-- Explore how planning integrates with [Lead/Worker mode](/docs/tutorials/lead-worker) or [Subagents](/docs/experimental/subagents) for even more sophisticated workflows
+- Explore how planning integrates with [Lead/Worker mode](/docs/tutorials/lead-worker) or [Subagents](/docs/guides/subagents) for even more sophisticated workflows
 
 Remember, the goal is to get the right approach, in the right order, with the right safeguards. That's what makes the difference between a quick fix and a robust, maintainable solution.

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -302,6 +302,10 @@ const config: Config = {
           {
             from: '/docs/guides/isolated-development-environments',
             to: '/docs/tutorials/isolated-development-environments'
+          },
+          {
+            from: '/docs/experimental/subagents',
+            to: '/docs/guides/subagents'
           }         
         ],
       },


### PR DESCRIPTION
This PR moves the subagents topic from the /experimental section to /guides because the ALPHA_FEATURES check was removed.

Move topic to /guides section:
- `docs/experimental/subagents.md` -> `docs/guides/subagents.md`
  - Remove Experimental Feature warning and Prerequisites section

Updated subagent links in blogs:
- `blog/2025-07-21-orchestrating-subagents/index.md`
- `blog/2025-07-28-ai-to-ai/index.md`
- `blog/2025-08-13-pulse-mcp-automates-recipe/index.md`
- `blog/2025-08-14-agent-coordination-patterns/index.md`
- `blog/2025-08-18-understanding-context-windows/index.md`
- `blog/2025-09-26-subagents-vs-subrecipes/index.md`

Updated subagent links in docs:
- `docs/experimental/index.md`:
  -  Remove "Subagents" card and add "Using goose in ACP Clients"
- `docs/guides/config-file.md` and `docs/guides/environment-variables.md`:
  - Remove "subagents" mention from `ALPHA_FEATURES` description
- `docs/tutorials/plan-feature-devcontainer-setup.md`:
  - Update link
- `docusaurus.config.ts`:
  - Add redirects

Also updated the sidebar-position value in /guides topics so it will be easier to position topics:
- `docs/guides/acp-clients.md`
- `docs/guides/allowlist.md`
- `docs/guides/cli-providers.md`
- `docs/guides/config-file.md`
- `docs/guides/enhanced-code-editing.md`
- `docs/guides/file-management.md`
- `docs/guides/goose-cli-commands.md`
- `docs/guides/goose-permissions.md`
- `docs/guides/handling-llm-rate-limits-with-goose.md`
- `docs/guides/interactive-chat/_category_.json`
- `docs/guides/logs.md`
- `docs/guides/managing-projects.md`
- `docs/guides/managing-tools/_category_.json`
- `docs/guides/multi-model/_category_.json`
- `docs/guides/recipes/_category_.json`
- `docs/guides/running-tasks.md`
- `docs/guides/tips.md`
- `docs/guides/updating-goose.md`
- `docs/guides/using-goosehints.md`
- `docs/guides/using-gooseignore.md`
 
