### PR TITLE
fix(ui): prevent incorrect provider type suffix in update dialog #5908

### DIFF
--- a/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
@@ -157,7 +157,7 @@ function ProviderCards({
   }, [providers, isOnboarding, configureProviderViaModal, onProviderLaunch]);
 
   const initialData = editingProvider && {
-    engine: editingProvider.config.engine.toLowerCase() + '_compatible',
+    engine: editingProvider.config.engine.toLowerCase(),
     display_name: editingProvider.config.display_name,
     api_url: editingProvider.config.base_url,
     api_key: '',


### PR DESCRIPTION
## Summary

The base engine names (e.g., 'openai', 'anthropic') are persisted correctly in the backend configuration. However, `ProviderGrid.tsx` was appending a `_compatible` suffix to the engine key before passing it to `CustomProviderForm`.

`CustomProviderForm` expects the raw base engine name to correctly map it to the dropdown selection. Receiving the suffixed version caused the lookup to fail, defaulting the provider type to "OpenAI Compatible" and subsequently overwriting the correct configuration on save.

This fix removes the unnecessary suffix, ensuring the form receives the correct engine key. This change is isolated to the custom provider configuration flow in the UI.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

Manual testing for following cases:

- verified Anthropic custom providers now save/reload correctly
- verified OpenAI + Ollama providers still work

Automated testing: 
- no additional tests failed with this change

### Related Issues
Relates to #5908 