### PR TITLE
fix: use correct parameter name in read_module handler

### DIFF
--- a/crates/goose/src/agents/code_execution_extension.rs
+++ b/crates/goose/src/agents/code_execution_extension.rs
@@ -365,9 +365,9 @@ impl CodeExecutionClient {
     ) -> Result<Vec<Content>, String> {
         let path = arguments
             .as_ref()
-            .and_then(|a| a.get("path"))
+            .and_then(|a| a.get("module_path"))
             .and_then(|v| v.as_str())
-            .ok_or("Missing required parameter: path")?;
+            .ok_or("Missing required parameter: module_path")?;
 
         let tools = self.get_tool_infos().await;
         let parts: Vec<&str> = path.trim_start_matches('/').split('/').collect();
@@ -791,7 +791,10 @@ mod tests {
         let client = CodeExecutionClient::new(context).unwrap();
 
         let mut args = JsonObject::new();
-        args.insert("path".to_string(), Value::String("nonexistent".to_string()));
+        args.insert(
+            "module_path".to_string(),
+            Value::String("nonexistent".to_string()),
+        );
 
         let result = client.handle_read_module(Some(args)).await;
         assert!(result.is_err());


### PR DESCRIPTION
## Summary

Handler is looking for 'path' but the ReadModuleParams schema defines 'module_path'. This caused the tool to fail with 'Missing required parameter: path' when the LLM correctly used 'module_path'.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Unit and manual testing with main branch build

### Related Issues
Relates to:  https://github.com/block/goose/issues/6147
