### PR TITLE
docs: publish MCP elicitation guide

### DIFF
--- a/documentation/docs/guides/mcp-elicitation.md
+++ b/documentation/docs/guides/mcp-elicitation.md
@@ -3,7 +3,6 @@ sidebar_position: 55
 title: MCP Elicitation
 sidebar_label: MCP Elicitation
 description: How extensions can request structured information from you during a task
-unlisted: true
 ---
 
 import Tabs from '@theme/Tabs';


### PR DESCRIPTION
## Summary
Remove `unlisted: true` from the MCP elicitation documentation to make it publicly visible on the docs site.

## Changes
- Removed `unlisted: true` from the frontmatter of `documentation/docs/guides/mcp-elicitation.md`

This will make the MCP Elicitation guide accessible to users browsing the documentation.