### PR TITLE
Improve schedule execution visibility for recipes that failed

### DIFF
--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -655,7 +655,8 @@ impl Scheduler {
                 schedule_sessions.push((session.id.clone(), session));
             }
         }
-        schedule_sessions.sort_by(|a, b| b.0.cmp(&a.0));
+        // Sort by created_at timestamp, newest first
+        schedule_sessions.sort_by(|a, b| b.1.created_at.cmp(&a.1.created_at));
 
         let result_sessions: Vec<(String, Session)> =
             schedule_sessions.into_iter().take(limit).collect();


### PR DESCRIPTION
## Summary

### Problem

When a recipe has no `prompt` field, the scheduler:

1. Creates a session in the database
2. Skips agent execution (logs warning)
3. Updates session with `schedule_id`
4. Returns "success" with empty session
5. Sessions with 0 messages don't appear in UI
6. **Users have no visibility that their schedule failed**

### Solution

Create visible failed sessions with error messages that show up in the UI, so users can see what went wrong.

### Note
This is primarily for backwards compatibility. The root cause issue is that we allow schedules to be created off recipes with empty prompts, but that'll be addressed in a follow up PR.

### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Related Issues
Relates to https://github.com/block/goose/issues/5045

### Screenshots/Demos (for UX changes)
Before:  
<img width="797" height="201" alt="Screenshot 2025-10-23 at 4 29 03 PM" src="https://github.com/user-attachments/assets/2e40aece-000a-4b0b-8e5f-412301a4378f" />

After:   
<img width="846" height="251" alt="Screenshot 2025-10-23 at 4 29 35 PM" src="https://github.com/user-attachments/assets/eaa0ee6f-07aa-4b04-9257-3fc6453d2b4b" />