### PR TITLE
Enhanced PostHog Error Tracking with Detailed Messages

### DIFF
--- a/crates/goose-server/src/routes/recipe.rs
+++ b/crates/goose-server/src/routes/recipe.rs
@@ -198,6 +198,7 @@ async fn create_recipe(
         }
         Err(e) => {
             tracing::error!("Error details: {:?}", e);
+            goose::posthog::emit_error("recipe_create_failed", &e.to_string());
             let error_response = CreateRecipeResponse {
                 recipe: None,
                 error: Some(format!("Failed to create recipe: {}", e)),
@@ -224,6 +225,7 @@ async fn encode_recipe(
         Ok(encoded) => Ok(Json(EncodeRecipeResponse { deeplink: encoded })),
         Err(err) => {
             tracing::error!("Failed to encode recipe: {}", err);
+            goose::posthog::emit_error("recipe_encode_failed", &err.to_string());
             Err(StatusCode::BAD_REQUEST)
         }
     }
@@ -249,6 +251,7 @@ async fn decode_recipe(
         },
         Err(err) => {
             tracing::error!("Failed to decode deeplink: {}", err);
+            goose::posthog::emit_error("recipe_decode_failed", &err.to_string());
             Err(StatusCode::BAD_REQUEST)
         }
     }
@@ -374,6 +377,7 @@ async fn schedule_recipe(
         Ok(_) => Ok(StatusCode::OK),
         Err(e) => {
             tracing::error!("Failed to schedule recipe: {}", e);
+            goose::posthog::emit_error("recipe_schedule_failed", &e.to_string());
             Err(StatusCode::INTERNAL_SERVER_ERROR)
         }
     }

--- a/crates/goose-server/src/routes/session.rs
+++ b/crates/goose-server/src/routes/session.rs
@@ -361,6 +361,7 @@ async fn edit_message(
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to copy session: {}", e);
+                    goose::posthog::emit_error("session_copy_failed", &e.to_string());
                     StatusCode::INTERNAL_SERVER_ERROR
                 })?;
 
@@ -368,6 +369,7 @@ async fn edit_message(
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to truncate conversation: {}", e);
+                    goose::posthog::emit_error("session_truncate_failed", &e.to_string());
                     StatusCode::INTERNAL_SERVER_ERROR
                 })?;
 
@@ -380,6 +382,7 @@ async fn edit_message(
                 .await
                 .map_err(|e| {
                     tracing::error!("Failed to truncate conversation: {}", e);
+                    goose::posthog::emit_error("session_truncate_failed", &e.to_string());
                     StatusCode::INTERNAL_SERVER_ERROR
                 })?;
 

--- a/crates/goose/src/agents/retry.rs
+++ b/crates/goose/src/agents/retry.rs
@@ -137,6 +137,10 @@ impl RetryManager {
                 "Maximum retry attempts ({}) exceeded",
                 retry_config.max_retries
             );
+            crate::posthog::emit_error(
+                "retry_max_exceeded",
+                &format!("Max retries ({}) exceeded", retry_config.max_retries),
+            );
             return Ok(RetryResult::MaxAttemptsReached);
         }
 

--- a/crates/goose/src/posthog.rs
+++ b/crates/goose/src/posthog.rs
@@ -218,10 +218,17 @@ pub fn emit_session_started() {
 pub struct ErrorContext {
     pub component: Option<String>,
     pub action: Option<String>,
+    pub error_message: Option<String>,
 }
 
-pub fn emit_error(error_type: &str) {
-    emit_error_with_context(error_type, ErrorContext::default());
+pub fn emit_error(error_type: &str, error_message: &str) {
+    emit_error_with_context(
+        error_type,
+        ErrorContext {
+            error_message: Some(error_message.to_string()),
+            ..Default::default()
+        },
+    );
 }
 
 pub fn emit_error_with_context(error_type: &str, context: ErrorContext) {
@@ -272,6 +279,10 @@ async fn send_error_event(
     }
     if let Some(action) = &context.action {
         event.insert_prop("action", action.as_str()).ok();
+    }
+    if let Some(error_message) = &context.error_message {
+        let sanitized = sanitize_string(error_message);
+        event.insert_prop("error_message", sanitized).ok();
     }
 
     if let Some(platform_version) = get_platform_version() {

--- a/crates/goose/src/scheduler.rs
+++ b/crates/goose/src/scheduler.rs
@@ -260,7 +260,10 @@ impl Scheduler {
 
                 match result {
                     Ok(_) => tracing::info!("Job '{}' completed", task_job_id),
-                    Err(e) => tracing::error!("Job '{}' failed: {}", task_job_id, e),
+                    Err(ref e) => {
+                        tracing::error!("Job '{}' failed: {}", task_job_id, e);
+                        crate::posthog::emit_error("scheduler_job_failed", &e.to_string());
+                    }
                 }
             })
         })

--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -43,7 +43,7 @@ import { NoProviderOrModelError, useAgent } from './hooks/useAgent';
 import { useNavigation } from './hooks/useNavigation';
 import { errorMessage } from './utils/conversionUtils';
 import { usePageViewTracking } from './hooks/useAnalytics';
-import { trackOnboardingCompleted } from './utils/analytics';
+import { trackOnboardingCompleted, trackErrorWithContext } from './utils/analytics';
 
 function PageViewTracker() {
   usePageViewTracking();
@@ -129,6 +129,11 @@ const PairRouteWrapper = ({
           setActiveSessionId(newSession.id);
         } catch (error) {
           console.error('[PairRouteWrapper] Failed to create session:', error);
+          trackErrorWithContext(error, {
+            component: 'PairRouteWrapper',
+            action: 'create_session',
+            recoverable: true,
+          });
         } finally {
           setIsCreatingSession(false);
         }
@@ -428,6 +433,11 @@ export function AppInner() {
         });
       } catch (error) {
         console.error('Unexpected error opening shared session:', error);
+        trackErrorWithContext(error, {
+          component: 'AppInner',
+          action: 'open_shared_session',
+          recoverable: true,
+        });
         // Navigate to shared session view with error
         const shareToken = link.replace('goose://sessions/', '');
         const options = {


### PR DESCRIPTION
## Summary
Noticed we weren't sending the error context and also covered some more key places we were missing.

### Overview
This PR improves PostHog error telemetry by including detailed, sanitized error messages alongside error types. Previously, only categorical error types (e.g., "auth", "rate_limit") were sent, making it difficult to diagnose issues. Now, the actual error content is included for better observability.

### Changes

#### Backend (Rust)

**`crates/goose/src/posthog.rs`**
- Extended `ErrorContext` struct with new `error_message` field
- Updated `emit_error()` signature to accept `error_type` and `error_message`
- Added sanitization of error messages before sending to PostHog

**`crates/goose/src/agents/agent.rs`**
- Added detailed error messages to existing `emit_error` calls for:
  - `tool_execution_failed` - includes tool name and error
  - `context_length` and other `ProviderError` variants
  - `compaction_failed` - new tracking for compaction failures

**`crates/goose/src/agents/retry.rs`**
- Added `retry_max_exceeded` error tracking when max retry attempts are reached

**`crates/goose/src/scheduler.rs`**
- Added `scheduler_job_failed` error tracking for scheduled job failures

**`crates/goose-server/src/routes/agent.rs`**
- Added error tracking for:
  - `recipe_deeplink_decode_failed`
  - `session_create_failed`
  - `session_resume_failed`
  - `extension_load_failed` (during session resume)
  - `extension_add_failed` (via API)

**`crates/goose-server/src/routes/session.rs`**
- Added error tracking for:
  - `session_copy_failed`
  - `session_truncate_failed`

**`crates/goose-server/src/routes/recipe.rs`**
- Added error tracking for:
  - `recipe_create_failed`
  - `recipe_encode_failed`
  - `recipe_decode_failed`
  - `recipe_schedule_failed`

#### Frontend (TypeScript)

**`ui/desktop/src/App.tsx`**
- Added `trackErrorWithContext` for:
  - `create_session` in `PairRouteWrapper` - catches session creation failures from recipes
  - `open_shared_session` in `AppInner` - catches shared session deeplink failures

### Error Types Added

| Error Type | Location | Description |
|------------|----------|-------------|
| `tool_execution_failed` | agent.rs | Tool call execution error |
| `compaction_failed` | agent.rs | Context compaction failure |
| `retry_max_exceeded` | retry.rs | Max retry attempts reached |
| `scheduler_job_failed` | scheduler.rs | Scheduled job failure |
| `recipe_deeplink_decode_failed` | routes/agent.rs | Recipe deeplink decoding error |
| `session_create_failed` | routes/agent.rs | Session creation error |
| `session_resume_failed` | routes/agent.rs | Session resume error |
| `extension_load_failed` | routes/agent.rs | Extension loading during resume |
| `extension_add_failed` | routes/agent.rs | Extension add via API |
| `session_copy_failed` | routes/session.rs | Session copy error |
| `session_truncate_failed` | routes/session.rs | Conversation truncation error |
| `recipe_create_failed` | routes/recipe.rs | Recipe creation error |
| `recipe_encode_failed` | routes/recipe.rs | Recipe encoding error |
| `recipe_decode_failed` | routes/recipe.rs | Recipe decoding error |
| `recipe_schedule_failed` | routes/recipe.rs | Recipe scheduling error |

### Privacy
All error messages are sanitized using the existing `sanitize_string()` function before being sent to PostHog, which redacts API keys, tokens, and PII patterns.