### PR TITLE
fix: goose recipe list can return duplicated entries

### DIFF
--- a/crates/goose/src/recipe/local_recipes.rs
+++ b/crates/goose/src/recipe/local_recipes.rs
@@ -29,7 +29,13 @@ fn local_recipe_dirs() -> Vec<PathBuf> {
     local_dirs.push(get_recipe_library_dir(true));
     local_dirs.push(get_recipe_library_dir(false));
 
-    local_dirs
+    let mut dirs: Vec<PathBuf> = local_dirs
+        .into_iter()
+        .map(|dir| dir.canonicalize().unwrap_or(dir))
+        .collect();
+    dirs.sort();
+    dirs.dedup();
+    dirs
 }
 
 pub fn load_local_recipe_file(recipe_name: &str) -> Result<RecipeFile> {


### PR DESCRIPTION
Closes: #5293 

## Pull Request Description

This PR addresses an issue where running goose recipe list resulted in duplicate recipe entries when the `GOOSE_RECIPE_PATH ` environment variable was set to the same directory as the default global recipe directory (`~/.config/goose/recipes`).

The root cause was that the duplication occurred because the `local_recipe_dirs()` function aggregates recipe directories from multiple sources: the current working directory, directories specified via `GOOSE_RECIPE_PATH`, the global recipe directory, and local project-specific recipe directories. When `GOOSE_RECIPE_PATH` pointed to the default global recipe directory, the same path was included more than once. Since these paths were not normalized before being processed, the application scanned the same directory multiple times, resulting in duplicate entries when listing recipes.

### Changes Made

To resolve this issue, deduplication logic was added to the local_recipe_dirs() function. The solution works as follows:

- Canonicalize paths: Convert all collected paths into their absolute canonical forms (resolving symlinks and normalization like . and ..).
- Sort paths: Ensure paths are sorted so duplicates are adjacent.
- Remove duplicates: Use dedup() to eliminate repeated entries.

This ensures that each recipe directory is processed exactly once.

NOTE: this could be solved with HashSet too, but I saw that sort and dedup is used in `lead_worked.rs` so I used a similar approach

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance - used Goose for approach validation 

### Testing

Tested with the same command shared in the issue 

```
GOOSE_RECIPE_PATH="$HOME/.config/goose/recipes" goose recipe list --format json | jq   
```



