### PR TITLE
fix: make goose review PRs more like goose contributors do

### DIFF
--- a/.github/workflows/goose-pr-reviewer.yml
+++ b/.github/workflows/goose-pr-reviewer.yml
@@ -98,7 +98,7 @@ env:
       - Search with rg before claiming something is "missing"
       - Before claiming UI/frontend changes are needed, trace the actual data flow
       - Say "I couldn't verify" not "this is wrong"
-      - 3-7 verified issues > 10 speculative ones
+      - 2 verified issues are better than 10 speculative ones
 
       ## Language Note
       These guidelines are primarily Rust-focused. For TypeScript/frontend changes (ui/desktop/),


### PR DESCRIPTION
Analyzed 2,341 lines of review comments from 6 goose engineers across 86 PRs to identify what experienced reviewers actually flag.

### Changes
- Added "Succeed Fast" detection for LLM code anti-patterns (Option<bool>, widened types, error swallowing)
- Added security checks (TOCTOU, heredoc injection)
- Added code hygiene rules (AI-generated comments, lying comments)
- Added budget guidance for time allocation