### PR TITLE
crates/goose/providers/api_client.rs: surface payload parsing error

### DIFF
--- a/crates/goose/src/providers/api_client.rs
+++ b/crates/goose/src/providers/api_client.rs
@@ -186,8 +186,8 @@ impl fmt::Debug for AuthMethod {
 impl ApiResponse {
     pub async fn from_response(response: Response) -> Result<Self> {
         let status = response.status();
-        let payload = response.json().await.ok();
-        Ok(Self { status, payload })
+        let payload = response.json().await?;
+        Ok(Self { status, payload: Some(payload) })
     }
 }
 


### PR DESCRIPTION
Errors from API requests are obfuscated and hard to debug, eg if you're using a custom API provider:

```
2025-10-12T19:40:04.645988Z  WARN goose::providers::base: Fast model claude-3-7-sonnet-latest failed with error: Request failed: Response body is not valid JSON. Falling back to regular model claude-sonnet-4-5-20250929
    at crates/goose/src/providers/base.rs:359

2025-10-12T19:40:06.848444Z ERROR goose::session::storage: Failed to generate session description: Request failed: Response body is not valid JSON
    at crates/goose/src/session/storage.rs:1315
```

with this change, i was able to see the 404 error which led me to figure out that i did not need the `/v1` suffix when configuring `ANTHROPIC_HOST`:
```
Error: Request failed: Request failed with status: 404 Not Found
```