### PR TITLE
fix: when changing modes mid chat or in settings need to notify

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1547,7 +1547,7 @@ export default function ChatInput({
             </div>
           </Tooltip>
           <div className="w-px h-4 bg-border-default mx-2" />
-          <BottomMenuModeSelection />
+          <BottomMenuModeSelection hasActiveSession={messages.length > 0} />
           {sessionId && process.env.ALPHA && (
             <>
               <div className="w-px h-4 bg-border-default mx-2" />

--- a/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuModeSelection.tsx
@@ -9,8 +9,13 @@ import {
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
 import { trackModeChanged } from '../../utils/analytics';
+import { toast } from 'react-toastify';
 
-export const BottomMenuModeSelection = () => {
+interface BottomMenuModeSelectionProps {
+  hasActiveSession?: boolean;
+}
+
+export const BottomMenuModeSelection = ({ hasActiveSession }: BottomMenuModeSelectionProps) => {
   const [gooseMode, setGooseMode] = useState('auto');
   const { read, upsert } = useConfig();
 
@@ -38,6 +43,16 @@ export const BottomMenuModeSelection = () => {
       await upsert('GOOSE_MODE', newMode, false);
       setGooseMode(newMode);
       trackModeChanged(gooseMode, newMode);
+
+      if (hasActiveSession) {
+        toast.info('Mode changed. Restart this session for the change to take effect.', {
+          position: 'top-right',
+          autoClose: 5000,
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+        });
+      }
     } catch (error) {
       console.error('Error updating goose mode:', error);
       throw new Error(`Failed to store new goose mode: ${newMode}`);

--- a/ui/desktop/src/components/settings/mode/ModeSection.tsx
+++ b/ui/desktop/src/components/settings/mode/ModeSection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { all_goose_modes, ModeSelectionItem } from './ModeSelectionItem';
 import { useConfig } from '../../ConfigContext';
 import { ConversationLimitsDropdown } from './ConversationLimitsDropdown';
+import { toast } from 'react-toastify';
 
 export const ModeSection = () => {
   const [currentMode, setCurrentMode] = useState('auto');
@@ -9,9 +10,24 @@ export const ModeSection = () => {
   const { read, upsert } = useConfig();
 
   const handleModeChange = async (newMode: string) => {
+    if (currentMode === newMode) {
+      return;
+    }
+
     try {
       await upsert('GOOSE_MODE', newMode, false);
       setCurrentMode(newMode);
+
+      toast.info(
+        'Mode changed. Any active sessions should be restarted for the change to take effect.',
+        {
+          position: 'top-right',
+          autoClose: 5000,
+          hideProgressBar: true,
+          closeOnClick: true,
+          pauseOnHover: true,
+        }
+      );
     } catch (error) {
       console.error('Error updating goose mode:', error);
       throw new Error(`Failed to store new goose mode: ${newMode}`);


### PR DESCRIPTION
When changing chat modes - you need to currently restart sessions. This will tell you via a simple toast to do that if you change when in active chat or in settings.