### PR TITLE
force re-render fields to pick up custom params usage in instructions

### DIFF
--- a/ui/desktop/src/components/recipes/shared/RecipeFormFields.tsx
+++ b/ui/desktop/src/components/recipes/shared/RecipeFormFields.tsx
@@ -38,6 +38,16 @@ export function RecipeFormFields({
   const [newParameterName, setNewParameterName] = useState('');
   const [expandedParameters, setExpandedParameters] = useState<Set<string>>(new Set());
 
+  // Force re-render when instructions, prompt, or activities change
+  const [_forceRender, setForceRender] = useState(0);
+
+  React.useEffect(() => {
+    return form.store.subscribe(() => {
+      // Force re-render when any form field changes to update parameter usage indicators
+      setForceRender((prev) => prev + 1);
+    });
+  }, [form.store]);
+
   const parseParametersFromInstructions = React.useCallback(
     (instructions: string, prompt?: string, activities?: string[]): Parameter[] => {
       const instructionVars = extractTemplateVariables(instructions);


### PR DESCRIPTION
Fixes issue where custom param added is not picked up as enabled after adding param to instructions field

