### PR TITLE
fix : opening a session to view it modifies session history order in desktop

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -283,7 +283,7 @@ async fn resume_agent(
                     })?;
 
             agent
-                .update_provider(provider, &payload.session_id)
+                .load_provider(provider)
                 .await
                 .map_err(|e| ErrorResponse {
                     message: format!("Could not configure agent: {}", e),

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1326,6 +1326,14 @@ impl Agent {
             .context("Failed to persist provider config to session")
     }
 
+    pub async fn load_provider(&self, provider: Arc<dyn Provider>) -> Result<()> {
+        let mut current_provider = self.provider.lock().await;
+        *current_provider = Some(provider.clone());
+
+        self.update_router_tool_selector(Some(provider.clone()), None)
+            .await
+    }
+
     pub async fn update_router_tool_selector(
         &self,
         provider: Option<Arc<dyn Provider>>,


### PR DESCRIPTION
Closes: #6140

## PR Description

This PR fixes an issue where opening a session from the History tab in read-only mode updated the session’s `updated_at` timestamp, causing it to move to the top of the history list and break chronological ordering.
The root cause was that `resume_agent()` was calling `update_provider()`, which persisted provider data to the database and updated the `updated_at` timestamp even when the session was only being viewed.

### Changes Made

To fix this, a new `load_provider()` method was introduced to restore the provider state in memory only, without writing to the database or updating timestamps. `resume_agent()` now uses this method when loading sessions from history.

- Added `load_provider()` to restore provider state without persistence  
- Updated `resume_agent()` to use `load_provider()` instead of `update_provider()`

## Type of Change
- [x] Bug fix

## AI Assistance
- [x] This PR was created or reviewed with AI assistance - used Goose to test different approaches for the solution

## Testing

Tested in the Desktop UI by opening sessions from the History tab and confirming the session order remains unchanged.

## Screenshots / Demos

**Before:**
![beforeHistory](https://github.com/user-attachments/assets/c046e00d-1706-4ada-a347-8700d1c42c2e)


**After:** 

![afterHistory](https://github.com/user-attachments/assets/59fe5fc8-70bf-4146-a616-5c01dd56b98c)

