### PR TITLE
only run fork on branch PRs

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -13,8 +13,16 @@ on:
 name: Live Provider Tests
 
 jobs:
+  check-fork:
+    runs-on: ubuntu-latest
+    # Skip entire workflow for PRs from forks (they don't have access to secrets)
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - run: echo "Not a fork PR - proceeding with smoke tests"
+
   changes:
     runs-on: ubuntu-latest
+    needs: check-fork
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:


### PR DESCRIPTION
We don't need to run these on forks, also they won't work as require access to secrets, so they will only be run from branches.