### PR TITLE
fixing typo in blog metadata

### DIFF
--- a/documentation/blog/2025-10-24-intro-to-agent-client-protocol-acp/index.md
+++ b/documentation/blog/2025-10-24-intro-to-agent-client-protocol-acp/index.md
@@ -72,11 +72,11 @@ If you're ready to see how fast and simple this setup really is, watch the full 
   <meta property="og:title" content="Intro to Agent Client Protocol (ACP): The Standard for AI Agent-Editor Integration" />
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://block.github.io/goose/blog/2025/10/24/intro-to-agent-client-protocol-acp" />
-  <meta property="og:description" content="Fix the awkward gap between AI agents and code editors with the Agent Client Protocol (ACP). Learn why this new open standard makes agents like goose truly editor-agnostic, improving AI-human collaboration and restoring developer flow state. ACP works alongside protocols like MCP to create an open AI tooling ecosystem.." />
+  <meta property="og:description" content="Fix the awkward gap between AI agents and code editors with the Agent Client Protocol (ACP). Learn why this new open standard makes agents like goose truly editor-agnostic, improving AI-human collaboration and restoring developer flow state. ACP works alongside protocols like MCP to create an open AI tooling ecosystem." />
   <meta property="og:image" content="https://block.github.io/goose/assets/images/choose-your-ide-c308664c1783e1651d9a4f4d6ff7d731.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta property="twitter:domain" content="block.github.io/goose" />
   <meta name="twitter:title" content="Intro to Agent Client Protocol (ACP): The Standard for AI Agent-Editor Integration" />
-  <meta name="twitter:description" content="Fix the awkward gap between AI agents and code editors with the Agent Client Protocol (ACP). Learn why this new open standard makes agents like goose truly editor-agnostic, improving AI-human collaboration and restoring developer flow state. ACP works alongside protocols like MCP to create an open AI tooling ecosystem.." />
-  <meta name="twitter:image" content="https://block.github.io/goose/assets/images/åchoose-your-ide-c308664c1783e1651d9a4f4d6ff7d731.png"/>
+  <meta name="twitter:description" content="Fix the awkward gap between AI agents and code editors with the Agent Client Protocol (ACP). Learn why this new open standard makes agents like goose truly editor-agnostic, improving AI-human collaboration and restoring developer flow state. ACP works alongside protocols like MCP to create an open AI tooling ecosystem." />
+  <meta name="twitter:image" content="https://block.github.io/goose/assets/images/choose-your-ide-c308664c1783e1651d9a4f4d6ff7d731.png"/>
 </head>


### PR DESCRIPTION

This pull request makes a minor update to the blog post's meta tags for improved social sharing. The changes fix a typo in the image URL and remove an extra period from the description fields to ensure accurate and clean metadata.

- Metadata improvements:
  * Removed an extra period at the end of the `og:description` and `twitter:description` meta tags for consistency and correctness.
  * Fixed a typo in the `twitter:image` URL by removing an invalid character, ensuring the correct image is used when sharing on Twitter.