### PR TITLE
chore: suggest using text/markdown when fetching content

### DIFF
--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -492,13 +492,19 @@ impl ComputerControllerServer {
         let save_as = params.save_as;
 
         // Fetch the content
-        let response = self.http_client.get(url).send().await.map_err(|e| {
-            ErrorData::new(
-                ErrorCode::INTERNAL_ERROR,
-                format!("Failed to fetch URL: {}", e),
-                None,
-            )
-        })?;
+        let response = self
+            .http_client
+            .get(url)
+            .header("Accept", "text/markdown, */*")
+            .send()
+            .await
+            .map_err(|e| {
+                ErrorData::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("Failed to fetch URL: {}", e),
+                    None,
+                )
+            })?;
 
         let status = response.status();
         if !status.is_success() {

--- a/crates/goose-mcp/src/developer/rmcp_developer.rs
+++ b/crates/goose-mcp/src/developer/rmcp_developer.rs
@@ -325,6 +325,8 @@ impl ServerHandler for DeveloperServer {
             **Important**: Each shell command runs in its own process. Things like directory changes or
             sourcing files do not persist between tool calls. So you may need to repeat them each time by
             stringing together commands.
+
+            If fetching web content, consider adding Accept: text/markdown header
         "#};
 
         let windows_specific = indoc! {r#"


### PR DESCRIPTION
fixes https://github.com/block/goose/issues/5752 - which means it may get clearer content back for agent consonsumption.

Please explain the motivation behind the feature request.
I’d like goose to hint to web servers that it prefers markdown, but will also take other content types. This is helpful when requesting / reading docs and is much more token efficient than the agent reading HTML/JS/CSS

Describe the solution you'd like
Simply adding Accepts: text/markdown to outgoing requests would be sufficient.

Additional context

https://x.com/bcherny/status/1988860326306087102?s=46



(brings it in line with direction of other agents). 
