### PR TITLE
fix: prevent duplicate rendering when tool returns both mcp-ui and mcp-apps resources

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -164,7 +164,10 @@ export default function ToolCallWithResponse({
   }
 
   const requestWithMeta = toolRequest as ToolRequestWithMeta;
-  const hasMcpAppResourceURI = Boolean(requestWithMeta._meta?.ui?.resourceUri);
+  const resultWithMeta = toolResponse?.toolResult as ToolResultWithMeta;
+  const hasMcpAppResourceURI = Boolean(
+    requestWithMeta._meta?.ui?.resourceUri || resultWithMeta?.value?._meta?.ui?.resourceUri
+  );
 
   return (
     <>


### PR DESCRIPTION
## Summary
Fixes #6377

When a tool returns both an mcp-ui resource AND an mcp-apps resource, the UI was rendering both, causing duplicate display.

## Changes
- Updated `ToolCallWithResponse` to check for the presence of an MCP App resource URI (`_meta.ui.resourceUri`)
- When an MCP App resource URI is present, only render the MCP App wrapper (not the inline mcp-ui resource)
- When no MCP App resource URI is present, render the inline mcp-ui resource as before

This ensures only one rendering path is used based on whether the tool response is intended for MCP Apps or MCP UI.

## Testing
1. Add the MCP server: https://mcp-git-mcp-apps-playground-link-svelte.vercel.app/mcp
2. Ask to create a playground link with a simple Svelte 5 counter component
3. Verify the UI is rendered only once (not duplicated)