### PR TITLE
fix Windows build ring crate missing advapi32 link

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[target.x86_64-pc-windows-msvc]
+rustflags = ["-C", "link-args=advapi32.lib"]
+
+[target.x86_64-pc-windows-gnu]
+rustflags = ["-C", "link-args=-ladvapi32"]


### PR DESCRIPTION
## Summary
Windows build fails due to missing link to advapi32.dll needed to build `ring` crate.
```
error: linking with `link.exe` failed: exit code: 1120
  |
  = note: "C:\\Program Files\\Microsoft Visual Studio\\2022\\Community\\VC\\Tools\\MSVC\\14.44.35207\\bin\\HostX64\\x64\\link.exe" "/NOLOGO" 
...
goose\\target\\debug\\build\\ring-33b93150c5211568\\build_script_build-33b93150c5211568.exe" "/OPT:REF,NOICF" "/DEBUG" "/PDBALTPATH:%_PDB%" "/NATVIS:<sysroot>\\lib\\rustlib\\etc\\intrinsic.natvis" "/NATVIS:<sysroot>\\lib\\rustlib\\etc\\liballoc.natvis" "/NATVIS:<sysroot>\\lib\\rustlib\\etc\\libcore.natvis" "/NATVIS:<sysroot>\\lib\\rustlib\\etc\\libstd.natvis"
...
  = note: libjobserver-de3391caf3272945.rlib(jobserver-de3391caf3272945.jobserver.37a54c1ed64fde8f-cgu.3.rcgu.o) : error LNK2019: unresolved external symbol SystemFunction036 referenced in function _ZN9jobserver3imp9getrandom17h9e1b1b056175cb58E␍

          P:\goose\target\debug\build\ring-33b93150c5211568\build_script_build-33b93150c5211568.exe : fatal error LNK1120: 1 unresolved externals␍
```          

GPT suggested doing this fix:

`.cargo/config.toml`
```
[target.x86_64-pc-windows-msvc]
rustflags = ["-C", "link-args=advapi32.lib"]

[target.x86_64-pc-windows-gnu]
rustflags = ["-C", "link-args=-ladvapi32"]
```
and this works, but adding the link this way looks fairly unstandard, maybe someone with better Rust skill could suggest a better/more canonical way to do it? I don't have much time to delve into this.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [x] Build / Release
- [ ] Other (specify below)

### Testing
Windows build 
