### PR TITLE
Send all the logs we output

### DIFF
--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -455,7 +455,7 @@ pub struct RequestLog {
     temp_path: PathBuf,
 }
 
-const LOGS_TO_KEEP: usize = 10;
+pub const LOGS_TO_KEEP: usize = 10;
 
 impl RequestLog {
     pub fn start<Payload>(model_config: &ModelConfig, payload: &Payload) -> Result<Self>

--- a/crates/goose/src/session/diagnostics.rs
+++ b/crates/goose/src/session/diagnostics.rs
@@ -1,4 +1,5 @@
 use crate::config::paths::Paths;
+use crate::providers::utils::LOGS_TO_KEEP;
 use crate::session::SessionManager;
 use std::fs::{self};
 use std::io::Cursor;
@@ -36,7 +37,7 @@ pub async fn generate_diagnostics(session_id: &str) -> anyhow::Result<Vec<u8>> {
 
         log_files.sort_by_key(|e| e.metadata().ok().and_then(|m| m.modified().ok()));
 
-        for entry in log_files.iter().rev().take(3) {
+        for entry in log_files.iter().rev().take(LOGS_TO_KEEP) {
             let path = entry.path();
             let name = path.file_name().unwrap().to_str().unwrap();
             zip.start_file(format!("logs/{}", name), options)?;


### PR DESCRIPTION
We were only sending 3 reports, which is enough if the user immediately sends feedback. but in at least one case they did not and we got the later requests.

we could consider sending all the jsonls here, but since we always keep 10 around this feels saver?
