### PR TITLE
Don't disable extensions after they fail to activate in new chat session

### DIFF
--- a/ui/desktop/src/components/settings/extensions/extension-manager.test.ts
+++ b/ui/desktop/src/components/settings/extensions/extension-manager.test.ts
@@ -37,26 +37,22 @@ describe('Extension Manager', () => {
       mockAddToAgent.mockResolvedValue(undefined);
 
       await addToAgentOnStartup({
-        addToConfig: mockAddToConfig,
         sessionId: 'test-session',
         extensionConfig: mockExtensionConfig,
       });
 
       expect(mockAddToAgent).toHaveBeenCalledWith(mockExtensionConfig, 'test-session', true);
-      expect(mockAddToConfig).not.toHaveBeenCalled();
     });
 
     it('should successfully add extension on startup with custom toast options', async () => {
       mockAddToAgent.mockResolvedValue(undefined);
 
       await addToAgentOnStartup({
-        addToConfig: mockAddToConfig,
         sessionId: 'test-session',
         extensionConfig: mockExtensionConfig,
       });
 
       expect(mockAddToAgent).toHaveBeenCalledWith(mockExtensionConfig, 'test-session', true);
-      expect(mockAddToConfig).not.toHaveBeenCalled();
     });
 
     it('should retry on 428 errors', async () => {
@@ -67,7 +63,6 @@ describe('Extension Manager', () => {
         .mockResolvedValue(undefined);
 
       await addToAgentOnStartup({
-        addToConfig: mockAddToConfig,
         sessionId: 'test-session',
         extensionConfig: mockExtensionConfig,
       });
@@ -75,14 +70,13 @@ describe('Extension Manager', () => {
       expect(mockAddToAgent).toHaveBeenCalledTimes(3);
     });
 
-    it('should disable extension after max retries', async () => {
+    it('should show error toast after max retries but keep extension enabled', async () => {
       const error428 = new Error('428 Precondition Required');
       mockAddToAgent.mockRejectedValue(error428);
       mockToastService.configure = vi.fn();
       mockToastService.error = vi.fn();
 
       await addToAgentOnStartup({
-        addToConfig: mockAddToConfig,
         sessionId: 'test-session',
         extensionConfig: mockExtensionConfig,
       });
@@ -90,7 +84,7 @@ describe('Extension Manager', () => {
       expect(mockAddToAgent).toHaveBeenCalledTimes(4); // Initial + 3 retries
       expect(mockToastService.error).toHaveBeenCalledWith({
         title: 'test-extension',
-        msg: 'Extension failed to start and will be disabled.',
+        msg: 'Extension failed to start and will retry on a new session.',
         traceback: '428 Precondition Required',
       });
     });

--- a/ui/desktop/src/components/settings/extensions/extension-manager.ts
+++ b/ui/desktop/src/components/settings/extensions/extension-manager.ts
@@ -83,7 +83,6 @@ export async function activateExtension({
 }
 
 interface AddToAgentOnStartupProps {
-  addToConfig: (name: string, extensionConfig: ExtensionConfig, enabled: boolean) => Promise<void>;
   extensionConfig: ExtensionConfig;
   toastOptions?: ToastServiceOptions;
   sessionId: string;
@@ -95,7 +94,6 @@ interface AddToAgentOnStartupProps {
  * TODO(Douwe): Delete this after basecamp lands
  */
 export async function addToAgentOnStartup({
-  addToConfig,
   extensionConfig,
   sessionId,
 }: AddToAgentOnStartupProps): Promise<void> {
@@ -113,21 +111,9 @@ export async function addToAgentOnStartup({
     toastService.configure({ silent: false });
     toastService.error({
       title: extensionConfig.name,
-      msg: 'Extension failed to start and will be disabled.',
+      msg: 'Extension failed to start and will retry on a new session.',
       traceback: finalError instanceof Error ? finalError.message : String(finalError),
     });
-
-    try {
-      await toggleExtension({
-        toggle: 'toggleOff',
-        extensionConfig,
-        addToConfig,
-        toastOptions: { silent: true },
-        sessionId,
-      });
-    } catch (toggleErr) {
-      console.error('Failed to toggle off after error:', toggleErr);
-    }
   }
 }
 

--- a/ui/desktop/src/utils/providerUtils.ts
+++ b/ui/desktop/src/utils/providerUtils.ts
@@ -84,7 +84,6 @@ export const initializeSystem = async (
 
       try {
         await addToAgentOnStartup({
-          addToConfig: options.addExtension!,
           extensionConfig,
           toastOptions: { silent: false },
           sessionId,


### PR DESCRIPTION
## Summary
Don't disable extensions after they fail to activate in new chat session
Verified it works locally and stays enabled and tries to activate in a new chat after failing in a previous chat.
Will come back to issue of double stacking toasts in an upcoming PR with some toast cleanup.

closes https://github.com/block/goose/issues/5397

<img width="469" height="220" alt="Screenshot 2025-10-29 at 3 34 23 PM" src="https://github.com/user-attachments/assets/1e3b5ad4-4dae-4108-b338-70bd3567926f" />
