### PR TITLE
fix hermit `text file busy` issues on linux

### DIFF
--- a/ui/desktop/src/bin/node-setup-common.sh
+++ b/ui/desktop/src/bin/node-setup-common.sh
@@ -57,19 +57,33 @@ log "Updated PATH to include ~/.config/goose/mcp-hermit/bin."
 log "Checking for hermit in PATH."
 which hermit >> "$LOG_FILE"
 
-# Fix hermit self-update lock issues on Linux
-if [[ "$(uname -s)" == "Linux" ]]; then
-    log "Creating temp dir with bin subdirectory for hermit copy to avoid self-update locks and bin directory issues."
-    HERMIT_TMP_DIR="/tmp/hermit_tmp_$$/bin"
-    mkdir -p "$HERMIT_TMP_DIR"
-    cp ~/.config/goose/mcp-hermit/bin/hermit "$HERMIT_TMP_DIR/hermit"
-    chmod +x "$HERMIT_TMP_DIR/hermit"
-    export PATH="$HERMIT_TMP_DIR:$PATH"
-fi
+# Check if hermit environment is already initialized (only run init on first setup)
+if [ ! -f bin/activate-hermit ]; then
+    log "Hermit environment not yet initialized. Setting up hermit."
 
-# Initialize hermit
-log "Initializing hermit."
-hermit init >> "$LOG_FILE"
+    # Fix hermit self-update lock issues on Linux by using temp binary for init only
+    if [[ "$(uname -s)" == "Linux" ]]; then
+        log "Creating temp dir with bin subdirectory for hermit copy to avoid self-update locks."
+        HERMIT_TMP_DIR="/tmp/hermit_tmp_$$/bin"
+        mkdir -p "$HERMIT_TMP_DIR"
+        cp ~/.config/goose/mcp-hermit/bin/hermit "$HERMIT_TMP_DIR/hermit"
+        chmod +x "$HERMIT_TMP_DIR/hermit"
+        export PATH="$HERMIT_TMP_DIR:$PATH"
+        HERMIT_CLEANUP_DIR="/tmp/hermit_tmp_$$"
+    fi
+
+    # Initialize hermit
+    log "Initializing hermit."
+    hermit init >> "$LOG_FILE"
+
+    # Clean up temp dir if it was created
+    if [[ -n "${HERMIT_CLEANUP_DIR:-}" ]]; then
+        log "Cleaning up temporary hermit binary directory."
+        rm -rf "$HERMIT_CLEANUP_DIR"
+    fi
+else
+    log "Hermit environment already initialized. Skipping init."
+fi
 
 # Activate the environment with output redirected to log
 if [[ "$(uname -s)" == "Linux" ]]; then
@@ -80,11 +94,6 @@ fi
 # Install Node.js using hermit
 log "Installing Node.js with hermit."
 hermit install node >> "$LOG_FILE"
-
-# Clean up temp dir
-if [[ "$(uname -s)" == "Linux" ]]; then
-    rm -rf "/tmp/hermit_tmp_$$"
-fi
 
 # Verify installations
 log "Verifying installation locations:"


### PR DESCRIPTION
## Summary
For several months, Linux users have frequently been unable to add STDIO MCP extensions (e.g., extensions using the `npx` command, etc.). Obviously this is a **key functionality** and affects a **lot** of MCP servers!

The goose setup script fails on Linux with a `text file busy` error. I suspect this is because Hermit tries to self-update its running binary, which Linux locks, unlike macOS. The fix uses a temporary `bin/hermit` copy on Linux to prevent lock conflicts, redirects activation output to a log file for clean stderr, and skips these changes on macOS to preserve existing behavior.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
I've manually tested this on Linux. **I need a macOS user to test these changes.** Steps to test on macOS:

1. Checkout the PR locally or open it in a codespace. To check out the PR locally, ensure you have the GitHub CLI installed, then run `gh pr checkout 5372` in the `goose` directory. To open the PR in a codespace, view the PR in GitHub and click `Code` in the top right of the PR, then `Codespaces > Create codespace on best/fix-hermit-lock`.
2. Disable & enable a STDIO MCP server. You can do this in goose desktop by running `just run-ui` from the `goose` directory to start the desktop UI, then navigating to `Extensions` in the sidebar. Once there, find any MCP server that uses an STDIO command such as `npx`, disable it, and enable it again. If you don't see any MCP servers that use `npx`, add a new one, `npx -y @angiejones/mcp-selenium` for example. If you see an error, please report it to me! If not, everything should be fine. Play around with goose a bit to make sure.
3. If you are using a codespace, you will need to test using the goose CLI.

### Related Issues
Relates to #2351, #5048, #3030 