### PR TITLE
Fix: Ensure Developer Extension Always Load in Goose Web

### DIFF
--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -54,22 +54,21 @@ fn get_extensions_map() -> IndexMap<String, ExtensionEntry> {
         }
     }
 
-    if !extensions_map.is_empty() {
-        for (name, def) in PLATFORM_EXTENSIONS.iter() {
-            if !extensions_map.contains_key(*name) {
-                extensions_map.insert(
-                    name.to_string(),
-                    ExtensionEntry {
-                        config: ExtensionConfig::Platform {
-                            name: def.name.to_string(),
-                            description: def.description.to_string(),
-                            bundled: Some(true),
-                            available_tools: Vec::new(),
-                        },
-                        enabled: true,
+    // Always add platform extensions if they're not already present
+    for (name, def) in PLATFORM_EXTENSIONS.iter() {
+        if !extensions_map.contains_key(*name) {
+            extensions_map.insert(
+                name.to_string(),
+                ExtensionEntry {
+                    config: ExtensionConfig::Platform {
+                        name: def.name.to_string(),
+                        description: def.description.to_string(),
+                        bundled: Some(true),
+                        available_tools: Vec::new(),
                     },
-                );
-            }
+                    enabled: true,
+                },
+            );
         }
     }
     extensions_map


### PR DESCRIPTION
When running **Goose Web** , the built-in extensions were not always being loaded.  
This caused Goose Web to start without critical capabilities such as:

- File editing
- Shell execution
- Access to platform extensions
- Developer tools

As a result, Goose Web sessions in the browser showed **no filesystem tools**.

### ✅ What This PR Does
This update guarantees that Goose Web always has the necessary built-in extensions loaded, even when the user’s config or environment doesn't explicitly enable them.

### Key Changes
#### 1. `goose-cli`  
- Checks whether the `developer` extension is enabled.
- Automatically injects a **default developer extension config** if missing.
- Prevents empty extension environments and ensures core tooling is always available.

#### 2. `goose/src/config/extensions.rs`
- Ensures **all platform extensions** are always registered if missing.
- Consolidates logic so platform extensions cannot be accidentally omitted.

### 🧪 Why This Matters
We rely on Goose Web heavily during conferences and hands-on labs.  
Before this fix, Goose Web would silently launch **without any extensions**, leaving the agent unable to perform essential operations like:

- creating files  
- running shell commands  
- generating project structure  

This PR ensures a consistent and fully-functional Goose Web environment regardless of configuration.

### 🚧 Status
Marked as **Draft** because we are actively using this branch for the **AI Engineer Summit** labs this week.

### 📷 Screenshot of the original issue
<img width="934" height="618" alt="Screenshot 2025-11-19 at 11 09 37 AM" src="https://github.com/user-attachments/assets/96f65e64-68b8-48e5-8e13-4ab239060dc2" />


