### PR TITLE
fix(ci): add missing dependencies to openapi-schema-check job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,11 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      - name: Install Dependencies
+        run: |
+          sudo apt update -y
+          sudo apt install -y libdbus-1-dev libxcb1-dev
+
       - name: Cache Cargo artifacts
         uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
## Summary
The `openapi-schema-check` CI job was failing with `rust-lld: error: unable to find library -lxcb` because it was missing the system dependencies that the `rust-build-and-test` job has.

This adds `libdbus-1-dev` and `libxcb1-dev` to the job, matching the build job's dependencies.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
The CI itself will validate this fix passes.

### Related Issues
Relates to #6363 (blocked by this CI failure)
