### PR TITLE
Fix typo in prompt

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1891,7 +1891,7 @@ fn add_provider() -> anyhow::Result<()> {
         .mask('▪')
         .interact()?;
 
-    let models_input: String = cliclack::input("Available models (seperate with commas):")
+    let models_input: String = cliclack::input("Available models (separate with commas):")
         .placeholder("model-a, model-b, model-c")
         .validate(|input: &String| {
             if input.trim().is_empty() {


### PR DESCRIPTION
## Summary
This PR fixes the typo "seperate" in a `goose configure` prompt for available models input

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [x] Other (specify below)

Typo fix

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance