### PR TITLE
fix(github-copilot): Properly handle streaming errors and filter images from non-user messages

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -70,10 +70,16 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
             match content {
                 MessageContent::Text(text) => {
                     if !text.text.is_empty() {
-                        if let Some(image_path) = detect_image_path(&text.text) {
-                            if let Ok(image) = load_image_file(image_path) {
-                                content_array.push(json!({"type": "text", "text": text.text}));
-                                content_array.push(convert_image(&image, image_format));
+                        // Only detect and load embedded images from text in user messages
+                        // Many providers don't support images in assistant or system messages
+                        if message.role == Role::User {
+                            if let Some(image_path) = detect_image_path(&text.text) {
+                                if let Ok(image) = load_image_file(image_path) {
+                                    content_array.push(json!({"type": "text", "text": text.text}));
+                                    content_array.push(convert_image(&image, image_format));
+                                } else {
+                                    text_array.push(text.text.clone());
+                                }
                             } else {
                                 text_array.push(text.text.clone());
                             }
@@ -202,7 +208,21 @@ pub fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<
                 MessageContent::ToolConfirmationRequest(_) => {}
                 MessageContent::ActionRequired(_) => {}
                 MessageContent::Image(image) => {
-                    content_array.push(convert_image(image, image_format));
+                    // Only add images to user messages - many providers don't support images
+                    // in system or assistant messages
+                    if message.role == Role::User {
+                        content_array.push(convert_image(image, image_format));
+                    } else {
+                        tracing::warn!(
+                            "Skipping image in {:?} message - images only supported in user messages",
+                            message.role
+                        );
+                        // Add placeholder text so the model knows there was an image
+                        content_array.push(json!({
+                            "type": "text",
+                            "text": "[Image content removed - not supported in assistant messages]"
+                        }));
+                    }
                 }
                 MessageContent::FrontendToolRequest(request) => match &request.tool_call {
                     Ok(tool_call) => {
@@ -1008,6 +1028,88 @@ mod tests {
             .as_str()
             .unwrap()
             .starts_with("data:image/png;base64,"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_assistant_text_with_image_path_no_image_loading() -> anyhow::Result<()>
+    {
+        // Create a temporary PNG file with valid PNG magic numbers
+        let temp_dir = tempfile::tempdir()?;
+        let png_path = temp_dir.path().join("output.png");
+        let png_data = [
+            0x89, 0x50, 0x4E, 0x47, // PNG magic number
+            0x0D, 0x0A, 0x1A, 0x0A, // PNG header
+            0x00, 0x00, 0x00, 0x0D, // Rest of fake PNG data
+        ];
+        std::fs::write(&png_path, png_data)?;
+        let png_path_str = png_path.to_str().unwrap();
+
+        // Create assistant message with text containing an image path
+        // This should NOT load the image (would cause "image urls not allowed in non-user messages")
+        let message =
+            Message::assistant().with_text(format!("I saved the output to {}", png_path_str));
+        let spec = format_messages(&[message], &ImageFormat::OpenAi);
+
+        assert_eq!(spec.len(), 1);
+        assert_eq!(spec[0]["role"], "assistant");
+
+        // Content should be plain text, NOT an array with image
+        // The image path should remain in the text without being loaded
+        let content = spec[0]["content"].as_str();
+        assert!(
+            content.is_some(),
+            "Assistant message content should be a string, not an array with image"
+        );
+        assert!(content.unwrap().contains(png_path_str));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_format_messages_filters_images_in_non_user_messages() -> anyhow::Result<()> {
+        use crate::conversation::message::MessageContent;
+
+        // Create an assistant message with an image (should be filtered to placeholder)
+        let assistant_msg = Message::new(
+            Role::Assistant,
+            0,
+            vec![MessageContent::image("base64imagedata", "image/png")],
+        );
+
+        // Create a user message with an image (should be preserved)
+        let user_msg = Message::new(
+            Role::User,
+            0,
+            vec![MessageContent::image("userbase64data", "image/jpeg")],
+        );
+
+        let messages = vec![assistant_msg, user_msg];
+        let spec = format_messages(&messages, &ImageFormat::OpenAi);
+
+        assert_eq!(spec.len(), 2);
+
+        // Check assistant message - image should be replaced with placeholder text
+        assert_eq!(spec[0]["role"], "assistant");
+        let assistant_content = spec[0]["content"].as_array().unwrap();
+        assert_eq!(assistant_content.len(), 1);
+        // The image should be replaced with placeholder text, not image_url
+        assert_eq!(assistant_content[0]["type"], "text");
+        assert!(assistant_content[0]["text"]
+            .as_str()
+            .unwrap()
+            .contains("not supported"));
+
+        // Check user message - image should be preserved as image_url
+        assert_eq!(spec[1]["role"], "user");
+        let user_content = spec[1]["content"].as_array().unwrap();
+        assert_eq!(user_content.len(), 1);
+        assert_eq!(user_content[0]["type"], "image_url");
+        assert!(user_content[0]["image_url"]["url"]
+            .as_str()
+            .unwrap()
+            .starts_with("data:image/jpeg;base64,"));
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

Fixes #5845 - Goose randomly becomes unresponsive when using GitHub Copilot provider.

This PR addresses two related issues:

- **Streaming error handling in GitHub Copilot provider**: Added proper HTTP status code checking before processing streaming responses, error response parsing, and empty response detection. Previously, errors during streaming were silently ignored, causing Goose to appear unresponsive.

- **Image filtering for non-user messages**: Many providers (including GitHub Copilot) don't support images in assistant or system messages. Added filtering to:
  - Replace `MessageContent::Image` in non-user messages with placeholder text
  - Only detect and load embedded images from text paths in user messages (prevents assistant messages mentioning image paths from accidentally loading images)

## Changes

1. `crates/goose/src/providers/githubcopilot.rs` - Added streaming error handling
2. `crates/goose/src/providers/formats/openai.rs` - Added image filtering for non-user messages

## Test plan

- [x] All existing tests pass (24 tests in openai module)
- [x] Added new tests for image filtering behavior:
  - `test_format_messages_filters_images_in_non_user_messages`
  - `test_format_messages_assistant_text_with_image_path_no_image_loading`
- [x] Manual testing with GitHub Copilot provider:
  1. Start Goose with GitHub Copilot provider
  2. Share an image and ask Goose to process it
  3. Ask follow-up questions involving image processing
  4. Ask unrelated questions - previously would fail with "image urls not allowed in non-user messages"
  5. Verified errors are now properly surfaced to the user instead of silent hangs

🤖 Generated with [Claude Code](https://claude.com/claude-code)