### PR TITLE
fix: disable subagents unless env var explicitly provided

### DIFF
--- a/crates/goose/src/agents/recipe_tools/dynamic_task_tools.rs
+++ b/crates/goose/src/agents/recipe_tools/dynamic_task_tools.rs
@@ -93,6 +93,9 @@ pub struct TaskParameter {
 }
 
 pub fn should_enabled_subagents(model_name: &str) -> bool {
+    if std::env::var("GOOSE_ENABLE_SUBAGENTS").is_err() {
+        return false;
+    }
     let config = crate::config::Config::global();
     let is_autonomous = config.get_goose_mode().unwrap_or(GooseMode::Auto) == GooseMode::Auto;
     if !is_autonomous {

--- a/scripts/test_subrecipes.sh
+++ b/scripts/test_subrecipes.sh
@@ -22,6 +22,7 @@ export PATH="$SCRIPT_DIR/target/release:$PATH"
 # Set default provider and model if not already set
 export GOOSE_PROVIDER="${GOOSE_PROVIDER:-anthropic}"
 export GOOSE_MODEL="${GOOSE_MODEL:-claude-sonnet-4-5-20250929}"
+export GOOSE_ENABLE_SUBAGENTS=1
 
 echo "Using provider: $GOOSE_PROVIDER"
 echo "Using model: $GOOSE_MODEL"


### PR DESCRIPTION
Running into a number of issues with subagents, such as subagents...

1. not returning, with no visibility into what they are doing in the UX
2. flooding session history with tens or hundreds of small sessions which seem to spiral and get very far away from the original top level work
3. hanging indefinitely on the cli

Seems appropriate to disable them across the board for now until these kinds of issues can be addressed