### PR TITLE
chore: upgrade rmcp to 0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5553,9 +5553,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f35acda8f89fca5fd8c96cae3c6d5b4c38ea0072df4c8030915f3b5ff469c1c"
+checksum = "1fdad1258f7259fdc0f2dfc266939c82c3b5d1fd72bcde274d600cdc27e60243"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5581,9 +5581,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9f1d5220aaa23b79c3d02e18f7a554403b3ccea544bbb6c69d6bcb3e854a274"
+checksum = "ede0589a208cc7ce81d1be68aa7e74b917fcd03c81528408bab0457e187dcd9b"
 dependencies = [
  "darling 0.21.0",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ description = "An AI agent"
 uninlined_format_args = "allow"
 
 [workspace.dependencies]
-rmcp = { version = "0.8.1", features = ["schemars", "auth"] }
+rmcp = { version = "0.8.3", features = ["schemars", "auth"] }
 
 # Patch for Windows cross-compilation issue with crunchy
 [patch.crates-io]

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -2920,7 +2920,10 @@
             "type": "string"
           },
           "sizes": {
-            "type": "string"
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
           },
           "src": {
             "type": "string"

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -285,7 +285,7 @@ export type GetToolsQuery = {
 
 export type Icon = {
     mimeType?: string;
-    sizes?: string;
+    sizes?: Array<string>;
     src: string;
 };
 


### PR DESCRIPTION
Upgrade to rmcp 0.8.3, pulling in some oauth related bugfixes