### PR TITLE
GH-5230(fix): case-sensitive executable path in .desktop file

### DIFF
--- a/ui/desktop/forge.deb.desktop
+++ b/ui/desktop/forge.deb.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Name=Goose
-Exec=/usr/lib/goose/Goose %U
+Exec=/usr/lib/goose/goose %U
 Icon=/usr/share/pixmaps/goose.png
 Terminal=false
 Type=Application


### PR DESCRIPTION
## Summary
Fix case sensitivity issue in .desktop file that prevents Goose from launching from KDE App Launcher. The installed `.desktop` file references `/usr/lib/goose/Goose` (capital G) but the actual executable is `/usr/lib/goose/goose` (lowercase g) on case-sensitive filesystems.

### Type of Change
- [x] Bug fix

### Testing
Manual testing on Ubuntu 25.04 with KDE Plasma desktop environment:
1. Verify the `.desktop` file contains the correct Exec path with lowercase 'goose'
2. Test launching Goose from KDE App Launcher
3. Confirm application starts successfully without manual intervention

### Related Issues
Relates to #5176