### PR TITLE
Use Instructions as Prompt in Scheduler

### DIFF
--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -655,7 +655,9 @@ impl Scheduler {
                 schedule_sessions.push((session.id.clone(), session));
             }
         }
-        schedule_sessions.sort_by(|a, b| b.0.cmp(&a.0));
+
+        // Sort by created_at timestamp, newest first
+        schedule_sessions.sort_by(|a, b| b.1.created_at.cmp(&a.1.created_at));
 
         let result_sessions: Vec<(String, Session)> =
             schedule_sessions.into_iter().take(limit).collect();


### PR DESCRIPTION
### Problem
When a recipe has no `prompt` field, the scheduler:

- Creates a session in the database schedule_id
- Skips agent execution (logs warning in the background)
- Returns "success" with empty session
- Sessions with 0 messages don't appear in UI
- **Users have no visibility that their schedule failed**

### Solution
When executing a scheduled recipe, if the recipe has no `prompt` field but has an `instructions` field, use the `instructions` content directly as the prompt text for agent execution.

### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Related Issues
Relates to https://github.com/block/goose/issues/5045