### PR TITLE
fix: missing cmake and protobuf for windows build, deduplicate sh/pws…

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -138,14 +138,18 @@ copy-binary-windows:
     } else { \
         Write-Host 'Windows goose-scheduler-executor binary not found.' -ForegroundColor Yellow; \
     }"
-    @if [ -f ./temporal-service/temporal-service.exe ]; then \
-        echo "Copying Windows temporal-service binary..."; \
-        cp -p ./temporal-service/temporal-service.exe ./ui/desktop/src/bin/; \
-    else \
-        echo "Windows temporal-service binary not found. Building it..."; \
-        cd temporal-service && GOOS=windows GOARCH=amd64 go build -o temporal-service.exe main.go && cp temporal-service.exe ../ui/desktop/src/bin/; \
-    fi
-    @echo "Note: Temporal CLI for Windows will be downloaded at runtime if needed"
+    @powershell.exe -Command "if (Test-Path './temporal-service/temporal-service.exe') { \
+        Write-Host 'Copying Windows temporal-service binary...'; \
+        Copy-Item -Path './temporal-service/temporal-service.exe' -Destination './ui/desktop/src/bin/' -Force; \
+    } else { \
+        Write-Host 'Windows temporal-service binary not found. Building it...'; \
+        Push-Location 'temporal-service'; \
+        $env:GOOS='windows'; $env:GOARCH='amd64'; \
+        go build -o temporal-service.exe main.go; \
+        Copy-Item -Path 'temporal-service.exe' -Destination '../ui/desktop/src/bin/' -Force; \
+        Pop-Location; \
+    }"
+    @powershell.exe -Command "Write-Host 'Note: Temporal CLI for Windows will be downloaded at runtime if needed'"
 
 # Run UI with latest
 run-ui:


### PR DESCRIPTION
…h build commands

## Summary
Fix: install missing cmake and protobuf to docker image for windows release build started from cmd/powershell, to align with other platforms.

Build on Windows is broken otherwise.

Original problem was that the release-windows docker build command `apt-get install -y mingw-w64 protobuf-compiler cmake`... was missing `cmake` and `protobuf-compiler` when started from `powershell`, and not `sh`. Apparently someone added it to `sh`, but forgot to put it to the `powershell` part, so if the build was started from powershell, it didn't work.

I extracted the command to a variable, this way it's in one place and people won't have to remember to make the changes twice.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [x] Build / Release
- [ ] Other (specify below)

### Related Issues
Another stab at PR at https://github.com/block/goose/pull/4816
