### PR TITLE
Fallback session name

### DIFF
--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -232,7 +232,18 @@ impl SessionManager {
             .count();
 
         if user_message_count <= MSG_COUNT_FOR_SESSION_NAME_GENERATION {
-            let description = provider.generate_session_name(&conversation).await?;
+            let description = match provider.generate_session_name(&conversation).await {
+                Ok(name) => name,
+                Err(e) => {
+                    warn!(
+                        "Failed to generate session name: {}. Using fallback name.",
+                        e
+                    );
+                    let timestamp = chrono::Utc::now().format("%Y-%m-%d %H:%M:%S");
+                    format!("Unnamed Session ({})", timestamp)
+                }
+            };
+
             Self::update_session(id)
                 .description(description)
                 .apply()


### PR DESCRIPTION
Goose completely crashes if the provider throws an error on this request.

I wonder if we should have a mechanism to try again like:

user_message_count % 10 update the session name, but might be confusing to people if these start changing. Could also match this unnamed session string with that pattern and only retry those occasionally.
