### PR TITLE
feat: add @ file mention autocomplete to CLI (#5546)

### DIFF
--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -319,7 +319,9 @@ fn print_help() {
 Navigation:
 Ctrl+C - Clear current line if text is entered, otherwise exit the session
 Ctrl+J - Add a newline
-Up/Down arrows - Navigate through command history"
+Up/Down arrows - Navigate through command history
+Tab - Complete slash commands, prompt names, arguments, and file paths after @ symbol
+    Example: Type '@READ' and press Tab to complete to '@README.md'"
     );
 }
 

--- a/documentation/docs/guides/using-goosehints.md
+++ b/documentation/docs/guides/using-goosehints.md
@@ -110,6 +110,10 @@ These examples show two ways to reference other files:
 - **`@` syntax**: Automatically includes the file content in Goose's immediate context
 - **Plain reference**: Points Goose to files to review when needed (use for optional or very large files)
 
+:::tip CLI File Completion
+In the Goose CLI, you can use `@` followed by Tab to trigger fuzzy file completion. For example, typing `@READ` and pressing Tab will suggest `README.md`. This makes it easy to reference files in your prompts. In the desktop app, file suggestions appear automatically as you type after `@`.
+:::
+
 ### Nested `.goosehints` Files
 
 Goose supports hierarchical local hints in  git repositories. All `.goosehints` files from your current directory up to the root directory are automatically loaded and combined. If you're not working in a git repository, Goose only loads the `.goosehints` file from the current directory.


### PR DESCRIPTION
Add fuzzy file completion for @ mentions in the CLI to match desktop app functionality.

Changes:
- Implement fuzzy matching algorithm ported from MentionPopover.tsx
- Add recursive file scanning with smart ignore patterns
- Support Tab completion for @filename syntax
- Handle multiple @ symbols (complete from last)
- Add 18 comprehensive unit tests
- Update help text and documentation

Closes #5546

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

### Submitting a Recipe?
<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved and merged -->
**Email**: 
