### PR TITLE
rpm install in /opt/Goose to avoid conflicts with chrome-sandbox

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -72,7 +72,8 @@ module.exports = {
         categories: ['Development'],
         desktopTemplate: './forge.deb.desktop',
         options: {
-          icon: 'src/images/icon.png'
+          icon: 'src/images/icon.png',
+          prefix: '/opt'
         }
       },
     },
@@ -86,7 +87,8 @@ module.exports = {
         categories: ['Development'],
         desktopTemplate: './forge.rpm.desktop',
         options: {
-          icon: 'src/images/icon.png'
+          icon: 'src/images/icon.png',
+          prefix: '/opt'
         }
       },
     },


### PR DESCRIPTION
rpm install in /opt/Goose to avoid conflicts with chrome-sandbox from other apps

fixes https://github.com/block/goose/issues/3526

don't have linux to test this but it should work

