### PR TITLE
Fix bedrock tool input schema

### DIFF
--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -188,6 +188,14 @@ pub fn to_bedrock_tool_config(tools: &[Tool]) -> Result<bedrock::ToolConfigurati
 }
 
 pub fn to_bedrock_tool(tool: &Tool) -> Result<bedrock::Tool> {
+    let mut input_schema = tool.input_schema.as_ref().clone();
+
+    // If the schema doesn't have a "type" field, add it
+    // This is required by Bedrock
+    if !input_schema.contains_key("type") {
+        input_schema.insert("type".to_string(), Value::String("object".to_string()));
+    }
+
     Ok(bedrock::Tool::ToolSpec(
         bedrock::ToolSpecification::builder()
             .name(tool.name.to_string())
@@ -198,7 +206,7 @@ pub fn to_bedrock_tool(tool: &Tool) -> Result<bedrock::Tool> {
                     .unwrap_or_default(),
             )
             .input_schema(bedrock::ToolInputSchema::Json(to_bedrock_json(
-                &Value::Object(tool.input_schema.as_ref().clone()),
+                &Value::Object(input_schema),
             )))
             .build()?,
     ))


### PR DESCRIPTION
## Summary
The todo extension added in https://github.com/block/goose/pull/4868
causes errors with bedrock because bedrock expects an input schema.

Without this fix, bedrock tool calls fail with

Error: Server error: Failed to call Bedrock:
ValidationException(ValidationException { message: Some("The value at
toolConfig.tools.3.toolSpec.inputSchema.json.type must be one of the
following: object."), meta: ErrorMetadata { code:
Some("ValidationException"), message: Some("The value at
toolConfig.tools.3.toolSpec.inputSchema.json.type must be one of the
following: object."), extras: Some({"aws_request_id":
"9813e4c5-607f-47fc-8a6a-4387ef28acb7"}) } })

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested by seeing that an error no longer occurs after this patch.