### PR TITLE
fix: auto-create and show new tab when submitting from Hub

### DIFF
--- a/ui/desktop/src/components/TabbedPairRoute.tsx
+++ b/ui/desktop/src/components/TabbedPairRoute.tsx
@@ -18,7 +18,25 @@ export const TabbedPairRoute: React.FC<TabbedPairRouteProps> = ({
   const routeState = location.state as ViewOptions | undefined;
   const initialMessage = routeState?.initialMessage;
   const { isNavExpanded } = useNavigation();
-  const { openExistingSession, openMatrixChat } = useTabContext();
+  const { openExistingSession, openMatrixChat, handleNewTab } = useTabContext();
+
+  // Track if we've already handled the initial message to prevent duplicate handling
+  const [hasHandledInitialMessage, setHasHandledInitialMessage] = React.useState(false);
+
+  // Handle initial message from Hub - create a new tab with the message
+  useEffect(() => {
+    if (initialMessage && !hasHandledInitialMessage) {
+      console.log('📝 TabbedPairRoute: Handling initial message from Hub:', initialMessage);
+      
+      // Create a new tab - the initialMessage will be passed to TabbedChatContainer
+      // and auto-submitted in the new tab
+      handleNewTab();
+      setHasHandledInitialMessage(true);
+      
+      // Clear the location state to prevent re-handling on navigation
+      window.history.replaceState({}, '', window.location.href);
+    }
+  }, [initialMessage, hasHandledInitialMessage, handleNewTab]);
 
   // Handle resuming existing sessions from URL parameters
   useEffect(() => {


### PR DESCRIPTION
When a user submits a message from the Hub (home page), the app now:
- Automatically creates a new tab in the /pair route
- Makes that tab active
- Auto-submits the message in the new tab

This fixes the issue where messages from Hub would navigate to /pair but not create or show a new tab with the conversation.

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

### Submitting a Recipe?
<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved and merged -->
**Email**: 
