### PR TITLE
Fix scheduler jobs dates formatting

### DIFF
--- a/crates/goose-server/src/routes/schedule.rs
+++ b/crates/goose-server/src/routes/schedule.rs
@@ -8,8 +8,6 @@ use axum::{
 };
 use serde::{Deserialize, Serialize};
 
-use chrono::NaiveDateTime;
-
 use crate::state::AppState;
 use goose::scheduler::ScheduledJob;
 
@@ -80,12 +78,6 @@ pub struct SessionDisplayInfo {
     accumulated_total_tokens: Option<i32>,
     accumulated_input_tokens: Option<i32>,
     accumulated_output_tokens: Option<i32>,
-}
-
-fn parse_session_name_to_iso(session_name: &str) -> String {
-    NaiveDateTime::parse_from_str(session_name, "%Y%m%d_%H%M%S")
-        .map(|dt| dt.and_utc().to_rfc3339())
-        .unwrap_or_else(|_| String::new()) // Fallback to empty string if parsing fails
 }
 
 #[utoipa::path(
@@ -326,7 +318,7 @@ async fn sessions_handler(
                 display_infos.push(SessionDisplayInfo {
                     id: session_name.clone(),
                     name: session.name,
-                    created_at: parse_session_name_to_iso(&session_name),
+                    created_at: session.created_at.to_rfc3339(),
                     working_dir: session.working_dir.to_string_lossy().into_owned(),
                     schedule_id: session.schedule_id,
                     message_count: session.message_count,

--- a/ui/desktop/src/components/schedule/ScheduleDetailView.tsx
+++ b/ui/desktop/src/components/schedule/ScheduleDetailView.tsx
@@ -631,7 +631,7 @@ const ScheduleDetailView: React.FC<ScheduleDetailViewProps> = ({ scheduleId, onN
                     </h3>
                     <p className="text-xs text-text-subtle mt-1">
                       Created:{' '}
-                      {session.createdAt ? new Date(session.createdAt).toLocaleString() : 'N/A'}
+                      {session.createdAt ? formatToLocalDateWithTimezone(session.createdAt) : 'N/A'}
                     </p>
                     {session.messageCount !== undefined && (
                       <p className="text-xs text-text-subtle mt-1">


### PR DESCRIPTION
## Summary

Fixing 2 bugs:
- Session created dates showed "N/A" because the code tried to parse session IDs (format `YYYYMMDD_N`) as timestamps (format `YYYYMMDD_HHMMSS`) instead of using the actual `created_at` field from the `Session` struct.
- Using `.toLocaleString()` instead of `formatToLocalDateWithTimezone` was showing inconsistent dates in the UI.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Related Issues
Relates to https://github.com/block/goose/issues/5045