### PR TITLE
Fix Hacktoberfest Leaderboard

### DIFF
--- a/.github/workflows/update-hacktoberfest-leaderboard.yml
+++ b/.github/workflows/update-hacktoberfest-leaderboard.yml
@@ -2,220 +2,253 @@ name: Update Hacktoberfest Leaderboard
 
 on:
   schedule:
-  # Only during October
-    - cron: '0 * * 10 *'  # Runs every hour at the start of the hour during October
-  workflow_dispatch:  # Allows manual triggering
+    # Runs every hour at the start of the hour during October (UTC)
+    - cron: '0 * * 10 *'
+  workflow_dispatch:
 
 jobs:
   update-leaderboard:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
       issues: write
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v4
+      - name: Checkout repository
+        uses: actions/checkout@v4
 
-    - name: Update Leaderboard
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-          const owner = context.repo.owner;
-          const repo = context.repo.repo;
-          const issueNumber = 4775; // Your issue number
+      - name: Update Leaderboard
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issueNumber = 4775; // Update if needed
 
-          // Add your repositories here - you can include any repos you want to track
-          const REPOS = [
-            'block/goose',
-            // Add more repositories as needed, e.g.:
-            // 'taniashiba/your-other-repo',
-            // 'your-org/another-repo'
-          ];
+            // Track the Goose repo only
+            const REPOS = [
+              'block/goose'
+            ];
 
-          const POINT_VALUES = {
-            small: 5,
-            medium: 10,
-            large: 15
-          };
+            const POINT_VALUES = { small: 5, medium: 10, large: 15 };
 
-          const calculatePoints = (labels) => {
-            const size = labels.find(label => POINT_VALUES[label.name.toLowerCase()]);
-            return size ? POINT_VALUES[size.name.toLowerCase()] : POINT_VALUES.small;
-          };
-
-          const getBiggestPRSize = (prs) => {
-            const sizes = prs.map(pr => {
-              const sizeLabel = pr.labels.find(label => POINT_VALUES[label.name.toLowerCase()]);
-              return sizeLabel ? sizeLabel.name.toLowerCase() : 'small';
-            });
             
-            if (sizes.includes('large')) return 'large';
-            if (sizes.includes('medium')) return 'medium';
-            return 'small';
-          };
-
-          const fetchRecentPRs = async (repo) => {
-            try {
-              console.log(`Fetching recent PRs for ${repo}`);
-              const [repoOwner, repoName] = repo.split('/');
-              
-              const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
-              
-              const { data: prs } = await github.rest.pulls.list({
-                owner: repoOwner,
-                repo: repoName,
-                state: 'closed',
-                sort: 'updated',
-                direction: 'desc',
-                per_page: 100
-              });
-
-              console.log(`Fetched ${prs.length} PRs for ${repo}`);
-
-              const hacktoberfestPRs = prs.filter(pr => {
-                const isMerged = !!pr.merged_at;
-                const isRecent = new Date(pr.merged_at) > new Date(thirtyDaysAgo);
-                const isHacktoberfest = pr.labels.some(label => 
-                  label.name.toLowerCase() === 'hacktoberfest' || 
-                  label.name.toLowerCase() === 'hacktoberfest-completed'
-                );
-                return isMerged && isRecent && isHacktoberfest;
-              }).map(pr => ({
-                user: pr.user.login,
-                points: calculatePoints(pr.labels),
-                repo: repo,
-                prNumber: pr.number,
-                prTitle: pr.title,
-                labels: pr.labels
-              }));
-
-              return hacktoberfestPRs;
-            } catch (error) {
-              console.error(`Error fetching PRs for ${repo}: ${error.message}`);
-              return [];
-            }
-          };
-
-          const generateLeaderboard = async () => {
-            try {
-              const allPRs = await Promise.all(REPOS.map(fetchRecentPRs));
-              const flatPRs = allPRs.flat();
-
-              const leaderboard = flatPRs.reduce((acc, pr) => {
-                if (!acc[pr.user]) {
-                  acc[pr.user] = { 
-                    points: 0, 
-                    prs: 0, 
-                    userPRs: [] 
-                  };
-                }
-                acc[pr.user].points += pr.points;
-                acc[pr.user].prs += 1;
-                acc[pr.user].userPRs.push(pr);
-                return acc;
-              }, {});
-
-              const sortedLeaderboard = Object.entries(leaderboard)
-                .sort(([, a], [, b]) => {
-                  // First sort by points
-                  if (b.points !== a.points) return b.points - a.points;
-                  
-                  // If points are tied, sort by biggest PR size
-                  const aBiggest = getBiggestPRSize(a.userPRs);
-                  const bBiggest = getBiggestPRSize(b.userPRs);
-                  const sizeOrder = { large: 3, medium: 2, small: 1 };
-                  return sizeOrder[bBiggest] - sizeOrder[aBiggest];
-                })
-                .map(([username, data], index) => ({ 
-                  rank: index + 1, 
-                  username, 
-                  points: data.points, 
-                  prs: data.prs,
-                  biggestPR: getBiggestPRSize(data.userPRs)
-                }));
-
-              return sortedLeaderboard;
-            } catch (error) {
-              console.error(`Error generating leaderboard: ${error.message}`);
-              return [];
-            }
-          };
-
-          const updateIssue = async (leaderboardData) => {
-            const getRankEmoji = (rank) => {
-              if (rank <= 3) return '⭐⭐⭐';
-              if (rank <= 10) return '⭐';
-              return '';
+            const calculatePoints = (labels) => {
+              const size = labels.find(label => POINT_VALUES[label.name.toLowerCase()]);
+              return size ? POINT_VALUES[size.name.toLowerCase()] : POINT_VALUES.small;
             };
 
-            const issueBody = `# 🏆 Hacktoberfest 2025 Goose Leaderboard 🏆\n` +
-              `Hello, lovely contributors! As Hacktoberfest 2025 and the crisp Fall breeze refreshes us, we wanted to make the contribution process extra fun. Check our live leaderboard below to see who our top contributors are this year in real-time. Not only does this recognize your efforts, it also brings an amplified competitive vibe with each contribution.\n\n` +
-              `### 🌟 **Current Rankings:**\n\n` +
-              `| Rank | Contributor | Points | PRs | Biggest PR to Date |\n` +
-              `|------|-------------|--------|-----|--------------------|\n` +
-              `${leaderboardData.map(entry => '| ' + entry.rank + ' ' + getRankEmoji(entry.rank) + ' | @' + entry.username + ' | ' + entry.points + ' | ' + entry.prs + ' | ' + entry.biggestPR + ' |').join('\\n')}\n\n` +
-              `### 📜 How It Works:\n` +
-              `The top 20 contributors will earn the first ever goose swag from the swag shop along with LLM credits! To earn your place in the leaderboard, we have created a points system that is explained below. As you complete a task by successfully merging a PR, you will automatically be granted a certain # of points.\n\n` +
-              `#### 💯 Point System\n` +
-              `| Weight | Points Awarded | Description |\n` +
-              `|---------|-------------|-------------|\n` +
-              `| 🐭 **Small** | 5 points | For smaller tasks that take limited time to complete and/or don't require any product knowledge. |\n` +
-              `| 🐰 **Medium** | 10 points | For average tasks that take additional time to complete and/or require some product knowledge. |\n` +
-              `| 🐂 **Large** | 15 points | For heavy tasks that takes lots of time to complete and/or possibly require deep product knowledge. |\n\n` +
-              `#### 🎁 Rewards\n` +
-              `- Made it to the **top 5**? Our Top 5 Contributors with the most points will be awarded $100 gift cards to our brand new goose swag shop and $100 of LLM credits!\n` +
-              `- Reached the top **6-10**? Our Top 6-10 Contributors with the most points will be awarded $50 gift cards to our brand new goose swag shop and $50 of LLM credits!\n` +
-              `- Landed in the top **11-20**? Our Top 11-20 Contributors with the most points will be awarded $25 of LLM credits! Keep an eye on your progress to make sure you're one step ahead!\n\n` +
-              `### FAQ\n` +
-              `- **Frequency of Updates:** The leaderboard will be updated every hour.\n` +
-              `- **Criteria:** Rankings are based on how many points you earn across all approved PRs in the goose repo. To ensure your PRs are successfully merged:\n` +
-              `  - Ensure your contributions are aligned with our project's Code of Conduct.\n` +
-              `  - Refer to the goose repo's Contributing Guide.\n` +
-              `- **Tie-Breakers:** In the event of a tie in total points, the contributor with the highest value single contribution (large > medium > small) will be ranked higher.\n\n\n` +
-              `### 🚀 Get Featured:\n` +
-              `Want to see your name climbing our ranks?\n\n` +
-              `Explore our issues with the labels \`good-first-issue\` , \`no-code\` and \`hacktoberfest\` in the goose repo' Project Hub:\n\n` +
-              `- **goose**\n` +
-              `  - Hacktoberfest Project Hub\n` +
-              `  - Contributing Guide\n\n\n` +
-              `Excited to see everyone's hard work. Thank you so much for your invaluable contributions, and let the fun competition begin!\n\n` +
-              `Last updated: ${new Date().toUTCString()}`;
-
-            try {
-              await github.rest.issues.update({
-                owner,
-                repo,
-                issue_number: issueNumber,
-                body: issueBody
+            const getBiggestPRSize = (prs) => {
+              const sizes = prs.map(pr => {
+                const sizeLabel = pr.labels.find(label => POINT_VALUES[label.name.toLowerCase()]);
+                return sizeLabel ? sizeLabel.name.toLowerCase() : 'small';
               });
+              if (sizes.includes('large')) return 'large';
+              if (sizes.includes('medium')) return 'medium';
+              return 'small';
+            };
 
-              console.log("Issue updated successfully!");
-            } catch (error) {
-              throw new Error(`Failed to update issue: ${error.message}`);
+            // Strict October window (UTC)
+            const now = new Date();
+            const year = now.getUTCFullYear();
+            const startDate = new Date(Date.UTC(year, 9, 1, 0, 0, 0));       // Oct 1, 00:00:00 UTC
+            const endDate   = new Date(Date.UTC(year, 9, 31, 23, 59, 59));   // Oct 31, 23:59:59 UTC
+
+            const fetchRecentPRs = async (fullRepo) => {
+              try {
+                console.log(`Fetching recent PRs for ${fullRepo}`);
+                const [repoOwner, repoName] = fullRepo.split('/');
+
+                let allPRs = [];
+                let page = 1;
+
+                // Paginate through closed PRs sorted by updated desc
+                while (true) {
+                  const { data: prs } = await github.rest.pulls.list({
+                    owner: repoOwner,
+                    repo: repoName,
+                    state: 'closed',
+                    sort: 'updated',
+                    direction: 'desc',
+                    per_page: 100,
+                    page
+                  });
+
+                  allPRs = allPRs.concat(prs);
+
+                  if (prs.length < 100) break;
+
+                  // Early exit if the oldest updated item on this page precedes October
+                  const oldestUpdated = new Date(prs[prs.length - 1].updated_at);
+                  if (oldestUpdated < startDate) break;
+
+                  page++;
+                }
+
+                console.log(`Fetched ${allPRs.length} PRs for ${fullRepo}`);
+
+                // Strict: must be merged in October AND have label exactly "hacktoberfest"
+                const hacktoberfestPRs = allPRs
+                  .filter(pr => {
+                    if (!pr.merged_at) return false;
+                    const mergedAt = new Date(pr.merged_at);
+                    const inOctober = mergedAt >= startDate && mergedAt <= endDate;
+                    const isHacktoberfest = pr.labels.some(
+                      label => label.name.toLowerCase() === 'hacktoberfest'
+                    );
+                    return inOctober && isHacktoberfest;
+                  })
+                  .map(pr => ({
+                    user: pr.user.login,
+                    points: calculatePoints(pr.labels),
+                    repo: fullRepo,
+                    prNumber: pr.number,
+                    prTitle: pr.title,
+                    labels: pr.labels
+                  }));
+
+                return hacktoberfestPRs;
+              } catch (error) {
+                console.warn(`Error fetching PRs for ${fullRepo}: ${error.message}`);
+                return [];
+              }
+            };
+
+            const generateLeaderboard = async () => {
+              try {
+                const allPRs = (await Promise.all(REPOS.map(fetchRecentPRs))).flat();
+
+                const leaderboard = allPRs.reduce((acc, pr) => {
+                  if (!acc[pr.user]) {
+                    acc[pr.user] = { points: 0, prs: 0, userPRs: [] };
+                  }
+                  acc[pr.user].points += pr.points;
+                  acc[pr.user].prs += 1;
+                  acc[pr.user].userPRs.push(pr);
+                  return acc;
+                }, {});
+
+                // Tie-breaker rank for biggest PR size
+                const sizeOrder = { small: 1, medium: 2, large: 3 };
+
+                const sorted = Object.entries(leaderboard)
+                  .sort(([, a], [, b]) => {
+                    if (b.points !== a.points) return b.points - a.points;
+                    const aBig = getBiggestPRSize(a.userPRs);
+                    const bBig = getBiggestPRSize(b.userPRs);
+                    return sizeOrder[bBig] - sizeOrder[aBig];
+                  })
+                  .map(([username, data], index) => ({
+                    rank: index + 1,
+                    username,
+                    points: data.points,
+                    prs: data.prs,
+                    biggestPR: getBiggestPRSize(data.userPRs)
+                  }));
+
+                return sorted;
+              } catch (error) {
+                console.error(`Error generating leaderboard: ${error.message}`);
+                return [];
+              }
+            };
+
+            const updateIssue = async (leaderboardData) => {
+              const rankStars = (rank) => (rank <= 3 ? '⭐⭐⭐' : rank <= 10 ? '⭐' : '');
+
+              const tableRows = leaderboardData
+                .map(entry => `| ${entry.rank} ${rankStars(entry.rank)} | @${entry.username} | ${entry.points} | ${entry.prs} | ${entry.biggestPR} |`)
+                .join('\n');
+
+              const issueBody = `# 🏆 Hacktoberfest 2025 Goose Leaderboard 🏆
+              Hello, lovely contributors! As Hacktoberfest 2025 and the crisp Fall breeze refreshes us, we wanted to make the contribution process extra fun. Check our live leaderboard below to see who our top contributors are this year in real-time. Not only does this recognize your efforts, it also brings an amplified competitive vibe with each contribution.
+
+              ### 🌟 **Current Rankings:**
+
+              | Rank | Contributor | Points | PRs | Biggest PR to Date |
+              |------|-------------|--------|-----|--------------------|
+              ${tableRows}
+
+              ### 📜 How It Works:
+              The top 20 contributors will earn the first ever goose swag from the swag shop along with LLM credits! To earn your place in the leaderboard, we have created a points system that is explained below. As you complete a task by successfully merging a PR, you will automatically be granted a certain # of points.
+
+              #### 💯 Point System
+              | Weight | Points Awarded | Description |
+              |---------|-------------|-------------|
+              | 🐭 **Small** | 5 points | For smaller tasks that take limited time to complete and/or don't require any product knowledge. |
+              | 🐰 **Medium** | 10 points | For average tasks that take additional time to complete and/or require some product knowledge. |
+              | 🐂 **Large** | 15 points | For heavy tasks that takes lots of time to complete and/or possibly require deep product knowledge. |
+
+              #### 🎁 Rewards
+              - Made it to the **top 5**? Our Top 5 Contributors with the most points will be awarded $100 gift cards to our brand new goose swag shop and $100 of LLM credits!
+              - Reached the top **6-10**? Our Top 6-10 Contributors with the most points will be awarded $50 gift cards to our brand new goose swag shop and $50 of LLM credits!
+              - Landed in the top **11-20**? Our Top 11-20 Contributors with the most points will be awarded $25 of LLM credits! Keep an eye on your progress to make sure you're one step ahead!
+
+              ### FAQ
+              - **Frequency of Updates:** The leaderboard will be updated every hour.
+              - **Criteria:** Rankings are based on how many points you earn across all approved PRs in the goose repo. To ensure your PRs are successfully merged:
+                - Ensure your contributions are aligned with our project's Code of Conduct.
+                - Refer to the goose repo's Contributing Guide.
+              - **Tie-Breakers:** In the event of a tie in total points, the contributor with the highest value single contribution (large > medium > small) will be ranked higher.
+
+              ### 🚀 Get Featured:
+              Want to see your name climbing our ranks?
+
+              Explore our issues with the labels \`good-first-issue\`, \`no-code\` and \`hacktoberfest\` in the goose repo' Project Hub:
+
+              - **goose**
+                - Hacktoberfest Project Hub
+                - Contributing Guide
+
+              Excited to see everyone's hard work. Thank you so much for your invaluable contributions, and let the fun competition begin!
+
+              Last updated: ${new Date().toUTCString()}`;
+
+              try {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: issueBody
+                });
+                console.log("Issue updated successfully!");
+              } catch (err) {
+                console.error(`Failed to update issue #${issueNumber}: ${err.message}`);
+                throw err;
+              }
+            };
+
+            // Main execution
+            const leaderboardData = await generateLeaderboard();
+            if (leaderboardData.length > 0) {
+              await updateIssue(leaderboardData);
+            } else {
+              console.log("No leaderboard data to update.");
+              const emptyIssueBody = `# 🏆 Hacktoberfest 2025 Goose Leaderboard 🏆
+
+              Hello, lovely contributors! As Hacktoberfest 2025 and the crisp Fall breeze refreshes us, we wanted to make the contribution process extra fun. Check our live leaderboard below to see who our top contributors are this year in real-time. Not only does this recognize everyone's efforts, it also brings an amplified competitive vibe with each contribution.
+
+              ### 🌟 **Current Rankings:**
+
+              | Rank | Contributor | Points | PRs | Biggest PR to Date |
+              |------|-------------|--------|-----|--------------------|
+              | | | | | |
+
+              No qualifying PRs found at this time. Check back soon!
+
+              Last updated: ${new Date().toUTCString()}`;
+
+              try {
+                await github.rest.issues.update({
+                  owner,
+                  repo,
+                  issue_number: issueNumber,
+                  body: emptyIssueBody
+                });
+                console.log("Updated issue with empty leaderboard message.");
+              } catch (err) {
+                console.error(`Failed to update issue #${issueNumber} (empty state): ${err.message}`);
+                throw err;
+              }
             }
-          };
-
-          // Main execution
-          const leaderboardData = await generateLeaderboard();
-          if (leaderboardData.length > 0) {
-            await updateIssue(leaderboardData);
-          } else {
-            console.log("No leaderboard data to update.");
-            const emptyIssueBody = `# 🏆 Hacktoberfest 2025 Goose Leaderboard 🏆\n` +
-              `Hello, lovely contributors! As Hacktoberfest 2025 and the crisp Fall breeze refreshes us, we wanted to make the contribution process extra fun. Check our live leaderboard below to see who our top contributors are this year in real-time. Not only does this recognize everyone's efforts, it also brings an amplified competitive vibe with each contribution.\n\n` +
-              `### 🌟 **Current Rankings:**\n\n` +
-              `| Rank | Contributor | Points | PRs | Biggest PR to Date |\n` +
-              `|------|-------------|--------|-----|--------------------|\n` +
-              `| | | | | |\n\n` +
-              `No qualifying PRs found at this time. Check back soon!\n\n` +
-              `Last updated: ${new Date().toUTCString()}`;
-            
-            await github.rest.issues.update({
-              owner,
-              repo,
-              issue_number: issueNumber,
-              body: emptyIssueBody
-            });
-            console.log("Updated issue with empty leaderboard message.");
-          }


### PR DESCRIPTION
# Fix Hacktoberfest Leaderboard (2025)

**Summary**
- Restores the hourly-updating Hacktoberfest leaderboard for **October 2025**.
- Replaces fragile logic with a strict **October (UTC) merged window**, **full pagination**, and consistent **issue body** rendering.

**Why**
- The previous workflow wasn’t updating because:
  - Missing `pull-requests: read` permission prevented `pulls.list` from returning data.
  - Node 16 action (`actions/github-script@v6`) was outdated.
  - PR window was “last 30 days” (not strictly October).
  - Issue body assembly had inconsistencies in some branches/edits.

**What Changed**
- `uses: actions/github-script@v7` (Node 20).
- Added `permissions: pull-requests: read` (kept `contents: read`, `issues: write`).
- **Strict October window (UTC)** for `merged_at`:
  - `Oct 1 00:00:00 UTC` → `Oct 31 23:59:59 UTC`.
- **Pagination** of closed PRs (100/page) with early exit before October.
- **Strict size labels** only: `small | medium | large` → 5 | 10 | 15 points.
- Tie-breaker: highest single PR size (small < medium < large).
- Proper **template-literal** `issueBody` with rich copy + **empty-state** fallback.
- Kept token style consistent with repo: `github-token: ${{ secrets.GITHUB_TOKEN }}`.
- Tracks **only** `block/goose` for 2025 (can be expanded later).

**Files**
- `.github/workflows/update-hacktoberfest-leaderboard.yml`  
  _433 changes: 233 additions & 200 deletions_


**Edge Cases / Notes**
- Points default to **small (5)** if none of `small|medium|large` labels are present.
- Only PRs **merged in October (UTC)** and labeled **`hacktoberfest`** are counted.
- If >100 closed PRs are present, pagination ensures none are missed.
- If no qualifying PRs exist, the issue shows a clear **empty-state** message.



