### PR TITLE
workflow: enable docs-update-recipe-ref

### DIFF
--- a/.github/workflows/docs-update-recipe-ref.yml
+++ b/.github/workflows/docs-update-recipe-ref.yml
@@ -24,9 +24,8 @@ on:
         type: boolean
         default: true
       
-  # Uncomment to enable automatic triggering on releases
-  # release:
-  #   types: [published]
+  release:
+    types: [published]
 
 permissions:
   contents: write       # Create branches and commit files


### PR DESCRIPTION
## Summary
This PR uncomments `on: release: types[publish]` to enable the docs-update-recipe-ref workflow reviewed in PR #5988 

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [x] Build / Release - Enable GitHub Action workflow on release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Tested via workflow_dispatch (manual trigger) on fork

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1211826021955341
  - https://app.asana.com/0/0/1212247991125691