### PR TITLE
perf: Avoid repeated MCP queries during streaming responses

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -289,11 +289,11 @@ impl Agent {
     async fn categorize_tools(
         &self,
         response: &Message,
-        _tools: &[rmcp::model::Tool],
+        tools: &[rmcp::model::Tool],
     ) -> ToolCategorizeResult {
         // Categorize tool requests
         let (frontend_requests, remaining_requests, filtered_response) =
-            self.categorize_tool_requests(response).await;
+            self.categorize_tool_requests(response, tools).await;
 
         ToolCategorizeResult {
             frontend_requests,

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -270,9 +270,8 @@ impl Agent {
     pub(crate) async fn categorize_tool_requests(
         &self,
         response: &Message,
+        tools: &[Tool],
     ) -> (Vec<ToolRequest>, Vec<ToolRequest>, Message) {
-        let tools = self.list_tools(None).await;
-
         // First collect all tool requests with coercion applied
         let tool_requests: Vec<ToolRequest> = response
             .content


### PR DESCRIPTION
Pass the already-available tools to categorize_tool_requests() instead of calling list_tools() on each streaming chunk. This was causing excessive queries to MCP extensions, especially noticeable with remote MCPs.