### PR TITLE
chore: manually update version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "goose"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "agent-client-protocol",
  "ahash",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "goose-bench"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "goose-cli"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "agent-client-protocol",
  "anstream",
@@ -3232,7 +3232,7 @@ dependencies = [
 
 [[package]]
 name = "goose-mcp"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "goose-server"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3342,7 +3342,7 @@ dependencies = [
 
 [[package]]
 name = "goose-test"
-version = "1.16.0"
+version = "1.17.0"
 dependencies = [
  "clap",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "1.16.0"
+version = "1.17.0"
 authors = ["Block <ai-oss-tools@block.xyz>"]
 license = "Apache-2.0"
 repository = "https://github.com/block/goose"

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.16.0"
+    "version": "1.17.0"
   },
   "paths": {
     "/action-required/tool-confirmation": {


### PR DESCRIPTION
We need to do this this time because the PR for 1.17.0 couldn't merge cleanly

https://github.com/block/goose/pull/6131

We can update the release workflow to only actually merge a version bump like this in the future to avoid conflicts, but we should do this manually for this one