### PR TITLE
fix: we don't need to warn about tool count when in code mode

### DIFF
--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -43,7 +43,7 @@ No extensions are defined. You should let the user know that they should add ext
 {% endif %}
 {% endif %}
 
-{% if extension_tool_limits is defined %}
+{% if extension_tool_limits is defined and not code_execution_mode %}
 {% with (extension_count, tool_count) = extension_tool_limits  %}
 # Suggestion
 


### PR DESCRIPTION
when code mode is enabled, we don't enumerate all the tools, so we don't need to warn about size, or add this extra noise to the system prompt as it isn't relevant.