### PR TITLE
Flake.nix corrected main

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,7 @@
             description = workspaceToml.workspace.package.description;
             homepage = workspaceToml.workspace.package.repository;
             license = licenses.asl20;  # Maps from "Apache-2.0" in Cargo.toml
+            mainProgram = "goose";
           };
         };
 


### PR DESCRIPTION
## Summary

Fix `nix run` (nix-flake mainProgram).
    
Running `nix run` on a clean checkout would build and then fail because
`goose-cli` could not be found. It can't be found because it's actually named just `goose`.
    
This fixes running `nix run github:block/goose` or `nix run` on a local copy of the source. Nix flake defaults to running `goose-cli`, this patch changes that to `goose` (which matches the built binary).

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [X] Build / Release
- [ ] Other (specify below)

### AI Assistance
No AI used.

### Testing
I ran `nix run` locally. And that passes :D.

**Email**: henrik.sjostrand@tele2.com
