### PR TITLE
fix(#5626): handle multi-text content better for openai format models

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -63,25 +63,23 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
         });
 
         let mut output = Vec::new();
+        let mut text_parts = Vec::new();
 
         for content in &message.content {
             match content {
                 MessageContent::Text(text) => {
                     if !text.text.is_empty() {
-                        // Check for image paths in the text
                         if let Some(image_path) = detect_image_path(&text.text) {
-                            // Try to load and convert the image
                             if let Ok(image) = load_image_file(image_path) {
                                 converted["content"] = json!([
                                     {"type": "text", "text": text.text},
                                     convert_image(&image, image_format)
                                 ]);
                             } else {
-                                // If image loading fails, just use the text
-                                converted["content"] = json!(text.text);
+                                text_parts.push(text.text.clone());
                             }
                         } else {
-                            converted["content"] = json!(text.text);
+                            text_parts.push(text.text.clone());
                         }
                     }
                 }
@@ -244,9 +242,14 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
             }
         }
 
+        if !text_parts.is_empty() {
+            converted["content"] = json!(text_parts.join("\n"));
+        }
+
         if converted.get("content").is_some() || converted.get("tool_calls").is_some() {
             output.insert(0, converted);
         }
+
         messages_spec.extend(output);
     }
 
@@ -1325,6 +1328,23 @@ mod tests {
             assert_eq!(obj.get(key).unwrap(), value);
         }
 
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_multiple_text_blocks() -> anyhow::Result<()> {
+        let message = Message::user()
+            .with_text("--- Resource: file:///test.md ---\n# Test\n\n---\n")
+            .with_text(" What is in the file?");
+
+        let spec = format_messages(&[message], &ImageFormat::OpenAi);
+
+        assert_eq!(spec.len(), 1);
+        assert_eq!(spec[0]["role"], "user");
+        assert_eq!(
+            spec[0]["content"],
+            "--- Resource: file:///test.md ---\n# Test\n\n---\n\n What is in the file?"
+        );
         Ok(())
     }
 


### PR DESCRIPTION
We weren't properly handling when messages have multiple text chunks in `providers/formats/openai.rs`

This surfaced in https://github.com/block/goose/issues/5626 when encountering a message with content like this:

```
"content": [
  {
    "type": "text",
    "text": "--- Resource: file:///Users/pjv/development/projects/test%20python%20project/test2.py ---\nfrom typing import NamedTuple\n\n\nclass Person(NamedTuple):\n  name: str\n  age: int | None = None\n\n\nperson = Person(\"Alice\", 25)\n\n---\n"
  },
  {
    "type": "text",
    "text": " what does this code do?"
  }
],
```

Previously when a message contained multiple text content chunks, we would overwrite the earlier ones and replace them with the last one. So this message `what does this code do?` would lead to an answer like `what code?`

**Example**

**Before:**

<img width="1786" height="1219" alt="Screenshot 2025-11-21 at 3 26 02 PM" src="https://github.com/user-attachments/assets/bd0ecd27-4b88-4746-a630-2e7d86ce16f9" />

**After:**

<img width="1786" height="1219" alt="Screenshot 2025-11-21 at 3 29 51 PM" src="https://github.com/user-attachments/assets/02bdc685-bb2c-40c3-80c0-3bf5230539e4" />