### PR TITLE
Fix legacy import

### DIFF
--- a/crates/goose/src/session/legacy.rs
+++ b/crates/goose/src/session/legacy.rs
@@ -1,3 +1,4 @@
+use crate::conversation::message::MessageMetadata;
 use crate::conversation::Conversation;
 use crate::session::Session;
 use anyhow::Result;
@@ -70,6 +71,7 @@ pub fn load_session(session_name: &str, session_path: &Path) -> Result<Session> 
                 .or_insert(serde_json::json!(DateTime::<Utc>::from(modified_time)));
             obj.entry("extension_data").or_insert(serde_json::json!({}));
             obj.entry("message_count").or_insert(serde_json::json!(0));
+            obj.entry("working_dir").or_insert(serde_json::json!(""));
 
             if let Some(desc) = obj.get_mut("description") {
                 if let Some(desc_str) = desc.as_str() {
@@ -85,8 +87,14 @@ pub fn load_session(session_name: &str, session_path: &Path) -> Result<Session> 
     }
 
     for line in lines.map_while(Result::ok) {
-        if let Ok(message) = serde_json::from_str(&line) {
-            messages.push(message);
+        if let Ok(mut message_json) = serde_json::from_str::<serde_json::Value>(&line) {
+            if let Some(obj) = message_json.as_object_mut() {
+                obj.entry("metadata")
+                    .or_insert(serde_json::to_value(MessageMetadata::default())?);
+            }
+            if let Ok(message) = serde_json::from_value(message_json) {
+                messages.push(message);
+            }
         }
     }
 
@@ -102,4 +110,32 @@ fn parse_session_timestamp(session_name: &str) -> Option<SystemTime> {
         .ok()
         .and_then(|dt| Local.from_local_datetime(&dt).single())
         .map(SystemTime::from)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::Role;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_legacy_session_without_metadata() {
+        let temp_dir = TempDir::new().unwrap();
+        let session_path = temp_dir.path().join("20240101_120000.jsonl");
+
+        let legacy_content = r#"{"description":"test","id":"20240101_120000","created_at":"2024-01-01T12:00:00Z","updated_at":"2024-01-01T12:00:00Z","extension_data":{},"message_count":0}
+{"id":"msg1","role":"user","created":1704110400,"content":[{"type":"text","text":"Hello"}]}
+{"id":"msg2","role":"assistant","created":1704110401,"content":[{"type":"text","text":"Hi there"}]}"#;
+
+        fs::write(&session_path, legacy_content).unwrap();
+
+        let session = load_session("20240101_120000", &session_path).unwrap();
+
+        assert_eq!(session.id, "20240101_120000");
+        let conversation = session.conversation.as_ref().unwrap();
+        let messages = conversation.messages();
+        assert_eq!(messages.len(), 2);
+        assert_eq!(messages[0].role, Role::User);
+        assert_eq!(messages[1].role, Role::Assistant);
+    }
 }


### PR DESCRIPTION
We added metadata to Message but don't handle that for legacy imports; anybody who did not import previous sessions on 1.10 would find an empty database on 1.11. this fixes that and adds a test to protect the future