### PR TITLE
docs: lowercase 'goose' in TabItem labels for consistency

### DIFF
--- a/documentation/blog/2025-08-11-mcp-ui-post-browser-world/index.md
+++ b/documentation/blog/2025-08-11-mcp-ui-post-browser-world/index.md
@@ -44,10 +44,10 @@ Starting from Goose v1.3.0, you can add MCP-UI as an extension.
 
 :::tip Add MCP-UI to Goose
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp-aharvard.netlify.app%2Fmcp&id=mcpuidemo&name=MCP-UI%20Demo&description=Demo%20MCP-UI-enabled%20extension)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
 
   **Endpoint URL**

--- a/documentation/docs/experimental/vs-code-extension.md
+++ b/documentation/docs/experimental/vs-code-extension.md
@@ -21,7 +21,7 @@ This tutorial covers how to install and use the [Goose VS Code Extension](https:
 ## Configuration
 
 <Tabs>
-<TabItem value="desktop" label="Goose Desktop">
+<TabItem value="desktop" label="goose Desktop">
 
 1. Open VS Code
 2. Open the Extensions view in VS Code:
@@ -34,7 +34,7 @@ This tutorial covers how to install and use the [Goose VS Code Extension](https:
 6. Open the Goose: Chat side panel to start a new conversation or view conversation history
 
 </TabItem>
-<TabItem value="cli" label="Goose CLI">
+<TabItem value="cli" label="goose CLI">
 
 Not available via CLI.
 

--- a/documentation/docs/mcp/agentql-mcp.md
+++ b/documentation/docs/mcp/agentql-mcp.md
@@ -14,10 +14,10 @@ This tutorial covers how to add the [AgentQL MCP Server](https://github.com/tiny
 :::tip TLDR
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=agentql-mcp&id=agentql&name=AgentQL&description=Transform%20unstructured%20web%20content%20into%20structured%20data&env=AGENTQL_API_KEY%3DAgentQL%20API%20Key)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y agentql-mcp
@@ -37,7 +37,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="agentql"
     extensionName="AgentQL"
@@ -51,7 +51,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     apiKeyLinkText="AGENTQL_API_KEY"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/alby-mcp.md
+++ b/documentation/docs/mcp/alby-mcp.md
@@ -21,10 +21,10 @@ You'll need a lightning wallet that supports [NWC](https://nwc.dev). If you don'
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40getalby%2Fmcp&id=alby&name=Alby&description=Connect%20Goose%20to%20your%20Bitcoin%20Lightning%20Wallet&env=NWC_CONNECTION_STRING%3DNWC%20Connection%20Secret)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @getalby/mcp
@@ -46,7 +46,7 @@ You'll need [Node.js](https://nodejs.org/) installed on your system to run this 
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <Tabs>
       <TabItem value="local" label="Local" default>
         <GooseDesktopInstaller
@@ -78,7 +78,7 @@ Bearer nostr+walletconnect://...
       </TabItem>
     </Tabs>
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <Tabs>
       <TabItem value="local" label="Local" default>
         1. Run the `configure` command:

--- a/documentation/docs/mcp/apify-mcp.md
+++ b/documentation/docs/mcp/apify-mcp.md
@@ -19,10 +19,10 @@ This tutorial covers how to add the [Apify MCP server](https://mcp.apify.com) as
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   Use `Add custom extension` in Settings → Extensions to add a `Streamable HTTP` extension type with:
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
   </TabItem>
 </Tabs>
@@ -34,7 +34,7 @@ https://mcp.apify.com
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     1. Obtain an [Apify Token](https://console.apify.com/settings/integrations)  
     2. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar  
     3. Click `Extensions`  
@@ -51,7 +51,7 @@ https://mcp.apify.com
     9. Navigate to the chat  
   </TabItem>
 
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="apify-mcp"
       type="http"
@@ -74,11 +74,11 @@ https://mcp.apify.com
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=@apify/actors-mcp-server&arg=start&id=mcp_apify_local&name=Apify%20Local%20MCP%20Server&description=Run%20Apify%20MCP%20server%20locally%20using%20your%20token&env=APIFY_TOKEN%3DYour%20Apify%20Token)
   </TabItem>
 
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @apify/actors-mcp-server
@@ -93,7 +93,7 @@ APIFY_TOKEN: <YOUR_APIFY_TOKEN>
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     1. Obtain an [Apify Token](https://console.apify.com/settings/integrations)  
     2. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar  
     3. Click `Extensions`  
@@ -110,7 +110,7 @@ APIFY_TOKEN: <YOUR_APIFY_TOKEN>
     9. Navigate to the chat  
   </TabItem>
 
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="apify-mcp"
       type="stdio"

--- a/documentation/docs/mcp/asana-mcp.md
+++ b/documentation/docs/mcp/asana-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [Asana MCP Server](https://github.com/roychr
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40roychri%2Fmcp-server-asana&id=asana&name=Asana&description=enable%20task%20automation%2C%20project%20tracking%2C%20and%20team%20collaboration&env=ASANA_ACCESS_TOKEN%3DAsana%20Access%20Token)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @roychri/mcp-server-asana
@@ -39,7 +39,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="asana"
     extensionName="Asana"
@@ -56,7 +56,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   See [Asana's developer docs](https://developers.asana.com/docs/personal-access-token) if you need detailed instructions on creating an access token.
   :::
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/autovisualiser-mcp.md
+++ b/documentation/docs/mcp/autovisualiser-mcp.md
@@ -19,13 +19,13 @@ This guide will cover enabling and using the Auto Visualiser MCP Server.
 
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseBuiltinInstaller
     extensionName="Auto Visualiser"
     description="Automatically generate interactive data visualizations"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Run the `configure` command:
   ```sh

--- a/documentation/docs/mcp/blender-mcp.md
+++ b/documentation/docs/mcp/blender-mcp.md
@@ -14,10 +14,10 @@ This tutorial covers how to add the [Blender MCP Server](https://github.com/ahuj
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=blender-mcp&id=blender&name=Blender&description=Blender%203D%20scene%20creation%20integration)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   uvx blender-mcp
@@ -51,7 +51,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 ### Add Blender MCP Server
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="blender"
     extensionName="Blender"
@@ -60,7 +60,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     args={["blender-mcp"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/brave-mcp.md
+++ b/documentation/docs/mcp/brave-mcp.md
@@ -17,10 +17,10 @@ This tutorial will get you started with the [Brave Search MCP Server](https://gi
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-brave-search&id=brave-search&name=Brave%20Search&description=Brave%20Search%20API&env=BRAVE_API_KEY%3DYour%20API%20Key)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @modelcontextprotocol/server-brave-search
@@ -40,7 +40,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="brave-search"
     extensionName="Brave Search"
@@ -52,7 +52,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     apiKeyLinkText="Brave Search API Key"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/browserbase-mcp.md
+++ b/documentation/docs/mcp/browserbase-mcp.md
@@ -12,10 +12,10 @@ This tutorial covers how to add the Browserbase MCP Server as a Goose extension 
 :::tip TLDR
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=@browserbasehq/mcp&id=browserbase&name=Browserbase&description=Automate%20web%20browsing%20and%20data%20extraction&env=BROWSERBASE_PROJECT_ID%3DBrowserbase%20Project%20ID&env=BROWSERBASE_API_KEY%3DBrowserbase%20API%20Key)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx @browserbasehq/mcp
@@ -32,7 +32,7 @@ This tutorial covers how to add the Browserbase MCP Server as a Goose extension 
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="browserbase"
     extensionName="Browserbase"
@@ -47,7 +47,7 @@ This tutorial covers how to add the Browserbase MCP Server as a Goose extension 
     apiKeyLinkText="Get your Browserbase credentials"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/chrome-devtools-mcp.md
+++ b/documentation/docs/mcp/chrome-devtools-mcp.md
@@ -11,10 +11,10 @@ This tutorial covers how to add the Chrome DevTools MCP Server as a Goose extens
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=chrome-devtools-mcp%40latest&id=chrome-devtools&name=Chrome%20DevTools&description=Browser%20automation%20and%20web%20performance%20testing%20capabilities)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y chrome-devtools-mcp@latest
@@ -30,7 +30,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="chrome-devtools"
       extensionName="Chrome DevTools"
@@ -42,7 +42,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
       note="Note that you'll need Node.js installed on your system to run this command, as it uses npx."
     />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/cloudflare-mcp.md
+++ b/documentation/docs/mcp/cloudflare-mcp.md
@@ -14,10 +14,10 @@ Cloudflare provides multiple specialized MCP servers for different aspects of th
 :::tip TLDR
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=mcp-remote&arg=https%3A%2F%2Fobservability.mcp.cloudflare.com%2Fsse&id=cloudflare-observability&name=Cloudflare%20Observability&description=Debug%20and%20get%20insight%20into%20your%20application%27s%20logs%20and%20analytics&env=CLOUDFLARE_API_TOKEN%3DCloudflare%20API%20Token)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx mcp-remote https://observability.mcp.cloudflare.com/sse
@@ -79,14 +79,14 @@ Choose one or more servers based on your needs. Here are the most popular config
 #### Observability Server (Recommended for debugging)
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   1. [Launch the installer](goose://extension?cmd=npx&arg=mcp-remote&arg=https%3A%2F%2Fobservability.mcp.cloudflare.com%2Fsse&id=cloudflare-observability&name=Cloudflare%20Observability&description=Debug%20and%20get%20insight%20into%20your%20application%27s%20logs%20and%20analytics&env=CLOUDFLARE_API_TOKEN%3DCloudflare%20API%20Token)
   2. Press `Yes` to confirm the installation
   3. Enter your Cloudflare API Token
   4. Click `Save Configuration`
   5. Scroll to the top and click `Exit` from the upper left corner
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -106,10 +106,10 @@ Choose one or more servers based on your needs. Here are the most popular config
 #### Workers Bindings Server (For Workers development)
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=mcp-remote&arg=https%3A%2F%2Fbindings.mcp.cloudflare.com%2Fsse&id=cloudflare-bindings&name=Cloudflare%20Workers%20Bindings&description=Build%20Workers%20applications%20with%20storage%2C%20AI%2C%20and%20compute%20primitives&env=CLOUDFLARE_API_TOKEN%3DCloudflare%20API%20Token)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   Command: `npx mcp-remote https://bindings.mcp.cloudflare.com/sse`
   </TabItem>
 </Tabs>
@@ -117,10 +117,10 @@ Choose one or more servers based on your needs. Here are the most popular config
 #### Radar Server (For traffic insights)
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=mcp-remote&arg=https%3A%2F%2Fradar.mcp.cloudflare.com%2Fsse&id=cloudflare-radar&name=Cloudflare%20Radar&description=Get%20global%20Internet%20traffic%20insights%2C%20trends%2C%20URL%20scans%2C%20and%20other%20utilities&env=CLOUDFLARE_API_TOKEN%3DCloudflare%20API%20Token)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   Command: `npx mcp-remote https://radar.mcp.cloudflare.com/sse`
   </TabItem>
 </Tabs>

--- a/documentation/docs/mcp/cloudinary-asset-management-mcp.md
+++ b/documentation/docs/mcp/cloudinary-asset-management-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [Cloudinary Asset Management MCP Server](htt
 :::tip TLDR
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=--package&arg=@cloudinary/asset-management&arg=--&arg=mcp&arg=start&id=cloudinary&name=Cloudinary%20Asset%20Management&description=Powerful%20media%20processing%20and%20transformation&env=CLOUDINARY_URL%3DCloudinary%20URL)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y --package @cloudinary/asset-management -- mcp start
@@ -38,7 +38,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="cloudinary"
     extensionName="Cloudinary Asset Management"
@@ -50,7 +50,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     apiKeyLinkText="Get your Cloudinary URL"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/cognee-mcp.md
+++ b/documentation/docs/mcp/cognee-mcp.md
@@ -27,7 +27,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="cli" label="goose CLI" default>
 
 1. First, install Cognee:
 ```bash

--- a/documentation/docs/mcp/computer-controller-mcp.md
+++ b/documentation/docs/mcp/computer-controller-mcp.md
@@ -21,13 +21,13 @@ Let Goose complete its tasks without interruption - avoid using your mouse or ke
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseBuiltinInstaller
     extensionName="Computer Controller"
     description="Automate everyday computer tasks and web interactions"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Run the `configure` command:
   ```sh
@@ -102,10 +102,10 @@ Anthropic's Claude 4 Sonnet was used for this task.
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
    1. Open a new session in Goose Desktop
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Open a terminal and start a new Goose session:
 

--- a/documentation/docs/mcp/container-use-mcp.md
+++ b/documentation/docs/mcp/container-use-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [Container Use MCP Server](https://container
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=container-use&arg=stdio&id=container-use&name=container%20use&description=use%20containers%20with%20dagger%20and%20git%20for%20isolated%20environments)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   container-use stdio
@@ -37,7 +37,7 @@ You'll need [Docker](https://www.docker.com/) installed on your system. If you w
   <TabItem value="remote-mcp" label="Remote MCP" default>
 
     <Tabs groupId="interface">
-      <TabItem value="ui" label="Goose Desktop" default>
+      <TabItem value="ui" label="goose Desktop" default>
         <GooseDesktopInstaller
             extensionId="container-use"
             extensionName="Container Use"
@@ -49,7 +49,7 @@ You'll need [Docker](https://www.docker.com/) installed on your system. If you w
             note="Requires Node.js and Docker installed; see [container-use.com/quickstart](https://container-use.com/quickstart)."
         />
     </TabItem>
-      <TabItem value="cli" label="Goose CLI">
+      <TabItem value="cli" label="goose CLI">
           <CLIExtensionInstructions
             name="Container Use"
             command="npx -y mcp-remote https://container-use.com/mcp"
@@ -62,7 +62,7 @@ You'll need [Docker](https://www.docker.com/) installed on your system. If you w
   <TabItem value="local-mcp" label="Local MCP">
 
     <Tabs groupId="interface">
-      <TabItem value="ui" label="Goose Desktop" default>
+      <TabItem value="ui" label="goose Desktop" default>
         <GooseDesktopInstaller
             extensionId="container-use"
             extensionName="Container Use"
@@ -74,7 +74,7 @@ You'll need [Docker](https://www.docker.com/) installed on your system. If you w
             note="Requires Docker installed; see [container-use.com/quickstart](https://container-use.com/quickstart)."
         />
     </TabItem>
-      <TabItem value="cli" label="Goose CLI">
+      <TabItem value="cli" label="goose CLI">
           <CLIExtensionInstructions
             name="Container Use"
             command="container-use stdio"

--- a/documentation/docs/mcp/dev.to-mcp.md
+++ b/documentation/docs/mcp/dev.to-mcp.md
@@ -16,10 +16,10 @@ This tutorial covers how to add the [Dev.to MCP Server](https://github.com/nicky
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?type=streamable_http&url=http%3A%2F%2Flocalhost%3A3000%2Fmcp&id=dev-to&name=Dev.to&description=Access%20Dev.to%20articles%20and%20content)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
 
   **Endpoint URL**
@@ -57,7 +57,7 @@ Your server will now be running at:
 
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="dev-to"
       extensionName="Dev.to"
@@ -67,7 +67,7 @@ Your server will now be running at:
     />
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="cli" label="goose CLI" default>
       <CLIExtensionInstructions
         name="dev.to"
         type="http"

--- a/documentation/docs/mcp/developer-mcp.md
+++ b/documentation/docs/mcp/developer-mcp.md
@@ -22,13 +22,13 @@ The Developer extension is already enabled by default when Goose is installed.
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseBuiltinInstaller
     extensionName="Developer"
     description="Automate developer-centric tasks like file editing and shell commands"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Run the `configure` command:
   ```sh
@@ -61,10 +61,10 @@ Anthropic's Claude 4 Sonnet was used for this task.
 
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
    1. Open a new session in Goose Desktop
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Open a terminal and start a new Goose session:
 

--- a/documentation/docs/mcp/elevenlabs-mcp.md
+++ b/documentation/docs/mcp/elevenlabs-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [ElevenLabs MCP Server](https://github.com/e
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=elevenlabs-mcp&id=elevenlabs&name=ElevenLabs&description=ElevenLabs%20voice%20synthesis%20server&env=ELEVENLABS_API_KEY)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   uvx elevenlabs-mcp

--- a/documentation/docs/mcp/fetch-mcp.md
+++ b/documentation/docs/mcp/fetch-mcp.md
@@ -18,10 +18,10 @@ This tutorial covers how to add the [Fetch MCP Server](https://github.com/modelc
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Web%20content%20fetching%20and%20processing%20capabilities)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   uvx mcp-server-fetch
@@ -37,7 +37,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="fetch"
     extensionName="Fetch"
@@ -46,7 +46,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     args={["mcp-server-fetch"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/figma-mcp.md
+++ b/documentation/docs/mcp/figma-mcp.md
@@ -18,10 +18,10 @@ The MCP Server requires a Dev or Full seat on Professional, Organization, or Ent
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?type=streamable_http&url=http%3A%2F%2F127.0.0.1%3A3845%2Fmcp&id=figma&name=Figma&description=Convert%20Figma%20designs%20into%20code%20and%20extract%20design%20context)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
     
     **Endpoint URL**
@@ -51,7 +51,7 @@ The Dev Mode MCP Server must be enabled in the [Figma desktop app](https://www.f
 
 2. Add the Figma extension to Goose:
    <Tabs groupId="interface">
-     <TabItem value="ui" label="Goose Desktop" default>
+     <TabItem value="ui" label="goose Desktop" default>
        <GooseDesktopInstaller
          extensionId="figma"
          extensionName="Figma"
@@ -60,7 +60,7 @@ The Dev Mode MCP Server must be enabled in the [Figma desktop app](https://www.f
          url="http://127.0.0.1:3845/mcp"
        />
      </TabItem>
-     <TabItem value="cli" label="Goose CLI">
+     <TabItem value="cli" label="goose CLI">
        <CLIExtensionInstructions            
          name="figma"
          type="http"

--- a/documentation/docs/mcp/filesystem-mcp.md
+++ b/documentation/docs/mcp/filesystem-mcp.md
@@ -29,7 +29,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="filesystem"
     extensionName="filesystem"
@@ -52,7 +52,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
   </TabItem>
 
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     1. Run the `configure` command:
     ```sh
     goose configure

--- a/documentation/docs/mcp/firecrawl-mcp.md
+++ b/documentation/docs/mcp/firecrawl-mcp.md
@@ -16,10 +16,10 @@ This tutorial will get you started with the [Firecrawl MCP Server](https://githu
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=firecrawl-mcp&id=firecrawl&name=Firecrawl&description=Web%20scraping%20and%20crawling%20capabilities&env=FIRECRAWL_API_KEY%3DYour%20API%20Key)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y firecrawl-mcp
@@ -39,7 +39,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="firecrawl"
     extensionName="Firecrawl"
@@ -51,7 +51,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     apiKeyLinkText="Firecrawl API Key"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="firecrawl"
       type="stdio"

--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [GitHub MCP Server](https://github.com/githu
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   Use `Add custom extension` in Settings → Extensions to add a `Streamable HTTP` extension type with:
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
   </TabItem>
 </Tabs>
@@ -37,7 +37,7 @@ This tutorial covers how to add the [GitHub MCP Server](https://github.com/githu
 These steps configure the Remote MCP Server. For other deployment options, see the [official GitHub MCP Server documentation](https://github.com/github/github-mcp-server).
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     1. Obtain a [GitHub Personal Access Token](https://github.com/settings/personal-access-tokens)
     2. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
     3. Click `Extensions`
@@ -54,7 +54,7 @@ These steps configure the Remote MCP Server. For other deployment options, see t
     8. Navigate to the chat
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="github"
       type="http"

--- a/documentation/docs/mcp/gitmcp-mcp.md
+++ b/documentation/docs/mcp/gitmcp-mcp.md
@@ -16,10 +16,10 @@ This tutorial covers how to add the [Git MCP Server](https://github.com/idosal/g
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=mcp-remote&arg=https%3A%2F%2Fgitmcp.io%2Fdocs&id=gitmcp&name=GitMCP&description=Remote%20MCP%20server%20from%20gitmcp.io)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y mcp-remote https://gitmcp.io/docs
@@ -32,7 +32,7 @@ This tutorial covers how to add the [Git MCP Server](https://github.com/idosal/g
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
         extensionId="Git-mcp"
         extensionName="Git mcp"
@@ -44,7 +44,7 @@ This tutorial covers how to add the [Git MCP Server](https://github.com/idosal/g
         note="Note that you'll need Node.js installed on your system to run this command, as it uses npx."
     />
  </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
       <CLIExtensionInstructions
         name="Git MCP"
         command="npx -y mcp-remote https://gitmcp.io/docs"
@@ -58,10 +58,10 @@ This tutorial covers how to add the [Git MCP Server](https://github.com/idosal/g
 In this example, Goose uses GitMCP to pull real-time documentation from the `openai/whisper` GitHub repository, explore how the speech-to-text model works, and surface accurate setup instructions and command-line usage—all directly from the source.
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
    1. Open a new session in Goose Desktop
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Open a terminal and start a new Goose session:
 

--- a/documentation/docs/mcp/google-drive-mcp.md
+++ b/documentation/docs/mcp/google-drive-mcp.md
@@ -17,10 +17,10 @@ This tutorial covers how to add the [Google Drive MCP Server](https://github.com
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-gdrive&id=google-drive&name=Google%20Drive&description=Google%20Drive%20integration&env=GDRIVE_CREDENTIALS_PATH%3DPath%20to%20Google%20Drive%20credentials&env=GDRIVE_OAUTH_PATH%3DPath%20to%20OAuth%20token)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   GDRIVE_OAUTH_PATH=$USER_HOME/.config/gcp-oauth.keys.json \ 
@@ -95,7 +95,7 @@ You'll need to re-authenticate once a day when using the Google Drive extension.
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="google-drive"
     extensionName="Google Drive"
@@ -115,7 +115,7 @@ You'll need to re-authenticate once a day when using the Google Drive extension.
   Replace `$USER_HOME` with your home directory. You must specify an absolute path for this extension to work.
   :::
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/google-maps-mcp.md
+++ b/documentation/docs/mcp/google-maps-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [Google Maps MCP Server](https://github.com/
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-google-maps&id=google-maps&name=Google%20Maps&description=Google%20Maps%20API%20integration&env=GOOGLE_MAPS_API_KEY%3DGoogle%20Maps%20API%20key)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @modelcontextprotocol/server-google-maps
@@ -38,7 +38,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface" defaultValue="ui">
-  <TabItem value="ui" label="Goose Desktop">
+  <TabItem value="ui" label="goose Desktop">
   <GooseDesktopInstaller
     extensionId="google-maps"
     extensionName="Google Maps"
@@ -52,7 +52,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     apiKeyLinkText="Google Maps API Key"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/goose-docs-mcp.md
+++ b/documentation/docs/mcp/goose-docs-mcp.md
@@ -16,10 +16,10 @@ This tutorial covers how to add the [Goose Docs MCP Server](https://github.com/i
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=mcp-remote&arg=https%3A%2F%2Fblock.gitmcp.io%2Fgoose%2F&id=goose-docs&name=Goose%20Docs&description=gitmcp%20for%20Goose%20documentation)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx mcp-remote https://block.gitmcp.io/goose/
@@ -31,7 +31,7 @@ This tutorial covers how to add the [Goose Docs MCP Server](https://github.com/i
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="goose-docs"
       extensionName="Goose Docs"
@@ -43,7 +43,7 @@ This tutorial covers how to add the [Goose Docs MCP Server](https://github.com/i
       note="Note that you'll need Node.js installed on your system to run this command, as it uses npx."
     />
  </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
       <CLIExtensionInstructions
         name="Goose Docs"
         command="npx mcp-remote https://block.gitmcp.io/goose/"

--- a/documentation/docs/mcp/gotohuman-mcp.md
+++ b/documentation/docs/mcp/gotohuman-mcp.md
@@ -17,10 +17,10 @@ This tutorial covers how to add the [gotoHuman MCP Server](https://github.com/go
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40gotohuman%2Fmcp-server&id=gotoHuman&name=gotoHuman&description=gotoHuman%20MCP%20server%20for%20human-in-the-loop%20approvals&env=GOTOHUMAN_API_KEY%3DgotoHuman%20API%20Key)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
    npx -y @gotohuman/mcp-server
@@ -36,7 +36,7 @@ This tutorial covers how to add the [gotoHuman MCP Server](https://github.com/go
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="gotoHuman"
     extensionName="gotoHuman"
@@ -50,7 +50,7 @@ This tutorial covers how to add the [gotoHuman MCP Server](https://github.com/go
     apiKeyLinkText="GOTOHUMAN_API_KEY"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
       <CLIExtensionInstructions
         name="gotoHuman MCP"
         command="npx -y @gotohuman/mcp-server"
@@ -78,10 +78,10 @@ Follow the steps to create a template and ensure you set a **Webhook Endpoint** 
 In this example, Goose sends a LinkedIn post draft to gotoHuman for approval using the `n8n news to post` template that was created.
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
    1. Open a new session in Goose Desktop
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Open a terminal and start a new Goose session:
 

--- a/documentation/docs/mcp/jetbrains-mcp.md
+++ b/documentation/docs/mcp/jetbrains-mcp.md
@@ -27,10 +27,10 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
 
     :::tip TLDR
     <Tabs groupId="interface">
-      <TabItem value="ui" label="Goose Desktop" default>
+      <TabItem value="ui" label="goose Desktop" default>
       Use `Add custom extension` in Settings → Extensions to add a `Server-Sent Events (SSE)` extension type with your IDE-specific SSE config.
       </TabItem>
-      <TabItem value="cli" label="Goose CLI">
+      <TabItem value="cli" label="goose CLI">
       Use `goose configure` to add a `Remote Extension (SSE)` extension type with your IDE-specific SSE config.
       </TabItem>
     </Tabs>
@@ -49,7 +49,7 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
 
     2. Add the JetBrains extension to Goose, replacing "YOUR_IDE_SPECIFIC_URL" in the instructions with the URL you copied:
        <Tabs groupId="interface">
-         <TabItem value="ui" label="Goose Desktop" default>
+         <TabItem value="ui" label="goose Desktop" default>
            1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
            2. Click `Extensions` on the sidebar
            3. Click `Add custom extension`
@@ -60,7 +60,7 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
            5. Click `Add Extension` to save the extension
            6. Navigate to the chat
          </TabItem>
-         <TabItem value="cli" label="Goose CLI">
+         <TabItem value="cli" label="goose CLI">
            <CLIExtensionInstructions            
              name="jetbrains"
              type="sse"
@@ -76,10 +76,10 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
 
     :::tip TLDR
     <Tabs groupId="interface">
-      <TabItem value="ui" label="Goose Desktop" default>
+      <TabItem value="ui" label="goose Desktop" default>
       [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40jetbrains%2Fmcp-proxy&id=jetbrains&name=JetBrains&description=Integrate%20Goose%20with%20any%20JetBrains%20IDE)
       </TabItem>
-      <TabItem value="cli" label="Goose CLI">
+      <TabItem value="cli" label="goose CLI">
       **Command**
       ```sh
       npx -y @jetbrains/mcp-proxy
@@ -104,7 +104,7 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
     2. Add the JetBrains extension to Goose:
 
        <Tabs groupId="interface">
-         <TabItem value="ui" label="Goose Desktop" default>
+         <TabItem value="ui" label="goose Desktop" default>
            <GooseDesktopInstaller
              extensionId="jetbrains"
              extensionName="JetBrains"
@@ -114,7 +114,7 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
              timeout={300}
            />
          </TabItem>
-         <TabItem value="cli" label="Goose CLI">
+         <TabItem value="cli" label="goose CLI">
              <CLIExtensionInstructions
                name="jetbrains"
                command="npx -y @jetbrains/mcp-proxy"
@@ -136,7 +136,7 @@ Anthropic's Claude 4 Sonnet was used for this task.
 
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
    1. Open [IntelliJ](https://www.jetbrains.com/idea/download) (JetBrains' Java and Kotlin IDE)
    2. Open a new session in Goose Desktop
    :::note
@@ -144,7 +144,7 @@ Anthropic's Claude 4 Sonnet was used for this task.
    :::
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Open [IntelliJ](https://www.jetbrains.com/idea/download) (JetBrains' Java and Kotlin IDE)
   2. Open a terminal within your IDE and start a new Goose session:

--- a/documentation/docs/mcp/kiwi-flight-search.md
+++ b/documentation/docs/mcp/kiwi-flight-search.md
@@ -20,10 +20,10 @@ This tutorial covers how to add the [Kiwi Flight Search MCP Server](https://mcp.
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   Use `Add custom extension` in Settings → Extensions to add a `Streamable HTTP` extension type with:
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
   </TabItem>
 </Tabs>
@@ -37,7 +37,7 @@ This tutorial covers how to add the [Kiwi Flight Search MCP Server](https://mcp.
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
     2. Click `Extensions`
     3. Click `Add custom extension`
@@ -49,7 +49,7 @@ This tutorial covers how to add the [Kiwi Flight Search MCP Server](https://mcp.
     6. Navigate to the chat
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="kiwi-flight-search"
       type="http"

--- a/documentation/docs/mcp/knowledge-graph-mcp.md
+++ b/documentation/docs/mcp/knowledge-graph-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [Knowledge Graph Memory MCP Server](https://
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-memory&id=knowledge_graph_memory&name=Knowledge%20Graph%20Memory&description=Graph-based%20memory%20system%20for%20persistent%20knowledge%20storage)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @modelcontextprotocol/server-memory
@@ -34,7 +34,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="knowledge_graph_memory"
     extensionName="Knowledge Graph Memory"
@@ -43,7 +43,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     args={["-y", "@modelcontextprotocol/server-memory"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/mbot-mcp.md
+++ b/documentation/docs/mcp/mbot-mcp.md
@@ -29,7 +29,7 @@ This tutorial will get you started with [deemkeen's MQTT MCP server](https://git
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/memory-mcp.md
+++ b/documentation/docs/mcp/memory-mcp.md
@@ -17,13 +17,13 @@ This tutorial covers enabling and using the Memory MCP Server, which is a built-
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseBuiltinInstaller
     extensionName="Memory"
     description="Store and recall personalized information for consistent assistance"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Run the `configure` command:
   ```sh
@@ -153,10 +153,10 @@ If you frequently work with API standards or other structured knowledge, Goose m
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
    1. Open a new session in Goose Desktop
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
   1. Open a terminal and start a new Goose session:
 

--- a/documentation/docs/mcp/mongodb-mcp.md
+++ b/documentation/docs/mcp/mongodb-mcp.md
@@ -11,10 +11,10 @@ The [MongoDB MCP Server](https://github.com/mongodb-js/mongodb-mcp-server) exten
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=mongodb-mcp-server&arg=--connection-string&arg=mongodb://localhost:27017&id=mongodb&name=MongoDB&description=MongoDB%20database%20integration)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y mongodb-mcp-server --connection-string mongodb://localhost:27017
@@ -55,7 +55,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="mongodb"
       extensionName="MongoDB"
@@ -69,7 +69,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     :::
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/neon-mcp.md
+++ b/documentation/docs/mcp/neon-mcp.md
@@ -26,10 +26,10 @@ The Neon MCP Server grants powerful database management capabilities and is inte
   <TabItem value="remote" label="Neon Remote MCP" default>
   :::tip TLDR
   <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.neon.tech%2Fmcp&id=neon&name=Neon&description=Manage%20Neon%20Postgres%20databases%2C%20projects%2C%20and%20branches)
     </TabItem>
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
     Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
 
     **Endpoint URL**
@@ -45,7 +45,7 @@ The Neon MCP Server grants powerful database management capabilities and is inte
   :::
 
   <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose Desktop" default>
       <GooseDesktopInstaller
         extensionId="neon"
         extensionName="Neon"
@@ -54,7 +54,7 @@ The Neon MCP Server grants powerful database management capabilities and is inte
         url="https://mcp.neon.tech/mcp"
       />
     </TabItem>
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
       <CLIExtensionInstructions
         name="neon-mcp-remote"
         type="http"
@@ -69,10 +69,10 @@ The Neon MCP Server grants powerful database management capabilities and is inte
   <TabItem value="local" label="Neon Local MCP">
   :::tip TLDR
   <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose Desktop" default>
       [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40neondatabase%2Fmcp-server-neon&arg=start&arg=%3CYOUR_NEON_API_KEY%3E&id=neon&name=Neon&description=Manage%20your%20Neon%20Postgres%20databases%2C%20projects%2C%20and%20branches)
     </TabItem>
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
       **Command**
       ```sh
       npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>
@@ -90,7 +90,7 @@ The Neon MCP Server grants powerful database management capabilities and is inte
   :::
 
   <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="neon"
       extensionName="Neon"
@@ -100,7 +100,7 @@ The Neon MCP Server grants powerful database management capabilities and is inte
     />
     </TabItem>
 
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
       <CLIExtensionInstructions
         name="Neon MCP"
         command="npx -y @neondatabase/mcp-server-neon start <YOUR_NEON_API_KEY>"

--- a/documentation/docs/mcp/netlify-mcp.md
+++ b/documentation/docs/mcp/netlify-mcp.md
@@ -14,10 +14,10 @@ This tutorial covers how to add the [Netlify MCP Server](https://github.com/netl
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40netlify%2Fmcp&id=netlify&name=Netlify&description=Build%2C%20deploy%2C%20and%20manage%20sites%20with%20Netlify%27s%20official%20MCP%20server.)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @netlify/mcp
@@ -41,7 +41,7 @@ netlify login
 ### Add Netlify MCP Server
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="netlify"
     extensionName="Netlify"
@@ -50,7 +50,7 @@ netlify login
     args={["-y", "@netlify/mcp"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/nostrbook-mcp.md
+++ b/documentation/docs/mcp/nostrbook-mcp.md
@@ -29,7 +29,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="nostrbook"
     extensionName="Nostrbook"
@@ -38,7 +38,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     args={["-y", "@nostrbook/mcp"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/openmetadata-mcp.md
+++ b/documentation/docs/mcp/openmetadata-mcp.md
@@ -11,10 +11,10 @@ The [OpenMetadata MCP Server](https://open-metadata.org/mcp) extension allows Go
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arghttp://localhost:8585/mcp&arg=--auth-server-url&arg=http://localhost:8585/mcp&id=openmetadata&name=OpenMetadata&description=OpenMetadata%20integration)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y mcp-remote http://localhost:8585/mcp --auth-server-url=http://localhost:8585/mcp --client-id=openmetadata --verbose --clean --header Authorization:${AUTH_HEADER}
@@ -34,7 +34,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="openmetadata"
       extensionName="OpenMetadata"
@@ -48,7 +48,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     :::
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/pdf-mcp.md
+++ b/documentation/docs/mcp/pdf-mcp.md
@@ -14,10 +14,10 @@ This tutorial covers how to add the [PDF Reader MCP Server](https://github.com/m
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=mcp-read-pdf&id=pdf_read&name=PDF%20Reader&description=Read%20large%20and%20complex%20PDF%20documents)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   uvx mcp-read-pdf
@@ -33,7 +33,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="pdf_read"
     extensionName="PDF Reader"
@@ -42,7 +42,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     args={["mcp-read-pdf"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/pieces-mcp.md
+++ b/documentation/docs/mcp/pieces-mcp.md
@@ -33,7 +33,7 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
 ### Add Pieces MCP Server
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="pieces"
     extensionName="Pieces for Developers"
@@ -41,7 +41,7 @@ http://localhost:39300/model_context_protocol/2024-11-05/sse
     url="http://localhost:39300/model_context_protocol/2024-11-05/sse"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
 
       ```sh

--- a/documentation/docs/mcp/playwright-mcp.md
+++ b/documentation/docs/mcp/playwright-mcp.md
@@ -14,10 +14,10 @@ This tutorial covers how to add the Playwright MCP Server as a Goose extension, 
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@playwright/mcp@latest&id=playwright&name=Playwright&description=Modern%20web%20testing%20and%20automation)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @playwright/mcp@latest
@@ -33,7 +33,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="playwright"
     extensionName="Playwright"
@@ -42,7 +42,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     args={["-y", "@playwright/mcp@latest"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/postgres-mcp.md
+++ b/documentation/docs/mcp/postgres-mcp.md
@@ -17,10 +17,10 @@ The PostgreSQL MCP Server extension allows Goose to interact directly with your 
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@modelcontextprotocol/server-postgres&arg=Your%20PostgreSQL%20connection%20URL&id=postgres&name=PostgreSQL&description=PostgreSQL%20database%20integration)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @modelcontextprotocol/server-postgres postgresql://localhost/mydb
@@ -63,7 +63,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="postgres"
     extensionName="PostgreSQL"
@@ -77,7 +77,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   :::
 
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/puppeteer-mcp.md
+++ b/documentation/docs/mcp/puppeteer-mcp.md
@@ -17,10 +17,10 @@ This tutorial covers how to add the [Puppeteer MCP Server](https://github.com/mo
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-puppeteer&id=puppeteer&name=Puppeteer&description=Headless%20browser%20automation)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @modelcontextprotocol/server-puppeteer
@@ -37,7 +37,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="puppeteer"
     extensionName="Puppeteer"
@@ -46,7 +46,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     args={["-y", "@modelcontextprotocol/server-puppeteer"]}
   />
 </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -196,10 +196,10 @@ In this example, I’ll show you how to use Goose with the Puppeteer Extension t
 This allows you to quickly identify and resolve accessibility issues without manually inspecting each page.
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
    1. Open a new session in Goose Desktop
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Open a terminal and start a new Goose session:
 
   ```sh

--- a/documentation/docs/mcp/reddit-mcp.md
+++ b/documentation/docs/mcp/reddit-mcp.md
@@ -17,10 +17,10 @@ This tutorial covers how to add the [Reddit MCP Server](https://github.com/adhik
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=--from&arg=git%2Bhttps%3A%2F%2Fgithub.com%2Fadhikasp%2Fmcp-reddit.git&arg=mcp-reddit&id=reddit&name=Reddit&description=Fetch%20and%20analyze%20Reddit%20content)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   uvx --from git+https://github.com/adhikasp/mcp-reddit.git mcp-reddit
@@ -36,7 +36,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="reddit"
       extensionName="Reddit"
@@ -46,7 +46,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     />
   </TabItem>
 
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="Reddit MCP"
       command="uvx --from git+https://github.com/adhikasp/mcp-reddit.git mcp-reddit"

--- a/documentation/docs/mcp/repomix-mcp.md
+++ b/documentation/docs/mcp/repomix-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [Repomix MCP Server](https://github.com/yama
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=repomix&arg=--mcp&id=repomix&name=Repomix&description=Pack%20repositories%20into%20AI-friendly%20formats%20for%20Goose)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y repomix --mcp
@@ -34,7 +34,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="repomix"
     extensionName="Repomix"
@@ -43,7 +43,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     args={["-y", "repomix", "--mcp"]}
   />
 </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/rube-mcp.md
+++ b/documentation/docs/mcp/rube-mcp.md
@@ -13,10 +13,10 @@ This tutorial covers how to add [Rube](https://rube.app) as a Goose extension to
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Frube.app%2Fmcp&id=rube&name=Rube&description=Seamlessly%20connect%20across%20500%2B%20applications%20including%20Slack%2C%20Gmail%2C%20Notion%2C%20Google%20Workspace%2C%20Microsoft%20Office%2C%20GitHub%2C%20and%20many%20more)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     Use `goose configure` to add a `Remote Extension (Streaming HTTP)` extension type with:
     
     **Endpoint URL**
@@ -37,7 +37,7 @@ Rube is a platform powered by Composio that provides unified access to 500+ apps
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="rube"
       extensionName="Rube"
@@ -46,7 +46,7 @@ Rube is a platform powered by Composio that provides unified access to 500+ apps
       url="https://rube.app/mcp"
     />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="rube"
       type="http"

--- a/documentation/docs/mcp/selenium-mcp.md
+++ b/documentation/docs/mcp/selenium-mcp.md
@@ -15,10 +15,10 @@ This tutorial covers how to add the [Selenium MCP Server](https://github.com/ang
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40angiejones%2Fmcp-selenium&id=selenium-mcp&name=Selenium%20MCP&description=automates%20browser%20interactions)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y @angiejones/mcp-selenium
@@ -35,7 +35,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="selenium-mcp"
     extensionName="Selenium MCP"
@@ -44,7 +44,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
     args={["-y", "@angiejones/mcp-selenium"]}
   />
 </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/speech-mcp.md
+++ b/documentation/docs/mcp/speech-mcp.md
@@ -19,10 +19,10 @@ This tutorial covers how to add the [Speech MCP Server](https://github.com/Kvadr
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=-p&arg=3.10.14&arg=speech-mcp@latest&id=speech_mcp&name=Speech%20Interface&description=Voice%20interaction%20with%20audio%20visualization%20for%20Goose)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   uvx -p 3.10.14 speech-mcp@latest
@@ -40,7 +40,7 @@ Before adding this extension, make sure [PortAudio](https://github.com/GoogleClo
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="speech_mcp"
     extensionName="Speech Interface"
@@ -49,7 +49,7 @@ Before adding this extension, make sure [PortAudio](https://github.com/GoogleClo
     args={["-p", "3.10.14", "speech-mcp@latest"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -198,10 +198,10 @@ In this example, you'll see how to use Goose with the Speech MCP Server Extensio
 This allows you to build with Goose hands-free, making development more accessible and interactive.
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
    1. Open a new session in Goose Desktop
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Open a terminal and start a new Goose session:
 
   ```sh

--- a/documentation/docs/mcp/square-mcp.md
+++ b/documentation/docs/mcp/square-mcp.md
@@ -39,10 +39,10 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   <TabItem value="remote" label="Square Remote MCP" default>
   :::tip TLDR
   <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](https://mcp.squareup.com/goose)
     </TabItem>
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
     **Command**
     ```sh
     npx mcp-remote https://mcp.squareup.com/sse
@@ -52,7 +52,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   :::
 
   <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose Desktop" default>
      1. [Launch the installer](https://mcp.squareup.com/goose)
      2. Click `OK` to confirm the installation
      3. Goose should open a browser tab to an OAuth permissions page. Double-check which permissions you want to allow, and click `Grant Access`.
@@ -60,7 +60,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
      5. In Goose, navigate to the chat
 
     </TabItem>
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
       <CLIExtensionInstructions
         name="square-mcp-remote"
         type="stdio"
@@ -77,11 +77,11 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   <TabItem value="local" label="Square Local MCP">
   :::tip TLDR
   <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?cmd=npx&arg=square-mcp-server&arg=start&id=mcp_square_api&name=Square%20MCP%20Server&description=Square%20API%20MCP%20Server&env=ACCESS_TOKEN%3DYour%20Access%20Token&env=SANDBOX%3Dtrue)
 
     </TabItem>
-    <TabItem value="cli" label="Goose CLI">
+    <TabItem value="cli" label="goose CLI">
     **Command**
     ```sh
     npx square-mcp-server start
@@ -99,7 +99,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   :::
 
   <Tabs groupId="interface">
-    <TabItem value="ui" label="Goose Desktop" default>
+    <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="mcp_square_api"
       extensionName="Square MCP Server"
@@ -115,7 +115,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
       apiKeyLinkText="Square Access Token"
     />
     </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="square-mcp"
       type="stdio"

--- a/documentation/docs/mcp/tavily-mcp.md
+++ b/documentation/docs/mcp/tavily-mcp.md
@@ -14,10 +14,10 @@ This tutorial covers how to add the [Tavily Web Search MCP Server](https://githu
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=tavily-mcp&id=tavily&name=Tavily%20Web%20Search&description=Search%20the%20web%20with%20Tavily%20MCP&env=TAVILY_API_KEY%3DTavily%20API%20Key)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   npx -y tavily-mcp
@@ -37,7 +37,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="tavily"
     extensionName="Tavily Web Search"
@@ -51,7 +51,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     apiKeyLinkText="Tavily API Key"
   />
 </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure

--- a/documentation/docs/mcp/tutorial-mcp.md
+++ b/documentation/docs/mcp/tutorial-mcp.md
@@ -19,12 +19,12 @@ The Tutorial extension serves as an interactive learning tool that:
 1. Ensure the Tutorial extension is enabled:
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseBuiltinInstaller
     extensionName="Tutorial"
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
 
 ```sh
 goose configure

--- a/documentation/docs/mcp/vercel-mcp.md
+++ b/documentation/docs/mcp/vercel-mcp.md
@@ -19,10 +19,10 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?url=https%3A%2F%2Fmcp.vercel.com&type=streamable_http&id=vercel&name=Vercel&description=Access%20deployments%2C%20manage%20projects%2C%20and%20more%20with%20Vercel%E2%80%99s%20official%20MCP%20server)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     ```sh
     npx mcp-remote https://mcp.vercel.com
     ```
@@ -33,7 +33,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 ## Configuration
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
     <GooseDesktopInstaller
       extensionId="Vercel"
       extensionName="Vercel"
@@ -42,7 +42,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
       url="https://mcp.vercel.com"
     />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
       name="Vercel"
       type="http"

--- a/documentation/docs/mcp/vs-code-mcp.md
+++ b/documentation/docs/mcp/vs-code-mcp.md
@@ -32,7 +32,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 1. Add the [VS Code MCP Extension](https://marketplace.visualstudio.com/items?itemName=block.vscode-mcp-extension) to your VS Code. No additional settings required in VS Code.
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="cli" label="goose CLI" default>
   1. Run the `configure` command:
   ```sh
   goose configure
@@ -118,7 +118,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
   6. No additional environment variables are required for basic setup
   
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
+  <TabItem value="ui" label="goose Desktop">
   1. [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=vscode-mcp-server&id=vscode-mcp&name=VS%20Code%20MCP&description=VS%20Code%20integration%20and%20file%20operations)
   2. Press `Yes` to confirm the installation
   3. Click `Save Configuration`

--- a/documentation/docs/mcp/youtube-transcript-mcp.md
+++ b/documentation/docs/mcp/youtube-transcript-mcp.md
@@ -14,10 +14,10 @@ This tutorial covers how to add the [YouTube Transcript MCP Server](https://gith
 
 :::tip TLDR
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=--from&arg=git%2Bhttps%3A%2F%2Fgithub.com%2Fjkawamoto%2Fmcp-youtube-transcript&arg=mcp-youtube-transcript&id=youtube-transcript&name=YouTube%20Transcript&description=Access%20YouTube%20video%20transcripts)
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   **Command**
   ```sh
   uvx --from git+https://github.com/jkawamoto/mcp-youtube-transcript mcp-youtube-transcript
@@ -34,7 +34,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
 :::
 
 <Tabs groupId="interface">
-  <TabItem value="ui" label="Goose Desktop" default>
+  <TabItem value="ui" label="goose Desktop" default>
   <GooseDesktopInstaller
     extensionId="youtube-transcript"
     extensionName="YouTube Transcript"
@@ -43,7 +43,7 @@ Note that you'll need [uv](https://docs.astral.sh/uv/#installation) installed on
     args={["--from", "git+https://github.com/jkawamoto/mcp-youtube-transcript", "mcp-youtube-transcript"]}
   />
   </TabItem>
-  <TabItem value="cli" label="Goose CLI">
+  <TabItem value="cli" label="goose CLI">
   1. Run the `configure` command:
   ```sh
   goose configure


### PR DESCRIPTION
## Summary

Updated all TabGroup TabItem labels to use lowercase 'goose' instead of 'Goose' for both Desktop and CLI variants. This change affects 55 files across MCP extension docs, tutorials, and blog posts, ensuring consistent branding throughout the documentation.

Changes:
- 'Goose Desktop' → 'goose Desktop'
- 'Goose CLI' → 'goose CLI'

Updated files include all MCP extension documentation, experimental vs-code-extension doc, and the MCP UI blog post.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)


