### PR TITLE
chore: improve timeout for entering password when running goose ui from source

### DIFF
--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -28,8 +28,9 @@ export const findAvailablePort = (): Promise<number> => {
 
 // Check if goosed server is ready by polling the status endpoint
 export const checkServerStatus = async (client: Client): Promise<boolean> => {
-  const interval = 100;
-  const maxAttempts = 200;
+  const interval = 100; // ms
+  const maxAttempts = 1200; // 120s
+
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     try {
       await status({ client, throwOnError: true });


### PR DESCRIPTION
Right now we only have 20sec to enter our password when we run goose ui locally and goosed starts and needs the keychain password. I often miss it and goose turns into a brick, and needs to be relaunched. This will give 2min instead of 20sec.