### PR TITLE
chore: adds .yarn to gitignore

### DIFF
--- a/documentation/.gitignore
+++ b/documentation/.gitignore
@@ -7,6 +7,7 @@
 # Generated files
 .docusaurus
 .cache-loader
+.yarn
 
 # Misc
 .DS_Store


### PR DESCRIPTION
Signed-off-by: Anthony D. Mays <anthony@morganlatimer.com>

## Summary
Adds `.yarn` folder to .gitignore in `documentation/` project to prevent adding 1K+ files to git after installing deps.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [x] Build / Release
- [ ] Other (specify below)

### Testing
Manual testing
