### PR TITLE
fix(cli): correct bash syntax in terminal integration functions

### DIFF
--- a/crates/goose-cli/src/commands/term.rs
+++ b/crates/goose-cli/src/commands/term.rs
@@ -39,11 +39,11 @@ static BASH_CONFIG: ShellConfig = ShellConfig {
 alias @goose='{goose_bin} term run'
 alias @g='{goose_bin} term run'
 
-goose_preexec() {{
+goose_preexec() {
     [[ "$1" =~ ^goose\ term ]] && return
     [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
     ('{goose_bin}' term log "$1" &) 2>/dev/null
-}}
+}
 
 if [[ -z "$goose_preexec_installed" ]]; then
     goose_preexec_installed=1
@@ -52,11 +52,11 @@ fi{command_not_found_handler}"#,
     command_not_found: Some(
         r#"
 
-command_not_found_handle() {{
+command_not_found_handle() {
     echo "🪿 Command '$1' not found. Asking goose..."
     '{goose_bin}' term run "$@"
     return 0
-}}"#,
+}"#,
     ),
 };
 
@@ -65,22 +65,22 @@ static ZSH_CONFIG: ShellConfig = ShellConfig {
 alias @goose='{goose_bin} term run'
 alias @g='{goose_bin} term run'
 
-goose_preexec() {{
+goose_preexec() {
     [[ "$1" =~ ^goose\ term ]] && return
     [[ "$1" =~ ^(@goose|@g)($|[[:space:]]) ]] && return
     ('{goose_bin}' term log "$1" &) 2>/dev/null
-}}
+}
 
 autoload -Uz add-zsh-hook
 add-zsh-hook preexec goose_preexec{command_not_found_handler}"#,
     command_not_found: Some(
         r#"
 
-command_not_found_handler() {{
+command_not_found_handler() {
     echo "🪿 Command '$1' not found. Asking goose..."
     '{goose_bin}' term run "$@"
     return 0
-}}"#,
+}"#,
     ),
 };
 


### PR DESCRIPTION
Fixed bash syntax error by changing double curly braces to single curly braces in function definitions for bash and zsh terminal integration. The double braces were being output literally, causing 'syntax error near unexpected token' errors.

Changes:
- goose_preexec() function definitions in BASH_CONFIG and ZSH_CONFIG
- command_not_found_handle/handler() function definitions

Fixes the error:
bash: eval: line 100: syntax error near unexpected token '{{' bash: eval: line 100: 'goose_preexec() {{'

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #6142  
Discussion: https://github.com/block/goose/issues/6142#issuecomment-3672521022


### Screenshots/Demos (for UX changes)
Before:  

After:   

