### PR TITLE
chore: upgrade to node v24 as engine

### DIFF
--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -115,7 +115,7 @@
         "vitest": "^4.0.15"
       },
       "engines": {
-        "node": "^22.17.1"
+        "node": "^24.0.0"
       }
     },
     "node_modules/@acemir/cssom": {

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -4,7 +4,7 @@
   "version": "1.18.0",
   "description": "Goose App",
   "engines": {
-    "node": "^22.17.1"
+    "node": "^24.0.0"
   },
   "main": ".vite/build/main.js",
   "scripts": {


### PR DESCRIPTION
Node LTS Is now 24, and this seems reasonable/good to do