### PR TITLE
feat: support extra field in chatcompletion tool_calls for gemini openai compat

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -322,8 +322,14 @@ impl Provider for OpenAiProvider {
             log.write(&json_response, Some(&usage))?;
             Ok((message, ProviderUsage::new(model, usage)))
         } else {
-            let payload =
-                create_request(model_config, system, messages, tools, &ImageFormat::OpenAi, false)?;
+            let payload = create_request(
+                model_config,
+                system,
+                messages,
+                tools,
+                &ImageFormat::OpenAi,
+                false,
+            )?;
 
             let mut log = RequestLog::start(&self.model, &payload)?;
             let json_response = self
@@ -438,8 +444,14 @@ impl Provider for OpenAiProvider {
                 }
             }))
         } else {
-            let payload =
-                create_request(&self.model, system, messages, tools, &ImageFormat::OpenAi, true)?;
+            let payload = create_request(
+                &self.model,
+                system,
+                messages,
+                tools,
+                &ImageFormat::OpenAi,
+                true,
+            )?;
             let mut log = RequestLog::start(&self.model, &payload)?;
 
             let response = self


### PR DESCRIPTION
## Summary
Various model providers have started including additional fields in in tool_calls of openai-compatible(ish) chatcompletion responses, for example [gemini's](https://ai.google.dev/gemini-api/docs/thought-signatures#sequential_function_calling_example_2) `thought_signature` and databricks' `thoughtSignature`. This change adds an `extra` Map field in `DeltaToolCallFunction` to support arbitrary additional fields. Then added inclusion of these additional fields in databricks `format_messages` which fixes `400: content block is missing a thought_signature` errors when trying to use tools w/ gemini-3 in databricks. 


### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Added unit tests and tested manually with `databricks-gemini-3-pro` and `databricks-gemini-3-flash`


### Screenshots/Demos (for UX changes)
<img width="1151" height="455" alt="image" src="https://github.com/user-attachments/assets/feaa75f2-7a6d-4421-908b-374707624725" />
 

