### PR TITLE
Improve PR preview site artifact clean-up

### DIFF
--- a/scripts/clean-gh-pages.sh
+++ b/scripts/clean-gh-pages.sh
@@ -1,4 +1,3 @@
-
 #!/bin/bash
 
 set -e  # Exit on error


### PR DESCRIPTION
The previous logic only cleaned up pr-previews which left behind "empty" directories (containing only a hidden .jekyll-ignore file), which seemed to be the case for some but not all of the since-removed preview directories.

This improves it so that we always remove everything under pr-previews/ that isn't a currently-deployed preview directory.