### PR TITLE
[MCP-UI] add CSP for images to proxy HTML

### DIFF
--- a/crates/goose-server/src/routes/templates/mcp_ui_proxy.html
+++ b/crates/goose-server/src/routes/templates/mcp_ui_proxy.html
@@ -9,6 +9,7 @@
       - script-src: Allow scripts from any origin, inline, eval, wasm, and blob URLs
       - style-src: Allow styles from any origin and inline styles
       - font-src: Allow fonts from any origin
+      - img-src: Allow images from any origin
       - connect-src: Allow network requests to any origin
       - frame-src: Allow embedding iframes from any origin (required for proxy functionality)
       - media-src: Allow audio/video media from any origin
@@ -17,7 +18,7 @@
     -->
     <meta 
       http-equiv="Content-Security-Policy" 
-      content="default-src 'self'; script-src * 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-eval' blob:; style-src * 'unsafe-inline'; font-src *; connect-src *; frame-src *; media-src *; base-uri 'self'; upgrade-insecure-requests"/>
+      content="default-src 'self'; script-src * 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-eval' blob:; style-src * 'unsafe-inline'; font-src *; img-src *; connect-src *; frame-src *; media-src *; base-uri 'self'; upgrade-insecure-requests"/>
     <title>MCP-UI Proxy</title>
     <style>
       body,


### PR DESCRIPTION
## Summary

This PR fixes an issue in the MCP-UI proxy HTML document where image sources were unable to load. 

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  image of cheeseburger does not load (fork and knife icon expected for restaurants with no image) 
<img width="1430" height="1112" alt="image" src="https://github.com/user-attachments/assets/a1220a24-3c98-4a65-9e2b-6a5839054581" />

After:   image of cheeseburger does load (fork and knife icon expected for restaurants with no image) 
<img width="1261" height="1110" alt="image" src="https://github.com/user-attachments/assets/a61363e9-5d05-43fc-8b58-ee1d9ee4ffc5" />

