### PR TITLE
fix: update MCP Apps _meta.ui.resourceUri to use nested format (SEP-1865)

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -24,19 +24,21 @@ interface ToolGraphNode {
   depends_on: number[];
 }
 
+type UiMeta = {
+  ui?: {
+    resourceUri?: string;
+  };
+};
+
 type ToolResultWithMeta = {
   status?: string;
   value?: CallToolResponse & {
-    _meta?: {
-      'ui/resourceUri'?: string;
-    };
+    _meta?: UiMeta;
   };
 };
 
 type ToolRequestWithMeta = ToolRequestMessageContent & {
-  _meta?: {
-    'ui/resourceUri'?: string;
-  };
+  _meta?: UiMeta;
   toolCall: {
     status: 'success';
     value: {
@@ -78,12 +80,12 @@ function maybeRenderMCPApp(
   append?: (value: string) => void
 ): React.ReactNode {
   const requestWithMeta = toolRequest as ToolRequestWithMeta;
-  let resourceUri = requestWithMeta._meta?.['ui/resourceUri'];
+  let resourceUri = requestWithMeta._meta?.ui?.resourceUri;
 
   if (!resourceUri && toolResponse) {
     const resultWithMeta = toolResponse.toolResult as ToolResultWithMeta;
     if (resultWithMeta?.status === 'success' && resultWithMeta.value) {
-      resourceUri = resultWithMeta.value._meta?.['ui/resourceUri'];
+      resourceUri = resultWithMeta.value._meta?.ui?.resourceUri;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #6364

The draft spec SEP-1865 expects `_meta.ui.resourceUri` (nested object structure) but goose was expecting `_meta['ui/resourceUri']` (flat key with slash), which prevented MCP Apps UI from rendering.

## Changes

Updated `ui/desktop/src/components/ToolCallWithResponse.tsx` to use the correct nested format:

- Changed `UiMeta` type from flat key to nested structure
- Updated `maybeRenderMCPApp` function to access `_meta?.ui?.resourceUri` instead of `_meta?.['ui/resourceUri']`

## Testing

- TypeScript compiles without errors
- ESLint passes
