### PR TITLE
5527 multiple file popups

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -142,6 +142,7 @@ export default function ChatInput({
   const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const [showCreateRecipeModal, setShowCreateRecipeModal] = useState(false);
   const [showEditRecipeModal, setShowEditRecipeModal] = useState(false);
+  const [isFilePickerOpen, setIsFilePickerOpen] = useState(false);
 
   // Save queue state (paused/interrupted) to storage
   useEffect(() => {
@@ -1014,12 +1015,18 @@ export default function ChatInput({
   };
 
   const handleFileSelect = async () => {
-    const path = await window.electron.selectFileOrDirectory();
-    if (path) {
-      const newValue = displayValue.trim() ? `${displayValue.trim()} ${path}` : path;
-      setDisplayValue(newValue);
-      setValue(newValue);
-      textAreaRef.current?.focus();
+    if (isFilePickerOpen) return;
+    setIsFilePickerOpen(true);
+    try {
+      const path = await window.electron.selectFileOrDirectory();
+      if (path) {
+        const newValue = displayValue.trim() ? `${displayValue.trim()} ${path}` : path;
+        setDisplayValue(newValue);
+        setValue(newValue);
+        textAreaRef.current?.focus();
+      }
+    } finally {
+      setIsFilePickerOpen(false);
     }
   };
 
@@ -1457,9 +1464,10 @@ export default function ChatInput({
             <Button
               type="button"
               onClick={handleFileSelect}
+              disabled={isFilePickerOpen}
               variant="ghost"
               size="sm"
-              className="flex items-center justify-center text-text-default/70 hover:text-text-default text-xs cursor-pointer transition-colors"
+              className={`flex items-center justify-center text-text-default/70 hover:text-text-default text-xs transition-colors ${isFilePickerOpen ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'}`}
             >
               <Attach className="w-4 h-4" />
             </Button>

--- a/ui/desktop/src/components/bottom_menu/DirSwitcher.tsx
+++ b/ui/desktop/src/components/bottom_menu/DirSwitcher.tsx
@@ -8,12 +8,24 @@ interface DirSwitcherProps {
 
 export const DirSwitcher: React.FC<DirSwitcherProps> = ({ className = '' }) => {
   const [isTooltipOpen, setIsTooltipOpen] = useState(false);
+  const [isDirectoryChooserOpen, setIsDirectoryChooserOpen] = useState(false);
 
   const handleDirectoryChange = async () => {
-    window.electron.directoryChooser(true);
+    if (isDirectoryChooserOpen) return;
+    setIsDirectoryChooserOpen(true);
+    try {
+      await window.electron.directoryChooser(true);
+    } finally {
+      setIsDirectoryChooserOpen(false);
+    }
   };
 
   const handleDirectoryClick = async (event: React.MouseEvent) => {
+    if (isDirectoryChooserOpen) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
     const isCmdOrCtrlClick = event.metaKey || event.ctrlKey;
 
     if (isCmdOrCtrlClick) {
@@ -28,11 +40,17 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({ className = '' }) => {
 
   return (
     <TooltipProvider>
-      <Tooltip open={isTooltipOpen} onOpenChange={setIsTooltipOpen}>
+      <Tooltip
+        open={isTooltipOpen && !isDirectoryChooserOpen}
+        onOpenChange={(open) => {
+          if (!isDirectoryChooserOpen) setIsTooltipOpen(open);
+        }}
+      >
         <TooltipTrigger asChild>
           <button
-            className={`z-[100] hover:cursor-pointer text-text-default/70 hover:text-text-default text-xs flex items-center transition-colors pl-1 [&>svg]:size-4 ${className}`}
+            className={`z-[100] ${isDirectoryChooserOpen ? 'opacity-50' : 'hover:cursor-pointer hover:text-text-default'} text-text-default/70 text-xs flex items-center transition-colors pl-1 [&>svg]:size-4 ${className}`}
             onClick={handleDirectoryClick}
+            disabled={isDirectoryChooserOpen}
           >
             <FolderDot className="mr-1" size={16} />
             <div className="max-w-[200px] truncate [direction:rtl]">


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
Added state to track file picker status, disabled the button when file picker open.
Also, not mentioned in the original issue but the same behavior occurs for the directory chooser as well so I went ahead and fixed it.
Added state to track directory chooser status, disabled the button when directory chooser open.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual Testing

### Related Issues
Relates to #5527 
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  
<img width="1544" height="886" alt="image" src="https://github.com/user-attachments/assets/da92ea44-75c8-448b-a0c4-a3f7e61bbb6e" />


After:
<img width="1512" height="942" alt="image" src="https://github.com/user-attachments/assets/7ad7d4a9-4eea-4e5a-bda7-4f6c2a61785e" />

<img width="1512" height="870" alt="image" src="https://github.com/user-attachments/assets/9b7b003a-025a-4151-9f66-d804ce3b7f6b" />


### Submitting a Recipe?
<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved and merged -->
**Email**: 
