### PR TITLE
Add dev and alpha environment indicator

### DIFF
--- a/ui/desktop/src/components/GooseSidebar/AppSidebar.tsx
+++ b/ui/desktop/src/components/GooseSidebar/AppSidebar.tsx
@@ -15,6 +15,7 @@ import { ChatSmart, Gear } from '../icons';
 import { ViewOptions, View } from '../../utils/navigationUtils';
 import { useChatContext } from '../../contexts/ChatContext';
 import { DEFAULT_CHAT_TITLE } from '../../contexts/ChatContext';
+import EnvironmentBadge from './EnvironmentBadge';
 
 interface SidebarProps {
   onSelectSession: (sessionId: string) => void;
@@ -165,7 +166,9 @@ const AppSidebar: React.FC<SidebarProps> = ({ currentPath }) => {
         <SidebarMenu>{menuItems.map((entry, index) => renderMenuItem(entry, index))}</SidebarMenu>
       </SidebarContent>
 
-      <SidebarFooter />
+      <SidebarFooter className="pb-2 flex items-start">
+        <EnvironmentBadge />
+      </SidebarFooter>
     </>
   );
 };

--- a/ui/desktop/src/components/GooseSidebar/EnvironmentBadge.tsx
+++ b/ui/desktop/src/components/GooseSidebar/EnvironmentBadge.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/Tooltip';
+
+const EnvironmentBadge: React.FC = () => {
+  const isAlpha = process.env.ALPHA;
+  const isDevelopment = import.meta.env.DEV;
+
+  // Don't show badge in production
+  if (!isDevelopment && !isAlpha) {
+    return null;
+  }
+
+  const tooltipText = isAlpha ? 'Alpha' : 'Dev';
+  const bgColor = isAlpha ? 'bg-purple-600' : 'bg-orange-400';
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <div
+          className={`${bgColor} w-3 h-3 rounded-full cursor-default`}
+          data-testid="environment-badge"
+          aria-label={tooltipText}
+        />
+      </TooltipTrigger>
+      <TooltipContent side="right">{tooltipText}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default EnvironmentBadge;

--- a/ui/desktop/src/components/GooseSidebar/index.ts
+++ b/ui/desktop/src/components/GooseSidebar/index.ts
@@ -1,1 +1,2 @@
 export { default as AppSidebar } from './AppSidebar';
+export { default as EnvironmentBadge } from './EnvironmentBadge';


### PR DESCRIPTION
## Summary
Added subtle environment badge in bottom left sidebar if dev or alpha to help distinguish between the production app and local dev environment.

Verified locally does not show in the bundled app.

<img width="942" height="801" alt="Screenshot 2025-10-09 at 9 12 21 AM" src="https://github.com/user-attachments/assets/ffbb8495-73ff-4b8d-983a-27b2760ede29" />
<img width="946" height="802" alt="Screenshot 2025-10-09 at 9 04 54 AM" src="https://github.com/user-attachments/assets/1d796d14-a839-4a1e-9777-a49c9f268e21" />
<img width="941" height="799" alt="Screenshot 2025-10-09 at 9 05 24 AM" src="https://github.com/user-attachments/assets/a573a964-8969-476d-8758-e3aabce4f54b" />