### PR TITLE
Using --resume with --name should still accept session IDs

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -75,7 +75,7 @@ async fn get_session_id(identifier: Identifier) -> Result<String> {
 
         sessions
             .into_iter()
-            .find(|s| s.description == name)
+            .find(|s| s.id == name || s.description.contains(&name))
             .map(|s| s.id)
             .ok_or_else(|| anyhow::anyhow!("No session found with name '{}'", name))
     } else if let Some(path) = identifier.path {

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1,6 +1,5 @@
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
-use console::style;
 
 use goose::config::{Config, ExtensionConfig};
 
@@ -890,10 +889,6 @@ pub async fn cli() -> Result<()> {
 
                     let result = session.interactive(None).await;
 
-                    if let Some(id) = session.session_id() {
-                        println!("Closing session. Session ID: {}", style(id).cyan());
-                    }
-
                     let session_duration = session_start.elapsed();
                     let exit_type = if result.is_ok() { "normal" } else { "error" };
 
@@ -1107,10 +1102,6 @@ pub async fn cli() -> Result<()> {
 
                 let result = session.headless(contents).await;
 
-                if let Some(id) = session.session_id() {
-                    println!("Closing session. Session ID: {}", style(id).cyan());
-                }
-
                 let session_duration = session_start.elapsed();
                 let exit_type = if result.is_ok() { "normal" } else { "error" };
 
@@ -1273,11 +1264,6 @@ pub async fn cli() -> Result<()> {
                     eprintln!("Session ended with error: {}", e);
                     std::process::exit(1);
                 }
-
-                if let Some(id) = session.session_id() {
-                    println!("Closing session. Session ID: {}", style(id).cyan());
-                }
-
                 Ok(())
             };
         }

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use clap::{Args, Parser, Subcommand};
+use console::style;
 
 use goose::config::{Config, ExtensionConfig};
 
@@ -889,6 +890,10 @@ pub async fn cli() -> Result<()> {
 
                     let result = session.interactive(None).await;
 
+                    if let Some(id) = session.session_id() {
+                        println!("Closing session. Session ID: {}", style(id).cyan());
+                    }
+
                     let session_duration = session_start.elapsed();
                     let exit_type = if result.is_ok() { "normal" } else { "error" };
 
@@ -1102,6 +1107,10 @@ pub async fn cli() -> Result<()> {
 
                 let result = session.headless(contents).await;
 
+                if let Some(id) = session.session_id() {
+                    println!("Closing session. Session ID: {}", style(id).cyan());
+                }
+
                 let session_duration = session_start.elapsed();
                 let exit_type = if result.is_ok() { "normal" } else { "error" };
 
@@ -1264,6 +1273,11 @@ pub async fn cli() -> Result<()> {
                     eprintln!("Session ended with error: {}", e);
                     std::process::exit(1);
                 }
+
+                if let Some(id) = session.session_id() {
+                    println!("Closing session. Session ID: {}", style(id).cyan());
+                }
+
                 Ok(())
             };
         }

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -758,6 +758,11 @@ impl CliSession {
                 }
             }
         }
+
+        if let Some(id) = &self.session_id {
+            println!("Closing session. Session ID: {}", console::style(id).cyan());
+        }
+
         Ok(())
     }
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -743,6 +743,14 @@ pub fn display_session_info(
         );
     }
 
+    if let Some(id) = session_id {
+        println!(
+            "    {} {}",
+            style("session id:").dim(),
+            style(id).cyan().dim()
+        );
+    }
+
     println!(
         "    {} {}",
         style("working directory:").dim(),


### PR DESCRIPTION
## Pull Request Description

This PR restores the ability to resume a session using its ID and name interchangeably with the `--name` CLI flag

I also added print statements so that the session ID is printed to the console at session start and end, similar to how the session file path was printed at session start/end before the SQLite migration. This makes it easier to quickly resume a previous session from the same terminal, without needing to run `goose session list` and pick through the output to the correct session ID

Fixes #4935