### PR TITLE
feat(azure): Add GPT-5 reasoning model support via v1 API

### DIFF
--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -108,7 +108,8 @@ impl AzureProvider {
         let use_v1_api = use_v1_api_config.unwrap_or_else(|| {
             // Auto-detect: use v1 API for reasoning models (GPT-5, o1, o3, o4)
             // These models require reasoning_effort parameter which only works with v1 API
-            Self::is_reasoning_model(&deployment_name) || Self::is_reasoning_model(&model.model_name)
+            Self::is_reasoning_model(&deployment_name)
+                || Self::is_reasoning_model(&model.model_name)
         });
 
         if use_v1_api {

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -34,17 +34,29 @@ use rmcp::model::Tool;
 pub const OPEN_AI_DEFAULT_MODEL: &str = "gpt-4o";
 pub const OPEN_AI_DEFAULT_FAST_MODEL: &str = "gpt-4o-mini";
 pub const OPEN_AI_KNOWN_MODELS: &[(&str, usize)] = &[
+    // GPT-4 series
     ("gpt-4o", 128_000),
     ("gpt-4o-mini", 128_000),
     ("gpt-4.1", 128_000),
     ("gpt-4.1-mini", 128_000),
-    ("o1", 200_000),
-    ("o3", 200_000),
-    ("gpt-3.5-turbo", 16_385),
     ("gpt-4-turbo", 128_000),
-    ("o4-mini", 128_000),
-    ("gpt-5.1-codex", 400_000),
+    ("gpt-3.5-turbo", 16_385),
+    // GPT-5 series (reasoning models)
+    ("gpt-5", 272_000),
+    ("gpt-5-mini", 272_000),
+    ("gpt-5-nano", 272_000),
+    ("gpt-5.1", 400_000),
+    ("gpt-5.2", 400_000),
+    // GPT-5 Codex series (code-focused)
     ("gpt-5-codex", 400_000),
+    ("gpt-5.1-codex", 400_000),
+    ("gpt-5.1-codex-max", 400_000),
+    // O-series reasoning models
+    ("o1", 200_000),
+    ("o1-mini", 200_000),
+    ("o3", 200_000),
+    ("o3-mini", 200_000),
+    ("o4-mini", 200_000),
 ];
 
 pub const OPEN_AI_DOC_URL: &str = "https://platform.openai.com/docs/models";


### PR DESCRIPTION
## Summary

Adds support for GPT-5 reasoning models (gpt-5, gpt-5-mini, gpt-5-nano) in Azure OpenAI provider.

### Changes

**Azure OpenAI Provider (`azure.rs`):**
- Updated default API version to `2025-04-01-preview` (required for GPT-5)
- Added GPT-5 model variants to known models list
- Added automatic detection of reasoning models (GPT-5, o1, o3, o4)
- Added v1 API support (`/openai/v1/chat/completions`) for reasoning models
  - Reasoning models require `reasoning_effort` parameter which only works with v1 API
- Added `AZURE_OPENAI_USE_V1_API` config option for manual override

**OpenAI Provider (`openai.rs`):**
- Added GPT-5 model variants to known models list

### Why v1 API?

Azure OpenAI has two API formats:
1. **Legacy deployment-based**: `/openai/deployments/{deployment}/chat/completions`
2. **v1 API**: `/openai/v1/chat/completions`

GPT-5 reasoning models require the `reasoning_effort` parameter, which is only supported by the v1 API. This PR auto-detects reasoning models and uses the appropriate API format.

## Test plan

- [x] Code compiles without errors
- [x] Formatting passes (`cargo fmt`)
- [ ] Manual testing with Azure OpenAI GPT-5 deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)