### PR TITLE
fix: write messages from session in a batch for efficiency

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1177,9 +1177,7 @@ impl Agent {
                     }
                 }
 
-                for msg in &messages_to_add {
-                    SessionManager::add_message(&session_config.id, msg).await?;
-                }
+                SessionManager::add_messages(&session_config.id, messages_to_add.messages()).await?;
                 conversation.extend(messages_to_add);
                 if exit_chat {
                     break;


### PR DESCRIPTION
fixes: https://github.com/block/goose/issues/5576

this will write it at once, vs message by message. I have tested this cli and desktop, and even with mobile following along reading the DB, and seemed fine (fast even?)

@DOsinga I don't know what downside of doing this is vs status quo, I don't think it is a massive saving, "felt fast" but surely there aren't that many messages coming in. 