### PR TITLE
fix: add one-time cleanup for linux hermit locking issues

### DIFF
--- a/ui/desktop/src/bin/node-setup-common.sh
+++ b/ui/desktop/src/bin/node-setup-common.sh
@@ -23,6 +23,18 @@ trap 'log "An error occurred. Exiting with status $?."' ERR
 
 log "Starting node setup (common)."
 
+# One-time cleanup for existing Linux users to fix locking issues
+CLEANUP_MARKER="~/.config/goose/.mcp-hermit-cleanup-v1"
+if [[ "$(uname -s)" == "Linux" ]] && [ ! -f "$CLEANUP_MARKER" ]; then
+    log "Performing one-time cleanup of old mcp-hermit directory to fix locking issues."
+    if [ -d ~/.config/goose/mcp-hermit ]; then
+        rm -rf ~/.config/goose/mcp-hermit
+        log "Removed old mcp-hermit directory."
+    fi
+    touch "$CLEANUP_MARKER"
+    log "Cleanup completed. Marker file created."
+fi
+
 # Ensure ~/.config/goose/mcp-hermit/bin exists
 log "Creating directory ~/.config/goose/mcp-hermit/bin if it does not exist."
 mkdir -p ~/.config/goose/mcp-hermit/bin


### PR DESCRIPTION
## Summary
#5372 resolved hermit text file locking issues, but users had to manually run `rm -rf ~/.config/goose/mcp-hermit` to finalize the fix. This PR updates the script to do it automatically for Linux users.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
Tested manually on Linux. Script changes shouldn't affect macOS.

### Related Issues
Relates to #2351   
Discussion: https://github.com/block/goose/issues/2351#issuecomment-3514212750