### PR TITLE
fix: check server is ready so that we can decode the recipe deeplink

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -593,6 +593,13 @@ const createChat = async (
   );
   goosedClients.set(mainWindow.id, goosedClient);
 
+  console.log('[Main] Waiting for backend server to be ready...');
+  const serverReady = await checkServerStatus(goosedClient);
+  if (!serverReady) {
+    throw new Error('Backend server failed to start in time');
+  }
+  console.log('[Main] Backend server is ready');
+
   // Let windowStateKeeper manage the window
   mainWindowState.manage(mainWindow);
 
@@ -1059,7 +1066,6 @@ ipcMain.handle('get-goosed-host-port', async (event) => {
   if (!client) {
     return null;
   }
-  await checkServerStatus(client);
   return client.getConfig().baseUrl || null;
 });
 

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -598,7 +598,6 @@ const createChat = async (
   if (!serverReady) {
     throw new Error('Backend server failed to start in time');
   }
-  console.log('[Main] Backend server is ready');
 
   // Let windowStateKeeper manage the window
   mainWindowState.manage(mainWindow);


### PR DESCRIPTION
## Summary
**Issue:** When deeplink is triggered in chrome, a new window is created but the recipe is not loaded. 
**Why:**  There is a race condition that the server is not up when triggering decode recipe api call

<img width="1314" height="110" alt="Screenshot 2025-10-06 at 2 57 48 pm" src="https://github.com/user-attachments/assets/ca4bf695-73d3-47c2-b7ae-8c9a76630223" />

**Fix:** 
-  Check server is ready when creating a new window (in create_chat). 
-  This will the centralised place to check server status.  Removed the existing check in `get-goosed-host-port` handling as it is redundant now




### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Manual testing