### PR TITLE
fix: #3960 better approach to input schema for dynamic task params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2625,6 +2625,7 @@ dependencies = [
  "regex",
  "reqwest 0.12.12",
  "rmcp",
+ "schemars",
  "serde",
  "serde_json",
  "serde_urlencoded",

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -101,6 +101,7 @@ tokio-util = "0.7.15"
 unicode-normalization = "0.1"
 
 oauth2 = "5.0.0"
+schemars = { version = "1.0.4", default-features = false, features = ["derive"] }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }


### PR DESCRIPTION
Use rust structs to derive the input schema for the `dynamic_task__create_task` tool

Part of (or maybe all the) work for #3960