### PR TITLE
fix: do not load active extensions when no extensions in the recipe

### DIFF
--- a/crates/goose-cli/src/recipes/extract_from_cli.rs
+++ b/crates/goose-cli/src/recipes/extract_from_cli.rs
@@ -49,7 +49,7 @@ pub fn extract_recipe_info_from_cli(
     }
     let input_config = InputConfig {
         contents: recipe.prompt.filter(|s| !s.trim().is_empty()),
-        extensions_override: recipe.extensions,
+        extensions_override: recipe.extensions.or(Some(vec![])),
         additional_system_prompt: recipe.instructions,
     };
 
@@ -106,7 +106,8 @@ mod tests {
             input_config.additional_system_prompt,
             Some("test_instructions my_value".to_string())
         );
-        assert!(input_config.extensions_override.is_none());
+        assert!(input_config.extensions_override.is_some());
+        assert!(input_config.extensions_override.unwrap().is_empty());
 
         assert!(settings.is_some());
         let settings = settings.unwrap();
@@ -170,7 +171,8 @@ mod tests {
             input_config.additional_system_prompt,
             Some("test_instructions my_value".to_string())
         );
-        assert!(input_config.extensions_override.is_none());
+        assert!(input_config.extensions_override.is_some());
+        assert!(input_config.extensions_override.unwrap().is_empty());
 
         assert!(settings.is_some());
         let settings = settings.unwrap();


### PR DESCRIPTION
## Summary
Issue: When there is no `extensions` block in the recipe, it loads the active tools in the config file.  
Fix: set extensions_override to an empty list when Recipe extensions is None

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Unit test
