### PR TITLE
docs: clarify RELEASE PR descriptions

### DIFF
--- a/.github/actions/generate-release-pr-body/pr_body_template.txt
+++ b/.github/actions/generate-release-pr-body/pr_body_template.txt
@@ -3,15 +3,20 @@
 ## How to Release
 
 Push the release tag to trigger the release:
-   ```bash
-   git fetch && git tag v{{VERSION}} origin/release/{{VERSION}}
-   git push origin v{{VERSION}}
-   ```
+
+```bash
+git fetch
+git checkout release/{{VERSION}}
+git cherry-pick DESIRED_COMMIT_SHA(s)
+git tag v{{VERSION}}
+git push origin v{{VERSION}}
+```
+
 This PR will auto-merge once the tag is pushed.
 
 ## Important Notes
 
-- All commits in this release should have corresponding cherry-picks in `main`
+- All commits cherrypicked into this release should be from `main`
 - This PR can be closed if the release is not needed.
 
 ## Changes in This Release


### PR DESCRIPTION
@jamadeo Let me know if you see this as more clear.

I ran into the snippet included in the old description not pushing the tag when prepping https://github.com/block/goose/pull/5709 unless I mis-ran something. I did something manually and then reverse engineered these docs from the process I did.

Also, that branch did not merge when I pushed the tag https://github.com/block/goose/releases/tag/v1.14.2

Something may be failing in an automatic merge action?