### PR TITLE
fix: make ACP cancellation work

### DIFF
--- a/crates/goose-cli/src/commands/acp.rs
+++ b/crates/goose-cli/src/commands/acp.rs
@@ -542,6 +542,13 @@ impl acp::Agent for GooseAcpAgent {
 
         // Create and store cancellation token for this prompt
         let cancel_token = CancellationToken::new();
+        {
+            let mut sessions = self.sessions.lock().await;
+            let session = sessions
+                .get_mut(&session_id)
+                .ok_or_else(acp::Error::invalid_params)?;
+            session.cancel_token = Some(cancel_token.clone());
+        }
 
         let user_message = self.convert_acp_prompt_to_message(args.prompt);
 


### PR DESCRIPTION
Fixes cancellation by properly storing the cancel token on the session. Prior to this, hitting the cancel button in clients like zed etc didn't do anything during tool calling loops. Now it works.