### PR TITLE
changed z-index to make sure the search highlighter does not appear on modal overlay

### DIFF
--- a/ui/desktop/src/utils/searchHighlighter.ts
+++ b/ui/desktop/src/utils/searchHighlighter.ts
@@ -30,7 +30,7 @@ export class SearchHighlighter {
       left: 0;
       right: 0;
       bottom: 0;
-      z-index: 9999;
+      z-index: 1;
     `;
 
     // Find scroll container (look for our custom data attribute first, then fallback to radix)


### PR DESCRIPTION
## Summary
- Step to produce the bug
   - In recipe list, search by some keyword. You can see the keywords are highlighted in the list
   - Select a recipe and click the edit button, the edit recipe modal appears.  The highlights are still shown in the modal.  

- Expected behaviour
   The highlights should not be shown in the modal.  

- Fix
   Currently no search highlighter is used in any modal.  So changed the z-index for Search Highlighter to 1  will fix.  Therefore the highlight still appears on the main page but not the modal overlay.  

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual testing


### Screenshots/Demos (for UX changes)
Before:  
<img width="1101" height="790" alt="Screenshot 2026-01-08 at 9 06 28 am" src="https://github.com/user-attachments/assets/c1494dbe-3210-4e4d-ba99-a8fb52cb1d46" />

After:   
<img width="1043" height="780" alt="Screenshot 2026-01-08 at 9 45 34 am" src="https://github.com/user-attachments/assets/7d42b993-fc3b-4c72-9c81-4bfc90fa12b6" />


