### PR TITLE
fix: handle toolnames without underscores

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -208,6 +208,14 @@ const notificationToProgress = (notification: NotificationEvent): Progress => {
   return message.params as Progress;
 };
 
+// Helper function to extract toolcall name
+const getToolName = (toolCallName: string): string => {
+  const lastIndex = toolCallName.lastIndexOf('__');
+  if (lastIndex === -1) return toolCallName;
+
+  return toolCallName.substring(lastIndex + 2);
+}
+
 // Helper function to extract extension name for tooltip
 const getExtensionTooltip = (toolCallName: string): string | null => {
   const lastIndex = toolCallName.lastIndexOf('__');
@@ -315,7 +323,7 @@ function ToolCallView({
   // Function to create a descriptive representation of what the tool is doing
   const getToolDescription = (): string | null => {
     const args = toolCall.arguments as Record<string, ToolCallArgumentValue>;
-    const toolName = toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2);
+    const toolName = getToolName(toolCall.name);
 
     const getStringValue = (value: ToolCallArgumentValue): string => {
       return typeof value === 'string' ? value : JSON.stringify(value);
@@ -481,7 +489,7 @@ function ToolCallView({
       return description;
     }
     // Fallback tool name formatting
-    return snakeToTitleCase(toolCall.name.substring(toolCall.name.lastIndexOf('__') + 2));
+    return snakeToTitleCase(getToolName(toolCall.name));
   };
   // Map LoadingStatus to ToolCallStatus
   const getToolCallStatus = (loadingStatus: LoadingStatus): ToolCallStatus => {


### PR DESCRIPTION
## Summary
Improve handling for tool calls without a `__` present in the name (see name truncation issue in the screenshot).


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
Manual testing

### Screenshot
<img width="910" height="522" alt="goose-ui-bug" src="https://github.com/user-attachments/assets/15a16258-2bd2-42f7-974b-2b2f4d120ee1" />