### PR TITLE
fix: prevent keychain requests during cargo test

### DIFF
--- a/crates/goose/src/config/signup_tetrate/tests.rs
+++ b/crates/goose/src/config/signup_tetrate/tests.rs
@@ -65,7 +65,8 @@ fn test_configure_tetrate() {
     // Create a test config with temporary paths
     let temp_dir = TempDir::new().unwrap();
     let config_path = temp_dir.path().join("test_config.yaml");
-    let config = Config::new(&config_path, "test_service").unwrap();
+    let secrets_path = temp_dir.path().join("test_secrets.yaml");
+    let config = Config::new_with_file_secrets(&config_path, &secrets_path).unwrap();
 
     // Configure with a test API key
     let test_key = "test-api-key-123".to_string();

--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -276,12 +276,17 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_lead_worker_provider() {
+        // Both API keys needed: openai for worker, anthropic for lead (GOOSE_LEAD_PROVIDER=anthropic)
         let _guard = EnvVarGuard::new(&[
             "GOOSE_LEAD_MODEL",
             "GOOSE_LEAD_PROVIDER",
             "GOOSE_LEAD_TURNS",
+            "OPENAI_API_KEY",
+            "ANTHROPIC_API_KEY",
         ]);
 
+        _guard.set("OPENAI_API_KEY", "fake-openai-no-keyring");
+        _guard.set("ANTHROPIC_API_KEY", "fake-anthropic-no-keyring");
         _guard.set("GOOSE_LEAD_MODEL", "gpt-4o");
 
         let gpt4mini_config = ModelConfig::new_or_fail("gpt-4o-mini");
@@ -309,8 +314,10 @@ mod tests {
             "GOOSE_LEAD_TURNS",
             "GOOSE_LEAD_FAILURE_THRESHOLD",
             "GOOSE_LEAD_FALLBACK_TURNS",
+            "OPENAI_API_KEY",
         ]);
 
+        _guard.set("OPENAI_API_KEY", "fake-openai-no-keyring");
         _guard.set("GOOSE_LEAD_MODEL", "grok-3");
 
         let result = create("openai", ModelConfig::new_or_fail("gpt-4o-mini")).await;
@@ -338,8 +345,10 @@ mod tests {
             "GOOSE_LEAD_TURNS",
             "GOOSE_LEAD_FAILURE_THRESHOLD",
             "GOOSE_LEAD_FALLBACK_TURNS",
+            "OPENAI_API_KEY",
         ]);
 
+        _guard.set("OPENAI_API_KEY", "fake-openai-no-keyring");
         let result = create("openai", ModelConfig::new_or_fail("gpt-4o-mini")).await;
 
         match result {

--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -30,19 +30,19 @@ pub struct LiteLLMProvider {
 impl LiteLLMProvider {
     pub async fn from_env(model: ModelConfig) -> Result<Self> {
         let config = crate::config::Config::global();
-        let api_key: String = config
-            .get_secret("LITELLM_API_KEY")
-            .unwrap_or_else(|_| String::new());
+        let secrets = config
+            .get_secrets("LITELLM_API_KEY", &["LITELLM_CUSTOM_HEADERS"])
+            .unwrap_or_default();
+        let api_key = secrets.get("LITELLM_API_KEY").cloned().unwrap_or_default();
         let host: String = config
             .get_param("LITELLM_HOST")
             .unwrap_or_else(|_| "https://api.litellm.ai".to_string());
         let base_path: String = config
             .get_param("LITELLM_BASE_PATH")
             .unwrap_or_else(|_| "v1/chat/completions".to_string());
-        let custom_headers: Option<HashMap<String, String>> = config
-            .get_secret("LITELLM_CUSTOM_HEADERS")
-            .or_else(|_| config.get_param("LITELLM_CUSTOM_HEADERS"))
-            .ok()
+        let custom_headers: Option<HashMap<String, String>> = secrets
+            .get("LITELLM_CUSTOM_HEADERS")
+            .cloned()
             .map(parse_custom_headers);
         let timeout_secs: u64 = config.get_param("LITELLM_TIMEOUT").unwrap_or(600);
 

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -67,7 +67,8 @@ impl OpenAiProvider {
         let model = model.with_fast(OPEN_AI_DEFAULT_FAST_MODEL.to_string());
 
         let config = crate::config::Config::global();
-        let api_key: String = config.get_secret("OPENAI_API_KEY")?;
+        let secrets = config.get_secrets("OPENAI_API_KEY", &["OPENAI_CUSTOM_HEADERS"])?;
+        let api_key = secrets.get("OPENAI_API_KEY").unwrap().clone();
         let host: String = config
             .get_param("OPENAI_HOST")
             .unwrap_or_else(|_| "https://api.openai.com".to_string());
@@ -76,10 +77,9 @@ impl OpenAiProvider {
             .unwrap_or_else(|_| "v1/chat/completions".to_string());
         let organization: Option<String> = config.get_param("OPENAI_ORGANIZATION").ok();
         let project: Option<String> = config.get_param("OPENAI_PROJECT").ok();
-        let custom_headers: Option<HashMap<String, String>> = config
-            .get_secret("OPENAI_CUSTOM_HEADERS")
-            .or_else(|_| config.get_param("OPENAI_CUSTOM_HEADERS"))
-            .ok()
+        let custom_headers: Option<HashMap<String, String>> = secrets
+            .get("OPENAI_CUSTOM_HEADERS")
+            .cloned()
             .map(parse_custom_headers);
         let timeout_secs: u64 = config.get_param("OPENAI_TIMEOUT").unwrap_or(600);
 


### PR DESCRIPTION
## Summary

When `OPENAI_API_KEY` is set via environment variable, Goose still prompted for keychain access because secondary config lookups (e.g. `OPENAI_CUSTOM_HEADERS`) fell through to keyring.

This adds `get_secrets(primary, maybe_secret)` that checks if the primary key exists in environment variables. If it does, all lookups use env-only mode, completely bypassing keyring. Secondary keys also fall back to `get_param()` automatically.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

Verified no keychain access occurs by temporarily adding a panic in the keyring path - all tests still passed.

### Related Issues
Relates to #4018