### PR TITLE
feat(prompt): add audio summarizer prompt with ElevenLabs integration

### DIFF
--- a/documentation/src/pages/prompt-library/data/prompts/audio-summarizer.json
+++ b/documentation/src/pages/prompt-library/data/prompts/audio-summarizer.json
@@ -1,0 +1,23 @@
+{
+  "id": "audio-summarizer",
+  "title": "Generate Audio Summary from Webpage",
+  "description": "Summarizes a webpage URL into bullet points and generates an MP3 audio file of the summary using ElevenLabs.",
+  "category": "productivity",
+  "job": "productivity",
+  "example_prompt": "Hey goose , summarize the article at https://en.wikipedia.org/wiki/Coronavirus into short bulletpoints. Then, take that summary and generate an audio file using the ElevenLabs MCP with the 'Rachel' voice.",
+  "example_result": "Based on the available content, here is a summarized version of the article about Coronavirus in bullet points:\n- Coronaviruses are a group of related viruses that cause diseases in mammals and birds.\n- In humans, coronaviruses can lead to respiratory tract infections, which can range from mild, like some cases of the common cold, to severe, such as SARS, MERS, and COVID-19.\n- The name \"coronavirus\" is derived from the Latin word \"corona,\" meaning \"crown\" or \"halo,\" which refers to the characteristic appearance of the virus particles.\n- Coronaviruses have a genome composed of a single strand of RNA and have characteristic surface spike proteins.\n- They are classified within the family Coronaviridae and the subfamily Orthocoronavirinae.\n- These viruses are further grouped into four genera: Alphacoronavirus, Betacoronavirus, Gammacoronavirus, and Deltacoronavirus.\n- Transmission between humans typically occurs through respiratory droplets, especially from coughs and sneezes.\n- Major outbreaks in recent history include the Severe Acute Respiratory Syndrome (SARS) in 2003, Middle East Respiratory Syndrome (MERS) in 2012, and COVID-19 starting in late 2019.\n\nNow, let's use the above summary to generate an audio file using the ElevenLabs MCP and the 'Rachel' voice. The audio file has been successfully generated using the 'Rachel' voice. You can find the file saved on your desktop under the name tts_Coron_20251029_145539.mp3.",
+  "extensions": [
+    {
+      "name": "ElevenLabs MCP",
+      "description": "Generates high-quality, human-sounding text-to-speech audio and AI voices.",
+      "is_builtin": true,
+      "environmentVariables": [
+        {
+          "name": "ELEVENLABS_API_KEY",
+          "value": "",
+          "required": true
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
This PR adds a new productivity prompt to the Goose Prompt Library: Generate Audio Summary from Webpage. This prompt helps users convert any webpage into a summarized, listenable audio file using the built-in ElevenLabs MCP.


- [ X] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
The new prompt has been tested manually in a local build of the Goose desktop application.
1. Added the audio-summarizer.json file to the documentation/src/pages/prompt-library/data/prompts/ directory.

2.Launched the Goose app and verified that the new prompt appeared correctly in the library.

3.Used the example_prompt and confirmed the output matched the expected example_result.

### Related Issues
Relates to #https://github.com/block/goose/issues/4960


