### PR TITLE
Skip the smoke tests for dependabot PRs

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -18,7 +18,7 @@ name: Live Provider Tests
 jobs:
   check-fork:
     runs-on: ubuntu-latest
-    # Skip entire workflow for PRs from forks (they don't have access to secrets)
+    # Skip entire workflow for fork PRs and dependabot PRs (they don't have access to secrets)
     if: github.actor != 'dependabot[bot]' && (github.event_name == 'workflow_dispatch' || github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     steps:
       - run: echo "Not a fork PR - proceeding with smoke tests"


### PR DESCRIPTION
As documented [here](https://docs.github.com/en/code-security/dependabot/troubleshooting-dependabot/troubleshooting-dependabot-on-github-actions#troubleshooting-failures-when-dependabot-triggers-existing-workflows), dependabot PRs are like fork PRs in that they don't have access to secrets. This means the smoke tests can't run on them.