### PR TITLE
fix(extensions/desktop): only show env vars for stdio mcps

### DIFF
--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.tsx
@@ -353,7 +353,6 @@ export default function ExtensionModal({
                 submitAttempted={submitAttempted}
               />
 
-              {/* Divider */}
               <hr className="border-t border-borderSubtle" />
 
               {/* Command */}
@@ -374,40 +373,41 @@ export default function ExtensionModal({
                 />
               </div>
 
-              {/* Divider */}
-              <hr className="border-t border-borderSubtle" />
+              {formData.type === 'stdio' && (
+                <>
+                  <hr className="border-t border-borderSubtle" />
 
-              {/* Environment Variables */}
-              <div>
-                <EnvVarsSection
-                  envVars={formData.envVars}
-                  onAdd={handleAddEnvVar}
-                  onRemove={handleRemoveEnvVar}
-                  onChange={handleEnvVarChange}
-                  submitAttempted={submitAttempted}
-                  onPendingInputChange={setHasPendingEnvVars}
-                />
-              </div>
+                  <div>
+                    <EnvVarsSection
+                      envVars={formData.envVars}
+                      onAdd={handleAddEnvVar}
+                      onRemove={handleRemoveEnvVar}
+                      onChange={handleEnvVarChange}
+                      submitAttempted={submitAttempted}
+                      onPendingInputChange={setHasPendingEnvVars}
+                    />
+                  </div>
+                </>
+              )}
+
+              {formData.type === 'streamable_http' && (
+                <>
+                  {/* Divider */}
+                  <hr className="border-t border-borderSubtle" />
+
+                  <div>
+                    <HeadersSection
+                      headers={formData.headers}
+                      onAdd={handleAddHeader}
+                      onRemove={handleRemoveHeader}
+                      onChange={handleHeaderChange}
+                      submitAttempted={submitAttempted}
+                      onPendingInputChange={handlePendingHeaderChange}
+                    />
+                  </div>
+                </>
+              )}
             </div>
-          )}
-
-          {/* Request Headers - Only for streamable_http */}
-          {formData.type === 'streamable_http' && (
-            <>
-              {/* Divider */}
-              <hr className="border-t border-borderSubtle mb-4" />
-
-              <div className="mb-6">
-                <HeadersSection
-                  headers={formData.headers}
-                  onAdd={handleAddHeader}
-                  onRemove={handleRemoveHeader}
-                  onChange={handleHeaderChange}
-                  submitAttempted={submitAttempted}
-                  onPendingInputChange={handlePendingHeaderChange}
-                />
-              </div>
-            </>
           )}
 
           <DialogFooter className="pt-2">


### PR DESCRIPTION
Right now we show env vars when configuring a streamable http extension, but this is misleading as they aren't used for anything in this case. This changes makes it so for stdio we show env vars only and for streamable http we show headers only.

### Screenshots
Before:  
<img width="1271" height="1047" alt="Screenshot 2025-10-28 at 8 41 58 PM" src="https://github.com/user-attachments/assets/ad61fe93-1896-41a5-ae9b-97b1159dc43a" />

After:  
<img width="1052" height="912" alt="Screenshot 2025-10-28 at 8 41 24 PM" src="https://github.com/user-attachments/assets/22efe42b-58e9-4a42-b286-69b6bbc7e5dc" />
