### PR TITLE
fix sessions coming back with empty messages

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -197,7 +197,7 @@ async fn resume_agent(
     State(state): State<Arc<AppState>>,
     Json(payload): Json<ResumeAgentRequest>,
 ) -> Result<Json<Session>, ErrorResponse> {
-    let session = SessionManager::get_session(&payload.session_id, false)
+    let session = SessionManager::get_session(&payload.session_id, true)
         .await
         .map_err(|err| {
             error!("Failed to resume session {}: {}", payload.session_id, err);


### PR DESCRIPTION
## Summary
Noticed that loading sessions from history was coming back with empty messages and not loading the session.

In this [PR](https://github.com/block/goose/pull/5419) `resume_agent` `get_session` parameter `include_messages` was changed to `false` but we do want the messages for the front end to load the session in chat now after [next camp](https://github.com/block/goose/pull/5706)