### PR TITLE
Fix mcp large response race condition

### DIFF
--- a/crates/goose/src/agents/large_response_handler.rs
+++ b/crates/goose/src/agents/large_response_handler.rs
@@ -64,7 +64,7 @@ fn write_large_text_to_file(content: &str) -> Result<String, std::io::Error> {
     std::fs::create_dir_all(&temp_dir)?;
 
     // Generate a unique filename with timestamp
-    let timestamp = Utc::now().format("%Y%m%d_%H%M%S");
+    let timestamp = Utc::now().format("%Y%m%d_%H%M%S%.6f");
     let filename = format!("mcp_response_{}.txt", timestamp);
     let file_path = temp_dir.join(&filename);
 


### PR DESCRIPTION
## Summary
When multiple subagents are running in parallel and they call an mcp
tool that returns a large response, these responses may all be returned
at the exact same second which can result in subagents receiving paths
containing the incorrect information.

We fix this by adding microseconds to the filename so that this is very
unlikely to occur anymore. Maybe a better solution is to check if the
file exists, but I think this is sufficient for now.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested that this race condition no longer occurs when the main agent calls subagents to run in parallel.
