### PR TITLE
feat: add check-everything for unified style checks

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -4,6 +4,20 @@
 default:
   @just --list
 
+# Run all style checks and formatting (precommit validation)
+check-everything:
+    @echo "🔧 RUNNING ALL STYLE CHECKS..."
+    @echo "  → Formatting Rust code..."
+    cargo fmt --all
+    @echo "  → Running clippy linting..."
+    ./scripts/clippy-lint.sh
+    @echo "  → Checking UI code formatting..."
+    cd ui/desktop && npm run lint:check
+    @echo "  → Validating OpenAPI schema..."
+    ./scripts/check-openapi-schema.sh
+    @echo ""
+    @echo "✅ All style checks passed!"
+
 # Default release command
 release-binary:
     @echo "Building release version..."


### PR DESCRIPTION
## Summary
Add `just check-everything` target that runs all style-related checks in one command: cargo fmt, clippy linting, UI linting, and OpenAPI schema validation. This provides a single precommit validation command to prevent CI failures.

### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Related Issues
Relates to #5649  
