### PR TITLE
fix old sessions with tool results not loading

### DIFF
--- a/crates/goose/src/conversation/message.rs
+++ b/crates/goose/src/conversation/message.rs
@@ -1306,9 +1306,6 @@ mod tests {
 
     #[test]
     fn test_legacy_tool_response_deserialization() {
-        // Test backwards compatibility: old sessions stored tool_result.value as Vec<Content>
-        // directly, but new format wraps it in CallToolResult with a content field.
-        // This test ensures we can still load old session data.
         let legacy_json = r#"{
             "role": "user",
             "created": 1640995200,
@@ -1349,7 +1346,6 @@ mod tests {
 
     #[test]
     fn test_new_tool_response_deserialization() {
-        // Test that the new format (with CallToolResult struct) also works
         let new_json = r#"{
             "role": "user",
             "created": 1640995200,

--- a/crates/goose/src/conversation/tool_result_serde.rs
+++ b/crates/goose/src/conversation/tool_result_serde.rs
@@ -67,8 +67,6 @@ where
     }
 }
 
-/// Backwards-compatible serde module for ToolResult<CallToolResult>.
-/// Handles both the new CallToolResult format and legacy Vec<Content> format from older sessions.
 pub mod call_tool_result {
     use super::*;
     use rmcp::model::{CallToolResult, Content};
@@ -90,12 +88,10 @@ pub mod call_tool_result {
         #[derive(Deserialize)]
         #[serde(untagged)]
         enum ResultFormat {
-            // New format: value is a CallToolResult struct with content field
             NewSuccess {
                 status: String,
                 value: CallToolResult,
             },
-            // Legacy format: value was Vec<Content> directly
             LegacySuccess {
                 status: String,
                 value: Vec<Content>,
@@ -121,7 +117,6 @@ pub mod call_tool_result {
             }
             ResultFormat::LegacySuccess { status, value } => {
                 if status == "success" {
-                    // Convert legacy Vec<Content> to CallToolResult
                     Ok(Ok(CallToolResult::success(value)))
                 } else {
                     Err(serde::de::Error::custom(format!(


### PR DESCRIPTION
## Summary
https://github.com/block/goose/pull/6074 broke loading old sessions with tool results

<img width="510" height="206" alt="Screenshot 2025-12-12 at 12 47 43 PM" src="https://github.com/user-attachments/assets/c501ca26-49df-4554-9998-e6c60b7dc14d" />

From goose:

Old sessions stored tool results as a Vec<Content> (just an array of content items), but the new code expects a CallToolResult struct which has a different shape (it wraps the content in a struct with a content field and potentially other metadata).

When deserializing old sessions, the ResultFormat enum in tool_result_serde.rs tries to parse the value field as CallToolResult, but it finds Vec<Content> instead, causing the "data did not match any variant of untagged enum ResultFormat" error.
