### PR TITLE
Fix: /clear doesn't update session metrics

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -632,9 +632,6 @@ impl CliSession {
                         .total_tokens(Some(0))
                         .input_tokens(Some(0))
                         .output_tokens(Some(0))
-                        .accumulated_total_tokens(Some(0))
-                        .accumulated_input_tokens(Some(0))
-                        .accumulated_output_tokens(Some(0))
                         .apply()
                         .await
                     {


### PR DESCRIPTION
Fixes. https://github.com/block/goose/issues/5651