### PR TITLE
Fix extension manager resource deadlock

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -705,9 +705,13 @@ impl ExtensionManager {
         // Loop through each extension and try to read the resource, don't raise an error if the resource is not found
         // TODO: do we want to find if a provided uri is in multiple extensions?
         // currently it will return the first match and skip any others
-        for extension_name in self.extensions.lock().await.keys() {
+
+        // Collect extension names first to avoid holding the lock during iteration
+        let extension_names: Vec<String> = self.extensions.lock().await.keys().cloned().collect();
+
+        for extension_name in extension_names {
             let result = self
-                .read_resource_from_extension(uri, extension_name, cancellation_token.clone())
+                .read_resource_from_extension(uri, &extension_name, cancellation_token.clone())
                 .await;
             match result {
                 Ok(result) => return Ok(result),


### PR DESCRIPTION
## Summary
The loop in the read_resource method will lock self.extensions and the same loop within the read_resource_from_extension method also locks the same variable causing a deadlock when the is ran. This patch fixes this by first collecting the names before calling into
read_resource_from_extension.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
This was manually tested and observed that the deadlock no longer occurs
