### PR TITLE
modified docs/tutorials/cicd Github Action's install path to follow download_cli script

### DIFF
--- a/documentation/docs/tutorials/cicd.md
+++ b/documentation/docs/tutorials/cicd.md
@@ -69,7 +69,7 @@ jobs:
            run: |
               mkdir -p /home/runner/.local/bin
               curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \
-              | CONFIGURE=false INSTALL_PATH=/home/runner/.local/bin bash
+              | CONFIGURE=false GOOSE_BIN_DIR=/home/runner/.local/bin bash
               echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
          - name: Configure Goose
@@ -159,7 +159,7 @@ steps:
       run: |
           mkdir -p /home/runner/.local/bin
           curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \
-            | CONFIGURE=false INSTALL_PATH=/home/runner/.local/bin bash
+            | CONFIGURE=false GOOSE_BIN_DIR=/home/runner/.local/bin bash
           echo "/home/runner/.local/bin" >> $GITHUB_PATH
 
     - name: Configure Goose


### PR DESCRIPTION

## Summary
<!-- Describe your change -->
Fixed documentation inconsistency in CI/CD tutorial where `INSTALL_PATH` was referenced, but the actual install script (`download_cli.sh`) uses `GOOSE_BIN_DIR`.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Verified the fix by:
1. Created a Dockerfile following the [CI/CD tutorial](https://block.github.io/goose/docs/tutorials/cicd)
- **Test Dockerfile:**
```dockerfile
FROM ubuntu:22.04

RUN apt-get update && apt-get install -y curl bzip2 libxcb1

# FAILS if replace GOOSE_BIN_DIR with INSTALL_PATH
RUN mkdir -p /app/.local/bin \
    && curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh \
    | CONFIGURE=false GOOSE_BIN_DIR=/app/.local/bin bash

RUN /app/.local/bin/goose --version
```
3. Tested with `GOOSE_BIN_DIR` (should work as expected)
4. Tested with `INSTALL_PATH` (should fail as expected)
5. Also confirmed that both `env CONFIGURE=false` and `CONFIGURE=false` syntax work identically.

### Related Issues
Relates to #3946  
Discussion: [LINK](https://github.com/block/goose/issues/3946#issuecomment-3411717251)


### Screenshots/Demos (for UX changes)
Before:  

After:   

<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved & merged -->
**Email**: 
