### PR TITLE
Don't persist ephemeral extensions when resuming sessions

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -4,8 +4,8 @@ use console::style;
 use goose::agents::types::{RetryConfig, SessionConfig};
 use goose::agents::Agent;
 use goose::config::{
-    extensions::{get_extension_by_name, set_extension, ExtensionEntry},
-    get_all_extensions, get_enabled_extensions, Config, ExtensionConfig,
+    extensions::get_extension_by_name, get_all_extensions, get_enabled_extensions, Config,
+    ExtensionConfig,
 };
 use goose::providers::create;
 use goose::recipe::{Response, SubRecipe};
@@ -220,7 +220,7 @@ fn check_missing_extensions_or_exit(saved_extensions: &[ExtensionConfig]) {
             .join(", ");
 
         if !cliclack::confirm(format!(
-            "Extension(s) {} from previous session are no longer in config. Re-add them to config?",
+            "Extension(s) {} from previous session are no longer available. Restore for this session?",
             names
         ))
         .initial_value(true)
@@ -230,13 +230,6 @@ fn check_missing_extensions_or_exit(saved_extensions: &[ExtensionConfig]) {
             println!("{}", style("Resume cancelled.").yellow());
             process::exit(0);
         }
-
-        missing.into_iter().for_each(|config| {
-            set_extension(ExtensionEntry {
-                enabled: true,
-                config,
-            });
-        });
     }
 }
 


### PR DESCRIPTION
Fixes #5973

## Summary

When resuming sessions with ephemeral extensions (added via `--with-extension`) or recipe extensions, they should be restored for the session only, not permanently saved to config. Otherwise the user ends up with a duplicate garbage extension entry in `~/.config/goose/config.yaml`:
```
goose session --with-extension "uvx mcp_gdrive@latest"
# ... do work, exit session ...

goose session --resume --session-id <id>
# Prompt: "Extension(s) mcpgdrive_sgoMpj77 from previous session are no longer in config. Re-add them to config?"
# Answer: Yes
```
now `~/.config/goose/config.yaml` has:
```
  mcpgdrivelatest_gbtrm2lw:
    enabled: true
    type: stdio
    name: mcpgdrivelatest_gBtrm2lw
    description: ''
    cmd: uvx
    args:
    - mcp_gdrive@latest
    envs: {}
    env_keys: []
    timeout: 300
    bundled: null
    available_tools: []
```

## Changes

- Updated prompt message: "Restore for this session?" (was "Re-add them to config?")
- Removed `set_extension()` call that wrote to config.yaml
- Cleaned up unused imports

## Root cause

`check_missing_extensions_or_exit()` called `set_extension()` which writes to config.yaml. Unnecessary since extensions are already restored from `saved_state.extensions`.