### PR TITLE
Summarization iteratively removes tool call responses

### DIFF
--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -220,14 +220,13 @@ pub async fn check_if_compaction_needed(
     Ok(needs_compaction)
 }
 
-
 fn filter_tool_responses<'a>(messages: &[&'a Message], remove_percent: u32) -> Vec<&'a Message> {
     fn has_tool_response(msg: &Message) -> bool {
         msg.content
             .iter()
             .any(|c| matches!(c, MessageContent::ToolResponse(_)))
     }
-    
+
     if remove_percent == 0 {
         return messages.to_vec();
     }
@@ -317,14 +316,9 @@ async fn do_compact(
                 return Ok(Some((response, provider_usage)));
             }
             Err(e) => {
-                // Check if this is a context length error
                 if matches!(e, ProviderError::ContextLengthExceeded(_)) {
                     if attempt < removal_percentages.len() - 1 {
-                        debug!(
-                            "Context length exceeded on attempt {}, trying to remove more messages",
-                            attempt + 1
-                        );
-                        continue; // Try next removal percentage
+                        continue;
                     } else {
                         return Err(anyhow::anyhow!(
                             "Failed to compact messages: context length still exceeded after {} attempts with maximum removal",


### PR DESCRIPTION
This will help solidify compaction, so even in the event of picking up context from a subagent, or shifting the model it will have a much stronger chance of succeeding.

Will wait on https://github.com/block/goose/pull/5392, and build a test with the scaffolding that provides.