### PR TITLE
fix: update Husky prepare script to v9 format

### DIFF
--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -35,7 +35,7 @@
     "test:run": "vitest run",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
-    "prepare": "cd ../.. && husky install",
+    "prepare": "husky",
     "start-alpha-gui": "ALPHA=true npm run start-gui"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
Fix Husky v9 deprecation warning in `ui/desktop/package.json`

### Why
Currently, npm install prints:
husky - install command is DEPRECATED
because the old prepare script used the deprecated install command.

### How
Updated "prepare" script in package.json from:
  "prepare": "cd ../.. && husky install"
to:
  "prepare": "husky"

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
1. cd ui/desktop
2. npm install
3. No Husky deprecation warning should appear

### Related Issues
Relates to #5521 