### PR TITLE
feat: default todo message

### DIFF
--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -48,7 +48,7 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
             PlatformExtensionDef {
                 name: todo_extension::EXTENSION_NAME,
                 description:
-                    "Enable a todo list for Goose so it can keep track of what it is doing",
+                    "Enable a todo list for goose so it can keep track of what it is doing",
                 default_enabled: true,
                 client_factory: |ctx| Box::new(todo_extension::TodoClient::new(ctx).unwrap()),
             },

--- a/crates/goose/src/agents/todo_extension.rs
+++ b/crates/goose/src/agents/todo_extension.rs
@@ -50,30 +50,24 @@ impl TodoClient {
                 icons: None,
                 website_url: None,
             },
-            instructions: Some(indoc! {r#"
-                Task Management
-
-                Your TODO content is automatically available in your context.
+            instructions: Some(
+                indoc! {r#"
+                Your todo content is automatically available in your context.
 
                 Workflow:
                 - Start: write initial checklist
                 - During: update progress
                 - End: verify all complete
 
-                Warning: todo_write overwrites entirely; always include ALL content you want to keep
-
-                Keep items short, specific, action-oriented. Not using the todo tool for complex tasks is an error.
-
-                For autonomous work, missing requirements means failure - document all requirements in TODO immediately.
-
                 Template:
-                - [ ] Implement feature X
-                  - [ ] Update API
-                  - [ ] Write tests
-                  - [ ] Run tests
-                  - [ ] Run lint
-                - [ ] Blocked: waiting on credentials
-            "#}.to_string()),
+                - [x] Requirement 1
+                - [ ] Task
+                  - [ ] Sub-task
+                - [ ] Requirement 2
+                - [ ] Another task
+            "#}
+                .to_string(),
+            ),
         };
 
         Ok(Self {


### PR DESCRIPTION
Improve todo usage for autonomous work:
- Remove "2+ steps" threshold from todo instructions
- Show default reminder when todo is empty

Goose tends to forget requirements during longer autonomous tasks. This nudges it to write things down immediately rather than deciding whether a task is "complex enough" to warrant tracking.
