### PR TITLE
Remove subagent instructions from system prompt

### DIFF
--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
@@ -30,18 +30,6 @@ No extensions are defined. You should let the user know that they should add ext
 
 
 
-# sub agents
-
-Execute self contained tasks where step-by-step visibility is not important through subagents.
-
-- Delegate via `dynamic_task__create_task` for: result-only operations, parallelizable work, multi-part requests,
-  verification, exploration
-- Parallel subagents for multiple operations, single subagents for independent work
-- Explore solutions in parallel — launch parallel subagents with different approaches (if non-interfering)
-- Provide all needed context — subagents cannot see your context
-- Use extension filters to limit resource access
-- Use return_last_only when only a summary or simple answer is required — inform subagent of this choice.
-
 # Response Guidelines
 
 - Use Markdown formatting for all responses.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
@@ -54,18 +54,6 @@ how to use this extension
     - list_resources
     
 
-# sub agents
-
-Execute self contained tasks where step-by-step visibility is not important through subagents.
-
-- Delegate via `dynamic_task__create_task` for: result-only operations, parallelizable work, multi-part requests,
-  verification, exploration
-- Parallel subagents for multiple operations, single subagents for independent work
-- Explore solutions in parallel — launch parallel subagents with different approaches (if non-interfering)
-- Provide all needed context — subagents cannot see your context
-- Use extension filters to limit resource access
-- Use return_last_only when only a summary or simple answer is required — inform subagent of this choice.
-
 # Response Guidelines
 
 - Use Markdown formatting for all responses.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
@@ -68,18 +68,6 @@ Explain that minimizing extensions helps with the recall of the correct tools to
     - list_resources
     
 
-# sub agents
-
-Execute self contained tasks where step-by-step visibility is not important through subagents.
-
-- Delegate via `dynamic_task__create_task` for: result-only operations, parallelizable work, multi-part requests,
-  verification, exploration
-- Parallel subagents for multiple operations, single subagents for independent work
-- Explore solutions in parallel — launch parallel subagents with different approaches (if non-interfering)
-- Provide all needed context — subagents cannot see your context
-- Use extension filters to limit resource access
-- Use return_last_only when only a summary or simple answer is required — inform subagent of this choice.
-
 # Response Guidelines
 
 - Use Markdown formatting for all responses.

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -59,20 +59,6 @@ Explain that minimizing extensions helps with the recall of the correct tools to
 {% endif %}
 
 {{tool_selection_strategy}}
-{% if enable_subagents %}
-
-# sub agents
-
-Execute self contained tasks where step-by-step visibility is not important through subagents.
-
-- Delegate via `dynamic_task__create_task` for: result-only operations, parallelizable work, multi-part requests,
-  verification, exploration
-- Parallel subagents for multiple operations, single subagents for independent work
-- Explore solutions in parallel — launch parallel subagents with different approaches (if non-interfering)
-- Provide all needed context — subagents cannot see your context
-- Use extension filters to limit resource access
-- Use return_last_only when only a summary or simple answer is required — inform subagent of this choice.
-  {% endif %}
 
 # Response Guidelines
 


### PR DESCRIPTION
The subagent guidance in the system prompt is redundant with comprehensive instructions embedded directly in the tool descriptions themselves. The `dynamic_task__create_task` tool already explains the isolation context, extension handling, and return behavior, while `subagent__execute_task` details the execution strategies with clear examples.

Rather than maintaining duplicate instructions that could drift out of sync, consolidating this information into the tool descriptions provides a cleaner, more maintainable approach that reduces cognitive overhead while preserving all necessary guidance for effective subagent usage.