### PR TITLE
fix(ui): respect width parameter in MCP app size-changed notifications

### DIFF
--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -203,9 +203,7 @@ export default function McpAppRenderer({
   const handleSizeChanged = useCallback((height: number, width?: number) => {
     const newHeight = Math.max(DEFAULT_IFRAME_HEIGHT, height);
     setIframeHeight(newHeight);
-    if (width !== undefined) {
-      setIframeWidth(width);
-    }
+    setIframeWidth(width ?? null);
   }, []);
 
   const { iframeRef, proxyUrl } = useSandboxBridge({
@@ -268,6 +266,7 @@ export default function McpAppRenderer({
           src={proxyUrl}
           style={{
             width: iframeWidth ? `${iframeWidth}px` : '100%',
+            maxWidth: '100%',
             height: `${iframeHeight}px`,
             border: 'none',
             overflow: 'hidden',


### PR DESCRIPTION
closes: #6366

## PR Description

This PR fixes a bug where the MCP app iframe was ignoring the width parameter in size-changed notifications. The fix enables MCP apps to dynamically control both their width and height.

- Adds state management for iframe width
- Updates the size-changed handler to capture and apply the width parameter
- Applies dynamic width to iframe styling with fallback to 100%


### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance
