### PR TITLE
feat: dynamically load ollama models

### DIFF
--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -286,7 +286,6 @@ impl Provider for OllamaProvider {
         }))
     }
 
-    /// Fetch the list of available models from Ollama
     async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
         let response = self
             .api_client

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -16,7 +16,7 @@ import { Select } from '../../../ui/Select';
 import { useConfig } from '../../../ConfigContext';
 import { useModelAndProvider } from '../../../ModelAndProviderContext';
 import type { View } from '../../../../utils/navigationUtils';
-import Model, { getProviderMetadata } from '../modelInterface';
+import Model, { getProviderMetadata, fetchModelsForProviders } from '../modelInterface';
 import { getPredefinedModelsFromEnv, shouldShowPredefinedModels } from '../predefinedModelsUtils';
 import { ProviderType } from '../../../../api';
 
@@ -146,24 +146,7 @@ export const SwitchModelModal = ({ sessionId, onClose, setView }: SwitchModelMod
         setLoadingModels(true);
 
         // Fetching models for all providers
-        const modelPromises = activeProviders.map(async (p) => {
-          const providerName = p.name;
-          try {
-            let models = await getProviderModels(providerName);
-            // Fallback to known_models if server returned none
-            if ((!models || models.length === 0) && p.metadata.known_models?.length) {
-              models = p.metadata.known_models.map((m) => m.name);
-            }
-            return { provider: p, models, error: null };
-          } catch (e: unknown) {
-            return {
-              provider: p,
-              models: null,
-              error: `Failed to fetch models for ${providerName}${e instanceof Error ? `: ${e.message}` : ''}`,
-            };
-          }
-        });
-        const results = await Promise.all(modelPromises);
+        const results = await fetchModelsForProviders(activeProviders, getProviderModels);
 
         // Process results and build grouped options
         const groupedOptions: {


### PR DESCRIPTION
## Summary
I am porting the changes in https://github.com/block/goose/pull/4342 with some modification:

- added fetch_supported_models() for Ollama provider. Now the models UI can show an alphabetically sorted list for ollama
- updated the leader/worker model to fetch models from providers dynamically instead of using the static known models list. 


### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manually verified on UI

### Related Issues
Fixes https://github.com/block/goose/issues/4273


### Screenshots/Demos (for UX changes)
After:   
<img width="710" height="593" alt="Screenshot 2025-10-21 at 6 02 26 PM" src="https://github.com/user-attachments/assets/ef00c833-1216-40da-97d6-30a0f9486862" />
<img width="614" height="880" alt="Screenshot 2025-10-21 at 6 02 42 PM" src="https://github.com/user-attachments/assets/ce299977-be55-40b6-99eb-86b13c783445" />

