### PR TITLE
fix(ci): prevent gh-pages branch bloat

### DIFF
--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -46,6 +46,7 @@ jobs:
 
       - name: Checkout gh-pages branch
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        continue-on-error: true      # Branch may not exist on first deploy or in forks
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
         with:
           ref: gh-pages


### PR DESCRIPTION
## Problem

The `gh-pages` branch grew to **9.6 GB** causing GitHub Pages deployments to fail with:
```
System.IO.IOException: No space left on device
```

### Root Cause

The deploy workflow had `keep_files: true` which preserved **all** existing files across deployments:

```yaml
- name: Deploy to /gh-pages
  uses: peaceiris/actions-gh-pages@v3
  with:
    keep_files: true  # <-- THE PROBLEM
```

This caused bloat because:
1. **Docusaurus hashes asset filenames** (e.g., `image-abc123.png`)
2. When an image is updated/renamed, a **new** hashed file is created
3. The **old** file is never deleted due to `keep_files: true`
4. Over months of deployments, thousands of orphaned files accumulate

Example:
```
Deploy #1: image-aaa.png (500KB)
Deploy #2: image-bbb.png (500KB) + image-aaa.png still there
Deploy #3: image-ccc.png (500KB) + image-bbb.png + image-aaa.png
... repeat 100x ...
```

## Solution

1. **Set `keep_files: false`** - Do clean deployments instead of accumulating files
2. **Set `force_orphan: true`** - Prevent git history bloat by creating fresh commits
3. **Preserve `pr-preview/` directory** - Copy it from the current gh-pages before deploying so active PR previews aren't deleted

Each deployment now produces a clean `gh-pages` branch with only:
- The current documentation build (~500 MB)
- Active PR preview directories

## Testing

- [x] Manually cleaned gh-pages branch (9.6 GB → 515 MB)
- [x] Verified site deploys correctly after cleanup
- [ ] Verify PR previews are preserved after this change merges

## Related

This PR was created after manually cleaning the gh-pages branch to fix the immediate deployment failure.