### PR TITLE
Fix keyboard shortcut conflict for Focus Goose Window

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1771,6 +1771,14 @@ async function appMain() {
     console.error('Error registering launcher hotkey:', e);
   }
 
+  try {
+    globalShortcut.register('CommandOrControl+Alt+G', () => {
+      focusWindow();
+    });
+  } catch (e) {
+    console.error('Error registering focus window hotkey:', e);
+  }
+
   session.defaultSession.webRequest.onBeforeSendHeaders((details, callback) => {
     details.requestHeaders['Origin'] = 'http://localhost:5173';
     callback({ cancel: false, requestHeaders: details.requestHeaders });
@@ -1948,7 +1956,7 @@ async function appMain() {
     fileMenu.submenu.append(
       new MenuItem({
         label: 'Focus Goose Window',
-        accelerator: 'CmdOrCtrl+Alt+Shift+G',
+        accelerator: 'CmdOrCtrl+Alt+G',
         click() {
           focusWindow();
         },


### PR DESCRIPTION
- Changed Focus Goose Window shortcut from Cmd+Option+Shift+G to Cmd+Option+G
- Registered new global shortcut for Focus Window (Cmd+Option+G)
- Quick Launcher remains on Cmd+Option+Shift+G
- Resolves conflict where both actions shared the same shortcut

Fixes #5782