### PR TITLE
fix: resolve mcp-hermit cleanup path expansion issue

### DIFF
--- a/ui/desktop/src/bin/node
+++ b/ui/desktop/src/bin/node
@@ -7,10 +7,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source the common setup script
-source "$SCRIPT_DIR/node-setup-common.sh"
+source "${SCRIPT_DIR}/node-setup-common.sh"
 
 # Final step: Execute node with passed arguments
-log "Executing 'node' command with arguments: $*"
-node "$@" || log "Failed to execute 'node' with arguments: $*"
+log "Executing 'node' command with arguments: ${*}"
+node "${@}" || log "Failed to execute 'node' with arguments: ${*}"
 
 log "node script completed successfully."

--- a/ui/desktop/src/bin/node-setup-common.sh
+++ b/ui/desktop/src/bin/node-setup-common.sh
@@ -10,12 +10,12 @@ set -euo pipefail
 LOG_FILE="/tmp/mcp.log"
 
 # Clear the log file at the start
-> "$LOG_FILE"
+> "${LOG_FILE}"
 
 # Function for logging
 log() {
-    local MESSAGE="$1"
-    echo "$(date +'%Y-%m-%d %H:%M:%S') - $MESSAGE" | tee -a "$LOG_FILE" >&2
+    local MESSAGE="${1}"
+    echo "$(date +'%Y-%m-%d %H:%M:%S') - ${MESSAGE}" | tee -a "${LOG_FILE}" >&2
 }
 
 # Trap errors and log them before exiting
@@ -24,31 +24,31 @@ trap 'log "An error occurred. Exiting with status $?."' ERR
 log "Starting node setup (common)."
 
 # One-time cleanup for existing Linux users to fix locking issues
-CLEANUP_MARKER=${HOME}/.config/goose/.mcp-hermit-cleanup-v1
-if [[ "$(uname -s)" == "Linux" ]] && [ ! -f "$CLEANUP_MARKER" ]; then
+CLEANUP_MARKER="${HOME}/.config/goose/.mcp-hermit-cleanup-v1"
+if [[ "$(uname -s)" == "Linux" ]] && [ ! -f "${CLEANUP_MARKER}" ]; then
     log "Performing one-time cleanup of old mcp-hermit directory to fix locking issues."
-    if [ -d ${HOME}/.config/goose/mcp-hermit ]; then
-        rm -rf ${HOME}/.config/goose/mcp-hermit
+    if [ -d "${HOME}/.config/goose/mcp-hermit" ]; then
+        rm -rf "${HOME}/.config/goose/mcp-hermit"
         log "Removed old mcp-hermit directory."
     fi
-    touch "$CLEANUP_MARKER"
+    touch "${CLEANUP_MARKER}"
     log "Cleanup completed. Marker file created."
 fi
 
 # Ensure ${HOME}/.config/goose/mcp-hermit/bin exists
 log "Creating directory ${HOME}/.config/goose/mcp-hermit/bin if it does not exist."
-mkdir -p ${HOME}/.config/goose/mcp-hermit/bin
+mkdir -p "${HOME}/.config/goose/mcp-hermit/bin"
 
 # Change to the ${HOME}/.config/goose/mcp-hermit directory
 log "Changing to directory ${HOME}/.config/goose/mcp-hermit."
-cd ${HOME}/.config/goose/mcp-hermit
+cd "${HOME}/.config/goose/mcp-hermit"
 
 
 # Check if hermit binary exists and download if not
-if [ ! -f ${HOME}/.config/goose/mcp-hermit/bin/hermit ]; then
+if [ ! -f "${HOME}/.config/goose/mcp-hermit/bin/hermit" ]; then
     log "Hermit binary not found. Downloading hermit binary."
     curl -fsSL "https://github.com/cashapp/hermit/releases/download/stable/hermit-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/').gz" \
-        | gzip -dc > ${HOME}/.config/goose/mcp-hermit/bin/hermit && chmod +x ${HOME}/.config/goose/mcp-hermit/bin/hermit
+        | gzip -dc > "${HOME}/.config/goose/mcp-hermit/bin/hermit" && chmod +x "${HOME}/.config/goose/mcp-hermit/bin/hermit"
     log "Hermit binary downloaded and made executable."
 else
     log "Hermit binary already exists. Skipping download."
@@ -56,42 +56,42 @@ fi
 
 
 log "setting hermit cache to be local for MCP servers"
-mkdir -p ${HOME}/.config/goose/mcp-hermit/cache
-export HERMIT_STATE_DIR=${HOME}/.config/goose/mcp-hermit/cache
+mkdir -p "${HOME}/.config/goose/mcp-hermit/cache"
+export HERMIT_STATE_DIR="${HOME}/.config/goose/mcp-hermit/cache"
 
 
 # Update PATH
-export PATH=${HOME}/.config/goose/mcp-hermit/bin:$PATH
+export PATH="${HOME}/.config/goose/mcp-hermit/bin:${PATH}"
 log "Updated PATH to include ${HOME}/.config/goose/mcp-hermit/bin."
 
 
 # Verify hermit installation
 log "Checking for hermit in PATH."
-which hermit >> "$LOG_FILE"
+which hermit >> "${LOG_FILE}"
 
 # Check if hermit environment is already initialized (only run init on first setup)
-if [ ! -f bin/activate-hermit ]; then
+if [ ! -f "bin/activate-hermit" ]; then
     log "Hermit environment not yet initialized. Setting up hermit."
 
     # Fix hermit self-update lock issues on Linux by using temp binary for init only
     if [[ "$(uname -s)" == "Linux" ]]; then
         log "Creating temp dir with bin subdirectory for hermit copy to avoid self-update locks."
         HERMIT_TMP_DIR="/tmp/hermit_tmp_$$/bin"
-        mkdir -p "$HERMIT_TMP_DIR"
-        cp ${HOME}/.config/goose/mcp-hermit/bin/hermit "$HERMIT_TMP_DIR/hermit"
-        chmod +x "$HERMIT_TMP_DIR/hermit"
-        export PATH="$HERMIT_TMP_DIR:$PATH"
+        mkdir -p "${HERMIT_TMP_DIR}"
+        cp "${HOME}/.config/goose/mcp-hermit/bin/hermit" "${HERMIT_TMP_DIR}/hermit"
+        chmod +x "${HERMIT_TMP_DIR}/hermit"
+        export PATH="${HERMIT_TMP_DIR}:${PATH}"
         HERMIT_CLEANUP_DIR="/tmp/hermit_tmp_$$"
     fi
 
     # Initialize hermit
     log "Initializing hermit."
-    hermit init >> "$LOG_FILE"
+    hermit init >> "${LOG_FILE}"
 
     # Clean up temp dir if it was created
     if [[ -n "${HERMIT_CLEANUP_DIR:-}" ]]; then
         log "Cleaning up temporary hermit binary directory."
-        rm -rf "$HERMIT_CLEANUP_DIR"
+        rm -rf "${HERMIT_CLEANUP_DIR}"
     fi
 else
     log "Hermit environment already initialized. Skipping init."
@@ -100,12 +100,12 @@ fi
 # Activate the environment with output redirected to log
 if [[ "$(uname -s)" == "Linux" ]]; then
     log "Activating hermit environment."
-    { . bin/activate-hermit; } >> "$LOG_FILE" 2>&1
+    { . "bin/activate-hermit"; } >> "${LOG_FILE}" 2>&1
 fi
 
 # Install Node.js using hermit
 log "Installing Node.js with hermit."
-hermit install node >> "$LOG_FILE"
+hermit install node >> "${LOG_FILE}"
 
 # Verify installations
 log "Verifying installation locations:"
@@ -116,18 +116,18 @@ log "npx: $(which npx)"
 
 log "Checking for GOOSE_NPM_REGISTRY and GOOSE_NPM_CERT environment variables for custom npm registry setup..."
 # Check if GOOSE_NPM_REGISTRY is set and accessible
-if [ -n "${GOOSE_NPM_REGISTRY:-}" ] && curl -s --head --fail "$GOOSE_NPM_REGISTRY" > /dev/null; then
-    log "Checking custom goose registry availability: $GOOSE_NPM_REGISTRY"
-    log "$GOOSE_NPM_REGISTRY is accessible. Using it for npm registry."
-    export NPM_CONFIG_REGISTRY="$GOOSE_NPM_REGISTRY"
+if [ -n "${GOOSE_NPM_REGISTRY:-}" ] && curl -s --head --fail "${GOOSE_NPM_REGISTRY}" > /dev/null; then
+    log "Checking custom goose registry availability: ${GOOSE_NPM_REGISTRY}"
+    log "${GOOSE_NPM_REGISTRY} is accessible. Using it for npm registry."
+    export NPM_CONFIG_REGISTRY="${GOOSE_NPM_REGISTRY}"
 
     # Check if GOOSE_NPM_CERT is set and accessible
-    if [ -n "${GOOSE_NPM_CERT:-}" ] && curl -s --head --fail "$GOOSE_NPM_CERT" > /dev/null; then
-        log "Downloading certificate from: $GOOSE_NPM_CERT"
-        curl -sSL -o ${HOME}/.config/goose/mcp-hermit/cert.pem "$GOOSE_NPM_CERT"
+    if [ -n "${GOOSE_NPM_CERT:-}" ] && curl -s --head --fail "${GOOSE_NPM_CERT}" > /dev/null; then
+        log "Downloading certificate from: ${GOOSE_NPM_CERT}"
+        curl -sSL -o "${HOME}/.config/goose/mcp-hermit/cert.pem" "${GOOSE_NPM_CERT}"
         if [ $? -eq 0 ]; then
             log "Certificate downloaded successfully."
-            export NODE_EXTRA_CA_CERTS=${HOME}/.config/goose/mcp-hermit/cert.pem
+            export NODE_EXTRA_CA_CERTS="${HOME}/.config/goose/mcp-hermit/cert.pem"
         else
             log "Unable to download the certificate. Skipping certificate setup."
         fi

--- a/ui/desktop/src/bin/npx
+++ b/ui/desktop/src/bin/npx
@@ -7,10 +7,10 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source the common setup script
-source "$SCRIPT_DIR/node-setup-common.sh"
+source "${SCRIPT_DIR}/node-setup-common.sh"
 
 # Final step: Execute npx with passed arguments
-log "Executing 'npx' command with arguments: $*"
-npx "$@" || log "Failed to execute 'npx' with arguments: $*"
+log "Executing 'npx' command with arguments: ${*}"
+npx "${@}" || log "Failed to execute 'npx' with arguments: ${*}"
 
 log "npx script completed successfully."


### PR DESCRIPTION
## Summary
Issue: mcp-hermit cleanup fails with "No such file or directory" error - this was already fixed recently by replacing tilde with ${HOME} variable

Solution: Add proper quoting to the cleanup marker path to prevent shell expansion issues and ensure robust path handling

The root cause was already addressed in a recent PR, but this adds additional safety with proper quoting around path variables.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Related Issues
Relates to #5944 
