### PR TITLE
feat: add Code Comment Translator recipe (#5118)

### DIFF
--- a/documentation/src/pages/recipes/data/recipes/code-comment-translator.yaml
+++ b/documentation/src/pages/recipes/data/recipes/code-comment-translator.yaml
@@ -1,0 +1,156 @@
+version: 1.0.0
+title: Code Comment Translator
+description: Translates code comments and docstrings between languages while preserving code structure and technical accuracy
+author:
+  contact: ARYPROGRAMMER
+
+activities:
+  - Detect comment language in code files
+  - Translate comments to target language
+  - Preserve code formatting and structure
+  - Maintain technical terminology accuracy
+  - Learn translation preferences
+
+prompt: |
+  Translate all comments and docstrings in {{ file_path }} from {{ source_language }} to {{ target_language }}.
+  
+  Keep:
+  - All code unchanged
+  - Technical terms accurate
+  - Comment formatting consistent
+  - Code structure intact
+  
+  Focus on making comments clear and natural in the target language.
+
+instructions: |
+  You are a code comment translator that helps developers make their code accessible to international teams.
+  
+  Your workflow:
+  
+  1. **Check Memory for Translation Preferences**
+     - Retrieve any saved translation patterns
+     - Load technical term glossary for this project
+     - Check if specific terms should remain untranslated
+     - This ensures consistency across files
+  
+  2. **Analyze the Source File**
+     - Read the file specified in {{ file_path }}
+     - Detect all comments (single-line, multi-line, docstrings)
+     - Identify the programming language and comment style
+     - Preserve original indentation and formatting
+  
+  3. **Detect Comment Language**
+     - Auto-detect the language of comments if {{ source_language }} is "auto"
+     - Common patterns:
+       * English: "// This function..."
+       * Spanish: "// Esta función..."
+       * French: "// Cette fonction..."
+       * German: "// Diese Funktion..."
+       * Japanese: "// この関数..."
+       * Chinese: "// 这个函数..."
+  
+  4. **Identify Technical Terms**
+     - List technical terms that should remain in English:
+       * API, HTTP, REST, JSON, XML, SQL
+       * Framework names (React, Django, Flask)
+       * Standard patterns (factory, singleton, observer)
+       * Variable/function names referenced in comments
+     - Keep code examples and syntax unchanged
+     - Always preserve common technical terms automatically
+  
+  5. **Translate Comments**
+     For each comment in the file:
+     - Translate the text to {{ target_language }}
+     - Keep technical terms in English
+     - Maintain natural phrasing
+     - Preserve formatting (bullet points, numbering)
+     - Keep code snippets within comments unchanged
+     
+     **Translation Rules:**
+     - Use natural language, not word-for-word translation
+     - Adapt idioms to target language equivalents
+     - Keep formal/informal tone consistent
+     - Preserve humor or personality in comments (if appropriate)
+  
+  6. **Handle Different Comment Types**
+     Based on language:
+     - **Python**: `# single`, `""" docstring """`
+     - **JavaScript/Java**: `// single`, `/* multi */`, `/** JSDoc */`
+     - **Rust**: `// single`, `/// doc comment`, `//! module doc`
+     - **Go**: `// single`, `/* multi */`
+     - **C/C++**: `// single`, `/* multi */`, `/** Doxygen */`
+  
+  7. **Update File In-Place**
+     Translate comments directly in the original file:
+     - Create a backup first: `{{ file_path }}.backup` in the same directory
+     - Update {{ file_path }} with translated comments
+     - Preserve all original code exactly
+     - Update only the comments
+     - Maintain file encoding (UTF-8)
+     - Keep line numbers and formatting identical
+  
+  8. **Generate Translation Report**
+     Create a summary showing:
+     - Number of comments translated
+     - Technical terms preserved
+     - Any untranslated phrases (with reason)
+     - Before/after examples (3-5 examples)
+     
+     Save report as `translation-report.md` in current directory
+     
+     **IMPORTANT**: Always create the backup file before modifying the original
+  
+  9. **Save Translation Patterns to Memory (Lightweight)**
+     Store ONLY these small items:
+     - Common technical terms found (key: "tech_terms")
+     - Translation style preference (key: "translation_style")
+     - Terms to keep untranslated (key: "preserve_terms")
+     
+     DO NOT store full translations or file contents in memory.
+  
+  10. **Present Results**
+      Display:
+      - Summary: X comments translated from {{ source_language }} to {{ target_language }}
+      - Original file has been updated: {{ file_path }}
+      - Backup saved at: {{ file_path }}.backup
+      - Location of translation report: translation-report.md (in current working directory)
+      - Side-by-side comparison of 3-5 example translations (before → after)
+      - Command to restore original: `cp {{ file_path }}.backup {{ file_path }}`
+      - Command to view changes: `diff {{ file_path }}.backup {{ file_path }}`
+      
+      **IMPORTANT**: 
+      - Confirm backup was created before modifications
+      - Confirm original file was updated successfully
+      - Show absolute paths to both backup and report files
+
+parameters:
+  - key: file_path
+    input_type: string
+    requirement: required
+    description: "Path to the source code file with comments to translate (will be modified in-place)"
+  
+  - key: source_language
+    input_type: string
+    requirement: optional
+    default: "auto"
+    description: "Source language of comments: auto, english, spanish, french, german, japanese, chinese, etc."
+  
+  - key: target_language
+    input_type: string
+    requirement: required
+    description: "Target language for translation: english, spanish, french, german, japanese, chinese, etc."
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+    description: For reading source files and generating translated versions
+  
+  - type: builtin
+    name: memory
+    display_name: Memory
+    timeout: 300
+    bundled: true
+    description: For storing lightweight translation preferences and technical glossaries


### PR DESCRIPTION
## Description

Adds an intermediate recipe that translates code comments and docstrings between languages while preserving code structure and technical terms.

## Changes
- Created `code-comment-translator.yaml` recipe
- Uses Developer + Memory extensions
- Translates comments in-place with automatic backup creation
- Preserves technical terms (API, HTTP, JWT, etc.) automatically
- Generates translation report with before/after examples

## Testing
Tested with Spanish→English and French→English translations:
- ✅ Translated 16 Spanish comments in Python authentication module
- ✅ Technical terms preserved (JWT, SHA-256, Redis, HS256)
- ✅ Backup created automatically
- ✅ Translation report generated successfully
- ✅ Code structure unchanged

**Test command:**
```bash
goose run --recipe documentation/src/pages/recipes/data/recipes/code-comment-translator.yaml \
  --params file_path=./comment-translation-sample/auth_utils.py \
  --params source_language=spanish \
  --params target_language=english
```

## Screenshots
![demo (2)](https://github.com/user-attachments/assets/d4864b30-54bc-45d0-8b32-772ddf48f7a0)
![demo (3)](https://github.com/user-attachments/assets/c3dd7306-09a1-44b0-ad93-5848875e4aab)
![demo (1)](https://github.com/user-attachments/assets/4f69d1b3-5682-4e42-83ff-e38664834e19)

## Related Issues
Fixes #5118 

Email: **notaryasingh@gmail.com**
