### PR TITLE
Remove October 2nd deadline from Tetrate offer

### DIFF
--- a/documentation/blog/2025-08-27-get-started-for-free-with-tetrate/index.md
+++ b/documentation/blog/2025-08-27-get-started-for-free-with-tetrate/index.md
@@ -10,7 +10,7 @@ authors:
 
  You shouldn’t need a credit card to vibe code with Goose. While Goose is completely free to use, the reality is that most performant LLMs aren't. You want to experience Goose in action without breaking the bank or jumping through hoops. We've been thinking about how to make that first step easier for newcomers to Goose.
 
-That's why we're thrilled about our newest provider integration: [Tetrate's Agent Router Service](https://router.tetrate.ai). From August 27th through October 2nd, new Goose users can get $10 in credits to use Goose with any model on the Tetrate platform.
+That's why we're thrilled about our newest provider integration: [Tetrate's Agent Router Service](https://router.tetrate.ai). New Goose users can get $10 in credits to use Goose with any model on the Tetrate platform.
 
 <!--truncate-->
 

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -120,7 +120,7 @@ Goose works with [supported LLM providers](/docs/getting-started/providers) that
     Goose will open a browser for you to authenticate.
       
     :::info Free Credits Offer
-    You'll receive $10 in free credits the first time you automatically authenticate with Tetrate through Goose. This offer is available to both new and existing Tetrate users and is valid through October 2, 2025.
+    You'll receive $10 in free credits the first time you automatically authenticate with Tetrate through Goose. This offer is available to both new and existing Tetrate users.
     :::
 
     Tetrate provides access to multiple AI models with built-in rate limiting and automatic failover. If you prefer a different provider, choose automatic setup with OpenRouter or manually configure a provider.
@@ -133,7 +133,7 @@ Goose works with [supported LLM providers](/docs/getting-started/providers) that
     Goose will open a browser for you to authenticate.
       
     :::info Free Credits Offer
-    You'll receive $10 in free credits the first time you automatically authenticate with Tetrate through Goose. This offer is available to both new and existing Tetrate users and is valid through October 2, 2025.
+    You'll receive $10 in free credits the first time you automatically authenticate with Tetrate through Goose. This offer is available to both new and existing Tetrate users.
     :::
 
     Tetrate provides access to multiple AI models with built-in rate limiting and automatic failover. If you prefer a different provider, choose automatic setup with OpenRouter or manually configure a provider.

--- a/documentation/src/components/OnboardingProviderSetup.js
+++ b/documentation/src/components/OnboardingProviderSetup.js
@@ -18,7 +18,7 @@ export const OnboardingProviderSetup = () => {
               </h5>
             </div>
             <div className="admonition-content" style={{paddingBottom: '1rem'}}>
-              <p style={{marginBottom: '0'}}>You'll receive $10 in free credits the first time you automatically authenticate with Tetrate through Goose. This offer is available to both new and existing Tetrate users and is valid through October 2, 2025.</p>
+              <p style={{marginBottom: '0'}}>You'll receive $10 in free credits the first time you automatically authenticate with Tetrate through Goose. This offer is available to both new and existing Tetrate users.</p>
             </div>
           </div>
         </li>


### PR DESCRIPTION
- Keep Tetrate offering intact
- Remove references to October 2, 2025 deadline
- Updated in blog post, quickstart docs, and onboarding component

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved & merged -->
**Email**: 
