### PR TITLE
Fix Terminal.app markdown rendering in goose CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2704,6 +2704,7 @@ dependencies = [
  "indicatif",
  "is-terminal",
  "jsonschema",
+ "libc",
  "nix 0.30.1",
  "once_cell",
  "open",
@@ -3769,9 +3770,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdbus-sys"

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -59,6 +59,7 @@ is-terminal = "0.4.16"
 anstream = "0.6.18"
 url = "2.5.7"
 open = "5.3.2"
+libc = { version = "0.2.177", package = "libc" }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
Goose CLI did not display markdown syntax highlighting in Terminal.app on macOS, despite the terminal supporting full color capabilities. Headers appeared as regular text with # symbols, bold markers **text** were shown literally, and code blocks had no syntax highlighting.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

## Technical Details
- **Root Cause**: `std::io::stdout().is_terminal()` returns false in Terminal.app
- **Solution**: Multi-layered detection using `libc::isatty()` fallback and `TERM_PROGRAM` detection
- **Dependencies**: Added `libc` crate for Unix terminal detection
- **Compatibility**: Maintains full backward compatibility with existing terminals

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #4468


### Screenshots/Demos (for UX changes)
Before:  

<img width="708" height="582" alt="Screenshot 2025-10-18 at 10 57 46 PM" src="https://github.com/user-attachments/assets/cfcbde7f-f514-4177-a9d0-7f6be5fa3934" />

---

After:   

<img width="706" height="471" alt="Screenshot 2025-10-18 at 10 58 13 PM" src="https://github.com/user-attachments/assets/b1658a13-962a-4c1f-adab-175e48e8a33c" />

---

<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved & merged -->
**Email**: rak1729e@gmail.com
