### PR TITLE
Remove gtag analytics error

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -68,7 +68,7 @@ const config: Config = {
         gtag: process.env.NODE_ENV === 'production' ? {
           trackingID: 'G-ZS5D6SB4ZJ',
           anonymizeIP: true,
-        } : undefined,
+        } : false,
       } satisfies Preset.Options,
     ],
   ],


### PR DESCRIPTION
Sometimes, i still see the google analytics runtime error when developing the docs locally. This is my attempt to remove that error so we can develop faster.