### PR TITLE
fix : Custom providers with empty API keys show as configured in desktop

### DIFF
--- a/crates/goose-server/src/routes/utils.rs
+++ b/crates/goose-server/src/routes/utils.rs
@@ -94,13 +94,11 @@ pub fn inspect_keys(
 pub fn check_provider_configured(metadata: &ProviderMetadata, provider_type: ProviderType) -> bool {
     let config = Config::global();
 
-    // TODO(Douwe): if the provider doesn't need an API key, it should be considered configured always
     if provider_type == ProviderType::Custom || provider_type == ProviderType::Declarative {
         if let Ok(loaded_provider) = load_provider(metadata.name.as_str()) {
             return config
                 .get_secret::<String>(&loaded_provider.config.api_key_env)
-                .map(|s| !s.is_empty())
-                .unwrap_or(false);
+                .is_ok();
         }
     }
     // Special case: Zero-config providers (no config keys)


### PR DESCRIPTION
Closes: #6047

## PR Description

This PR aims to resolve the issue with custom providers that were created via the CLI with an empty API key (valid for local or no-auth endpoints like Ollama) were incorrectly shown as **not configured** in the Desktop UI.

This was caused by `check_provider_configured()` validating that the API key was non-empty instead of checking whether it existed in the config.

## Solution

Updated `check_provider_configured()` to treat a provider as configured if the API key exists in the config, even if it is empty.

**File modified**
- `crates/goose-server/src/routes/utils.rs`

## Type of Change
- [x] Bug fix

## Testing

- Tested in Desktop UI by creating a custom provider via CLI with an empty API key

## Screenshots / Demos

Before: 
<img width="798" height="466" alt="image" src="https://github.com/user-attachments/assets/687d81a2-83d1-413c-8d2e-ffb0a40ce20e" />

 After: 
![afterEmptyString](https://github.com/user-attachments/assets/4086b2fb-a872-40c2-94d7-9932f8e95af2)
