### PR TITLE
fix: filter tools in Ollama streaming when chat mode is enabled

### DIFF
--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -254,11 +254,19 @@ impl Provider for OllamaProvider {
         messages: &[Message],
         tools: &[Tool],
     ) -> Result<MessageStream, ProviderError> {
+        let config = crate::config::Config::global();
+        let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
+        let filtered_tools = if goose_mode == GooseMode::Chat {
+            &[]
+        } else {
+            tools
+        };
+
         let mut payload = create_request(
             &self.model,
             system,
             messages,
-            tools,
+            filtered_tools,
             &super::utils::ImageFormat::OpenAi,
         )?;
         payload["stream"] = json!(true);


### PR DESCRIPTION
## Summary

Fixes #6117

When using chat mode with Ollama models that don't support tool calling (e.g., `deepseek-coder:6.7b`), users were getting a 400 error:

```
Request failed: Bad request (400): registry.ollama.ai/library/deepseek-coder:6.7b does not support tools.
```

## Root Cause

The `stream()` function in the Ollama provider was not checking `GooseMode::Chat` and always passed tools to the API. The `complete_with_model()` function already had this check, but since streaming is the default behavior, the bug affected most users.

## Changes

Added the same `GooseMode::Chat` filtering logic to the `stream()` function that already exists in `complete_with_model()`:

```rust
let config = crate::config::Config::global();
let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
let filtered_tools = if goose_mode == GooseMode::Chat {
    &[]
} else {
    tools
};
```

## Testing

- Verified the fix compiles successfully
- Verified clippy passes with no warnings
- Manual testing with `deepseek-coder:6.7b` in chat mode should now work without errors

## Did I use AI?
Yes, I did. While I was looking into the problem, goose wanted to fix it, and the fix seemed plausible. 