### PR TITLE
docs(prompt-library): add github-issue-labeler intermediate prompt

### DIFF
--- a/documentation/src/pages/prompt-library/data/prompts/github-issue-labeler.json
+++ b/documentation/src/pages/prompt-library/data/prompts/github-issue-labeler.json
@@ -9,7 +9,7 @@
   "extensions": [
     {
       "name": "GitHub",
-      "command": "npx -y @modelcontextprotocol/server-github",
+      "command": "goose session --with-streamable-http-extension \"https://api.githubcopilot.com/mcp/\"",
       "is_builtin": false,
       "link": "https://block.github.io/goose/docs/mcp/github-mcp",
       "environmentVariables": [


### PR DESCRIPTION
## Summary
Added the intermediate prompt **GitHub Open Issues Analyzer** to the Prompt Library.  
This prompt uses the GitHub MCP server and Developer extension to analyze open issues in a GitHub repository, summarizing each with labels, title, assignees, main problem, and links.

### Type of Change
- [x] Documentation

### Testing
- Verified JSON syntax and required fields.
- Confirmed extension usage and environment variable documentation.
- Local build and CLI tested.
- **Tested in Goose Desktop:** Prompt works as expected using my own repository.
- **Screenshot attached:** Shows prompt output in Goose Desktop for my repository.

### Related Issues
Relates to #4997

### Screenshots/Demos (for UX changes)
Before: N/A

### Goose Desktop Prompt Output
![Goose Desktop prompt output screenshot](https://github.com/user-attachments/assets/199e41f5-7a3b-4427-9f8d-d9a540b3e767)


**Email**: mohammedthahacse@gmail.com
