### PR TITLE
fix : enhance fuzzy file search in goose desktop

### DIFF
--- a/ui/desktop/src/components/MentionPopover.tsx
+++ b/ui/desktop/src/components/MentionPopover.tsx
@@ -108,13 +108,29 @@ const MentionPopover = forwardRef<
   // Filter and sort files based on query
   const displayFiles = useMemo((): FileItemWithMatch[] => {
     if (!query.trim()) {
-      return files.slice(0, 15).map((file) => ({
-        ...file,
-        matchScore: 0,
-        matches: [],
-        matchedText: file.name,
-      })); // Show first 15 files when no query
+      const currentWorkingDir = window.appConfig.get('GOOSE_WORKING_DIR') as string;
+      return files
+        .map((file) => ({
+          ...file,
+          matchScore: 0,
+          matches: [],
+          matchedText: file.name,
+          depth: currentWorkingDir
+            ? file.path.replace(currentWorkingDir, '').split('/').length - 1
+            : 999,
+        }))
+        .sort((a, b) =>
+          a.depth !== b.depth
+            ? a.depth - b.depth
+            : a.isDirectory !== b.isDirectory
+              ? a.isDirectory
+                ? 1
+                : -1
+              : a.name.localeCompare(b.name)
+        );
     }
+
+    const currentWorkingDir = window.appConfig.get('GOOSE_WORKING_DIR') as string;
 
     const results = files
       .map((file) => {
@@ -136,9 +152,15 @@ const MentionPopover = forwardRef<
           matchedText = file.path;
         }
 
+        let finalScore = bestMatch.score;
+        if (finalScore > 0 && currentWorkingDir) {
+          const depth = file.path.replace(currentWorkingDir, '').split('/').length - 1;
+          finalScore += depth <= 1 ? 50 : depth <= 2 ? 30 : depth <= 3 ? 15 : 0;
+        }
+
         return {
           ...file,
-          matchScore: bestMatch.score,
+          matchScore: finalScore,
           matches: bestMatch.matches,
           matchedText,
         };
@@ -146,15 +168,15 @@ const MentionPopover = forwardRef<
       .filter((file) => file.matchScore > 0)
       .sort((a, b) => {
         // Sort by score first, then prefer files over directories, then alphabetically
-        if (Math.abs(a.matchScore - b.matchScore) < 1) {
-          if (a.isDirectory !== b.isDirectory) {
-            return a.isDirectory ? 1 : -1; // Files first
-          }
-          return a.name.localeCompare(b.name);
-        }
-        return b.matchScore - a.matchScore;
-      })
-      .slice(0, 20); // Increase to 20 results
+        const scoreDiff = b.matchScore - a.matchScore;
+        return Math.abs(scoreDiff) >= 1
+          ? scoreDiff
+          : a.isDirectory !== b.isDirectory
+            ? a.isDirectory
+              ? 1
+              : -1
+            : a.name.localeCompare(b.name);
+      });
 
     return results;
   }, [files, query]);
@@ -412,12 +434,15 @@ const MentionPopover = forwardRef<
   const scanFilesFromRoot = useCallback(async () => {
     setIsLoading(true);
     try {
-      // Start from common user directories for better performance
-      let startPath = '/Users'; // Default to macOS
-      if (window.electron.platform === 'win32') {
-        startPath = 'C:\\Users';
-      } else if (window.electron.platform === 'linux') {
-        startPath = '/home';
+      let startPath = window.appConfig.get('GOOSE_WORKING_DIR') as string;
+
+      if (!startPath) {
+        startPath = '/Users'; // Default to macOS
+        if (window.electron.platform === 'win32') {
+          startPath = 'C:\\Users';
+        } else if (window.electron.platform === 'linux') {
+          startPath = '/home';
+        }
       }
 
       const scannedFiles = await scanDirectoryFromRoot(startPath);
@@ -432,36 +457,38 @@ const MentionPopover = forwardRef<
 
   // Scroll selected item into view
   useEffect(() => {
-    if (listRef.current) {
+    if (listRef.current && selectedIndex >= 0 && selectedIndex < displayFiles.length) {
       const selectedElement = listRef.current.children[selectedIndex] as HTMLElement;
       if (selectedElement) {
-        selectedElement.scrollIntoView({ block: 'nearest' });
+        selectedElement.scrollIntoView({
+          block: 'nearest',
+          behavior: 'smooth',
+        });
       }
     }
-  }, [selectedIndex]);
+  }, [selectedIndex, displayFiles.length]);
 
   const handleItemClick = (index: number) => {
-    onSelectedIndexChange(index);
-    onSelect(displayFiles[index].path);
-    onClose();
+    if (index >= 0 && index < displayFiles.length) {
+      onSelectedIndexChange(index);
+      onSelect(displayFiles[index].path);
+      onClose();
+    }
   };
 
   if (!isOpen) return null;
 
-  const displayedFiles = displayFiles.slice(0, 8); // Show up to 8 files
-  const remainingCount = displayFiles.length - displayedFiles.length;
-
   return (
     <div
       ref={popoverRef}
-      className="fixed z-50 bg-background-default border border-borderStandard rounded-lg shadow-lg min-w-96 max-w-lg"
+      className="fixed z-50 bg-background-default border border-borderStandard rounded-lg shadow-lg min-w-96 max-w-lg max-h-80"
       style={{
         left: position.x,
         top: position.y - 10, // Position above the chat input
         transform: 'translateY(-100%)', // Move it fully above
       }}
     >
-      <div className="p-3">
+      <div className="p-3 flex flex-col max-h-80">
         {isLoading ? (
           <div className="flex items-center justify-center py-4">
             <div className="animate-spin rounded-full h-4 w-4 border-t-2 border-b-2 border-textSubtle"></div>
@@ -469,8 +496,17 @@ const MentionPopover = forwardRef<
           </div>
         ) : (
           <>
-            <div ref={listRef} className="space-y-1">
-              {displayedFiles.map((file, index) => (
+            {displayFiles.length > 0 && (
+              <div className="text-xs text-textSubtle mb-2 px-1">
+                {displayFiles.length} file{displayFiles.length !== 1 ? 's' : ''} found
+              </div>
+            )}
+            <div
+              ref={listRef}
+              className="space-y-1 overflow-y-auto flex-1 scrollbar-thin scrollbar-thumb-borderStandard scrollbar-track-transparent"
+              style={{ maxHeight: '280px' }}
+            >
+              {displayFiles.map((file, index) => (
                 <div
                   key={file.path}
                   onClick={() => handleItemClick(index)}
@@ -490,26 +526,18 @@ const MentionPopover = forwardRef<
                 </div>
               ))}
 
-              {!isLoading && displayedFiles.length === 0 && query && (
+              {!isLoading && displayFiles.length === 0 && query && (
                 <div className="p-4 text-center text-textSubtle text-sm">
                   No files found matching "{query}"
                 </div>
               )}
 
-              {!isLoading && displayedFiles.length === 0 && !query && (
+              {!isLoading && displayFiles.length === 0 && !query && (
                 <div className="p-4 text-center text-textSubtle text-sm">
                   Start typing to search for files
                 </div>
               )}
             </div>
-
-            {remainingCount > 0 && (
-              <div className="mt-2 pt-2 border-t border-borderSubtle">
-                <div className="text-xs text-textSubtle text-center">
-                  Show {remainingCount} more...
-                </div>
-              </div>
-            )}
           </>
         )}
       </div>


### PR DESCRIPTION
Closes: https://github.com/block/goose/issues/5054

### Pull Request Description

This PR aims to fix the "@" fuzzy/reference search functionality in Goose Desktop to show files relative to the current working directory instead of the entire system, and adds proper scrolling to display all available files without artificial limits.

### Type of Change

- [x] Feature
- [x] Bug fix
- [x] Performance improvement

### Changes made:

- File Search Scope: Changed "@" fuzzy search to start from the current working directory `GOOSE_WORKING_DIR` instead of user's home directory, and enhanced scoring algorithm to prioritize files closer to current working directory.

- Scrolling Support and UI Improvements: Removed artificial 8-file limit and added full scrolling functionality with max-height: 280px and smooth scroll behavior also added file count indicator and improved keyboard navigation with proper scroll-into-view behavior

### Testing

Tested it in the Goose desktop by using the change 


### Screenshots/Demos (for UX changes)

![gooseSearch](https://github.com/user-attachments/assets/0afe2fb8-e045-4200-8b04-ec4ad7d0a371)

