### PR TITLE
chore: avoid accidentally using native tls again

### DIFF
--- a/scripts/check-no-native-tls.sh
+++ b/scripts/check-no-native-tls.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# Prevent native-tls/OpenSSL from being added to the dependency tree.
+# These cause Linux compatibility issues with OpenSSL version mismatches.
+# See: https://github.com/block/goose/issues/6034
+
+set -e
+
+BANNED_CRATES=("native-tls" "openssl-sys" "openssl")
+FOUND_BANNED=0
+
+for crate in "${BANNED_CRATES[@]}"; do
+    if cargo tree -i "$crate" 2>/dev/null | grep -q "$crate"; then
+        echo "ERROR: Found banned crate '$crate' in dependency tree"
+        echo "This causes Linux compatibility issues with OpenSSL versions."
+        echo "Use rustls-based alternatives instead (e.g., rustls-tls-native-roots)."
+        echo ""
+        echo "Dependency chain:"
+        cargo tree -i "$crate"
+        echo ""
+        FOUND_BANNED=1
+    fi
+done
+
+if [ $FOUND_BANNED -eq 1 ]; then
+    exit 1
+fi
+
+echo "✓ No banned TLS crates found (native-tls, openssl, openssl-sys)"

--- a/scripts/clippy-lint.sh
+++ b/scripts/clippy-lint.sh
@@ -36,4 +36,7 @@ run_clippy
 echo ""
 check_all_baseline_rules
 echo ""
+echo "🔒 Checking for banned TLS crates..."
+"$SCRIPT_DIR/check-no-native-tls.sh"
+echo ""
 echo "✅ Done"


### PR DESCRIPTION
to prevent such things like this: 

https://github.com/block/goose/pull/6051

this hopefully checks that we don't use native-tls. It has caused issues before and rust tls is hardened, audited and well used. 