### PR TITLE
Enable recipe deeplink parameters for pre-population

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,6 +2789,7 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "url",
+ "urlencoding",
  "uuid",
  "webbrowser 1.0.4",
  "winapi",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -59,6 +59,7 @@ is-terminal = "0.4.16"
 anstream = "0.6.18"
 url = "2.5.7"
 open = "5.3.2"
+urlencoding = "2.1"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 winapi = { version = "0.3", features = ["wincred"] }

--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -376,6 +376,14 @@ enum RecipeCommand {
             help = "recipe name to get recipe file or full path to the recipe file to generate deeplink"
         )]
         recipe_name: String,
+        /// Recipe parameters in key=value format (can be specified multiple times)
+        #[arg(
+            short = 'p',
+            long = "param",
+            value_name = "KEY=VALUE",
+            help = "Recipe parameter in key=value format (can be specified multiple times)"
+        )]
+        params: Vec<String>,
     },
 
     /// Open a recipe in Goose Desktop
@@ -384,6 +392,14 @@ enum RecipeCommand {
         /// Recipe name to get recipe file to open
         #[arg(help = "recipe name or full path to the recipe file")]
         recipe_name: String,
+        /// Recipe parameters in key=value format (can be specified multiple times)
+        #[arg(
+            short = 'p',
+            long = "param",
+            value_name = "KEY=VALUE",
+            help = "Recipe parameter in key=value format (can be specified multiple times)"
+        )]
+        params: Vec<String>,
     },
 
     /// List available recipes
@@ -1366,11 +1382,17 @@ pub async fn cli() -> anyhow::Result<()> {
                 RecipeCommand::Validate { recipe_name } => {
                     handle_validate(&recipe_name)?;
                 }
-                RecipeCommand::Deeplink { recipe_name } => {
-                    handle_deeplink(&recipe_name)?;
+                RecipeCommand::Deeplink {
+                    recipe_name,
+                    params,
+                } => {
+                    handle_deeplink(&recipe_name, &params)?;
                 }
-                RecipeCommand::Open { recipe_name } => {
-                    handle_open(&recipe_name)?;
+                RecipeCommand::Open {
+                    recipe_name,
+                    params,
+                } => {
+                    handle_open(&recipe_name, &params)?;
                 }
                 RecipeCommand::List { format, verbose } => {
                     handle_list(&format, verbose)?;

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -449,6 +449,10 @@ function BaseChatContent({
           parameters={recipe.parameters}
           onSubmit={setRecipeUserParams}
           onClose={() => setView('chat')}
+          initialValues={
+            (window.appConfig?.get('recipeParameters') as Record<string, string> | undefined) ||
+            undefined
+          }
         />
       )}
 

--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -6,29 +6,31 @@ interface ParameterInputModalProps {
   parameters: Parameter[];
   onSubmit: (values: Record<string, string>) => void;
   onClose: () => void;
+  initialValues?: Record<string, string>;
 }
 
 const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
   parameters,
   onSubmit,
   onClose,
+  initialValues,
 }) => {
   const [inputValues, setInputValues] = useState<Record<string, string>>({});
   const [validationErrors, setValidationErrors] = useState<Record<string, string>>({});
   const [showCancelOptions, setShowCancelOptions] = useState(false);
 
-  // Pre-fill the form with default values from the recipe
+  // Pre-fill the form with default values from the recipe and initialValues from deeplink
   useEffect(() => {
-    const initialValues: Record<string, string> = {};
+    const defaultValues: Record<string, string> = {};
     parameters.forEach((param) => {
       if (param.requirement === 'optional' && param.default) {
-        const defaultValue =
+        defaultValues[param.key] =
           param.input_type === 'boolean' ? param.default.toLowerCase() : param.default;
-        initialValues[param.key] = defaultValue;
       }
     });
-    setInputValues(initialValues);
-  }, [parameters]);
+
+    setInputValues({ ...defaultValues, ...initialValues });
+  }, [parameters, initialValues]);
 
   const handleChange = (name: string, value: string): void => {
     setInputValues((prevValues: Record<string, string>) => ({ ...prevValues, [name]: value }));


### PR DESCRIPTION
## Summary
Add support for passing parameters via URL query strings in recipe deeplinks. Parameters are parsed from the URL, stored in chat context, and used to pre-populate the Recipe Parameters dialog.

## Changes
- **CLI**: Add `-p`/`--param` flag to `recipe deeplink` and `recipe open` commands
- **Electron**: Parse query parameters from deeplink URLs
- **React**: Pass parameters to ParameterInputModal for pre-population
- **Hook**: Initialize and auto-submit parameters from deeplink

## Example Usage
```bash
goose recipe deeplink recipe.yaml -p key1=value1 -p key2=value2
```

Generates:
```
goose://recipe?config=<base64>&key1=value1&key2=value2
```

## Test Plan
- [x] Tested with clean-up-feature-flag recipe
- [x] Parameters successfully pre-populate in UI dialog
- [x] Auto-submission works when recipe is accepted
- [x] TypeScript compilation passes
- [x] Lint checks pass


https://github.com/user-attachments/assets/b3356e9e-1eb7-4b5e-b13a-c21aa8a2c51f



🤖 Generated with [Claude Code](https://claude.com/claude-code)