### PR TITLE
fix: Added "Merged consecutive assistant messages" to the acceptable issues for moim injection check

### DIFF
--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -26,9 +26,10 @@ pub async fn inject_moim(
 
         let (fixed, issues) = fix_conversation(Conversation::new_unvalidated(messages));
 
-        let has_unexpected_issues = issues
-            .iter()
-            .any(|issue| !issue.contains("Merged consecutive user messages"));
+        let has_unexpected_issues = issues.iter().any(|issue| {
+            !issue.contains("Merged consecutive user messages")
+                && !issue.contains("Merged consecutive assistant messages")
+        });
 
         if has_unexpected_issues {
             tracing::warn!("MOIM injection caused unexpected issues: {:?}", issues);


### PR DESCRIPTION
This happens every turn and is expected