### PR TITLE
docs: update cognee, jetbrains, mbot extensions config

### DIFF
--- a/documentation/docs/mcp/cognee-mcp.md
+++ b/documentation/docs/mcp/cognee-mcp.md
@@ -7,7 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
-This tutorial covers how to add the [Cognee MCP Server](https://github.com/topoteretes/cognee) as a Goose extension to enable knowledge graph memory capabilities, connecting to over 30 data sources for enhanced context and retrieval.
+This tutorial covers how to add the [Cognee MCP Server](https://github.com/topoteretes/cognee/tree/main/cognee-mcp) as a Goose extension to enable knowledge graph memory capabilities, connecting to over 30 data sources for enhanced context and retrieval.
 
 :::tip TLDR
 **Command**
@@ -17,7 +17,6 @@ uv --directory /path/to/cognee-mcp run python src/server.py
 **Environment Variables**
 ```
 LLM_API_KEY: <YOUR_OPENAI_API_KEY>
-EMBEDDING_API_KEY: <YOUR_OPENAI_API_KEY>
 ```
 :::
 
@@ -34,7 +33,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 ```bash
 # Clone and install Cognee
 git clone https://github.com/topoteretes/cognee
-cd cognee-mcp
+cd cognee/cognee-mcp
 uv sync --dev --all-extras --reinstall
 
 # On Linux, install additional dependencies
@@ -153,7 +152,7 @@ goose configure
 
 8. Add the required environment variables:
 :::info
-You'll need OpenAI API keys for both LLM and embedding models. [Get your API keys here](https://platform.openai.com/api-keys).
+You'll need an API key for your LLM provider. By default, this is an [OpenAI API key](https://platform.openai.com/api-keys).
 :::
 
  ```sh
@@ -188,15 +187,6 @@ You'll need OpenAI API keys for both LLM and embedding models. [Get your API key
   │  ▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
   │
   ◇  Add another environment variable?
-  │  Yes
-  │
-  ◇  Environment variable name:
-  │  EMBEDDING_API_KEY
-  │
-  ◇  Environment variable value:
-  │  ▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪
-  │
-  ◇  Add another environment variable?
   │  No 
   // highlight-end
   └  Added Cognee extension
@@ -204,6 +194,10 @@ You'll need OpenAI API keys for both LLM and embedding models. [Get your API key
 
   </TabItem>
 </Tabs>
+
+:::info
+See the [Cognee MCP documentation](https://docs.cognee.ai/how-to-guides/deployment/mcp) for supported configuration options. 
+:::
 
 ## Example Usage
 

--- a/documentation/docs/mcp/mbot-mcp.md
+++ b/documentation/docs/mcp/mbot-mcp.md
@@ -13,18 +13,12 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 This tutorial will get you started with [deemkeen's MQTT MCP server](https://github.com/deemkeen/mbotmcp) for the [MakeBlock mbot2 rover](https://www.makeblock.com/products/buy-mbot2), and outline some code changes we made along the way.
 
 :::tip TLDR
-<Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=/path/to/java&arg=-jar&arg=/path/to/mbotmcp-0.0.1-SNAPSHOT.jar&name=mbot2&description=mbot2&env=MQTT_SERVER_URI%3Dtcp://1.2.3.4:1883&env=MQTT_USERNAME%3Dyour_username&env=MQTT_PASSWORD%3Dyour_password)
-  </TabItem>
-  <TabItem value="cli" label="Goose CLI">
   **Command**
   ```sh
   /path/to/java -jar /path/to/mbotmcp-0.0.1-SNAPSHOT.jar
   ```
-  </TabItem>
-</Tabs>
-  **Environment Variable**
+
+  **Environment Variables**
   ```
   MQTT_SERVER_URI: tcp://1.2.3.4:1883
   MQTT_PASSWORD: <string or blank>
@@ -35,20 +29,6 @@ This tutorial will get you started with [deemkeen's MQTT MCP server](https://git
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
-  <GooseDesktopInstaller
-    extensionId="mbot2"
-    extensionName="mbot2"
-    description="mbot2"
-    command="/path/to/java"
-    args={["-jar", "/path/to/mbotmcp-0.0.1-SNAPSHOT.jar"]}
-    envVars={[
-      { name: "MQTT_SERVER_URI", label: "tcp://1.2.3.4:1883" },
-      { name: "MQTT_USERNAME", label: "your_username" },
-      { name: "MQTT_PASSWORD", label: "your_password" }
-    ]}
-  />
-  </TabItem>
   <TabItem value="cli" label="Goose CLI">
   1. Run the `configure` command:
   ```sh

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -130,13 +130,20 @@
   {
     "id": "cognee-mcp",
     "name": "Cognee",
-    "description": "Knowledge graph and cognitive AI capabilities",
-    "command": "uvx cognee-mcp",
+    "description": "Knowledge graph and cognitive AI capabilities (requires local server setup)",
+    "command": "uv --directory /path/to/cognee-mcp run python src/server.py",
     "link": "https://github.com/topoteretes/cognee",
-    "installation_notes": "Install using uvx package manager.",
+    "installation_notes": "This is a local extension. You must first clone and install the Cognee MCP server locally before using this extension. Update the placeholder path before running the 'goose session' command.",
     "is_builtin": false,
-    "endorsed": false,
-    "environmentVariables": []
+    "endorsed": true,
+    "show_install_link": false,
+    "environmentVariables": [
+      {
+        "name": "LLM_API_KEY",
+        "description": "API key for your LLM provider",
+        "required": true
+      }
+    ]
   },
   {
     "id": "computercontroller",
@@ -298,10 +305,11 @@
   {
     "id": "jetbrains",
     "name": "JetBrains",
-    "description": "Integrate Goose with any JetBrains IDE",
-    "command": "npx -y @jetbrains/mcp-proxy",
+    "description": "Integrate with any JetBrains IDE (requires local setup, dependent on your IDE version)",
+    "url": "http://localhost:<PORT>/sse",
+    "type": "remote",
     "link": "https://github.com/JetBrains/mcp-jetbrains",
-    "installation_notes": "Install using npx package manager. Requires the MCP Server plugin to be installed in your JetBrains IDE.",
+    "installation_notes": "IDE v2025.2 and later: Enable SSE configuration from Settings > Tools > MCP Server, then update the placeholder SSE URL in the following command. If installing from the link, you must update the URL from the Extensions page before activating the extension. For earlier IDE versions, you must install the MCP Server plugin and use npx package manager to install the extension.",
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": []
@@ -320,13 +328,30 @@
   {
     "id": "mbot-mcp",
     "name": "MBot",
-    "description": "Chatbot and conversational AI integration",
-    "command": "npx -y mbot-mcp",
+    "description": "Control a MakeBlock mbot2 rover through MQTT (requires local setup)",
+    "command": "/path/to/java -jar /path/to/mbotmcp-0.0.1-SNAPSHOT.jar",
     "link": "https://github.com/deemkeen/mbotmcp",
-    "installation_notes": "Install using npx package manager.",
+    "installation_notes": "This is a local extension. You must first download the JAR file from the repository, install Java, and update the placeholder paths before running the 'goose session' command.",
     "is_builtin": false,
     "endorsed": false,
-    "environmentVariables": []
+    "show_install_link": false,
+    "environmentVariables": [
+      {
+        "name": "MQTT_SERVER_URI",
+        "description": "MQTT server URI (example: tcp://1.2.3.4:1883)",
+        "required": true
+      },
+      {
+        "name": "MQTT_USERNAME", 
+        "description": "MQTT username (empty string if no auth required)",
+        "required": true
+      },
+      {
+        "name": "MQTT_PASSWORD",
+        "description": "MQTT password (empty string if no auth required)", 
+        "required": true
+      }
+    ]
   },
   {
     "id": "memory",


### PR DESCRIPTION
## Summary
This PR updates the config used to generate the cognee, jetbrains, mbot extension cards, along with some changes to corresponding tutorials.

- `documentation/docs/mcp/cognee-mcp.md`:
  - Point to cognee/cognee-mcp readme
  - Remove optional embedding env var
  - Add link to Cognee MCP docs for more config details
- `documentation/docs/mcp/mbot-mcp.md`:
  - Remove Desktop tabs in TLDR and Configuration sections because the install is blocked
- `documentation/static/servers.json`:
  - Update configs:
    - cognee - Use correct path, doc prereqs, hide install link
    - jetbrains - Default to latest IDE support, doc prereqs 
    - mbot - Use correct path, doc prereqs, hide install link

Error for blocked deeplink installs: "Failed to install extension: Invalid command: uv. Only cu, docker, jbang, npx, uvx, goosed, npx.cmd, i-ching-mcp-server are allowed."

### Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Manual testing

### Related Issues
Relates to #4121