### PR TITLE
fix: adding more open models

### DIFF
--- a/scripts/test_providers.sh
+++ b/scripts/test_providers.sh
@@ -30,7 +30,7 @@ SCRIPT_DIR=$(pwd)
 
 # Format: "provider -> model1|model2|model3"
 PROVIDERS=(
-  "openrouter -> google/gemini-2.5-pro|google/gemini-2.5-flash|anthropic/claude-sonnet-4.5|qwen/qwen3-coder:exacto|z-ai/glm-4.6:exacto|nvidia/nemotron-3-nano-30b-a3b"
+  "openrouter -> google/gemini-2.5-pro|anthropic/claude-sonnet-4.5|qwen/qwen3-coder:exacto|z-ai/glm-4.6:exacto|nvidia/nemotron-3-nano-30b-a3b"
   "xai -> grok-3"
   "openai -> gpt-4o|gpt-4o-mini|gpt-3.5-turbo|gpt-5"
   "anthropic -> claude-sonnet-4-5-20250929|claude-opus-4-1-20250805"


### PR DESCRIPTION
Looking for reliably passing runs, shifting to "exacto" as random providers for qwen3 aren't always the same.

