### PR TITLE
docs: promote planning guide

### DIFF
--- a/documentation/docs/guides/config-files.md
+++ b/documentation/docs/guides/config-files.md
@@ -33,7 +33,7 @@ The following settings can be configured at the root level of your config.yaml f
 | `GOOSE_MAX_TURNS` | [Maximum number of turns](/docs/guides/sessions/smart-context-management#maximum-turns) allowed without user input | Integer (e.g., 10, 50, 100) | 1000 | No |
 | `GOOSE_LEAD_PROVIDER` | Provider for lead model in [lead/worker mode](/docs/guides/environment-variables#leadworker-model-configuration) | Same as `GOOSE_PROVIDER` options | Falls back to `GOOSE_PROVIDER` | No |
 | `GOOSE_LEAD_MODEL` | Lead model for lead/worker mode | Model name | None | No |
-| `GOOSE_PLANNER_PROVIDER` | Provider for [planning mode](/docs/guides/multi-model/creating-plans) | Same as `GOOSE_PROVIDER` options | Falls back to `GOOSE_PROVIDER` | No |
+| `GOOSE_PLANNER_PROVIDER` | Provider for [planning mode](/docs/guides/creating-plans) | Same as `GOOSE_PROVIDER` options | Falls back to `GOOSE_PROVIDER` | No |
 | `GOOSE_PLANNER_MODEL` | Model for planning mode | Model name | Falls back to `GOOSE_MODEL` | No |
 | `GOOSE_TOOLSHIM` | Enable tool interpretation | true/false | false | No |
 | `GOOSE_TOOLSHIM_OLLAMA_MODEL` | Model for tool interpretation | Model name (e.g., "llama3.2") | System default | No |

--- a/documentation/docs/guides/creating-plans.md
+++ b/documentation/docs/guides/creating-plans.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 17
+sidebar_position: 87
 title: Creating Plans Before Working
 sidebar_label: Creating Plans
 ---

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -84,7 +84,7 @@ export GOOSE_LEAD_FALLBACK_TURNS=2
 
 ### Planning Mode Configuration
 
-These variables control goose's [planning functionality](/docs/guides/multi-model/creating-plans).
+These variables control goose's [planning functionality](/docs/guides/creating-plans).
 
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
@@ -201,7 +201,7 @@ These variables allow you to override the default context window size (token lim
 | `GOOSE_CONTEXT_LIMIT` | Override context limit for the main model | Integer (number of tokens) | Model-specific default or 128,000 |
 | `GOOSE_LEAD_CONTEXT_LIMIT` | Override context limit for the lead model in [lead/worker mode](/docs/tutorials/lead-worker) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 | `GOOSE_WORKER_CONTEXT_LIMIT` | Override context limit for the worker model in lead/worker mode | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
-| `GOOSE_PLANNER_CONTEXT_LIMIT` | Override context limit for the [planner model](/docs/guides/multi-model/creating-plans) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
+| `GOOSE_PLANNER_CONTEXT_LIMIT` | Override context limit for the [planner model](/docs/guides/creating-plans) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 
 **Examples**
 

--- a/documentation/docs/guides/multi-model/index.mdx
+++ b/documentation/docs/guides/multi-model/index.mdx
@@ -24,8 +24,8 @@ import TabItem from '@theme/TabItem';
     />
     <Card 
       title="Creating Plans Before Working"
-      description="Manual planning mode that uses a dedicated model to break complex projects into detailed, actionable steps."
-      link="/docs/guides/multi-model/creating-plans"
+      description="Manual planning mode that optionally uses a dedicated model to break complex projects into detailed, actionable steps."
+      link="/docs/guides/creating-plans"
     />
     <Card 
       title="Planning Complex Tasks"

--- a/documentation/docs/guides/sessions/smart-context-management.md
+++ b/documentation/docs/guides/sessions/smart-context-management.md
@@ -287,7 +287,7 @@ Context limits are automatically detected based on your model name, but goose pr
 | **Main** | Set context limit for the main model (also serves as fallback for other models) | LiteLLM proxies, custom models with non-standard names | `GOOSE_CONTEXT_LIMIT` |
 | **Lead** | Set larger context for planning in [lead/worker mode](/docs/tutorials/lead-worker) | Complex planning tasks requiring more context | `GOOSE_LEAD_CONTEXT_LIMIT` |
 | **Worker** | Set smaller context for execution in lead/worker mode | Cost optimization during execution phase | `GOOSE_WORKER_CONTEXT_LIMIT` |
-| **Planner** | Set context for [planner models](/docs/guides/multi-model/creating-plans) | Large planning tasks requiring extensive context | `GOOSE_PLANNER_CONTEXT_LIMIT` |
+| **Planner** | Set context for [planner models](/docs/guides/creating-plans) | Large planning tasks requiring extensive context | `GOOSE_PLANNER_CONTEXT_LIMIT` |
 
 :::info
 This setting only affects the displayed token usage and progress indicators. Actual context management is handled by your LLM, so you may experience more or less usage than the limit you set, regardless of what the display shows.

--- a/documentation/docs/tutorials/lead-worker.md
+++ b/documentation/docs/tutorials/lead-worker.md
@@ -113,7 +113,7 @@ export RUST_LOG=goose::providers::lead_worker=info
 ```
 
 ## Planning Mode Compatibility
-The lead/worker model is an automatic alternative to the [goose CLI's `/plan` command](/docs/guides/multi-model/creating-plans). You can assign separate models to use as the lead/worker and planning models. For example:
+The lead/worker model is an automatic alternative to the [goose CLI's `/plan` command](/docs/guides/creating-plans). You can assign separate models to use as the lead/worker and planning models. For example:
 
 ```bash
 export GOOSE_PROVIDER="openai"

--- a/documentation/docs/tutorials/plan-feature-devcontainer-setup.md
+++ b/documentation/docs/tutorials/plan-feature-devcontainer-setup.md
@@ -10,7 +10,7 @@ description: "Learn how to use goose's Plan feature to break down complex tasks 
 
 Using goose for large, complex tasks can feel overwhelming, especially when you're unsure of exactly how you want to approach it in advance. I experienced this when I needed to set up a complex development environment for an [API course](https://github.com/LinkedInLearning/java-automated-api-testing-with-rest-assured-5989068) I published. Between Docker configurations, database initialization, devcontainer setup, and GitHub Codespaces integration, there are dozens of moving pieces that need to work together perfectly. One missing configuration or incorrect dependency can derail the entire process.
 
-This tutorial shows you how to use goose's [Plan feature](/docs/guides/multi-model/creating-plans) to transform a complex devcontainer setup into a systematic, executable roadmap. You'll learn how to brainstorm with goose, refine your requirements, and let goose create both a detailed plan and implementation checklist.
+This tutorial shows you how to use goose's [Plan feature](/docs/guides/creating-plans) to transform a complex devcontainer setup into a systematic, executable roadmap. You'll learn how to brainstorm with goose, refine your requirements, and let goose create both a detailed plan and implementation checklist.
 
 ## What You'll Learn
 

--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -164,8 +164,8 @@ const config: Config = {
             to: '/docs/tutorials/goose-in-docker'
           },
           {
-            from: '/docs/guides/creating-plans',
-            to: '/docs/guides/multi-model/creating-plans'
+            from: '/docs/guides/multi-model/creating-plans',
+            to: '/docs/guides/creating-plans'
           },
           {
             from: '/docs/guides/config-file',


### PR DESCRIPTION
## Summary
This PR moves the "Creating Plans Before Working" topic out of the "Multi-Model Configuration" section and directly under /guides.

- `documentation/docs/guides/creating-plans.md`:
  - Moved topic and updated sidebar_position
 - `documentation/docusaurus.config.ts`:
   - Reverse redirect
   
- Updated links:
  - `documentation/docs/guides/config-files.md`
  - `documentation/docs/guides/environment-variables.md`
  - `documentation/docs/guides/multi-model/index.mdx`
    - I think this page is still useful for discovery even though it no longer has any child topics. The /plan feature allows you to configure a planner model.
  - `documentation/docs/guides/sessions/smart-context-management.md`
  - `documentation/docs/tutorials/lead-worker.md`
  - `documentation/docs/tutorials/plan-feature-devcontainer-setup.md`

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
Manual testing

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212240451925508