### PR TITLE
Remove empty settings card for Scheduling Engine

### DIFF
--- a/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
+++ b/ui/desktop/src/components/settings/chat/ChatSettingsSection.tsx
@@ -42,14 +42,6 @@ export default function ChatSettingsSection() {
 
       <Card className="pb-2 rounded-lg">
         <CardHeader className="pb-0">
-          <CardTitle className="">Scheduling Engine</CardTitle>
-          <CardDescription>
-            Choose which scheduling backend to use for scheduled recipes and tasks
-          </CardDescription>
-        </CardHeader>
-      </Card>
-      <Card className="pb-2 rounded-lg">
-        <CardHeader className="pb-0">
           <CardTitle className="">Tool Selection Strategy (preview)</CardTitle>
           <CardDescription>
             Experimental: configure how Goose selects tools for your requests, useful when there are


### PR DESCRIPTION
## Summary
The settings for for Scheduling Engine were removed but the card still exists, empty, in the settings UI.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
Manually built and ran the app to test that the settings page was not broken

### Related Issues
Fixes #5764


### Screenshots/Demos (for UX changes)
Before:  
<img width="1040" height="1354" alt="image" src="https://github.com/user-attachments/assets/dcab2444-b34f-4d58-940a-da802b9ee2c6" />

After:
<img width="1025" height="1267" alt="image" src="https://github.com/user-attachments/assets/bb5c4774-89fa-41e5-86c1-d312494c6232" />
