### PR TITLE
Add flag for enabling eleven labs voice dictation

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -22,7 +22,7 @@ import MentionPopover, { FileItemWithMatch } from './MentionPopover';
 import { useDictationSettings } from '../hooks/useDictationSettings';
 import { useContextManager } from './context_management/ContextManager';
 import { useChatContext } from '../contexts/ChatContext';
-import { COST_TRACKING_ENABLED } from '../updates';
+import { COST_TRACKING_ENABLED, VOICE_DICTATION_ELEVENLABS_ENABLED } from '../updates';
 import { CostTracker } from './bottom_menu/CostTracker';
 import { DroppedFile, useFileDrop } from '../hooks/useFileDrop';
 import { Recipe } from '../recipe';
@@ -1348,7 +1348,8 @@ export default function ChatInput({
                         OpenAI API key is not configured. Set it up in <b>Settings</b> {'>'}{' '}
                         <b>Models.</b>
                       </p>
-                    ) : dictationSettings.provider === 'elevenlabs' ? (
+                    ) : VOICE_DICTATION_ELEVENLABS_ENABLED &&
+                      dictationSettings.provider === 'elevenlabs' ? (
                       <p>
                         ElevenLabs API key is not configured. Set it up in <b>Settings</b> {'>'}{' '}
                         <b>Chat</b> {'>'} <b>Voice Dictation.</b>

--- a/ui/desktop/src/components/settings/dictation/ProviderInfo.tsx
+++ b/ui/desktop/src/components/settings/dictation/ProviderInfo.tsx
@@ -1,4 +1,5 @@
 import { DictationProvider } from '../../../hooks/useDictationSettings';
+import { VOICE_DICTATION_ELEVENLABS_ENABLED } from '../../../updates';
 
 interface ProviderInfoProps {
   provider: DictationProvider;
@@ -15,7 +16,7 @@ export const ProviderInfo = ({ provider }: ProviderInfoProps) => {
           configured in the Models section.
         </p>
       )}
-      {provider === 'elevenlabs' && (
+      {VOICE_DICTATION_ELEVENLABS_ENABLED && provider === 'elevenlabs' && (
         <div>
           <p className="text-xs text-text-muted">
             Uses ElevenLabs speech-to-text API for high-quality transcription.

--- a/ui/desktop/src/components/settings/dictation/ProviderSelector.tsx
+++ b/ui/desktop/src/components/settings/dictation/ProviderSelector.tsx
@@ -4,6 +4,7 @@ import { DictationProvider, DictationSettings } from '../../../hooks/useDictatio
 import { useConfig } from '../../ConfigContext';
 import { ElevenLabsKeyInput } from './ElevenLabsKeyInput';
 import { ProviderInfo } from './ProviderInfo';
+import { VOICE_DICTATION_ELEVENLABS_ENABLED } from '../../../updates';
 
 interface ProviderSelectorProps {
   settings: DictationSettings;
@@ -85,26 +86,30 @@ export const ProviderSelector = ({ settings, onProviderChange }: ProviderSelecto
             <div className="absolute right-0 mt-1 w-48 bg-background-default border border-border-default rounded-md shadow-lg z-10">
               <button
                 onClick={() => handleProviderChange('openai')}
-                className="w-full px-3 py-2 text-left text-sm transition-colors first:rounded-t-md hover:bg-background-subtle text-text-default"
+                className={`w-full px-3 py-2 text-left text-sm transition-colors hover:bg-background-subtle text-text-default ${!VOICE_DICTATION_ELEVENLABS_ENABLED ? 'first:rounded-t-md last:rounded-b-md' : 'first:rounded-t-md'}`}
               >
                 OpenAI Whisper
                 {!hasOpenAIKey && <span className="text-xs ml-1">(not configured)</span>}
                 {settings.provider === 'openai' && <span className="float-right">✓</span>}
               </button>
 
-              <button
-                onClick={() => handleProviderChange('elevenlabs')}
-                className="w-full px-3 py-2 text-left text-sm hover:bg-background-subtle transition-colors text-text-default last:rounded-b-md"
-              >
-                ElevenLabs
-                {settings.provider === 'elevenlabs' && <span className="float-right">✓</span>}
-              </button>
+              {VOICE_DICTATION_ELEVENLABS_ENABLED && (
+                <button
+                  onClick={() => handleProviderChange('elevenlabs')}
+                  className="w-full px-3 py-2 text-left text-sm hover:bg-background-subtle transition-colors text-text-default last:rounded-b-md"
+                >
+                  ElevenLabs
+                  {settings.provider === 'elevenlabs' && <span className="float-right">✓</span>}
+                </button>
+              )}
             </div>
           )}
         </div>
       </div>
 
-      {settings.provider === 'elevenlabs' && <ElevenLabsKeyInput />}
+      {VOICE_DICTATION_ELEVENLABS_ENABLED && settings.provider === 'elevenlabs' && (
+        <ElevenLabsKeyInput />
+      )}
 
       <ProviderInfo provider={settings.provider} />
     </div>

--- a/ui/desktop/src/components/settings/dictation/VoiceDictationToggle.tsx
+++ b/ui/desktop/src/components/settings/dictation/VoiceDictationToggle.tsx
@@ -7,6 +7,7 @@ import {
 } from '../../../hooks/dictationConstants';
 import { useConfig } from '../../ConfigContext';
 import { ProviderSelector } from './ProviderSelector';
+import { VOICE_DICTATION_ELEVENLABS_ENABLED } from '../../../updates';
 
 export const VoiceDictationToggle = () => {
   const [settings, setSettings] = useState<DictationSettings>({
@@ -24,6 +25,15 @@ export const VoiceDictationToggle = () => {
       if (savedSettings) {
         const parsed = JSON.parse(savedSettings);
         loadedSettings = parsed;
+
+        // If ElevenLabs is disabled and user has it selected, reset to OpenAI
+        if (!VOICE_DICTATION_ELEVENLABS_ENABLED && loadedSettings.provider === 'elevenlabs') {
+          loadedSettings = {
+            ...loadedSettings,
+            provider: 'openai',
+          };
+          localStorage.setItem(DICTATION_SETTINGS_KEY, JSON.stringify(loadedSettings));
+        }
       } else {
         loadedSettings = await getDefaultDictationSettings(getProviders);
       }

--- a/ui/desktop/src/updates.ts
+++ b/ui/desktop/src/updates.ts
@@ -2,3 +2,4 @@ export const UPDATES_ENABLED = true;
 export const COST_TRACKING_ENABLED = true;
 export const ANNOUNCEMENTS_ENABLED = false;
 export const CONFIGURATION_ENABLED = true;
+export const VOICE_DICTATION_ELEVENLABS_ENABLED = true;


### PR DESCRIPTION
## Summary
Add flag to enable eleven labs voice dictation (default true). Also resets to openAI provider as a forced migration path.

