### PR TITLE
fix: respect default_enabled value of platform extensions

### DIFF
--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -66,7 +66,7 @@ fn get_extensions_map() -> IndexMap<String, ExtensionEntry> {
                             bundled: Some(true),
                             available_tools: Vec::new(),
                         },
-                        enabled: true,
+                        enabled: def.default_enabled,
                     },
                 );
             }


### PR DESCRIPTION
Right now when adding new platform extensions to the config we do not honor the `default_enabled` value they have configured and just always turn them on. This makes it respect that config value.

I noticed this because `code_execution` was being turned on when added and I didn't expect that