### PR TITLE
fix: prevent infinite loop of tool-input notifications in MCP Apps

### DIFF
--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -6,7 +6,7 @@
  * @see SEP-1865 https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/draft/apps.mdx
  */
 
-import { useState, useCallback, useEffect, useMemo } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { useSandboxBridge } from './useSandboxBridge';
 import {
   ToolInput,
@@ -160,30 +160,13 @@ export default function McpAppRenderer({
     setIframeHeight(newHeight);
   }, []);
 
-  // Memoize tool props to prevent unnecessary re-renders and duplicate notifications
-  // These props are often passed as inline objects which create new references on each render
-  const memoizedToolInput = useMemo(
-    () => toolInput,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(toolInput)]
-  );
-  const memoizedToolInputPartial = useMemo(
-    () => toolInputPartial,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(toolInputPartial)]
-  );
-  const memoizedToolResult = useMemo(
-    () => toolResult,
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [JSON.stringify(toolResult)]
-  );
   const { iframeRef, proxyUrl } = useSandboxBridge({
     resourceHtml: resourceHtml || '',
     resourceCsp,
     resourceUri,
-    toolInput: memoizedToolInput,
-    toolInputPartial: memoizedToolInputPartial,
-    toolResult: memoizedToolResult,
+    toolInput,
+    toolInputPartial,
+    toolResult,
     toolCancelled,
     onMcpRequest: handleMcpRequest,
     onSizeChanged: handleSizeChanged,


### PR DESCRIPTION
## Summary

Fixes #6373

The MCP Apps sandbox bridge was sending an infinite loop of `ui/notifications/tool-input` notifications after receiving a tool result, causing re-rendering issues.

For testing, I used my demo mcp app: https://mcp-app-bench.onrender.com/mcp

### Before
Note the debug log panel on the right. Tool input is received many times when it should not be.
<img width="2032" height="1681" alt="image" src="https://github.com/user-attachments/assets/5bb68ee2-47b0-45f8-acf0-03a9d903c132" />


### After
Note the debug panel on the right. tool input and tool results are received once.
<img width="2032" height="1681" alt="image" src="https://github.com/user-attachments/assets/5274ebb5-5f9a-4578-89e6-55907f1fa8f2" />


## Root Cause

The issue was caused by two problems:

1. **Unstable object references**: When `toolInput`, `toolInputPartial`, or `toolResult` props are passed as inline objects, a new object reference is created on every render. This triggered useEffect hooks to run repeatedly, sending duplicate notifications.

2. **Timing issue**: The useEffect hooks for sending tool data run before the guest iframe sends `ui/notifications/initialized`, so the initial tool data was never sent.

## Solution

### Memoize props in `McpAppRenderer.tsx`
Added `useMemo` with `JSON.stringify` in the dependency array for `toolInput`, `toolInputPartial`, and `toolResult` to ensure stable object references when content has not changed.

### Send pending data on initialization in `useSandboxBridge.ts`
When the guest sends `ui/notifications/initialized`, we now check for any pending `toolInput` or `toolResult` and send them immediately.

## Testing

- TypeScript compiles without errors
- ESLint passes
