### PR TITLE
fix: show PowerShell PATH instructions for Windows users

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -243,6 +243,7 @@ fi
 if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
   echo ""
   echo "Warning: goose installed, but $GOOSE_BIN_DIR is not in your PATH."
+  
   if [ "$OS" = "windows" ]; then
     echo "To add goose to your PATH in PowerShell:"
     echo ""
@@ -257,14 +258,37 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
     echo "    goose configure"
     echo "or rerun this install script after updating your PATH."
   else
-    echo "Add it to your PATH by editing ~/.bashrc, ~/.zshrc, or similar:"
-    echo "    export PATH=\"$GOOSE_BIN_DIR:\$PATH\""
-    echo "Then reload your shell (e.g. 'source ~/.bashrc', 'source ~/.zshrc') to apply changes."
+    SHELL_NAME=$(basename "$SHELL")
+    
     echo ""
-    echo "Alternatively, you can run:"
-    echo "    goose configure"
-    echo "or rerun this install script after updating your PATH."
+    echo "The \$GOOSE_BIN_DIR is not in your PATH."
+    echo "What would you like to do?"
+    echo "1) Add it for me"
+    echo "2) I'll add it myself, show instructions"
+    
+    read -p "Enter choice [1/2]: " choice
+    
+    case "$choice" in
+      1)
+        RC_FILE="$HOME/.${SHELL_NAME}rc"
+        echo "Adding \$GOOSE_BIN_DIR to $RC_FILE..."
+        echo "export PATH=\"$GOOSE_BIN_DIR:\$PATH\"" >> "$RC_FILE"
+        echo "Done! Reload your shell or run 'source $RC_FILE' to apply changes."
+        ;;
+      2)
+        echo ""
+        echo "Add it to your PATH by editing ~/.${SHELL_NAME}rc or similar:"
+        echo "    export PATH=\"$GOOSE_BIN_DIR:\$PATH\""
+        echo "Then reload your shell (e.g. 'source ~/.${SHELL_NAME}rc') to apply changes."
+        ;;
+      *)
+        echo "Invalid choice. Please add \$GOOSE_BIN_DIR to your PATH manually."
+        ;;
+    esac
   fi
+  
   echo ""
 fi
+
+
 

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -238,11 +238,34 @@ else
 fi
 
 # --- 7) Check PATH and give instructions if needed ---
+# ...existing code...
+
+# --- 7) Check PATH and give instructions if needed ---
 if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
   echo ""
   echo "Warning: goose installed, but $GOOSE_BIN_DIR is not in your PATH."
-  echo "Add it to your PATH by editing ~/.bashrc, ~/.zshrc, or similar:"
-  echo "    export PATH=\"$GOOSE_BIN_DIR:\$PATH\""
-  echo "Then reload your shell (e.g. 'source ~/.bashrc', 'source ~/.zshrc') to apply changes."
+  if [ "$OS" = "windows" ]; then
+    echo "To add goose to your PATH in PowerShell:"
+    echo ""
+    echo "# Add to your PowerShell profile"
+    echo '$profilePath = $PROFILE'
+    echo 'if (!(Test-Path $profilePath)) { New-Item -Path $profilePath -ItemType File -Force }'
+    echo 'Add-Content -Path $profilePath -Value ''$env:PATH = "$env:USERPROFILE\.local\bin;$env:PATH"'''
+    echo "# Reload profile or restart PowerShell"
+    echo '. $PROFILE'
+    echo ""
+    echo "Alternatively, you can run:"
+    echo "    goose configure"
+    echo "or rerun this install script after updating your PATH."
+  else
+    echo "Add it to your PATH by editing ~/.bashrc, ~/.zshrc, or similar:"
+    echo "    export PATH=\"$GOOSE_BIN_DIR:\$PATH\""
+    echo "Then reload your shell (e.g. 'source ~/.bashrc', 'source ~/.zshrc') to apply changes."
+    echo ""
+    echo "Alternatively, you can run:"
+    echo "    goose configure"
+    echo "or rerun this install script after updating your PATH."
+  fi
   echo ""
 fi
+# ...existing code...

--- a/download_cli.sh
+++ b/download_cli.sh
@@ -237,8 +237,7 @@ else
   echo "Skipping 'goose configure', you may need to run this manually later"
 fi
 
-# --- 7) Check PATH and give instructions if needed ---
-# ...existing code...
+
 
 # --- 7) Check PATH and give instructions if needed ---
 if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
@@ -268,4 +267,4 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
   fi
   echo ""
 fi
-# ...existing code...
+


### PR DESCRIPTION

##  Problem

Goose CLI install script shows **Unix-style PATH instructions** on Windows (e.g., `.bashrc`, `.zshrc`).
This confuses Windows users, who primarily use **PowerShell**.
##  Before

```text
Warning: goose installed, but /home/rob-admin/.local/bin is not in your PATH.
Add it to your PATH by editing ~/.bashrc, ~/.zshrc, or similar...
```
##  After

```text
Warning: goose installed, but C:\Users\<user>\.local\bin is not in your PATH.
To add goose to your PATH in PowerShell:

$profilePath = $PROFILE
if (!(Test-Path $profilePath)) { New-Item -Path $profilePath -ItemType File -Force }
Add-Content -Path $profilePath -Value '$env:PATH = "$env:USERPROFILE\.local\bin;$env:PATH"'
. $PROFILE

Alternatively: goose configure
```
##  Fix

* Detect Windows and show **PowerShell instructions**.
* Keep Bash/Zsh for Unix systems.
* Added alternatives: `goose configure` or rerun script.
##  Benefit

Clearer setup for Windows users → **less confusion, smoother onboarding**.
