### PR TITLE
docs: remove speech-mcp

### DIFF
--- a/documentation/docs/mcp/speech-mcp.md
+++ b/documentation/docs/mcp/speech-mcp.md
@@ -1,7 +1,10 @@
 ---
 title: Speech Extension
 description: Add Speech MCP Server as a Goose Extension
+unlisted: true
 ---
+
+Unlist per https://github.com/block/goose/issues/5431
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -540,17 +540,6 @@
     "environmentVariables": []
   },
   {
-    "id": "speech_mcp",
-    "name": "Speech Interface",
-    "description": "Voice interaction with audio visualization for goose - enables real-time voice interaction, audio/video transcription, text-to-speech conversion, and multi-speaker audio generation",
-    "command": "uvx -p 3.10.14 speech-mcp@latest",
-    "link": "https://github.com/Kvadratni/speech-mcp",
-    "installation_notes": "Install using uvx package manager. Requires PortAudio to be installed on your system for PyAudio to capture audio from your microphone.",
-    "is_builtin": false,
-    "endorsed": true,
-    "environmentVariables": []
-  },
-  {
     "id": "square-mcp",
     "name": "Square",
     "description": "Square API for payments and business management",


### PR DESCRIPTION
## Summary
This PR (temporarily) removes the Speech Interface extension from the docs

Updated files:
- `documentation/docs/mcp/speech-mcp.md`:
  - Add `unlisted: true` to topic metadata
- `documentation/static/servers.json`:
  - Remove entry from Extensions library -- the tile isn't removed in the staged pr docs but should be removed in prod

### Type of Change
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Manual testing

### Related Issues
Relates to #5431

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211805680058972