### PR TITLE
Allow empty API Key when registering custom provider

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1940,7 +1940,10 @@ fn add_provider() -> Result<(), Box<dyn Error>> {
         })
         .interact()?;
 
-    let api_key: String = cliclack::password("API key:").mask('▪').interact()?;
+    let api_key: String = cliclack::password("API key:")
+        .allow_empty()
+        .mask('▪')
+        .interact()?;
 
     let models_input: String = cliclack::input("Available models (seperate with commas):")
         .placeholder("model-a, model-b, model-c")


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
Some providers like ollama/ramalama does not require an API Key to serve models locally, for that, we can make this option accept empty values.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Closes #4797