### PR TITLE
docs: add videos to multi-model page

### DIFF
--- a/documentation/docs/guides/multi-model/index.mdx
+++ b/documentation/docs/guides/multi-model/index.mdx
@@ -60,7 +60,7 @@ import VideoCarousel from '@site/src/components/VideoCarousel';
   videos={[
     { 
       type: 'iframe', 
-      src: 'https://youtube.com/embed/ZyhUTsChFUw',
+      src: 'https://www.youtube.com/embed/ZyhUTsChFUw',
       title: 'goose\'s Multi-Model Setup',
       description: 'Learn about lead/worker mode, from configuration to best practices',
       duration: '5:01'


### PR DESCRIPTION
## Summary
This PR adds related videos to the "Multi-Model Configuration" page.

- `documentation/docs/guides/multi-model/index.mdx`:
  - Add "More Videos" section and VideoCarousel component with lead/worker mode videos

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [X] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
Manual testing