### PR TITLE
feat(ui): add custom macOS dock menu with New Window option

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1770,6 +1770,19 @@ async function appMain() {
     }
   }, 2000); // 2 second delay after window is shown
 
+  // Setup macOS dock menu
+  if (process.platform === 'darwin') {
+    const dockMenu = Menu.buildFromTemplate([
+      {
+        label: 'New Window',
+        click: () => {
+          createNewWindow(app);
+        },
+      },
+    ]);
+    app.dock?.setMenu(dockMenu);
+  }
+
   // Get the existing menu
   const menu = Menu.getApplicationMenu();
 


### PR DESCRIPTION
## Summary
Adds a "New window" option for right clicking from the doc.  This comes in handy if you use macOS spaces/stage manager and you want multiple goose windows open on different spaces.

### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Manual Testing

### Screenshots/Demos (for UX changes)


https://github.com/user-attachments/assets/8d604156-8096-4c2d-9f48-dc652b052adb


