### PR TITLE
basecamp2 - Resume chat session from server with a cache

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -99,10 +99,6 @@ const PairRouteWrapper = ({
       chat={chat}
       setChat={setChat}
       setView={setView}
-      agentState={agentState}
-      loadCurrentChat={loadCurrentChat}
-      setFatalError={setFatalError}
-      setAgentWaitingMessage={setAgentWaitingMessage}
       setIsGoosehintsModalOpen={setIsGoosehintsModalOpen}
       resumeSessionId={resumeSessionId}
       initialMessage={initialMessage}
@@ -346,7 +342,6 @@ export function AppInner() {
             setAgentWaitingMessage,
             setIsExtensionsLoading,
           });
-          // Update the chat state with the loaded session to ensure sessionId is available globally
           setChat(loadedChat);
         } catch (e) {
           if (e instanceof NoProviderOrModelError) {

--- a/ui/desktop/src/components/Pair2.tsx
+++ b/ui/desktop/src/components/Pair2.tsx
@@ -1,10 +1,7 @@
-import { useEffect, useState } from 'react';
 import { View, ViewOptions } from '../utils/navigationUtils';
-import { AgentState, InitializationContext } from '../hooks/useAgent';
 import 'react-toastify/dist/ReactToastify.css';
 
 import { ChatType } from '../types/chat';
-import { useSearchParams } from 'react-router-dom';
 import BaseChat2 from './BaseChat2';
 
 export interface PairRouteState {
@@ -17,57 +14,22 @@ interface PairProps {
   setChat: (chat: ChatType) => void;
   setView: (view: View, viewOptions?: ViewOptions) => void;
   setIsGoosehintsModalOpen: (isOpen: boolean) => void;
-  setFatalError: (value: ((prevState: string | null) => string | null) | string | null) => void;
-  setAgentWaitingMessage: (msg: string | null) => void;
-  agentState: AgentState;
-  loadCurrentChat: (context: InitializationContext) => Promise<ChatType>;
 }
 
 export default function Pair({
+  chat,
+  setChat,
   setView,
   setIsGoosehintsModalOpen,
-  setFatalError,
-  setAgentWaitingMessage,
-  agentState,
-  loadCurrentChat,
   resumeSessionId,
 }: PairProps & PairRouteState) {
-  const [_searchParams, setSearchParams] = useSearchParams();
-  const [chat, setChat] = useState<ChatType | null>(null);
-
-  useEffect(() => {
-    const initializeFromState = async () => {
-      try {
-        const chat = await loadCurrentChat({
-          resumeSessionId,
-          setAgentWaitingMessage,
-        });
-        setChat(chat);
-        setSearchParams((prev) => {
-          prev.set('resumeSessionId', chat.sessionId);
-          return prev;
-        });
-      } catch (error) {
-        setFatalError(`Agent init failure: ${error instanceof Error ? error.message : '' + error}`);
-      }
-    };
-    initializeFromState();
-  }, [
-    agentState,
-    setChat,
-    setFatalError,
-    setAgentWaitingMessage,
-    loadCurrentChat,
-    resumeSessionId,
-    setSearchParams,
-  ]);
-
   return (
     <BaseChat2
       chat={chat}
       setChat={setChat}
       setView={setView}
       setIsGoosehintsModalOpen={setIsGoosehintsModalOpen}
+      resumeSessionId={resumeSessionId}
     />
   );
 }

--- a/ui/desktop/src/utils/sessionCache.ts
+++ b/ui/desktop/src/utils/sessionCache.ts
@@ -1,0 +1,130 @@
+import { Session } from '../api';
+import { getApiUrl } from '../config';
+
+/**
+ * In-memory cache for session data
+ * Maps session ID to Session object
+ */
+const sessionCache = new Map<string, Session>();
+
+/**
+ * In-flight request tracking to prevent duplicate fetches
+ * Maps session ID to Promise of Session
+ */
+const inFlightRequests = new Map<string, Promise<Session>>();
+
+/**
+ * Load a session from the server using the /agent/resume endpoint
+ * Implements caching to avoid redundant fetches
+ *
+ * @param sessionId - The unique identifier for the session
+ * @param forceRefresh - If true, bypass cache and fetch fresh data
+ * @returns Promise resolving to the Session object
+ * @throws Error if the request fails or session not found
+ */
+export async function loadSession(sessionId: string, forceRefresh = false): Promise<Session> {
+  if (!forceRefresh && sessionCache.has(sessionId)) {
+    return sessionCache.get(sessionId)!;
+  }
+
+  if (inFlightRequests.has(sessionId)) {
+    return inFlightRequests.get(sessionId)!;
+  }
+
+  const fetchPromise = (async () => {
+    try {
+      const url = getApiUrl('/agent/resume');
+      const secretKey = await window.electron.getSecretKey();
+
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-Secret-Key': secretKey,
+        },
+        body: JSON.stringify({
+          session_id: sessionId,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text().catch(() => 'Unknown error');
+        throw new Error(`Failed to load session: HTTP ${response.status} - ${errorText}`);
+      }
+
+      const session: Session = await response.json();
+      sessionCache.set(sessionId, session);
+
+      return session;
+    } catch (error) {
+      if (error instanceof Error) {
+        throw new Error(`Error loading session ${sessionId}: ${error.message}`);
+      }
+      throw new Error(`Error loading session ${sessionId}: Unknown error`);
+    } finally {
+      inFlightRequests.delete(sessionId);
+    }
+  })();
+
+  inFlightRequests.set(sessionId, fetchPromise);
+  return fetchPromise;
+}
+
+/**
+ * Clear a specific session from the cache
+ * Useful when a session has been updated and needs to be refetched
+ *
+ * @param sessionId - The unique identifier for the session to clear
+ */
+export function clearSessionCache(sessionId: string): void {
+  sessionCache.delete(sessionId);
+}
+
+/**
+ * Clear all sessions from the cache
+ * Useful for logout or when switching contexts
+ */
+export function clearAllSessionCache(): void {
+  sessionCache.clear();
+}
+
+/**
+ * Check if a session is currently cached
+ *
+ * @param sessionId - The unique identifier for the session
+ * @returns true if the session is in cache, false otherwise
+ */
+export function isSessionCached(sessionId: string): boolean {
+  return sessionCache.has(sessionId);
+}
+
+/**
+ * Get a session from cache without fetching
+ * Returns undefined if not cached
+ *
+ * @param sessionId - The unique identifier for the session
+ * @returns The cached Session object or undefined
+ */
+export function getCachedSession(sessionId: string): Session | undefined {
+  return sessionCache.get(sessionId);
+}
+
+/**
+ * Preload a session into cache
+ * Useful when you already have session data from another source
+ *
+ * @param session - The Session object to cache
+ */
+export function preloadSession(session: Session): void {
+  sessionCache.set(session.id, session);
+}
+
+/**
+ * Get the current cache size
+ * Useful for debugging and monitoring
+ *
+ * @returns The number of sessions currently cached
+ */
+export function getCacheSize(): number {
+  return sessionCache.size;
+}


### PR DESCRIPTION
## Summary
Added support for resuming chat session from server with a cache. Removed reliance on useAgent in Pair2.

Note: this gets us most of the way there but still some rough edges with race conditions from hub (if a session is loaded while the empty chat is still initializing) and improvements to the initial state before loading the chat session.

