### PR TITLE
refactor:  when changing provider/model,load existing provider/model

### DIFF
--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -76,12 +76,14 @@ export const SwitchModelModal = ({
   titleOverride,
 }: SwitchModelModalProps) => {
   const { getProviders, getProviderModels, read } = useConfig();
-  const { changeModel } = useModelAndProvider();
+  const { changeModel, currentModel, currentProvider } = useModelAndProvider();
   const [providerOptions, setProviderOptions] = useState<{ value: string; label: string }[]>([]);
   type ModelOption = { value: string; label: string; provider: string; isDisabled?: boolean };
   const [modelOptions, setModelOptions] = useState<{ options: ModelOption[] }[]>([]);
-  const [provider, setProvider] = useState<string | null>(initialProvider || null);
-  const [model, setModel] = useState<string>('');
+  const [provider, setProvider] = useState<string | null>(
+    initialProvider || currentProvider || null
+  );
+  const [model, setModel] = useState<string>(currentModel || '');
   const [isCustomModel, setIsCustomModel] = useState(false);
   const [validationErrors, setValidationErrors] = useState({
     provider: '',


### PR DESCRIPTION
Closes #6316 

## Summary

Pre-populates the "Switch Model" modal with the user's current provider and model selection, reducing friction when switching between models from the same provider.

### Type of Change
- [x] Refactor / Code quality

### Testing

Tested in desktop UI

### Screenshots/Demos (for UX changes)
Before:  

<img width="702" height="365" alt="image" src="https://github.com/user-attachments/assets/2bd08df0-0742-4ca5-81b2-8ac2fab39fda" />

After:   

<img width="638" height="419" alt="image" src="https://github.com/user-attachments/assets/5b0a9736-cde0-44bd-ada2-0ee8313ea516" />

