### PR TITLE
Fix: ensure stable YAML serialization by using BTreeMap

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -371,15 +371,15 @@ impl Config {
 
         // Convert to YAML for storage (sorted by key for stable serialization)
         let ordered: BTreeMap<String, serde_yaml::Value> = values
-        .into_iter()
-        .map(|(k, v)| {
-            let key = match k {
-                serde_yaml::Value::String(s) => s,
-                other => serde_yaml::to_string(&other).unwrap_or_else(|_| format!("{:?}", other)),
-            };
-            (key, v)
-        })
-        .collect();
+            .into_iter()
+            .map(|(k, v)| {
+                let key = match k {
+                    serde_yaml::Value::String(s) => s,
+                    other => serde_yaml::to_string(&other).unwrap_or_else(|_| format!("{:?}", other)),
+                };
+                (key, v)
+            })
+            .collect();
         let yaml_value = serde_yaml::to_string(&ordered)?;
 
         // Ensure the directory exists


### PR DESCRIPTION
## Summary
Replaced HashMap with BTreeMap in config serialization to maintain deterministic key order. Prevents random reordering of YAML files on each save, allowing clean diffs and consistent config outputs.
[base.rs](https://github.com/block/goose/blob/main/crates/goose/src/config/base.rs): Collect serde_yaml::Mapping into BTreeMap<String, serde_yaml::Value> by stringifying keys to ensure deterministic, sorted YAML output before writing to disk.
[base.rs](https://github.com/block/goose/blob/main/crates/goose/src/config/base.rs): Collect HashMap<String, serde_json::Value> into BTreeMap<String, serde_json::Value> before serde_yaml::to_string, preserving sorted order.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual Testing
1. Open ~/.config/goose/config.yaml
2. Run goose configure. Update the goose mode to "auto".
3. Run goose configure. Update the goose mode to "approve".
4. The entire order of the file will not change.

### Related Issues
Relates to #5127  
