### PR TITLE
Add cli flag to auto open recipe deeplink

### DIFF
--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -58,6 +58,7 @@ tokio-util = { version = "0.7.15", features = ["compat"] }
 is-terminal = "0.4.16"
 anstream = "0.6.18"
 url = "2.5.7"
+open = "5.3.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -281,6 +281,13 @@ enum RecipeCommand {
             help = "recipe name to get recipe file or full path to the recipe file to generate deeplink"
         )]
         recipe_name: String,
+        
+        /// Automatically open the deeplink in Goose Desktop
+        #[arg(
+            long = "open",
+            help = "Automatically open the generated deeplink in Goose Desktop"
+        )]
+        open: bool,
     },
 
     /// List available recipes
@@ -1212,8 +1219,8 @@ pub async fn cli() -> Result<()> {
                 RecipeCommand::Validate { recipe_name } => {
                     handle_validate(&recipe_name)?;
                 }
-                RecipeCommand::Deeplink { recipe_name } => {
-                    handle_deeplink(&recipe_name)?;
+                RecipeCommand::Deeplink { recipe_name, open } => {
+                    handle_deeplink(&recipe_name, open)?;
                 }
                 RecipeCommand::List { format, verbose } => {
                     handle_list(&format, verbose)?;


### PR DESCRIPTION
## What Changed
Adds a new `--open` flag to the `goose recipe deeplink` command. This flag automatically opens the generated deeplink in the Goose Desktop app.

## Why?
Simplifies the workflow of developing and testing recipes. 

## Demo


https://github.com/user-attachments/assets/8084efb8-8e1f-4bf2-8b3b-0bf90f029194



