### PR TITLE
Fix codex subagent configuration in documentation

### DIFF
--- a/documentation/docs/guides/subagents.mdx
+++ b/documentation/docs/guides/subagents.mdx
@@ -154,10 +154,10 @@ External subagents let you bring in AI agents from other providers and platforms
 ```yaml
 subagent:
   args:
-  - mcp
+  - mcp-server
   bundled: true
   cmd: codex
-  description: OpenAI Codex CLI Sub-agent
+  description: OpenAI Codex CLI Subagent
   enabled: true
   env_keys:
   - OPENAI_API_KEY


### PR DESCRIPTION
The latest version of Codex has changed the command `mcp` to `mcp-server`.

This PR fixes the codex subagent configuration example in the subagents documentation:

**Changes:**
- Updates `args` from `mcp` to `mcp-server` for accuracy
- Changes description from "Sub-agent" to "Subagent" for consistency with terminology used throughout the documentation

These are minor corrections to ensure the documentation accurately reflects the proper configuration for using Codex as an external subagent via MCP server.