### PR TITLE
fix: Issue #4540: `goose configure` -> Cursor Agent succeeds

### DIFF
--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -15,8 +15,8 @@ use crate::impl_provider_default;
 use crate::model::ModelConfig;
 use rmcp::model::Tool;
 
-pub const CURSOR_AGENT_DEFAULT_MODEL: &str = "gpt-5";
-pub const CURSOR_AGENT_KNOWN_MODELS: &[&str] = &["gpt-5", "opus-4.1", "sonnet-4"];
+pub const CURSOR_AGENT_DEFAULT_MODEL: &str = "auto";
+pub const CURSOR_AGENT_KNOWN_MODELS: &[&str] = &["auto", "gpt-5", "opus-4.1", "sonnet-4"];
 
 pub const CURSOR_AGENT_DOC_URL: &str = "https://docs.cursor.com/en/cli/overview";
 
@@ -267,7 +267,7 @@ impl CursorAgentProvider {
 
         // Only pass model parameter if it's in the known models list
         if CURSOR_AGENT_KNOWN_MODELS.contains(&self.model.model_name.as_str()) {
-            cmd.arg("-m").arg(&self.model.model_name);
+            cmd.arg("--model").arg(&self.model.model_name);
         }
 
         cmd.arg("-p")
@@ -455,7 +455,7 @@ mod tests {
         let provider = CursorAgentProvider::default();
         let config = provider.get_model_config();
 
-        assert_eq!(config.model_name, "gpt-5");
+        assert_eq!(config.model_name, "auto");
         // Context limit should be set by the ModelConfig
         assert!(config.context_limit() > 0);
     }


### PR DESCRIPTION
## Pull Request Description

As described in [issue #4540](https://github.com/block/goose/issues/4540), on Mac (at least) the Cursor Agent provider could not be configured via `goose configure` because the process failed with error: 

```
◇  Request failed: Command failed with exit code: Some(1)
│
└  Failed to configure provider: init chat completion request with tool did not succeed.
```

This was not (at least in my case) a permissions error, but a result of two difficulties with cursor-agent's model parameter. 

First, for some reason the documented "-m" argument to `cursor-agent` does not work in current versions; the full "--model" form must be used. 

Second, "gpt-5" was not recognized as a valid by `cursor-agent` (at least on my system, though the model is certainly available and listed under certain circumstances). Goose does not yet seem to implement real-time model enumeration for `cursor-agent`, so the quick fix is to use "auto" as the default. In effect, replacing the command arguments "-m gpt-5" with "--model auto" enables configuration to successfully conclude.

```
┌   goose-configure 
│
◇  What would you like to configure?
│  Configure Providers 
│
◇  Which model provider should we use?
│  Cursor Agent 
│
◇  Model fetch complete
│
◇  Enter a model from that provider:
│  auto
│
◓  Checking your configuration...                                                                                                                                
└  Configuration saved successfully
```