### PR TITLE
fix: include file attachments in queued messages

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -815,7 +815,7 @@ export default function ChatInput({
 
   // Helper function to handle interruption and queue logic when loading
   const handleInterruptionAndQueue = () => {
-    if (!isLoading || !displayValue.trim()) {
+    if (!isLoading || !hasSubmittableContent) {
       return false;
     }
 


### PR DESCRIPTION
**Closes:** #5866

## PR Description

This PR fixes an issue where queued messages were being sent **without** their attached files. when a user queued a message while another prompt was still processing, any drag-and-dropped or pasted files were not included. The issue was that the `handleInterruptionAndQueue()` only stored the trimmed text value and ignored file paths from `pastedImages` and `allDroppedFiles`, causing queued messages to lose their attachments and not count it as one message, even though `performSubmit()` handles file paths correctly.

## Changes made 

- Extracts file paths from `pastedImages` and `allDroppedFiles.`
- Builds a unified `contentToQueue` that combines text and file paths to count them as one.
- Replaces the previous `displayValue.trim()` usage with `contentToQueue`.
- Clears `pastedImages` and `droppedFiles` after queuing to prevent duplication.

## Type of Change

- [x] Bug fix

## AI Assistance

- [x] This PR was created or reviewed with AI assistance - used Goose to find the root cause 

## Testing

Tested in the desktop UI by dragging and dropping file attachments while another message was in progress, confirming the queued message includes attachments correctly.

## Screenshots / Demos (for UX changes)

**Before:**  

![beforeQueued-ezgif com-censor](https://github.com/user-attachments/assets/7cc9ef7f-3539-4f59-a432-603ba5de2c39)

**After:**  

![aferQueued-ezgif com-optimize](https://github.com/user-attachments/assets/53706756-96c8-41b1-9a8d-8d266e0c3ce5)
