### PR TITLE
Update cleanup marker logic for Fedora users.

### DIFF
--- a/ui/desktop/src/bin/node-setup-common.sh
+++ b/ui/desktop/src/bin/node-setup-common.sh
@@ -24,7 +24,7 @@ trap 'log "An error occurred. Exiting with status $?."' ERR
 log "Starting node setup (common)."
 
 # One-time cleanup for existing Linux users to fix locking issues
-CLEANUP_MARKER="${HOME}/.config/goose/.mcp-hermit-cleanup-v1"
+CLEANUP_MARKER=${HOME}/.config/goose/.mcp-hermit-cleanup-v1
 if [[ "$(uname -s)" == "Linux" ]] && [ ! -f "$CLEANUP_MARKER" ]; then
     log "Performing one-time cleanup of old mcp-hermit directory to fix locking issues."
     if [ -d ${HOME}/.config/goose/mcp-hermit ]; then


### PR DESCRIPTION
Update cleanup marker logic for Fedora users.

## Summary
<!-- Describe your change -->

Removes the double quotes from `CLEANUP_MARKER` for Fedora systems experiencing an error `touch: cannot access '~/.config/goose/.mcp-hermit-cleanup-v1': No such file or directory` when trying to add extensions.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

Manual testing. I made this change in my system to resolve the issue when I encountered it. I verified the same in a fresh Fedora Workstation 43 VM, too. 

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

### Submitting a Recipe?
<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved and merged -->
**Email**: 
