### PR TITLE
improvement: add useful error message when attempting to use unauthenticated cursor-agent

### DIFF
--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -259,12 +259,6 @@ impl CursorAgentProvider {
         messages: &[Message],
         _tools: &[Tool],
     ) -> Result<Vec<String>, ProviderError> {
-        if !self.get_authentication_status().await {
-            return Err(ProviderError::Authentication(
-                "You are not logged in to cursor-agent. Please run 'cursor-agent login' to authenticate first."
-                    .to_string()));
-        }
-
         let prompt = self.messages_to_cursor_agent_format(system, messages);
 
         if std::env::var("GOOSE_CURSOR_AGENT_DEBUG").is_ok() {
@@ -336,6 +330,11 @@ impl CursorAgentProvider {
         })?;
 
         if !exit_status.success() {
+            if !self.get_authentication_status().await {
+                return Err(ProviderError::Authentication(
+                    "You are not logged in to cursor-agent. Please run 'cursor-agent login' to authenticate first."
+                        .to_string()));
+            }
             return Err(ProviderError::RequestFailed(format!(
                 "Command failed with exit code: {:?}",
                 exit_status.code()


### PR DESCRIPTION
## Summary
Adds logic to check the authentication status of cursor-agent via `cursor-agent status` in `get_authentication_status` and adds a check in `execute_command`. Previous behaviour was to output an error of `Some(1)` when trying to use cursor-agent while unauthenticated. 


### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual testing with an unauthenticated cursor-agent, ran tests and linter.

### Related Issues
Relates to #5298
