### PR TITLE
feat: Disable llm session description generation to reduce latency

### DIFF
--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -238,7 +238,15 @@ impl SessionManager {
             .count();
 
         if user_message_count <= MSG_COUNT_FOR_SESSION_NAME_GENERATION {
-            let description = provider.generate_session_name(&conversation).await?;
+            let description = if std::env::var("DISABLE_GENERATED_SESSION_NAMING")
+                .unwrap_or_default()
+                .to_lowercase()
+                == "true"
+            {
+                "no session name".to_string()
+            } else {
+                provider.generate_session_name(&conversation).await?
+            };
             Self::update_session(id)
                 .description(description)
                 .apply()

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -159,6 +159,7 @@ These variables control how Goose manages conversation sessions and context.
 | `GOOSE_RANDOM_THINKING_MESSAGES` | Controls whether to show amusing random messages during processing | "true", "false" | "true" |
 | `GOOSE_CLI_SHOW_COST` | Toggles display of model cost estimates in CLI output | "true", "1" (case insensitive) to enable | false |
 | `GOOSE_AUTO_COMPACT_THRESHOLD` | Set the percentage threshold at which Goose [automatically summarizes your session](/docs/guides/sessions/smart-context-management#automatic-compaction). | Float between 0.0 and 1.0 (disabled at 0.0) | 0.8 |
+| `DISABLE_GENERATED_SESSION_NAMING` | Disables the generation of session names by an LLM | "true" to disable | false |
 
 **Examples**
 


### PR DESCRIPTION
## Pull Request Description

**Before**
Every session during the first few messages an llm is called with messages to generate an accurate session description.

**After**
By setting `DISABLE_GENERATED_SESSION_NAMING=true` env variable the session description will always be 'no session name' and llm will not be called

**Why**
This reduces latency on the first few turns of the agents by avoid an extra llm call (even with a fast model its still time). When we are doing automation use cases of the repetitive tasks there is no value to this description.

**Usage**
When running the command `DISABLE_GENERATED_SESSION_NAMING=true  ./target/debug/goose run  -t "say hello twice"` this is what the database looks like when true (top line) and default (false) second line in the session database.
<img width="405" height="103" alt="image" src="https://github.com/user-attachments/assets/e2da9bd9-7ad8-4450-ad6b-1840263b06ab" />
