### PR TITLE
fix: include apple silicon build of the desktop app in build artifacts

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -116,7 +116,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
             goose-*.tar.bz2
-            goose-*.zip
+            goose*.zip
             *.deb
             *.rpm
             download_cli.sh

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -118,7 +118,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
             goose-*.tar.bz2
-            goose-*.zip
+            goose*.zip
             *.deb
             *.rpm
             download_cli.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,7 +105,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
             goose-*.tar.bz2
-            goose-*.zip
+            goose*.zip
             *.deb
             *.rpm
             download_cli.sh
@@ -122,7 +122,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
             goose-*.tar.bz2
-            goose-*.zip
+            goose*.zip
             *.deb
             *.rpm
             download_cli.sh


### PR DESCRIPTION
We got reports that with 1.10.0 and 1.10.1 the apple silicon build of goose was not in the artifacts list.

Issue:

* We used to have `Goose*.zip` in our artifacts config which matches `Goose.zip` and included it
* Now the apple silicon build artifact is called `goose.zip` but we had config to match `goose-*.zip` when selecting artifacts, which doesn't match this.

Fix:

* Resolve it by switching back to `goose*.zip` which will match `goose.zip`