### PR TITLE
fix: propagate session ID to LLM request headers in rename task

### DIFF
--- a/crates/goose/tests/session_id_propagation_test.rs
+++ b/crates/goose/tests/session_id_propagation_test.rs
@@ -1,8 +1,11 @@
+use goose::agents::{Agent, SessionConfig};
 use goose::conversation::message::Message;
 use goose::model::ModelConfig;
 use goose::providers::api_client::{ApiClient, AuthMethod};
 use goose::providers::base::Provider;
 use goose::providers::openai::OpenAiProvider;
+use goose::session::session_manager::SessionType;
+use goose::session::SessionManager;
 use goose::session_context;
 use goose::session_context::SESSION_ID_HEADER;
 use serde_json::json;
@@ -152,4 +155,84 @@ async fn test_different_sessions_have_different_ids() {
             Some(session_id_2.to_string())
         ]
     );
+}
+
+#[tokio::test]
+async fn test_session_id_propagation_in_rename_task() {
+    let mock_server = MockServer::start().await;
+    let capture = HeaderCapture::new();
+    let capture_clone = capture.clone();
+
+    Mock::given(method("POST"))
+        .and(path("/v1/chat/completions"))
+        .respond_with(move |req: &Request| {
+            capture_clone.capture_session_header(req);
+            ResponseTemplate::new(200).set_body_json(json!({
+                "choices": [{
+                    "finish_reason": "stop",
+                    "index": 0,
+                    "message": {
+                        "content": "Test response",
+                        "role": "assistant"
+                    }
+                }],
+                "created": 1755133833,
+                "id": "chatcmpl-test",
+                "model": "gpt-5-nano",
+                "usage": {
+                    "completion_tokens": 10,
+                    "prompt_tokens": 8,
+                    "total_tokens": 18
+                }
+            }))
+        })
+        .mount(&mock_server)
+        .await;
+
+    let api_client = ApiClient::new(
+        mock_server.uri(),
+        AuthMethod::BearerToken("test-key".to_string()),
+    )
+    .unwrap();
+    let model = ModelConfig::new_or_fail("gpt-5-nano");
+    let provider = Arc::new(OpenAiProvider::new(api_client, model));
+
+    let agent = Agent::new();
+    agent.update_provider(provider).await.unwrap();
+
+    let session = SessionManager::create_session(
+        std::env::current_dir().unwrap(),
+        "initial".to_string(),
+        SessionType::User,
+    )
+    .await
+    .unwrap();
+
+    session_context::with_session_id(Some(session.id.clone()), async {
+        let stream = agent
+            .reply(
+                Message::user().with_text("test"),
+                SessionConfig {
+                    id: session.id.clone(),
+                    schedule_id: None,
+                    max_turns: Some(1),
+                    retry_config: None,
+                },
+                None,
+            )
+            .await
+            .unwrap();
+
+        use futures::StreamExt;
+        tokio::pin!(stream);
+        while stream.next().await.is_some() {}
+    })
+    .await;
+
+    let captured = capture.get_captured();
+    assert_eq!(captured.len(), 2);
+    assert_eq!(captured[0], Some(session.id.clone()));
+    assert_eq!(captured[1], Some(session.id.clone()));
+
+    SessionManager::delete_session(&session.id).await.unwrap();
 }


### PR DESCRIPTION
## Summary

Wrap session name generation task in session_context so that session ID injection works via api_client.rs. 

Without this, rename task requests lacked the goose-session-id header despite having the session ID as a parameter. 

This means you wouldn't get all requests grouped by the same ID, as the rename task is orphaned. By backfilling tests on this, we also pave the way to test more difficult otel trace propagation.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [x] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

I know what I want, but still struggle with rust, so I used an agent to investigate the several ways of how to do what I want. I also used it to adapt some similar mermaid diagrams to this, so it is easy to understand the mechanics.

### Testing

Unit test matrix covers success, error, and panic cases. Integration test verifies
goose-session-id header appears in rename task's LLM requests without timing dependencies.

Sets foundation for future trace context propagation tests.

### Screenshots/Demos (for UX changes)

#### Before: ApiClient cannot see the session ID on rename

```mermaid
sequenceDiagram
    participant Agent
    participant ReplyInternal
    participant NamingTask
    participant ApiClient
    participant LLM

    Agent->>ReplyInternal: reply(session_id=abc-123)

    rect rgb(255, 200, 200)
    Note over ReplyInternal,LLM: Before: rename task missing session header
    ReplyInternal->>NamingTask: tokio::spawn(without context)
    NamingTask->>ApiClient: generate_session_name()
    Note over ApiClient: current_session_id() → None
    ApiClient->>LLM: POST /chat (no goose-session-id)
    LLM-->>NamingTask: "Generated Name"
    end

    Note over NamingTask: Testing requires sleep-based timing
```

#### After: ApiClient can see the session ID on rename

```mermaid
sequenceDiagram
    participant Agent
    participant ReplyInternal
    participant NamingTask
    participant ApiClient
    participant LLM

    Agent->>ReplyInternal: reply(session_id=abc-123)

    rect rgb(191, 223, 255)
    Note over ReplyInternal,LLM: After: session ID injected in headers
    ReplyInternal->>NamingTask: tokio::spawn(with_session_id(abc-123))
    NamingTask->>ApiClient: generate_session_name()
    Note over ApiClient: current_session_id() → abc-123
    ApiClient->>LLM: POST /chat (goose-session-id: abc-123)
    LLM-->>NamingTask: "Generated Name"
    end

    Note over ReplyInternal: Process messages...
    ReplyInternal->>NamingTask: await handle
    NamingTask-->>ReplyInternal: complete
    Note over Agent: Task completion verified (deterministic)
```

### Related

Follows up https://github.com/block/goose/pull/5165