### PR TITLE
ci: prevent scheduled workflows from running in forks

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -21,6 +21,8 @@ jobs:
   # ------------------------------------
   prepare-version:
     name: Prepare Version
+    # Only run in the upstream repository, not in forks
+    if: github.repository == 'block/goose'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.set-version.outputs.version }}

--- a/.github/workflows/minor-release.yaml
+++ b/.github/workflows/minor-release.yaml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   release:
+    # Only run in the upstream repository, not in forks
+    if: github.repository == 'block/goose'
     uses: ./.github/workflows/create-release-pr.yaml
     with:
       bump_type: "minor"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -21,6 +21,8 @@ concurrency:
 jobs:
   prepare-version:
     name: Prepare Version
+    # Only run in the upstream repository, not in forks
+    if: github.repository == 'block/goose'
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.set-version.outputs.version }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -23,6 +23,8 @@ permissions:
 jobs:
   stale:
     name: 'Mark and Close Stale PRs'
+    # Only run in the upstream repository, not in forks
+    if: github.repository == 'block/goose'
     runs-on: ubuntu-latest
     
     steps:

--- a/.github/workflows/test-finder.yml
+++ b/.github/workflows/test-finder.yml
@@ -18,6 +18,8 @@ permissions:
 
 jobs:
   find-untested-code:
+    # Only run in the upstream repository, not in forks
+    if: github.repository == 'block/goose'
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/block/goose:latest

--- a/.github/workflows/update-hacktoberfest-leaderboard.yml
+++ b/.github/workflows/update-hacktoberfest-leaderboard.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   update-leaderboard:
+    # Only run in the upstream repository, not in forks
+    if: github.repository == 'block/goose'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/update-health-dashboard.yml
+++ b/.github/workflows/update-health-dashboard.yml
@@ -22,6 +22,8 @@ permissions:
 jobs:
   update-dashboard:
     name: 'Update Health Dashboard'
+    # Only run in the upstream repository, not in forks
+    if: github.repository == 'block/goose'
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
Add repository check conditions to scheduled and automated workflows to prevent them from running in forked repositories where they would fail due to missing secrets and incorrect context.

Affected workflows:
- Canary (push to main)
- Nightly Build (daily schedule)
- Update GitHub Health Dashboard (daily schedule)
- Daily Test Coverage Finder (manual trigger)
- Close Stale PRs (daily schedule)
- Update Hacktoberfest Leaderboard (hourly in October)
- Create Minor Release PR (weekly schedule)

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [x] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

### Submitting a Recipe?
<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved and merged -->
**Email**: 
