### PR TITLE
fix(install script): ensure script works when piped into bash

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -328,7 +328,17 @@ if [[ ":$PATH:" != *":$GOOSE_BIN_DIR:"* ]]; then
       echo "1) Add it for me"
       echo "2) I'll add it myself, show instructions"
 
-      read -p "Enter choice [1/2]: " choice
+      # Check whether stdin is a terminal. If it is not (for example, if
+      # this script has been piped into bash), we need to explicitly read user's
+      # choice from /dev/tty.
+      if [ -t 0 ]; then # terminal
+        read -p "Enter choice [1/2]: " choice
+      elif [ -r /dev/tty ]; then # not a terminal, but /dev/tty is available
+        read -p "Enter choice [1/2]: " choice < /dev/tty
+      else # non-interactive environment without /dev/tty
+        echo "Non-interactive environment detected without /dev/tty; defaulting to option 2 (show instructions)."
+        choice=2
+      fi
 
       case "$choice" in
       1)


### PR DESCRIPTION
## Summary

Fixes the `download_cli.sh` installation script to work correctly when piped into bash (e.g., curl ... | bash), such as suggested by the [Goose CLI install instructions](https://block.github.io/goose/docs/quickstart/). Previously, the read command would fail because stdin was the script itself rather than the terminal, preventing the script from waiting for user input when asking whether to add the goose bin directory to PATH.

- Adds conditional logic to detect if stdin is a terminal and reads from /dev/tty when it's not

The approach is similar to [rustup script](https://github.com/rust-lang/rustup/blob/86e0ac1453520bb8e4ba3b28b7ae4c1eba36b93c/rustup-init.sh#L177)


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ x] This PR was created or reviewed with AI assistance

### Testing
I have manually tested that with this change the script succeeds when piped into bash (which was not working previously) as well as still works when ran directly on both Mac and Linux.
 
### Related Issues
Relates to #6295


### Screenshots/Demos (for UX changes)
Before:  
<details>
<img width="1878" height="1586" alt="Screenshot from 2025-12-29 10-37-08" src="https://github.com/user-attachments/assets/26bd1182-efa6-4d1d-b0bc-942ad7fe5e6e" />

</details>


After:   
<details>
<img width="1878" height="1658" alt="Screenshot from 2025-12-29 10-39-41" src="https://github.com/user-attachments/assets/fff975e6-f5de-4296-b8f4-10c4a2fa697e" />

</details>

