### PR TITLE
include sessionId in tool request

### DIFF
--- a/ui/desktop/src/components/settings/permission/PermissionModal.tsx
+++ b/ui/desktop/src/components/settings/permission/PermissionModal.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuContent,
   DropdownMenuItem,
 } from '../../ui/dropdown-menu';
+import { useChatContext } from '../../../contexts/ChatContext';
 
 function getFirstSentence(text: string): string {
   const match = text.match(/^([^.?!]+[.?!])/);
@@ -27,6 +28,9 @@ export default function PermissionModal({ extensionName, onClose }: PermissionMo
     { value: 'never_allow', label: 'Never allow' },
   ] as { value: PermissionLevel; label: string }[];
 
+  const chatContext = useChatContext();
+  const sessionId = chatContext?.chat.sessionId || '';
+
   const [tools, setTools] = useState<ToolInfo[]>([]);
   const [updatedPermissions, setUpdatedPermissions] = useState<Record<string, string>>({});
 
@@ -41,8 +45,7 @@ export default function PermissionModal({ extensionName, onClose }: PermissionMo
     const fetchTools = async () => {
       try {
         const response = await getTools({
-          // TODO(Douwe): pass session ID or maybe? do we configure the tools for the agent or globally?
-          query: { extension_name: extensionName, session_id: '' },
+          query: { extension_name: extensionName, session_id: sessionId },
         });
         if (response.error) {
           console.error('Failed to get tools');
@@ -59,7 +62,7 @@ export default function PermissionModal({ extensionName, onClose }: PermissionMo
     };
 
     fetchTools();
-  }, [extensionName]);
+  }, [extensionName, sessionId]);
 
   const handleSettingChange = (toolName: string, newPermission: PermissionLevel) => {
     setUpdatedPermissions((prev) => ({


### PR DESCRIPTION
## Summary
`GET /agent/tools` endpoint requires a `session_id` but we're passing a hardcoded empty string, causing the modal to be in a perpetual loading state.

The modal now uses the active `sessionId` from `ChatContext`, allowing it to fetch tools from a session with loaded extensions.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)


### Related Issues
Fixes https://github.com/block/goose/issues/5364

### Screenshots
Before:
<img width="1890" height="1086" alt="Image" src="https://github.com/user-attachments/assets/361f85a4-5b1f-4414-881f-65b9bc8e4091" />

After: 
<img width="960" height="806" alt="Screenshot 2025-10-27 at 10 27 41 AM" src="https://github.com/user-attachments/assets/7b1bb362-6553-4600-9d87-b1e1354c2f14" />
