### PR TITLE
improvement: propagate McpErrors directly into ToolCallResult

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -940,7 +940,9 @@ impl ExtensionManager {
                 .map(|call| call.content)
                 .map_err(|e| match e {
                     ServiceError::McpError(error_data) => error_data,
-                    _ => ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), e.maybe_to_value()),
+                    _ => {
+                        ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), e.maybe_to_value())
+                    }
                 })
         };
 


### PR DESCRIPTION
**Issue:**

Before this change, we wrapped all errors which occured during tool calling in a:

```
ErrorData::new(ErrorCode::INTERNAL_ERROR, e.to_string(), None)
```

There are some issues with this. Only the message (albeit with original code embedded) was included, the error itself has an incorrect code, and no additional information about the error in the third param.

**Change:**

This change propgates the wrapped `ErrorData` from `ServiceError::McpError`s during tool calling into the `ToolCallResult` so that the model has better information about what happened. These will contain the proper error codes, original message, and additional data where the mcp sdk provides it.

**Testing**

I tested with the following prompt:

> Call the text_editor str_replace tool to replace the header of the README.md, but leave out the old_str param, which should cause and let me test an arguments error. Tell me exactly what the error says

**Before (actual error wrapped and obscured):**
<img width="1697" height="1199" alt="Screenshot 2025-10-21 at 10 28 48 AM" src="https://github.com/user-attachments/assets/f48372cf-d253-4cdd-89d4-e6f1d713b7e6" />

**After (actual error included directly):**
<img width="1697" height="1199" alt="Screenshot 2025-10-21 at 10 24 24 AM" src="https://github.com/user-attachments/assets/03c7849d-f19f-4632-8579-2ac4f6663ff8" />

Sonnet 4.5 did a valiant effort trying to include some info about the wrapped error, but other models are likely to be confused.
