### PR TITLE
docs: unlist tutorials for extensions with archived or moved servers

### DIFF
--- a/documentation/docs/mcp/brave-mcp.md
+++ b/documentation/docs/mcp/brave-mcp.md
@@ -1,6 +1,7 @@
 ---
 title: Brave Search Extension
 description: Add Brave Search API as a Goose Extension
+unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,6 +10,8 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/kD2YA61NTLU" />
+
+Server moved
 
 This tutorial will get you started with the [Brave Search MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/brave-search) as a Goose extension to enable interactive searches for both web and local searches.
 

--- a/documentation/docs/mcp/filesystem-mcp.md
+++ b/documentation/docs/mcp/filesystem-mcp.md
@@ -7,6 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import { PanelLeft, Settings } from 'lucide-react';
 
 <YouTubeShortEmbed videoUrl="https://youtube.com/embed/2IVPcjEr-yQ" /> 
 
@@ -41,6 +42,14 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
         "/path/to/other/allowed/dir"
     ]}
   />
+
+  After installing, update the extension with the actual paths to allowed directories:
+  1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
+  2. Click `Extensions` in the sidebar
+  3. On the `Filesystem` card, click the <Settings className="inline" size={16} /> button
+  4. Edit the command to replace the placeholder paths with space-separated paths to allowed directories
+  5. Click `Save Changes`
+
   </TabItem>
 
   <TabItem value="cli" label="Goose CLI">

--- a/documentation/docs/mcp/google-drive-mcp.md
+++ b/documentation/docs/mcp/google-drive-mcp.md
@@ -1,6 +1,7 @@
 ---
 title: Google Drive Extension
 description: Add Google Drive MCP Server as a Goose Extension
+unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,6 +10,8 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/p9HGYbJk9wU" />
+
+Server archived 
 
 This tutorial covers how to add the [Google Drive MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/gdrive) as a Goose extension, allowing you to list, read, and search files in Google Drive.
 

--- a/documentation/docs/mcp/google-maps-mcp.md
+++ b/documentation/docs/mcp/google-maps-mcp.md
@@ -1,6 +1,7 @@
 ---
 title: Google Maps Extension
 description: Add Google Maps MCP Server as a Goose Extension
+unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -8,6 +9,7 @@ import TabItem from '@theme/TabItem';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
+Server archived
 
 This tutorial covers how to add the [Google Maps MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/google-maps) as a Goose extension to enable geocoding, place searching, distance calculations, elevation data retrieval, and directions.
 

--- a/documentation/docs/mcp/kiwi-flight-search.md
+++ b/documentation/docs/mcp/kiwi-flight-search.md
@@ -1,6 +1,7 @@
 ---
 title: Kiwi Flight Search Extension
 description: Add Kiwi Flight Search MCP Server as a Goose Extension
+unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -12,6 +13,8 @@ import GooseBuiltinInstaller from '@site/src/components/GooseBuiltinInstaller';
 import { PanelLeft } from 'lucide-react';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/MhLU91zKE4M" />
+
+Server moved: https://apify.com/agentify/kiwi-mcp-server
 
 This tutorial covers how to add the [Kiwi Flight Search MCP Server](https://mcp.kiwi.com) as a Goose extension to enable flight search and price comparison.
 

--- a/documentation/docs/mcp/neon-mcp.md
+++ b/documentation/docs/mcp/neon-mcp.md
@@ -9,7 +9,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import { PanelLeft } from 'lucide-react';
 
-This tutorial covers how to add the [Neon MCP Server](https://github.com/neondatabase-labs/mcp-server-neon) as a Goose extension to interact with your Neon Postgres databases and manage your projects, branches, and more.
+This tutorial covers how to add the [Neon MCP Server](https://github.com/neondatabase/mcp-server-neon) as a Goose extension to interact with your Neon Postgres databases and manage your projects, branches, and more.
 
 Neon offers two versions of the MCP server:
 

--- a/documentation/docs/mcp/postgres-mcp.md
+++ b/documentation/docs/mcp/postgres-mcp.md
@@ -1,6 +1,7 @@
 ---
 title: PostgreSQL Extension
 description: Add PostgreSQL MCP Server as a Goose Extension
+unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,6 +10,8 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 <YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/PZlYQ5IthYM" />
+
+Server archived
 
 The PostgreSQL MCP Server extension allows Goose to interact directly with your PostgreSQL databases, enabling database operations, querying, and schema management capabilities. This makes it easy to work with your databases through natural language interactions.
 

--- a/documentation/docs/mcp/puppeteer-mcp.md
+++ b/documentation/docs/mcp/puppeteer-mcp.md
@@ -1,6 +1,7 @@
 ---
 title: Puppeteer Extension
 description: Add Puppeteer MCP Server as a Goose Extension
+unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';
@@ -9,6 +10,8 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 <YouTubeShortEmbed videoUrl="https://youtube.com/embed/rms0wVGnlXA" />
+
+Server archived
 
 This tutorial covers how to add the [Puppeteer MCP Server](https://github.com/modelcontextprotocol/servers/tree/HEAD/src/puppeteer) as a Goose extension, enabling Goose to interact with websites - navigating pages, filling forms, clicking buttons, taking screenshots, and executing JavaScript in a real browser environment.
 

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -64,30 +64,13 @@
   {
     "id": "blender-mcp",
     "name": "Blender",
-    "description": "3D modeling and animation integration",
+    "description": "3D modeling and animation integration (requires local server setup)",
     "command": "uvx blender-mcp",
     "link": "https://github.com/ahujasid/blender-mcp",
-    "installation_notes": "Install using uvx package manager.",
+    "installation_notes": "Install using uvx package manager. You must first download Blender, add the Blender MCP addon, and start the Blender MCP server.",
     "is_builtin": false,
     "endorsed": false,
     "environmentVariables": []
-  },
-  {
-    "id": "brave-mcp",
-    "name": "Brave Search",
-    "description": "Web search capabilities powered by Brave",
-    "command": "npx -y @brave/brave-search-mcp",
-    "link": "https://github.com/brave/brave-search-mcp-server",
-    "installation_notes": "Install using npx package manager.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": [
-      {
-        "name": "BRAVE_API_KEY",
-        "description": "Required environment variable",
-        "required": true
-      }
-    ]
   },
   {
     "id": "browserbase-mcp",
@@ -116,23 +99,6 @@
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": []
-  },
-  {
-    "id": "cloudflare-mcp",
-    "name": "Cloudflare",
-    "description": "Cloudflare API integration for DNS and domain management",
-    "command": "npx -y @cloudflare/mcp-server-cloudflare",
-    "link": "https://github.com/cloudflare/mcp-server-cloudflare",
-    "installation_notes": "Install using npx package manager.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": [
-      {
-        "name": "CLOUDFLARE_API_TOKEN",
-        "description": "Required environment variable",
-        "required": true
-      }
-    ]
   },
   {
     "id": "cloudinary-asset-management-mcp",
@@ -271,10 +237,10 @@
   {
     "id": "filesystem",
     "name": "Filesystem",
-    "description": "File system operations and management",
+    "description": "File system operations and management (requires updating local paths)",
     "command": "npx -y @modelcontextprotocol/server-filesystem /path/to/dir1 /path/to/dir2",
     "link": "https://github.com/modelcontextprotocol/servers",
-    "installation_notes": "Install using npx package manager.",
+    "installation_notes": "Install using npx package manager. Update the placeholder paths before running the 'goose session' command. If installing from the link, you must update the paths from the Extensions page before activating the extension.",
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": []
@@ -309,40 +275,6 @@
     "environmentVariables": []
   },
   {
-    "id": "google-drive-mcp",
-    "name": "Google Drive",
-    "description": "Google Drive file management and operations",
-    "command": "npx -y @google/drive-mcp",
-    "link": "https://github.com/google/drive-mcp",
-    "installation_notes": "Install using npx package manager.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": [
-      {
-        "name": "GOOGLE_DRIVE_CREDENTIALS",
-        "description": "Required environment variable",
-        "required": true
-      }
-    ]
-  },
-  {
-    "id": "google-maps-mcp",
-    "name": "Google Maps",
-    "description": "Maps, geocoding, and location services",
-    "command": "npx -y @google/maps-mcp",
-    "link": "https://github.com/google/maps-mcp",
-    "installation_notes": "Install using npx package manager.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": [
-      {
-        "name": "GOOGLE_MAPS_API_KEY",
-        "description": "Required environment variable",
-        "required": true
-      }
-    ]
-  },
-  {
     "id": "goose-docs",
     "name": "Goose Docs",
     "description": "GitMCP for Goose documentation",
@@ -373,18 +305,6 @@
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": []
-  },
-  {
-    "id": "kiwi-flight-search",
-    "name": "Kiwi Flight Search",
-    "description": "Search for flights",
-    "url": "https://mcp.kiwi.com",
-    "link": "https://mcp-install-instructions.alpic.cloud/servers/kiwi-com-flight-search",
-    "installation_notes": "This is a remote extension. Configure using the endpoint URL in Goose settings.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": [],
-    "type": "streamable-http"
   },
   {
     "id": "knowledge_graph_memory",
@@ -436,7 +356,7 @@
     "description": "Manage Neon Postgres databases, projects, and branches",
     "type": "streamable-http",
     "url": "https://mcp.neon.tech/mcp",
-    "link": "https://github.com/neondatabase-labs/mcp-server-neon",
+    "link": "https://github.com/neondatabase/mcp-server-neon",
     "installation_notes": "Streaming HTTP extension with OAuth browser authentication to your Neon account.",
     "is_builtin": false,
     "endorsed": true,
@@ -519,34 +439,6 @@
     "installation_notes": "Install using npx package manager.",
     "is_builtin": false,
     "endorsed": true,
-    "environmentVariables": []
-  },
-  {
-    "id": "postgres-mcp",
-    "name": "PostgreSQL",
-    "description": "PostgreSQL database integration",
-    "command": "uvx mcp-server-postgres",
-    "link": "https://github.com/modelcontextprotocol/servers",
-    "installation_notes": "Install using uvx package manager.",
-    "is_builtin": false,
-    "endorsed": false,
-    "environmentVariables": [
-      {
-        "name": "POSTGRES_CONNECTION_STRING",
-        "description": "Required environment variable",
-        "required": true
-      }
-    ]
-  },
-  {
-    "id": "puppeteer-mcp",
-    "name": "Puppeteer",
-    "description": "Browser automation and web scraping",
-    "command": "npx -y @puppeteer/mcp-server",
-    "link": "https://github.com/puppeteer/mcp-server",
-    "installation_notes": "Install using npx package manager.",
-    "is_builtin": false,
-    "endorsed": false,
     "environmentVariables": []
   },
   {


### PR DESCRIPTION
## Summary
This PR unlists the following tutorials whose MCP servers are archived or moved:
- `documentation/docs/mcp/brave-mcp.md`
- `documentation/docs/mcp/google-drive-mcp.md`
- `documentation/docs/mcp/google-maps-mcp.md`
- `documentation/docs/mcp/kiwi-flight-search.md`
- `documentation/docs/mcp/postgres-mcp.md`
- `documentation/docs/mcp/puppeteer-mcp.md`

Also:
- `documentation/static/servers.json`:
  - Remove unlisted extensions
  - Add more info to Blender, Filesystem description and install notes
- `documentation/docs/mcp/filesystem-mcp.md`
  - Add instructions about manually configuring paths before activation
- `documentation/docs/mcp/neon-mcp.md`:
  - Update redirected link to server repo

### Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Manual testing


Related issue #4121