### PR TITLE
nextcamp - fix new chat from pair and reload

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -89,7 +89,7 @@ const PairRouteWrapper = ({
   const setView = useNavigation();
   const routeState =
     (location.state as PairRouteState) || (window.history.state as PairRouteState) || {};
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [initialMessage] = useState(routeState.initialMessage);
 
   const resumeSessionId = searchParams.get('resumeSessionId') ?? undefined;
@@ -99,6 +99,16 @@ const PairRouteWrapper = ({
   // 2. From URL params (when resuming a session)
   // 3. From the existing chat state (when navigating to Pair directly)
   const sessionId = routeState.resumeSessionId || resumeSessionId || chat.sessionId;
+
+  // Update URL with session ID if it's not already there (new chat from pair)
+  useEffect(() => {
+    if (process.env.ALPHA && sessionId && sessionId !== resumeSessionId) {
+      setSearchParams((prev) => {
+        prev.set('resumeSessionId', sessionId);
+        return prev;
+      });
+    }
+  }, [sessionId, resumeSessionId, setSearchParams]);
 
   return process.env.ALPHA ? (
     <Pair2


### PR DESCRIPTION
## Summary
Fixed new chat from pair to get sessionID and also reload from a new chat in pair by adding sessionID to the url after a chat starts