### PR TITLE
fix(providers): fix for gemini-cli on windows to work around cmd's multiline prompt limitations #5911

### DIFF
--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -24,7 +24,7 @@ pub const GEMINI_CLI_DEFAULT_MODEL: &str = "gemini-2.5-pro";
 pub const GEMINI_CLI_KNOWN_MODELS: &[&str] = &[
     "gemini-2.5-pro",
     "gemini-2.5-flash",
-    "gemini-2.5-flash-lite"
+    "gemini-2.5-flash-lite",
 ];
 
 pub const GEMINI_CLI_DOC_URL: &str = "https://ai.google.dev/gemini-api/docs";


### PR DESCRIPTION
## Summary
Fixed an issue with gemini-cli on windows where prompts are given in a string to a `cmd` file. Multiline breaks the cmd's execution, so in case of windows, linebreaks are replaced by the next best thing.
Also stopped rejecting gemini-2.5-flash, and gemini-2.5-flash-lite

### Type of Change
- [x] Bug fix
- [x] Other (specify below)

### AI Assistance
- [ ] This PR was created or reviewed with AI assistance

### Testing
Manually tested adding gemini-cli. Tic-Tac-Toe example created and running (tools-use)

### Related Issues
Relates to #5911 
And solves it.