### PR TITLE
feat(snowflake): add support for newer Claude 4.5 and 4 models

### DIFF
--- a/crates/goose/src/providers/snowflake.rs
+++ b/crates/goose/src/providers/snowflake.rs
@@ -15,8 +15,18 @@ use crate::impl_provider_default;
 use crate::model::ModelConfig;
 use rmcp::model::Tool;
 
-pub const SNOWFLAKE_DEFAULT_MODEL: &str = "claude-4-sonnet";
-pub const SNOWFLAKE_KNOWN_MODELS: &[&str] = &["claude-4-sonnet", "claude-3-7-sonnet"];
+pub const SNOWFLAKE_DEFAULT_MODEL: &str = "claude-sonnet-4-5";
+pub const SNOWFLAKE_KNOWN_MODELS: &[&str] = &[
+    // Claude 4.5 series
+    "claude-sonnet-4-5",
+    "claude-haiku-4-5",
+    // Claude 4 series
+    "claude-4-sonnet",
+    "claude-4-opus",
+    // Claude 3 series
+    "claude-3-7-sonnet",
+    "claude-3-5-sonnet",
+];
 
 pub const SNOWFLAKE_DOC_URL: &str =
     "https://docs.snowflake.com/user-guide/snowflake-cortex/aisql#choosing-a-model";


### PR DESCRIPTION
  ## Summary
  Added support for newer Claude models (4.5 and 4 series) to the Snowflake provider. Updated the default model from `claude-3-7-sonnet` to `claude-sonnet-4-5` and added all
  currently available Claude models from the Snowflake Cortex documentation.

  ### Type of Change
  - [x] Feature

  ### Testing
  Model names verified against official Snowflake Cortex documentation.

  ### Related Issues
  Resolves #4155

  **Email**: kimanim68@gmail.com
