### PR TITLE
fix(openai): handle interleaved streaming chunks in tool call

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -512,11 +512,8 @@ where
                                                 }
                                             }
                                         }
-                                    } else {
-                                        done = true;
                                     }
-
-                                    if tool_chunk.choices[0].finish_reason == Some("tool_calls".to_string()) {
+                                    if tool_chunk.choices[0].finish_reason.is_some() {
                                         done = true;
                                     }
                                 } else {


### PR DESCRIPTION
## Summary
Some OpenAI-compatible APIs send interleaved chunks with content:null between tool_calls chunks during streaming. This caused premature termination of argument accumulation, resulting in empty tool call arguments.

Changes:
- Remove early done=true when chunk has no tool_calls
- Accept any finish_reason (not just 'tool_calls') to mark completion

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Tested with vllm and open source models