### PR TITLE
fix: allow subagent to run in parent --no-session mode

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -449,21 +449,10 @@ impl Agent {
                     );
                 }
             };
-            let session = match session.as_ref() {
-                Some(s) => s,
-                None => {
-                    return (
-                        request_id,
-                        Err(ErrorData::new(
-                            ErrorCode::INTERNAL_ERROR,
-                            "Session is required".to_string(),
-                            None,
-                        )),
-                    );
-                }
+            let (parent_session_id, parent_working_dir) = match session.as_ref() {
+                Some(s) => (Some(s.id.clone()), s.working_dir.clone()),
+                None => (None, std::env::current_dir().unwrap_or_default()),
             };
-            let parent_session_id = session.id.to_string();
-            let parent_working_dir = session.working_dir.clone();
 
             // Get extensions from the agent's runtime state rather than global config
             // This ensures subagents inherit extensions that were dynamically enabled by the parent

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -1,5 +1,8 @@
 use crate::{
-    agents::{subagent_task_config::TaskConfig, AgentEvent, SessionConfig},
+    agents::{
+        extension::PlatformExtensionContext, subagent_task_config::TaskConfig, Agent, AgentEvent,
+        SessionConfig,
+    },
     conversation::{message::Message, Conversation},
     execution::manager::AgentManager,
     session::SessionManager,
@@ -7,8 +10,8 @@ use crate::{
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
 use rmcp::model::{ErrorCode, ErrorData};
-use std::future::Future;
 use std::pin::Pin;
+use std::{future::Future, sync::Arc};
 use tracing::debug;
 
 /// Standalone function to run a complete subagent task with output options
@@ -101,17 +104,35 @@ fn get_agent_messages(
             .map_err(|e| anyhow!("Failed to create AgentManager: {}", e))?;
         let parent_session_id = task_config.parent_session_id;
         let working_dir = task_config.parent_working_dir;
-        let session = SessionManager::create_session(
-            working_dir.clone(),
-            format!("Subagent task for: {}", parent_session_id),
-        )
-        .await
-        .map_err(|e| anyhow!("Failed to create a session for sub agent: {}", e))?;
+        let (agent, session_id) = match parent_session_id {
+            Some(parent_session_id) => {
+                let session = SessionManager::create_session(
+                    working_dir.clone(),
+                    format!("Subagent task for: {}", parent_session_id),
+                )
+                .await
+                .map_err(|e| anyhow!("Failed to create a session for sub agent: {}", e))?;
 
-        let agent = agent_manager
-            .get_or_create_agent(session.id.clone())
-            .await
-            .map_err(|e| anyhow!("Failed to get sub agent session file path: {}", e))?;
+                let agent = agent_manager
+                    .get_or_create_agent(session.id.clone())
+                    .await
+                    .map_err(|e| anyhow!("Failed to get sub agent session file path: {}", e))?;
+                (agent, Some(session.id))
+            }
+            None => {
+                let agent = Arc::new(Agent::new());
+                agent
+                    .extension_manager
+                    .set_context(PlatformExtensionContext {
+                        session_id: None,
+                        extension_manager: Some(Arc::downgrade(&agent.extension_manager)),
+                        tool_route_manager: Some(Arc::downgrade(&agent.tool_route_manager)),
+                    })
+                    .await;
+                (agent, None)
+            }
+        };
+
         agent
             .update_provider(task_config.provider)
             .await
@@ -131,17 +152,20 @@ fn get_agent_messages(
             Conversation::new_unvalidated(
                 vec![Message::user().with_text(text_instruction.clone())],
             );
-        let session_config = SessionConfig {
-            id: session.id,
-            working_dir,
-            schedule_id: None,
-            execution_mode: None,
-            max_turns: task_config.max_turns.map(|v| v as u32),
-            retry_config: None,
+        let session_config = if let Some(session_id) = session_id {
+            Some(SessionConfig {
+                id: session_id,
+                working_dir,
+                schedule_id: None,
+                execution_mode: None,
+                max_turns: task_config.max_turns.map(|v| v as u32),
+                retry_config: None,
+            })
+        } else {
+            None
         };
-
         let mut stream = agent
-            .reply(conversation.clone(), Some(session_config), None)
+            .reply(conversation.clone(), session_config, None)
             .await
             .map_err(|e| anyhow!("Failed to get reply from agent: {}", e))?;
         while let Some(message_result) = stream.next().await {

--- a/crates/goose/src/agents/subagent_task_config.rs
+++ b/crates/goose/src/agents/subagent_task_config.rs
@@ -15,7 +15,7 @@ pub const GOOSE_SUBAGENT_MAX_TURNS_ENV_VAR: &str = "GOOSE_SUBAGENT_MAX_TURNS";
 #[derive(Clone)]
 pub struct TaskConfig {
     pub provider: Arc<dyn Provider>,
-    pub parent_session_id: String,
+    pub parent_session_id: Option<String>,
     pub parent_working_dir: PathBuf,
     pub extensions: Vec<ExtensionConfig>,
     pub max_turns: Option<usize>,
@@ -37,7 +37,7 @@ impl TaskConfig {
     /// Create a new TaskConfig with all required dependencies
     pub fn new(
         provider: Arc<dyn Provider>,
-        parent_session_id: String,
+        parent_session_id: Option<String>,
         parent_working_dir: PathBuf,
         extensions: Vec<ExtensionConfig>,
     ) -> Self {


### PR DESCRIPTION
## Summary
This PR is addressing the issue https://github.com/block/goose/issues/5288

**Root cause:**
Recently the subagent code change assumes that the parent recipe/agent always runs in a session mode. If the parent recipe/agent is triggered with `--no-session` mode, it returns the error. 

**Change**
Allow subrecipe/subagent to be run in the parent `--no-session` mode, and the subrecipe/subagent also runs in `no-session` mode. 

**Note**
There could be a refactoring in a separate PR to centralise the agent and session creation as there are multiple places to have the similar code.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)
