### PR TITLE
fix: gracefully close goosed listening port

### DIFF
--- a/crates/goose-server/src/commands/agent.rs
+++ b/crates/goose-server/src/commands/agent.rs
@@ -8,6 +8,25 @@ use tracing::info;
 
 use goose::providers::pricing::initialize_pricing_cache;
 
+// Graceful shutdown signal
+#[cfg(unix)]
+async fn shutdown_signal() {
+    use tokio::signal::unix::{signal, SignalKind};
+
+    let mut sigint = signal(SignalKind::interrupt()).expect("failed to install SIGINT handler");
+    let mut sigterm = signal(SignalKind::terminate()).expect("failed to install SIGTERM handler");
+
+    tokio::select! {
+        _ = sigint.recv() => {},
+        _ = sigterm.recv() => {},
+    }
+}
+
+#[cfg(not(unix))]
+async fn shutdown_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+}
+
 pub async fn run() -> Result<()> {
     // Initialize logging and telemetry
     crate::logging::setup_logging(Some("goosed"))?;
@@ -42,6 +61,10 @@ pub async fn run() -> Result<()> {
 
     let listener = tokio::net::TcpListener::bind(settings.socket_addr()).await?;
     info!("listening on {}", listener.local_addr()?);
-    axum::serve(listener, app).await?;
+    // Ensure the listener/socket is properly closed on cancellation by using graceful shutdown
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+    info!("server shutdown complete");
     Ok(())
 }


### PR DESCRIPTION
## Summary
goosed agent opens a listening port on 3000, but if the agent is closed forcibly, the port stays open, and at least on Windows, it cannot be closed in any other way than an OS restart.

This PR adds tokio listeners for sigint and sigterm on unix, ctrl+c on Windows with axum graceful shutdown / port close, to resolve the problem.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Windows build
