### PR TITLE
Handling special claude model response in github copilot provider

### DIFF
--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -557,10 +557,7 @@ impl Provider for GithubCopilotProvider {
 // This function ensures the first choice contains tool metadata so the shared formatter emits a
 // `ToolRequest` instead of returning only the plain-text choice.
 fn promote_tool_choice(response: Value) -> Value {
-    let Some(choices) = response
-        .get("choices")
-        .and_then(|c| c.as_array())
-    else {
+    let Some(choices) = response.get("choices").and_then(|c| c.as_array()) else {
         return response;
     };
 
@@ -605,7 +602,13 @@ mod tests {
         });
 
         let promoted = promote_tool_choice(response);
-        assert_eq!(promoted.get("choices").and_then(|c| c.as_array()).map(|c| c.len()), Some(2));
+        assert_eq!(
+            promoted
+                .get("choices")
+                .and_then(|c| c.as_array())
+                .map(|c| c.len()),
+            Some(2)
+        );
         let first_choice = promoted
             .get("choices")
             .and_then(|c| c.as_array())


### PR DESCRIPTION
## Summary

**Why**

With the PR https://github.com/block/goose/pull/6331,  the tool call are no longer triggered when we using `github copilot` provider with Claude models. 

That change in the PR let Goose consume GitHub Copilot’s SSE stream directly. Copilot’s Claude Sonnet stream doesn’t include function.arguments, so tool calls never fire.   

**Why it was working before PR https://github.com/block/goose/pull/6331**
Before #6331 we buffered the entire stream inside the provider, so Claude effectively behaved like a non-streaming model and tools worked.

**What**
 - Remove Claude models from GITHUB_COPILOT_STREAM_MODELS so they go through the completion path again.
-  In GithubCopilotProvider::complete_with_model, call promote_tool_choice() to reorder the completion response by promoting whichever choice contains tool_calls to index 0 before passing it to the shared OpenAI formatter.   This special handling is for the Claude models (more explain in the promote_tool_choice function comments.
  
### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Unit test and Manual testing