### PR TITLE
[DO NOT REVIEW] Added wal with shared cache

### DIFF
--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -462,7 +462,9 @@ impl SessionStorage {
         let options = SqliteConnectOptions::new()
             .filename(db_path)
             .create_if_missing(create_if_missing)
-            .busy_timeout(std::time::Duration::from_secs(5));
+            .busy_timeout(std::time::Duration::from_secs(5))
+            .shared_cache(true)
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
 
         sqlx::SqlitePool::connect_with(options).await.map_err(|e| {
             anyhow::anyhow!(


### PR DESCRIPTION
## Summary
There seems to be a WAL race condition within the `builder.rs` file where [a session is created](https://github.com/block/goose/blob/main/crates/goose-cli/src/session/builder.rs#L330-L339) and [get session](https://github.com/block/goose/blob/main/crates/goose-cli/src/session/builder.rs#L374-L376) immediately after, which in some instances can fail because the `read session` is looking at an old version of the sessions db + WAL page from one thread before the `write session` commit finishes propagating. 

I believe the culprit to be the lack of an explicit "commit" transaction with WAL enabled. In the [concurrency section](https://www.sqlite.org/wal.html#concurrency) of sqlite documentation, `When a read operation begins on a WAL-mode database, it first remembers the location of the last valid commit record in the WAL`. So even though we were relying on concurrency through `await?;` the commit never applied. 

This could also explain why the [Pragma wal_checkpoint](https://github.com/block/goose/pull/5202/files#diff-ea48b849d961f9dbe45e0cb71f8a8f7628d974c6917b2a4d1d0a65ab19ab7b41R656-R658) approach didn't work as the checkpoint didn't have a completed commit to apply WAL file changes to the database.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [x] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
I was unable to reproduce on multiple linux docker images, I went ahead and reproduced the "bug" (`create_session` and `get_session` race condition) by writing [concurrent create_session -> get_session race condition tests and ran them a few thousand times](https://github.com/block/goose/pull/5786). 

### Related Issues
Relates to [#5197](https://github.com/block/goose/issues/5197)
Discussion: 
- [Previous fix](https://github.com/block/goose/pull/5202)