### PR TITLE
feat/fix Re-enabled WAL with commit transaction management (Linux Verification Requested)

### DIFF
--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -607,7 +607,7 @@ impl SessionStorage {
 
     async fn import_legacy_session(&self, session: &Session) -> Result<()> {
         let mut tx = self.pool.begin().await?;
-        
+
         let recipe_json = match &session.recipe {
             Some(recipe) => Some(serde_json::to_string(recipe)?),
             None => None,
@@ -786,7 +786,7 @@ impl SessionStorage {
         session_type: SessionType,
     ) -> Result<Session> {
         let mut tx = self.pool.begin().await?;
-        
+
         let today = chrono::Utc::now().format("%Y%m%d").to_string();
         let session = sqlx::query_as(
             r#"
@@ -813,7 +813,7 @@ impl SessionStorage {
             .bind(working_dir.to_string_lossy().as_ref())
             .fetch_one(&mut *tx)
             .await?;
-        
+
         tx.commit().await?;
         Ok(session)
     }


### PR DESCRIPTION
## Summary
There seems to be a WAL race condition within the `builder.rs` file where [a session is created](https://github.com/block/goose/blob/main/crates/goose-cli/src/session/builder.rs#L330-L339) and [get session](https://github.com/block/goose/blob/main/crates/goose-cli/src/session/builder.rs#L374-L376) is called immediately after, which in some instances can fail because the [get_session](https://github.com/block/goose/blob/main/crates/goose/src/session/session_manager.rs#L811-L841) call is looking at an old version of the sessions db + WAL from one thread before the [create_session](https://github.com/block/goose/blob/main/crates/goose/src/session/session_manager.rs#L777-L809) changes finishes propagating. 

I believe the culprit to be the lack of an explicit `commit` transaction with WAL enabled. In the [concurrency section](https://www.sqlite.org/wal.html#concurrency) of sqlite documentation, ```When a read operation begins on a WAL-mode database, it first remembers the location of the last valid commit record in the WAL```. So even though we were relying on concurrency through `await?;` [create_session](https://github.com/block/goose/blob/main/crates/goose/src/session/session_manager.rs#L777-L809) never explicitly called commit, which possibly resulted in `get_session` "misses" on an old version of the database.

This could also explain why the [Pragma wal_checkpoint](https://github.com/block/goose/pull/5202/files#diff-ea48b849d961f9dbe45e0cb71f8a8f7628d974c6917b2a4d1d0a65ab19ab7b41R656-R658) approach didn't work as the checkpoint didn't have a completed commit to apply WAL file changes to the database.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [x] Refactor / Code quality
- [x] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
I was unable to reproduce on multiple linux docker images, I went ahead and reproduced the "bug" (`create_session` and `get_session` race condition) by writing [concurrent create_session -> get_session race condition tests and ran them a few thousand times](https://github.com/block/goose/pull/5786). 

[Ran a timing check on an existing concurrency test](https://github.com/block/goose/blob/1d8d6a17882af7345127acc90e02340ed4c77f88/crates/goose/src/session/session_manager.rs#L1172). ```time cargo test test_concurrent_session_creation --release -- --test-threads=1;```

Eyeballing the results, WAL takes about `.763s` and without takes `.848s`, about a 10% improvement.

### Related Issues
Relates to [#5197](https://github.com/block/goose/issues/5197)
Discussion: 
- [Previous fix](https://github.com/block/goose/pull/5202)