### PR TITLE
fix: skip temperature for goose-gpt-5 model

### DIFF
--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -625,7 +625,7 @@ pub fn create_request(
             }
         }
 
-        // o1 models use max_completion_tokens instead of max_tokens
+        // open ai reasoning models use max_completion_tokens instead of max_tokens
         if let Some(tokens) = model_config.max_tokens {
             let key = if is_openai_reasoning_model {
                 "max_completion_tokens"


### PR DESCRIPTION
## Summary
**Issue:** When specifying temperature with `goose-gpt-5` model (eg: run a recipe), the session exits with "bad request error"
**Why:** gpt-5 only allows default (1) temperature 
**Fix:** Ignore the temperature for `goose-gpt-5` (same thing has been handled in the openai)


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)