### PR TITLE
Add pending extension indicator to extension panel

### DIFF
--- a/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
+++ b/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
@@ -11,6 +11,7 @@ interface ExtensionItemProps {
   onToggle: (extension: FixedExtensionEntry) => Promise<boolean | void> | void;
   onConfigure?: (extension: FixedExtensionEntry) => void;
   isStatic?: boolean; // to not allow users to edit configuration
+  isPendingActivation?: boolean;
 }
 
 export default function ExtensionItem({
@@ -18,6 +19,7 @@ export default function ExtensionItem({
   onToggle,
   onConfigure,
   isStatic,
+  isPendingActivation = false,
 }: ExtensionItemProps) {
   // Add local state to track the visual toggle state
   const [visuallyEnabled, setVisuallyEnabled] = useState(extension.enabled);
@@ -79,7 +81,17 @@ export default function ExtensionItem({
       onClick={() => handleToggle(extension)}
     >
       <CardHeader>
-        <CardTitle className="">{getFriendlyTitle(extension)}</CardTitle>
+        <CardTitle className="flex items-center gap-2">
+          {getFriendlyTitle(extension)}
+          {isPendingActivation && (
+            <span
+              className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400 border border-amber-300 dark:border-amber-700"
+              title="Extension will be activated when you start a new chat session"
+            >
+              Pending
+            </span>
+          )}
+        </CardTitle>
 
         <CardAction onClick={(e) => e.stopPropagation()}>
           <div className="flex items-center justify-end gap-2">

--- a/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionList.tsx
+++ b/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionList.tsx
@@ -11,6 +11,7 @@ interface ExtensionListProps {
   isStatic?: boolean;
   disableConfiguration?: boolean;
   searchTerm?: string;
+  pendingActivationExtensions?: Set<string>;
 }
 
 export default function ExtensionList({
@@ -20,6 +21,7 @@ export default function ExtensionList({
   isStatic,
   disableConfiguration: _disableConfiguration,
   searchTerm = '',
+  pendingActivationExtensions = new Set(),
 }: ExtensionListProps) {
   const matchesSearch = (extension: FixedExtensionEntry): boolean => {
     if (!searchTerm) return true;
@@ -63,6 +65,7 @@ export default function ExtensionList({
                 onToggle={onToggle}
                 onConfigure={onConfigure}
                 isStatic={isStatic}
+                isPendingActivation={pendingActivationExtensions.has(extension.name)}
               />
             ))}
           </div>


### PR DESCRIPTION
## Summary
Add a marker to added extensions that have been installed but are yet to be enabled in the session. 


### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Manually tested by adding an extension from the goose extension library via the deeplink.

### Related Issues
Relates to #5473 


### Screenshots/Demos (for UX changes)
Before:  
<img width="1552" height="981" alt="Screenshot 2025-10-31 at 02 25 51" src="https://github.com/user-attachments/assets/a5aebce2-7e62-4cdd-8a34-8f8e0c6b4f00" />

After:
<img width="1552" height="981" alt="Screenshot 2025-10-31 at 02 26 36" src="https://github.com/user-attachments/assets/b8f7f4d3-54ff-4a6a-b6a6-ff36c6535384" />