### PR TITLE
docs: provide more clarity in tagging step of releases

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,7 @@ You'll generally create one of two release types: a regular feature release (min
 1. Run `git push origin release/<version> --set-upstream` and open a PR into `main`. Use `git log --oneline --cherry-pick --right-only v<previous-version>...release/$VERSION` to generate a PR description
 1. Wait for the bundled version of the app which will be linked from a comment on the PR
 1. Test the bundled version of the app
-1. When ready, tag the release: run `just tag-push` to create the tag and push it. This will start the release process
+1. Tag the release: check out the `release/<version>` branch locally to the latest revision and run `just tag-push` to create and push a tag. Make sure it doesn't error. This will start the release which you can monitor [here](https://github.com/block/goose/actions/workflows/release.yml)
 1. Once the release is created on [Github](https://github.com/block/goose/releases), merge the PR and run `just release-notes <prior release>` to generate release notes. Copy these into the release description.
 
 ## Patch release
@@ -22,7 +22,7 @@ Follow the above steps, but rather than starting on main, start on the release t
 1. Run `just prepare-release $VERSION`.
 1. Cherry-pick the relevant fixes from the main branch.
 1. Test this build. When ready to make the release, proceed to the next step.
-1. Tag the release: run `just tag-push` to create the tag and push it. This will start the build process for your new release.
+1. Tag the release: check out the `release/<version>` branch locally to the latest revision and run `just tag-push` to create and push a tag. Make sure it doesn't error. This will start the release which you can monitor [here](https://github.com/block/goose/actions/workflows/release.yml)
 1. Once the release is created on [Github](https://github.com/block/goose/releases), run `just release-notes <prior release>` to generate release notes. Copy these into the release description.
 
 Note that you won't merge this branch into main.


### PR DESCRIPTION
Doc improvement for the `just tag-push` part of releases