### PR TITLE
Hide recipe icon in empty chat

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1507,7 +1507,7 @@ export default function ChatInput({
               <BottomMenuExtensionSelection sessionId={sessionId} />
             </>
           )}
-          {sessionId && (
+          {sessionId && messages.length > 0 && (
             <>
               <div className="w-px h-4 bg-border-default mx-2" />
               <div className="flex items-center h-full">


### PR DESCRIPTION
## Summary
Noticed we're showing the recipe icon when empty chat. Should only show when we have messages.
