### PR TITLE
fix: update Hub background matrix nodes and text colors

### DIFF
--- a/ui/desktop/src/components/hub.tsx
+++ b/ui/desktop/src/components/hub.tsx
@@ -91,7 +91,11 @@ const NodeMatrixBackground: React.FC = () => {
         // Draw node
         ctx.beginPath();
         ctx.arc(node.x, node.y, node.size, 0, Math.PI * 2);
-        ctx.fillStyle = 'rgba(156, 163, 175, 0.4)'; // text-muted color with low opacity
+        // Use CSS variable for background color with 80% opacity
+        const bgColor = getComputedStyle(canvas).getPropertyValue('--background-default').trim() || '#ffffff';
+        ctx.fillStyle = bgColor.startsWith('#') 
+          ? `${bgColor}CC` // Add 80% opacity (CC in hex)
+          : bgColor.replace('rgb', 'rgba').replace(')', ', 0.8)');
         ctx.fill();
 
         // Draw connections
@@ -106,7 +110,10 @@ const NodeMatrixBackground: React.FC = () => {
             ctx.beginPath();
             ctx.moveTo(node.x, node.y);
             ctx.lineTo(otherNode.x, otherNode.y);
-            ctx.strokeStyle = `rgba(156, 163, 175, ${opacity})`;
+            // Use the same background color for connections
+            ctx.strokeStyle = bgColor.startsWith('#')
+              ? `${bgColor}${Math.round(opacity * 255).toString(16).padStart(2, '0')}`
+              : bgColor.replace('rgb', 'rgba').replace(')', `, ${opacity})`);
             ctx.lineWidth = 0.5;
             ctx.stroke();
           }
@@ -348,7 +355,7 @@ export default function Hub({
                 }}
               >
                 <Greeting className="text-4xl font-light text-text-default mb-4" />
-                <p className="text-text-muted text-lg">
+                <p className="text-text-default text-lg">
                   Start a new conversation to get help with your projects
                 </p>
               </div>


### PR DESCRIPTION
- Change matrix nodes to use app background color (--background-default) at 80% opacity
- Update connection lines to match background color with distance-based opacity
- Change subheading text from muted to default color for better visibility
- Matrix nodes now adapt to light/dark theme automatically

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

### Submitting a Recipe?
<!-- For Recipe Cookbook Submissions ONLY: Include your email below to receive $10 OpenRouter credits once approved and merged -->
**Email**: 
