### PR TITLE
fix: add conditional configuration for GOOSE_BIN_DIR in PATH

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -319,16 +319,18 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
     echo "or rerun this install script after updating your PATH."
   else
     SHELL_NAME=$(basename "$SHELL")
-    
+
     echo ""
     echo "The \$GOOSE_BIN_DIR is not in your PATH."
-    echo "What would you like to do?"
-    echo "1) Add it for me"
-    echo "2) I'll add it myself, show instructions"
-    
-    read -p "Enter choice [1/2]: " choice
-    
-    case "$choice" in
+
+    if [ "$CONFIGURE" = true ]; then
+      echo "What would you like to do?"
+      echo "1) Add it for me"
+      echo "2) I'll add it myself, show instructions"
+
+      read -p "Enter choice [1/2]: " choice
+
+      case "$choice" in
       1)
         RC_FILE="$HOME/.${SHELL_NAME}rc"
         echo "Adding \$GOOSE_BIN_DIR to $RC_FILE..."
@@ -344,7 +346,12 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
       *)
         echo "Invalid choice. Please add \$GOOSE_BIN_DIR to your PATH manually."
         ;;
-    esac
+      esac
+    else
+      echo ""
+      echo "Configure disabled. Please add \$GOOSE_BIN_DIR to your PATH manually."
+    fi
+
   fi
   
   echo ""


### PR DESCRIPTION
## Summary
This pull request introduces a conditional check to the `download_cli.sh` script, improving how the script handles adding `GOOSE_BIN_DIR` to the user's `PATH`. The main change is that the script now respects a `CONFIGURE` flag, which allows users to skip interactive configuration and receive manual instructions instead.

Enhancements to PATH configuration logic:

* Added a check for the `CONFIGURE` environment variable to determine whether to prompt the user interactively or simply show manual instructions for adding `GOOSE_BIN_DIR` to the `PATH`.
* If `CONFIGURE` is not enabled, the script now displays a message indicating that configuration is disabled and instructs the user to add `GOOSE_BIN_DIR` manually.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance
