### PR TITLE
Add support for headers in extensions deeplinks

### DIFF
--- a/documentation/src/pages/extensions/detail.tsx
+++ b/documentation/src/pages/extensions/detail.tsx
@@ -167,6 +167,34 @@ const getDocumentationPath = (serverId: string): string => {
                     </div>
                   )}
 
+                  {server.headers && server.headers.length > 0 && (
+                    <div className="space-y-4">
+                      <h2 className="text-lg font-medium text-textStandard m-0">
+                        Request Headers
+                      </h2>
+                      <div>
+                        {server.headers.map((header) => (
+                          <div
+                            key={header.name}
+                            className="border-b border-borderSubtle py-4 first:pt-0 last:border-0"
+                          >
+                            <div className="text-sm text-textStandard font-medium">
+                              {header.name}
+                            </div>
+                            <div className="text-textSubtle text-sm mt-1">
+                              {header.description}
+                            </div>
+                            {header.required && (
+                              <Badge variant="secondary" className="mt-2">
+                                Required
+                              </Badge>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  )}
+
                   <div className="card-footer">
                     {githubStars !== null && (
                       <a

--- a/documentation/src/types/prompt.ts
+++ b/documentation/src/types/prompt.ts
@@ -4,6 +4,12 @@ export type EnvironmentVariable = {
   required: boolean;
 };
 
+export type Header = {
+  name: string;
+  description: string;
+  required: boolean;
+};
+
 export type Extension = {
   name: string;
   command?: string;
@@ -12,6 +18,7 @@ export type Extension = {
   link?: string;
   installation_notes?: string;
   environmentVariables?: EnvironmentVariable[];
+  headers?: Header[];
 };
 
 export type Prompt = {

--- a/documentation/src/types/server.ts
+++ b/documentation/src/types/server.ts
@@ -14,4 +14,9 @@ export interface MCPServer {
     description: string;
     required: boolean;
   }[];
+  headers?: {
+    name: string;
+    description: string;
+    required: boolean;
+  }[];
 }

--- a/documentation/src/utils/install-links.ts
+++ b/documentation/src/utils/install-links.ts
@@ -25,6 +25,11 @@ export function getGooseInstallLink(server: MCPServer): string {
         .map(
           (env) => `env=${encodeURIComponent(`${env.name}=${env.description}`)}`
         ),
+      ...(server.headers || [])
+        .filter((header) => header.required)
+        .map(
+          (header) => `header=${encodeURIComponent(`${header.name}=${header.description}`)}`
+        ),
     ].join("&");
   
     return `goose://extension?${queryParams}`;

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -288,10 +288,11 @@
     "installation_notes": "This is a remote extension. Configure using the endpoint URL in Goose settings.",
     "is_builtin": false,
     "endorsed": true,
-    "environmentVariables": [
+    "environmentVariables": [],
+    "headers": [
       {
-        "name": "GITHUB_PERSONAL_ACCESS_TOKEN",
-        "description": "Required environment variable",
+        "name": "Authorization",
+        "description": "GitHub Personal Access Token",
         "required": true
       }
     ],


### PR DESCRIPTION
## Summary
Extensions deeplinks support specifying env vars but not http header vars 


### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
open a link such as

```
goose://extension?type=streamable_http&url=https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2F&id=github-mcp&name=GitHub&description=GitHub%20repository%20management%20and%20operations&header=Authorization%3Dyour%20token
```