### PR TITLE
fix(ui): enable MCP UI to send a prompt message when an element is clicked

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -276,6 +276,7 @@ function BaseChatContent({
         onRenderingComplete={handleRenderingComplete}
         onMessageUpdate={onMessageUpdate}
         submitElicitationResponse={submitElicitationResponse}
+        append={(text: string) => handleSubmit(text)}
       />
     </>
   );


### PR DESCRIPTION
## Summary
The `append` prop was not being passed from `BaseChat` to `ProgressiveMessageList`, which meant MCP UI buttons that send `prompt` type postMessages were calling an empty default function `() => {}` instead of actually submitting to the chat.

## Problem
When an MCP UI (rendered via `MCPUIResourceRenderer`) sends a prompt message like:
```javascript
window.parent.postMessage({
  type: 'prompt',
  payload: { prompt: 'Some action' }
}, '*');
```

The message was received by `@mcp-ui/client`, which called `appendPromptToChat(prompt)` in `MCPUIResourceRenderer`. However, since `append` was not passed down through the component chain, it defaulted to an empty function and nothing happened.

## Fix
Added the missing `append` prop to `ProgressiveMessageList` in `BaseChat.tsx`:
```tsx
append={(text: string) => handleSubmit(text)}
```

## Testing
- Tested with a custom MCP UI server that has interactive buttons
- Clicking buttons now properly sends prompts to the chat

## Related
This fix is also required for the MCP Apps feature branch (`feat/add-mcp-app-renderer`) to work properly, as it also relies on the `append` prop flowing down from `BaseChat`.



## Broken version

https://github.com/user-attachments/assets/0090ce64-d47a-4d3f-9736-4217fff17510



## Fixed version


https://github.com/user-attachments/assets/de8251b3-c0f6-4a87-b902-a7f70ae319ee

### watch on 2x speed