### PR TITLE
fix: include Windows GNU CLI artifact in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
             goose-*.tar.bz2
+            goose-*.zip
             Goose*.zip
             *.deb
             *.rpm
@@ -122,6 +123,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           artifacts: |
             goose-*.tar.bz2
+            goose-*.zip
             Goose*.zip
             *.deb
             *.rpm


### PR DESCRIPTION
The goose-x86_64-pc-windows-gnu.zip artifact was excluded from releases starting in v1.10.3 due to a case-sensitive pattern change in the release workflow.

This fix adds 'goose-*.zip' pattern alongside 'Goose*.zip' to ensure both CLI and desktop Windows builds are included in releases.

fixes https://github.com/block/goose/discussions/5275

Fixes the issue where Windows GNU CLI builds were missing from:
- v1.10.3
- v1.11.0
- v1.11.1
