### PR TITLE
feat: add 1M context support for Claude Sonnet 4

### DIFF
--- a/crates/goose-server/src/openapi.rs
+++ b/crates/goose-server/src/openapi.rs
@@ -15,7 +15,7 @@ use rmcp::model::{
 use utoipa::{OpenApi, ToSchema};
 
 use goose::config::declarative_providers::{
-    DeclarativeProviderConfig, LoadedProvider, ProviderEngine,
+    DeclarativeProviderConfig, LoadedProvider, ModelOverride, ProviderEngine,
 };
 use goose::conversation::message::{
     ConversationCompacted, FrontendToolRequest, Message, MessageContent, MessageMetadata,
@@ -428,6 +428,7 @@ derive_utoipa!(Icon as IconSchema);
         LoadedProvider,
         ProviderEngine,
         DeclarativeProviderConfig,
+        ModelOverride,
         ExtensionEntry,
         ExtensionConfig,
         ConfigKey,

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -279,6 +279,29 @@ goose supports using custom OpenAI-compatible endpoints, which is particularly u
 For enterprise deployments, you can pre-configure these values using environment variables or configuration files to ensure consistent governance across your organization.
 :::
 
+## Custom Providers
+
+Create custom provider configurations for Anthropic beta features (like 1M context) by adding a JSON file to `~/.config/goose/custom_providers/` (macOS/Linux) or `%APPDATA%\goose\custom_providers\` (Windows):
+
+```json
+{
+  "name": "anthropic_1m_context",
+  "engine": "anthropic",
+  "api_key_env": "ANTHROPIC_API_KEY",
+  "base_url": "https://api.anthropic.com",
+  "models": [{"name": "claude-sonnet-4-20250514", "context_limit": 200000}],
+  "model_overrides": [
+    {
+      "model_pattern": "claude-sonnet-4",
+      "context_limit": 1000000,
+      "headers": {"anthropic-beta": "context-1m-2025-08-07,*"}
+    }
+  ]
+}
+```
+
+The `*` in `anthropic-beta` merges your features with built-in ones. The `context_limit` prevents goose from compacting conversations prematurely.
+
 ## Using goose for Free
 
 goose is a free and open source AI agent that you can start using right away, but not all supported [LLM Providers][providers] provide a free tier. 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -2407,6 +2407,13 @@
             },
             "nullable": true
           },
+          "model_overrides": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ModelOverride"
+            },
+            "nullable": true
+          },
           "models": {
             "type": "array",
             "items": {
@@ -3411,6 +3418,29 @@
             "type": "boolean",
             "description": "Whether this model supports cache control",
             "nullable": true
+          }
+        }
+      },
+      "ModelOverride": {
+        "type": "object",
+        "required": [
+          "model_pattern"
+        ],
+        "properties": {
+          "context_limit": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
+          },
+          "headers": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "model_pattern": {
+            "type": "string"
           }
         }
       },

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -136,6 +136,7 @@ export type DeclarativeProviderConfig = {
     headers?: {
         [key: string]: string;
     } | null;
+    model_overrides?: Array<ModelOverride> | null;
     models: Array<ModelInfo>;
     name: string;
     supports_streaming?: boolean | null;
@@ -452,6 +453,14 @@ export type ModelInfo = {
      * Whether this model supports cache control
      */
     supports_cache_control?: boolean | null;
+};
+
+export type ModelOverride = {
+    context_limit?: number | null;
+    headers?: {
+        [key: string]: string;
+    } | null;
+    model_pattern: string;
 };
 
 export type ParseRecipeRequest = {


### PR DESCRIPTION
  ## Summary

  This PR adds support for Claude Sonnet 4's 1M context window through a flexible model override system in custom provider configurations. Users can enable extended context by creating a custom provider config that specifies model-specific context limits and headers.

  The implementation introduces a `ModelOverride` system that allows pattern-based matching of models to apply custom context limits and headers. The override system supports wildcard expansion (`*`) in the `anthropic-beta` header to automatically merge custom beta features with built-in ones.

  Key changes:
  - Added `ModelOverride` struct with pattern matching for model names
  - Extended `DeclarativeProviderConfig` to support `model_overrides` field
  - Modified `AnthropicProvider` to apply model overrides when creating providers from custom configs
  - Implemented beta header expansion with wildcard support to merge custom and built-in features
  - Extended `ModelConfig` to accept provider overrides for context limits

  ### Type of Change

  - [x] Feature
  - [ ] Bug fix
  - [ ] Refactor / Code quality
  - [ ] Performance improvement
  - [x] Documentation
  - [x] Tests
  - [ ] Security fix
  - [ ] Build / Release
  - [ ] Other (specify below)

  ### Testing

  - Added unit tests for `ModelOverride` pattern matching (`test_model_override_pattern_matching`)
  - Added tests for override configuration lookup (`test_get_model_override`)
  - Added integration tests for declarative provider deserialization with overrides (`test_load_anthropic_config_with_model_overrides`)
  - Added tests for override matching with headers (`test_claude_model_override_matching`)
  - Added tests for first-match precedence behavior (`test_first_claude_override_wins`)
  - Added test confirming context limit is properly applied from overrides (`test_model_override_applies_context_limit`)

### Example Custom Provider
```
{
  "name": "anthropic_1m_context",
  "engine": "anthropic",
  "display_name": "Anthropic (1M Context)",
  "description": "Anthropic provider with 1M context window for Sonnet-4",
  "api_key_env": "ANTHROPIC_API_KEY",
  "base_url": "https://api.anthropic.com",
  "models": [
    {
      "name": "claude-sonnet-4-0",
      "context_limit": 200000
    },
    {
      "name": "claude-sonnet-4-20250514",
      "context_limit": 200000
    }
  ],
  "model_overrides": [
    {
      "model_pattern": "claude-sonnet-4",
      "context_limit": 1000000,
      "headers": {
        "anthropic-beta": "context-1m-2025-08-07,*"
      }
    }
  ]
}
```

  ### Related Issues

  Fixes #4357


