### PR TITLE
Skip hidden & real format

### DIFF
--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -353,7 +353,9 @@ fn format_message_for_compacting(msg: &Message) -> String {
                 if let Ok(contents) = &res.tool_result {
                     let text_items: Vec<String> = contents
                         .iter()
-                        .filter_map(|content| content.as_text().map(|text_str| text_str.text.clone()))
+                        .filter_map(|content| {
+                            content.as_text().map(|text_str| text_str.text.clone())
+                        })
                         .collect();
 
                     if !text_items.is_empty() {


### PR DESCRIPTION
## Summary

compaction itself ran out of tokens because of how we created the thing to compact. we did not filter out the agent invisible messages, which basically means that after a few compaction turns you run out of space since we kept sending the already compacting messages over.

the other issue is that we would send raw json of the messages, including the id, visibility and everything which also uses 60% more tokens than this PR
