### PR TITLE
docs: clarify GOOSE_TERMINAL requires ~/.zshenv for zsh users

### DIFF
--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -425,12 +425,6 @@ Sometimes you want goose to use different commands or have different shell behav
 1. When goose runs commands, `GOOSE_TERMINAL` is automatically set to "1"
 2. Your shell configuration can detect this and change behavior while keeping your normal terminal usage unchanged
 
-:::caution Important for zsh users
-Goose runs commands using `zsh -c "command"`, which is a **non-interactive shell** that does not source `~/.zshrc`. You must put your `GOOSE_TERMINAL` customizations in `~/.zshenv` instead, which is sourced for all zsh invocations.
-
-For bash users, `~/.bashrc` works fine since bash sources it for non-interactive shells when invoked with `bash -c`.
-:::
-
 **Examples:**
 
 ```bash


### PR DESCRIPTION
## Summary

Fixes an issue where the `GOOSE_TERMINAL` documentation incorrectly advised zsh users to put customizations in `~/.zshrc`. Since goose runs commands using `zsh -c "command"` (a non-interactive shell), `~/.zshrc` is never sourced.

## Changes

- Add caution callout explaining zsh users must use `~/.zshenv` instead of `~/.zshrc`
- Add practical example for blocking `git commit` when run by goose
- Update file location guidance for zsh vs bash users

## Why this matters

Users following the existing docs would set up `GOOSE_TERMINAL` checks in `~/.zshrc` and wonder why they don't work. This was discovered when testing the git commit blocking feature - it only worked after moving the function to `~/.zshenv`.

## Testing

Verified that:
1. `GOOSE_TERMINAL=1` is set when goose runs shell commands
2. A git wrapper function in `~/.zshenv` successfully blocks `git commit`
3. The same function in `~/.zshrc` does NOT work (because it's not sourced)