### PR TITLE
fix: correct schema for openai tools

### DIFF
--- a/crates/goose/src/agents/recipe_tools/dynamic_task_tools.rs
+++ b/crates/goose/src/agents/recipe_tools/dynamic_task_tools.rs
@@ -47,6 +47,8 @@ impl From<ExecutionModeParam> for ExecutionMode {
     }
 }
 
+type JsonObject = serde_json::Map<String, Value>;
+
 /// Parameters for a single task
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct TaskParameter {
@@ -63,24 +65,19 @@ pub struct TaskParameter {
     pub description: Option<String>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "Option<Vec<serde_json::Map<String, Value>>>")]
-    pub extensions: Option<Vec<Value>>,
+    pub extensions: Option<Vec<JsonObject>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "Option<serde_json::Map<String, Value>>")]
-    pub settings: Option<Value>,
+    pub settings: Option<JsonObject>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "Option<Vec<serde_json::Map<String, Value>>>")]
-    pub parameters: Option<Vec<Value>>,
+    pub parameters: Option<Vec<JsonObject>>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "Option<serde_json::Map<String, Value>>")]
-    pub response: Option<Value>,
+    pub response: Option<JsonObject>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(with = "Option<serde_json::Map<String, Value>>")]
-    pub retry: Option<Value>,
+    pub retry: Option<JsonObject>,
 
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context: Option<Vec<String>>,


### PR DESCRIPTION
Currently openai won't work due to: 

Request failed: Invalid schema for function 'dynamic_task__create_task': In context=('properties', 'extensions', 'type', '0'), array schema items is not an object. (code: invalid_function_parameters, type: invalid_request_error) (status 400).

as that tool generates an invalid schema for openai, which started with: https://github.com/block/goose/pull/5189 