### PR TITLE
fix: Make Azure OpenAI API key optional to match documentation

### DIFF
--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -125,7 +125,7 @@ impl Provider for AzureProvider {
                 ConfigKey::new("AZURE_OPENAI_ENDPOINT", true, false, None),
                 ConfigKey::new("AZURE_OPENAI_DEPLOYMENT_NAME", true, false, None),
                 ConfigKey::new("AZURE_OPENAI_API_VERSION", true, false, Some("2024-10-21")),
-                ConfigKey::new("AZURE_OPENAI_API_KEY", true, true, Some("")),
+                ConfigKey::new("AZURE_OPENAI_API_KEY", false, true, Some("")),
             ],
         )
     }


### PR DESCRIPTION
## Summary

- Makes `AZURE_OPENAI_API_KEY` optional instead of required in the Azure OpenAI provider configuration
- Aligns the implementation with the [official documentation](https://block.github.io/goose/docs/getting-started/providers/) which states the API key is optional
- When no API key is provided, the provider falls back to Azure credential chain authentication (Azure CLI, managed identity, etc.)

## Changes

Single line change in `crates/goose/src/providers/azure.rs`:
- `ConfigKey::new("AZURE_OPENAI_API_KEY", true, true, Some(""))` → `ConfigKey::new("AZURE_OPENAI_API_KEY", false, true, Some(""))`

The underlying code at lines 81-84 already handles optional API keys correctly using `.ok()` and `.filter()`.

## Test plan

- [x] Verified via CLI: `goose configure` no longer requires API key for Azure OpenAI
- [x] Verified via Desktop GUI: Can configure Azure OpenAI without API key
- [x] Verified authentication works using Azure credential chain (Azure CLI)
- [x] Backward compatible: API key authentication still works when provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)