### PR TITLE
Fix Claude Code provider to default to Auto mode (#5638)

### DIFF
--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -112,14 +112,16 @@ impl ClaudeCodeProvider {
     /// Parse the JSON response from claude CLI
     fn apply_permission_flags(cmd: &mut Command) -> Result<(), ProviderError> {
         let config = Config::global();
-        match config.get_goose_mode() {
-            Ok(GooseMode::Auto) => {
+        let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
+
+        match goose_mode {
+            GooseMode::Auto => {
                 cmd.arg("--dangerously-skip-permissions");
             }
-            Ok(GooseMode::SmartApprove) => {
+            GooseMode::SmartApprove => {
                 cmd.arg("--permission-mode").arg("acceptEdits");
             }
-            Ok(GooseMode::Approve) => {
+            GooseMode::Approve => {
                 return Err(ProviderError::RequestFailed(
                     "\n\n\n### NOTE\n\n\n \
                     Claude Code CLI provider does not support Approve mode.\n \
@@ -128,11 +130,8 @@ impl ClaudeCodeProvider {
                         .to_string(),
                 ));
             }
-            Ok(GooseMode::Chat) => {
+            GooseMode::Chat => {
                 // Chat mode doesn't need permission flags
-            }
-            Err(_) => {
-                // Default behavior if mode is not set
             }
         }
         Ok(())


### PR DESCRIPTION
## Summary
Make Claude Code provider consistent with rest of codebase by using .unwrap_or(GooseMode::Auto) when GOOSE_MODE is not set. Previously, when GOOSE_MODE was not configured, Claude CLI was invoked without permission flags, causing it to ask for permission on every file edit.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance
(used goose)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual testing

### Related Issues
Relates to [#5638](https://github.com/block/goose/issues/5638)
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)

After:   
<img width="1052" height="912" alt="Screenshot 2025-11-08 at 3 46 22 PM" src="https://github.com/user-attachments/assets/6fc942db-dda6-432a-aa91-e9539b1eb264" />

