### PR TITLE
fix: use a lock to ensure only need to run tunnel just in case multiple go…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2871,6 +2871,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
+ "fs2",
  "futures",
  "goose",
  "goose-mcp",

--- a/crates/goose-server/Cargo.toml
+++ b/crates/goose-server/Cargo.toml
@@ -44,6 +44,7 @@ url = "2.5.7"
 rand = "0.9.2"
 hex = "0.4.3"
 socket2 = "0.6.1"
+fs2 = "0.4.3"
 
 [target.'cfg(windows)'.dependencies]
 winreg = { version = "0.55.0" }


### PR DESCRIPTION
there can be multiple goosed but should only be one tunnel running.

small one - would rather not need to do this, but as things are now, we let many goosed fly (pun intended) so as this is in process, don't really want to double up (not sure what would happen - probably nothing functionally good!)