### PR TITLE
Prompt fix to encourage waiting for params from previous subrecipe

### DIFF
--- a/crates/goose/src/agents/recipe_tools/dynamic_task_tools.rs
+++ b/crates/goose/src/agents/recipe_tools/dynamic_task_tools.rs
@@ -114,7 +114,13 @@ pub fn create_dynamic_task_tool() -> Tool {
 
     Tool::new(
         DYNAMIC_TASK_TOOL_NAME_PREFIX.to_string(),
-        "Create tasks with instructions or prompt. For simple tasks, only include the instructions field. Extensions control: omit field = use all current extensions; empty array [] = no extensions; array with names = only those extensions. Specify extensions as shortnames (the prefixes for your tools). Specify return_last_only as true and have your subagent summarize its work in its last message to conserve your own context. Optional: title, description, extensions, settings, retry, response schema, activities. Arrays for multiple tasks.".to_string(),
+        "Create tasks with instructions or prompt. For simple tasks, only include the instructions field. \
+        Extensions control: omit field = use all current extensions; empty array [] = no extensions; array with names = only those extensions. \
+        Specify extensions as shortnames (the prefixes for your tools). \
+        Specify return_last_only as true and have your subagent summarize its work in its last message to conserve your own context. \
+        Optional: title, description, extensions, settings, retry, response schema, activities. Arrays for multiple tasks.\n\n\
+        IMPORTANT: Each task runs in an isolated session. If a later task needs data from an earlier task's output, \
+        create and execute them one at a time so you can inspect the output and pass the needed information in the next task's instructions.".to_string(),
         input_schema,
     ).annotate(ToolAnnotations {
         title: Some("Create Dynamic Tasks".to_string()),

--- a/crates/goose/src/agents/recipe_tools/sub_recipe_tools.rs
+++ b/crates/goose/src/agents/recipe_tools/sub_recipe_tools.rs
@@ -29,7 +29,9 @@ pub fn create_sub_recipe_task_tool(sub_recipe: &SubRecipe) -> Tool {
             - For a single task: provide an array with one parameter set\n\
             - For multiple tasks: provide an array with multiple parameter sets, each with different values\n\n\
             Each task will run the same sub recipe but with different parameter values. \
-            This is useful when you need to execute the same sub recipe multiple times with varying inputs. \
+            This is useful when you need to execute the same sub recipe multiple times with varying inputs.\n\n\
+            IMPORTANT: Each task runs in an isolated session. If a later task needs data from an earlier task's output, \
+            create and execute them one at a time so you can inspect the output and pass the needed information as parameters to the next task. \
             After creating the tasks and execution_mode is provided, pass them to the task executor to run these tasks",
             sub_recipe.name
         ),


### PR DESCRIPTION
Fixes https://github.com/block/goose/issues/6078.

I don't see a mechanism where we would pipe the output from one recipe directly to a parameter of another, so this encourages the agent to think critically about if there might be a dependency here. If there is, it should run the subrecipes one at a time, and fill the parameters on the subsequent subrecipe afterwards.
