### PR TITLE
feat(mcp): support sampling in a scoped way

### DIFF
--- a/crates/goose/src/agents/types.rs
+++ b/crates/goose/src/agents/types.rs
@@ -1,4 +1,5 @@
 use crate::mcp_utils::ToolResult;
+use crate::providers::base::Provider;
 use rmcp::model::{Content, Tool};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
@@ -8,6 +9,9 @@ use utoipa::ToSchema;
 
 /// Type alias for the tool result channel receiver
 pub type ToolResultReceiver = Arc<Mutex<mpsc::Receiver<(String, ToolResult<Vec<Content>>)>>>;
+
+// We use double Arc here to allow easy provider swaps while sharing concurrent access
+pub type SharedProvider = Arc<Mutex<Option<Arc<dyn Provider>>>>;
 
 /// Default timeout for retry operations (5 minutes)
 pub const DEFAULT_RETRY_TIMEOUT_SECONDS: u64 = 300;

--- a/crates/goose/tests/mcp_integration_test.rs
+++ b/crates/goose/tests/mcp_integration_test.rs
@@ -205,8 +205,7 @@ async fn test_replayed_session(
         bundled: Some(false),
         available_tools: vec![],
     };
-
-    let extension_manager = ExtensionManager::new();
+    let extension_manager = ExtensionManager::new_without_provider();
 
     #[allow(clippy::redundant_closure_call)]
     let result = (async || -> Result<(), Box<dyn std::error::Error>> {

--- a/crates/goose/tests/mcp_replays/cargorun--quiet-pgoose-server--bingoosed--mcpdeveloper
+++ b/crates/goose/tests/mcp_replays/cargorun--quiet-pgoose-server--bingoosed--mcpdeveloper
@@ -1,4 +1,4 @@
-STDIN: {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"goose","version":"0.0.0"}}}
+STDIN: {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{"sampling":{}},"clientInfo":{"name":"goose","version":"0.0.0"}}}
 STDERR:   [2m2025-09-27T04:13:30.409389Z[0m [32m INFO[0m [1;32mgoose_mcp::mcp_server_runner[0m[32m: [32mStarting MCP server[0m
 STDERR:     [2;3mat[0m crates/goose-mcp/src/mcp_server_runner.rs:18
 STDERR:

--- a/crates/goose/tests/mcp_replays/github-mcp-serverstdio
+++ b/crates/goose/tests/mcp_replays/github-mcp-serverstdio
@@ -1,4 +1,4 @@
-STDIN: {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"goose","version":"0.0.0"}}}
+STDIN: {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{"sampling":{}},"clientInfo":{"name":"goose","version":"0.0.0"}}}
 STDERR: GitHub MCP Server running on stdio
 STDOUT: {"jsonrpc":"2.0","id":0,"result":{"protocolVersion":"2025-03-26","capabilities":{"logging":{},"prompts":{},"resources":{"subscribe":true,"listChanged":true},"tools":{"listChanged":true}},"serverInfo":{"name":"github-mcp-server","version":"version"}}}
 STDIN: {"jsonrpc":"2.0","method":"notifications/initialized"}

--- a/crates/goose/tests/mcp_replays/npx-y@modelcontextprotocol_server-everything
+++ b/crates/goose/tests/mcp_replays/npx-y@modelcontextprotocol_server-everything
@@ -1,4 +1,4 @@
-STDIN: {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"goose","version":"0.0.0"}}}
+STDIN: {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{"sampling":{}},"clientInfo":{"name":"goose","version":"0.0.0"}}}
 STDERR: 2025-09-26 23:13:04 - Starting npx setup script.
 STDERR: 2025-09-26 23:13:04 - Creating directory ~/.config/goose/mcp-hermit/bin if it does not exist.
 STDERR: 2025-09-26 23:13:04 - Changing to directory ~/.config/goose/mcp-hermit.

--- a/crates/goose/tests/mcp_replays/uvxmcp-server-fetch
+++ b/crates/goose/tests/mcp_replays/uvxmcp-server-fetch
@@ -1,4 +1,4 @@
-STDIN: {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"goose","version":"0.0.0"}}}
+STDIN: {"jsonrpc":"2.0","id":0,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{"sampling":{}},"clientInfo":{"name":"goose","version":"0.0.0"}}}
 STDERR: 2025-09-26 23:13:04 - Starting uvx setup script.
 STDERR: 2025-09-26 23:13:04 - Creating directory ~/.config/goose/mcp-hermit/bin if it does not exist.
 STDERR: 2025-09-26 23:13:04 - Changing to directory ~/.config/goose/mcp-hermit.


### PR DESCRIPTION
Implements basic support for MCP Sampling

* MCP servers can now request sampling and it will be handled by goose to route a sampling message to the provider for completion
* Works for desktop and CLI
* Does not yet implement human in the loop approval of these, which is a `SHOULD` for clients in the MCP spec, but added significant overhead to the initial implementation so the idea is to get a scoped and working implementation out and then iterate
* Sampling is supposed to be text, image, or audio. This does not handle audio, because interestingly goose does not handle audio message content. Can be a followup when we support it generally.

Demos of it working in CLI and Desktop with the [everything](https://github.com/modelcontextprotocol/servers/tree/main/src/everything) server the prompt

> Use the sampleLLM tool in the everything extension to have the mcp server request sampling from the model. Have the mcp server ask the model for a quote from the great gatsby

<img width="2120" height="551" alt="Screenshot 2025-10-24 at 5 28 49 PM" src="https://github.com/user-attachments/assets/377a32f4-e0d4-4631-a0d4-354e22025541" />

<img width="1932" height="1140" alt="Screenshot 2025-10-24 at 5 31 13 PM" src="https://github.com/user-attachments/assets/f3bd158d-8c33-4e5b-aa60-f83cea9d8e00" />