### PR TITLE
Revert "Fix gpt-5 input context limit (#4619)"

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -17,7 +17,7 @@ pub enum ConfigError {
 static MODEL_SPECIFIC_LIMITS: Lazy<Vec<(&'static str, usize)>> = Lazy::new(|| {
     vec![
         // openai
-        ("gpt-5", 400_000),
+        ("gpt-5", 272_000),
         ("gpt-4-turbo", 128_000),
         ("gpt-4.1", 1_000_000),
         ("gpt-4-1", 1_000_000),


### PR DESCRIPTION
The 400k includes the output tokens, so 272 is correct
