### PR TITLE
Fix: Prevent cross-contamination of cache data across analysis modes

### DIFF
--- a/crates/goose-mcp/src/developer/analyze/mod.rs
+++ b/crates/goose-mcp/src/developer/analyze/mod.rs
@@ -179,7 +179,7 @@ impl CodeAnalyzer {
             )
         })?;
 
-        if let Some(cached) = self.cache.get(&path.to_path_buf(), modified) {
+        if let Some(cached) = self.cache.get(&path.to_path_buf(), modified, mode) {
             tracing::trace!("Using cached result for {:?}", path);
             return Ok(cached);
         }
@@ -224,7 +224,8 @@ impl CodeAnalyzer {
 
         result.line_count = line_count;
 
-        self.cache.put(path.to_path_buf(), modified, result.clone());
+        self.cache
+            .put(path.to_path_buf(), modified, mode, result.clone());
 
         Ok(result)
     }

--- a/crates/goose-mcp/src/developer/analyze/types.rs
+++ b/crates/goose-mcp/src/developer/analyze/types.rs
@@ -131,7 +131,7 @@ pub struct FocusedAnalysisData<'a> {
 }
 
 /// Analysis modes
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum AnalysisMode {
     Structure, // Directory overview
     Semantic,  // File details


### PR DESCRIPTION
## Summary
This PR fixes a cache contamination bug where the `analyze` tool's (from Developer extension) LRU cache would incorrectly return cached results from one analysis mode (e.g., Structure) when a different mode (e.g., Semantic) was requested. The root cause was that the cache key only included the file path and modification time, but not the analysis mode, allowing different modes to overwrite each other's cached data. 

The fix adds the `AnalysisMode` enum as a third component to the `CacheKey` struct, ensuring that each combination of (path, modified time, mode) creates a separate cache entry. This prevents Structure mode's lightweight directory data from contaminating Semantic mode's detailed AST analysis results, which was problematic when both modes were used sequentially in the same session and would cause the tool to return incomplete results.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
I added a unit test for validating cache separation, and I also tested this manually on a local codebase 

### Related Issues
Fixes #5074 
