### PR TITLE
Add hint for focus mode when used on file paths for `analyze` tool

### DIFF
--- a/crates/goose-mcp/src/developer/analyze/mod.rs
+++ b/crates/goose-mcp/src/developer/analyze/mod.rs
@@ -318,6 +318,14 @@ impl CodeAnalyzer {
             outgoing_chains: &outgoing_chains,
         };
 
-        Ok(Formatter::format_focused_output(&focus_data))
+        let mut output = Formatter::format_focused_output(&focus_data);
+
+        if path.is_file() {
+            let hint = "NOTE: Focus mode works best with directory paths. \
+                        Use a parent directory in the path for cross-file analysis.\n\n";
+            output = format!("{}{}", hint, output);
+        }
+
+        Ok(output)
     }
 }


### PR DESCRIPTION
When using the `analyze` tool's focus mode on a file path instead of a directory, show a brief note suggesting that directory paths work better for cross-file analysis.

**Example**:
```
NOTE: Focus mode works best with directory paths. Use a parent directory in the path for cross-file analysis.

FOCUSED ANALYSIS: symbol_name
...
```

The hint appears only when both conditions are met: focus mode is active and the target is a file. Directory analysis is unchanged.