### PR TITLE
Allow auto focus and typing while chat is initializing

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1183,13 +1183,7 @@ export default function ChatInput({
     isExtensionsLoading;
 
   const isUserInputDisabled =
-    isAnyImageLoading ||
-    isAnyDroppedFileLoading ||
-    isRecording ||
-    isTranscribing ||
-    isCompacting ||
-    !agentIsReady ||
-    isExtensionsLoading;
+    isAnyImageLoading || isAnyDroppedFileLoading || isRecording || isTranscribing || isCompacting;
 
   // Queue management functions - no storage persistence, only in-memory
   const handleRemoveQueuedMessage = (messageId: string) => {


### PR DESCRIPTION
## Summary
Remove disabled input while agent is not ready or extensions are loading
I think we got a little heavy handed with this, user feedback made it clear that they should still be able to type right away 
Submit is still disabled until ready.

fixes https://github.com/block/goose/issues/5039