### PR TITLE
Fix community page mobile responsiveness and horizontal overflow

### DIFF
--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -417,3 +417,50 @@ html[data-theme="light"] .hide-in-light {
 .button-grant h2 {
   margin-top: 15px;
 }
+
+/* Prevent horizontal overflow */
+html, body {
+  overflow-x: hidden;
+  max-width: 100%;
+}
+
+/* Ensure skip to content link doesn't cause horizontal scroll */
+.skipToContent_fXgn {
+  position: absolute !important;
+  left: -9999px !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+}
+
+.skipToContent_fXgn:focus {
+  position: fixed !important;
+  left: 10px !important;
+  top: 10px !important;
+  width: auto !important;
+  height: auto !important;
+  overflow: visible !important;
+  z-index: 9999 !important;
+  padding: 10px 20px !important;
+  background: var(--background-prominent) !important;
+  color: var(--text-prominent) !important;
+  border-radius: 4px !important;
+}
+
+/* Ensure all containers respect viewport width */
+.container {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+/* Prevent navbar from causing horizontal overflow */
+.navbar {
+  max-width: 100%;
+  overflow-x: hidden;
+}
+
+/* Ensure main content doesn't overflow */
+main {
+  max-width: 100%;
+  overflow-x: hidden;
+}

--- a/documentation/src/pages/community/index.tsx
+++ b/documentation/src/pages/community/index.tsx
@@ -96,7 +96,7 @@ function CommunityAllStarsSection() {
         </p>
       </div>
       
-      <div className="flex justify-center">
+      <div className="flex flex-wrap justify-center gap-4 w-full px-4">
         {currentData.communityStars.map((contributor, index) => (
           <StarsCard key={index} contributor={contributor} />
         ))}
@@ -112,7 +112,7 @@ function CommunityAllStarsSection() {
             </p>
           </div>
           
-          <div className="flex justify-center">
+          <div className="flex flex-wrap justify-center gap-4 w-full px-4">
             {currentData.teamStars.map((contributor, index) => (
               <StarsCard key={index} contributor={{...contributor, totalCount: currentData.teamStars.length}} />
             ))}
@@ -413,9 +413,9 @@ function ContentCard({ content }): ReactNode {
 
 export function StarsCard({contributor}): ReactNode {
   return (
-    <div className={`col ${contributor.totalCount <= 3 ? 'col--4' : 'col--2'} mb-8`}>
+    <div className="w-full sm:w-[calc(50%-0.5rem)] md:w-[calc(33.333%-0.67rem)] lg:w-[calc(20%-0.8rem)] max-w-[280px]">
       <div 
-        className="h-full border-2 border-borderSubtle rounded-2xl cursor-pointer hover:shadow-xl hover:border-[var(--ifm-color-primary-dark)]"
+        className="h-full border-2 border-borderSubtle rounded-2xl cursor-pointer hover:shadow-xl hover:border-[var(--ifm-color-primary-dark)] transition-all"
       >
         <div className="card__header text-center">
           <div className="avatar avatar--vertical">


### PR DESCRIPTION
## Problem

@sheikhlimon reported "@taniandjerry @blackgirlbytes I think there's a Mobile layout issue on Community Stars Section StarsCard don't properly stack on smaller screens"


The community page had horizontal overflow issues on mobile and tablet devices, caused by:
2. Community Stars cards not properly wrapping on smaller screens
3. No defensive CSS to prevent horizontal scroll

This created ~12px of unwanted horizontal space, making the page scroll horizontally on mobile devices.

## Solution
### CSS Fixes (`documentation/src/css/custom.css`)
- Added `overflow-x: hidden` to `html`, `body`, and main containers
- Fixed skip-to-content link positioning to use `position: absolute` with `left: -9999px` when hidden
- Maintained accessibility by properly showing the link on focus
- Added `max-width: 100%` to prevent any element from exceeding viewport width

### Component Fixes (`documentation/src/pages/community/index.tsx`)
- Replaced Docusaurus `col` classes with Tailwind responsive width utilities
- Added proper responsive breakpoints for StarsCard component:
  - Mobile: 100% width
  - Small screens: 50% width (2 columns)
  - Medium screens: 33.333% width (3 columns)
  - Large screens: 20% width (5 columns)
- Added `flex-wrap` and proper gap spacing for community stars grid
- Added `transition-all` for smoother hover effects

## Testing
Verified no horizontal overflow at multiple viewport sizes:
- ✅ Mobile (500px width)
- ✅ Tablet (768px width)
- ✅ Desktop (1200px width)
- ✅ Large Desktop (1440px width)

## Screenshots
Before: Community stars had to scroll horizontally
<img width="876" height="872" alt="Screenshot 2025-12-11 at 5 55 56 PM" src="https://github.com/user-attachments/assets/e9ccd59f-0a6e-4b5c-89de-f35b50dbc075" />

<img width="584" height="346" alt="Screenshot 2025-12-11 at 5 43 13 PM" src="https://github.com/user-attachments/assets/e68ff7ae-1806-4569-8dde-74647d6f4fc7" />


After: Community stars vertically stacked
<img width="517" height="864" alt="Screenshot 2025-12-11 at 5 56 24 PM" src="https://github.com/user-attachments/assets/b981a4b3-9493-4d8d-8b61-2ebbd65316ba" />

<img width="879" height="862" alt="Screenshot 2025-12-11 at 5 56 11 PM" src="https://github.com/user-attachments/assets/3c0183c3-75cf-474b-8518-45f6e1f0794f" />


Yes, I used goose for this PR. 