### PR TITLE
Remove Advent of AI announcement banner

### DIFF
--- a/documentation/docusaurus.config.ts
+++ b/documentation/docusaurus.config.ts
@@ -511,14 +511,6 @@ const config: Config = {
         quickQuestions: ["What is goose?"],
       },
     },
-    announcementBar: {
-      id: 'advent-of-ai',
-      content:
-        '❄️ Level up your AI skills with <a target="_blank" rel="noopener noreferrer" href="https://adventofai.dev">Advent of AI</a> ❄️',
-      backgroundColor: '#20232a',
-      textColor: '#fff',
-      isCloseable: false,
-    },
     // announcementBar: {
     //   id: 'goose-grants',
     //   content:


### PR DESCRIPTION
The Advent of AI event has concluded. This PR removes the announcement banner from the documentation homepage while preserving the commented out goose grants banner for future use.