### PR TITLE
Add YouTube short to Chrome DevTools MCP tutorial

### DIFF
--- a/documentation/docs/mcp/chrome-devtools-mcp.md
+++ b/documentation/docs/mcp/chrome-devtools-mcp.md
@@ -5,8 +5,11 @@ description: Add Chrome DevTools MCP Server as a goose Extension
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+<YouTubeShortEmbed videoUrl="https://www.youtube.com/embed/I9FwKbPvgvU" />
 
 This tutorial covers how to add the Chrome DevTools MCP Server as a goose extension to enable browser automation, web performance testing, and interactive web application debugging in a Chrome browser.
 


### PR DESCRIPTION
## Summary

Adds a YouTube short demo video to the Chrome DevTools MCP Server tutorial, following the same pattern used in other tutorials like the PDF Reader extension.

## Changes

- Added `YouTubeShortEmbed` component to `chrome-devtools-mcp.md`
- Embedded video: https://www.youtube.com/shorts/I9FwKbPvgvU

## Preview

The tutorial will now display a collapsible "🎥 Plug & Play - Watch the demo" section at the top of the page, consistent with other MCP extension tutorials.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212559720361967