### PR TITLE
Filter preserved user messages to be text only.

### DIFF
--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -78,8 +78,7 @@ pub async fn compact_messages(
     };
 
     // Check if the most recent message is a user message with text content only
-    let (messages_to_compact, preserved_user_text) = if let Some(last_message) = messages.last()
-    {
+    let (messages_to_compact, preserved_user_text) = if let Some(last_message) = messages.last() {
         if matches!(last_message.role, rmcp::model::Role::User) && has_text_only(last_message) {
             // Remove the last user message before compaction and preserve its text
             (&messages[..messages.len() - 1], extract_text(last_message))


### PR DESCRIPTION
Avoids orphaning a tool call.

In the case of out of context error we keep the last user request.

Been testing with the proxy + this query

`run ls, get the 3rd biggest file. Count the words. Mod the number of words with the number of files. Get another file and do the same. Run this loop 7 times.`