### PR TITLE
fix: default tetrate model is broken, replace with haiku-4.5 (#5535)

### DIFF
--- a/crates/goose/src/config/signup_tetrate/mod.rs
+++ b/crates/goose/src/config/signup_tetrate/mod.rs
@@ -14,7 +14,7 @@ use tokio::sync::oneshot;
 use tokio::time::timeout;
 
 /// Default models for Tetrate Agent Router Service configuration
-pub const TETRATE_DEFAULT_MODEL: &str = "claude-4-sonnet-20250514";
+pub const TETRATE_DEFAULT_MODEL: &str = "claude-haiku-4-5";
 
 // Auth endpoints are on the main web domain
 const TETRATE_AUTH_URL: &str = "https://router.tetrate.ai/auth";


### PR DESCRIPTION
## Summary
This avoids model errors after initial sign-up with Tetrate router.


### Type of Change
<!-- Select all that apply -->
- [x] Bug fix

### AI Assistance
- [ ] This PR was created or reviewed with AI assistance

### Testing
Cant build myself.

### Related Issues
Relates to #5535 
