### PR TITLE
feat(gcp-vertex): add model list with org policy filtering

### DIFF
--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -108,6 +108,9 @@ pub struct ProviderMetadata {
     pub model_doc_link: String,
     /// Required configuration keys
     pub config_keys: Vec<ConfigKey>,
+    /// Whether this provider allows entering model names not in the fetched list
+    #[serde(default)]
+    pub allows_unlisted_models: bool,
 }
 
 impl ProviderMetadata {
@@ -138,6 +141,7 @@ impl ProviderMetadata {
                 .collect(),
             model_doc_link: model_doc_link.to_string(),
             config_keys,
+            allows_unlisted_models: false,
         }
     }
 
@@ -158,6 +162,7 @@ impl ProviderMetadata {
             known_models: models,
             model_doc_link: model_doc_link.to_string(),
             config_keys,
+            allows_unlisted_models: false,
         }
     }
 
@@ -170,7 +175,14 @@ impl ProviderMetadata {
             known_models: vec![],
             model_doc_link: "".to_string(),
             config_keys: vec![],
+            allows_unlisted_models: false,
         }
+    }
+
+    /// Set allows_unlisted_models flag (builder pattern)
+    pub fn with_unlisted_models(mut self) -> Self {
+        self.allows_unlisted_models = true;
+        self
     }
 }
 

--- a/crates/goose/src/providers/formats/gcpvertexai.rs
+++ b/crates/goose/src/providers/formats/gcpvertexai.rs
@@ -70,77 +70,49 @@ pub enum ModelError {
     UnsupportedLocation(String),
 }
 
+/// Default model for GCP Vertex AI.
+pub const DEFAULT_MODEL: &str = "gemini-2.5-flash";
+
+pub const KNOWN_MODELS: &[&str] = &[
+    "claude-opus-4-5@20251101",
+    "claude-sonnet-4-5@20250929",
+    "claude-opus-4-1@20250805",
+    "claude-haiku-4-5@20251001",
+    "claude-opus-4@20250514",
+    "claude-sonnet-4@20250514",
+    "claude-3-5-haiku@20241022",
+    "claude-3-haiku@20240307",
+    "gemini-3-pro",
+    "gemini-3-flash",
+    "gemini-2.5-pro",
+    "gemini-2.5-flash",
+    "gemini-2.5-flash-lite",
+    "gemini-2.0-flash",
+    "gemini-2.0-flash-lite",
+];
+
 /// Represents available GCP Vertex AI models for goose.
 ///
-/// This enum encompasses different model families and their versions
-/// that are supported in the GCP Vertex AI platform.
+/// This enum encompasses different model families that are supported
+/// in the GCP Vertex AI platform.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum GcpVertexAIModel {
-    /// Claude model family with specific versions
-    Claude(ClaudeVersion),
-    /// Gemini model family with specific versions
-    Gemini(GeminiVersion),
+    /// Claude model family
+    Claude(String),
+    /// Gemini model family
+    Gemini(String),
     /// MaaS (Model as a Service) models from Model Garden
     /// Contains (publisher, full_model_name)
     MaaS(String, String),
 }
 
-/// Represents available versions of the Claude model for goose.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum ClaudeVersion {
-    /// Claude Sonnet 4
-    Sonnet4,
-    /// Claude Opus 4
-    Opus4,
-    /// Generic Claude model for custom or new versions
-    Generic(String),
-}
-
-/// Represents available versions of the Gemini model for goose.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum GeminiVersion {
-    /// Gemini 1.5 Pro version
-    Pro15,
-    /// Gemini 2.0 Flash version
-    Flash20,
-    /// Gemini 2.0 Pro Experimental version
-    Pro20Exp,
-    /// Gemini 2.5 Pro Experimental version
-    Pro25Exp,
-    /// Gemini 2.5 Flash Preview version
-    Flash25Preview,
-    /// Gemini 2.5 Pro Preview version
-    Pro25Preview,
-    /// Gemini 2.5 Flash version
-    Flash25,
-    /// Gemini 2.5 Pro version
-    Pro25,
-    /// Generic Gemini model for custom or new versions
-    Generic(String),
-}
-
 impl fmt::Display for GcpVertexAIModel {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let model_id = match self {
-            Self::Claude(version) => match version {
-                ClaudeVersion::Sonnet4 => "claude-sonnet-4@20250514",
-                ClaudeVersion::Opus4 => "claude-opus-4@20250514",
-                ClaudeVersion::Generic(name) => name,
-            },
-            Self::Gemini(version) => match version {
-                GeminiVersion::Pro15 => "gemini-1.5-pro-002",
-                GeminiVersion::Flash20 => "gemini-2.0-flash-001",
-                GeminiVersion::Pro20Exp => "gemini-2.0-pro-exp-02-05",
-                GeminiVersion::Pro25Exp => "gemini-2.5-pro-exp-03-25",
-                GeminiVersion::Flash25Preview => "gemini-2.5-flash-preview-05-20",
-                GeminiVersion::Pro25Preview => "gemini-2.5-pro-preview-05-06",
-                GeminiVersion::Flash25 => "gemini-2.5-flash",
-                GeminiVersion::Pro25 => "gemini-2.5-pro",
-                GeminiVersion::Generic(name) => name,
-            },
-            Self::MaaS(_, model_name) => model_name,
-        };
-        write!(f, "{model_id}")
+        match self {
+            Self::Claude(name) => write!(f, "{name}"),
+            Self::Gemini(name) => write!(f, "{name}"),
+            Self::MaaS(_, name) => write!(f, "{name}"),
+        }
     }
 }
 
@@ -164,35 +136,19 @@ impl TryFrom<&str> for GcpVertexAIModel {
     type Error = ModelError;
 
     fn try_from(s: &str) -> Result<Self, Self::Error> {
-        // Known models
-        match s {
-            "claude-sonnet-4@20250514" => Ok(Self::Claude(ClaudeVersion::Sonnet4)),
-            "claude-opus-4@20250514" => Ok(Self::Claude(ClaudeVersion::Opus4)),
-            "gemini-1.5-pro-002" => Ok(Self::Gemini(GeminiVersion::Pro15)),
-            "gemini-2.0-flash-001" => Ok(Self::Gemini(GeminiVersion::Flash20)),
-            "gemini-2.0-pro-exp-02-05" => Ok(Self::Gemini(GeminiVersion::Pro20Exp)),
-            "gemini-2.5-pro-exp-03-25" => Ok(Self::Gemini(GeminiVersion::Pro25Exp)),
-            "gemini-2.5-flash-preview-05-20" => Ok(Self::Gemini(GeminiVersion::Flash25Preview)),
-            "gemini-2.5-pro-preview-05-06" => Ok(Self::Gemini(GeminiVersion::Pro25Preview)),
-            "gemini-2.5-flash" => Ok(Self::Gemini(GeminiVersion::Flash25)),
-            "gemini-2.5-pro" => Ok(Self::Gemini(GeminiVersion::Pro25)),
-            // MaaS models (Model as a Service from Model Garden)
-            _ if s.ends_with("-maas") => {
-                let publisher = s
-                    .split('-')
-                    .next()
-                    .ok_or_else(|| ModelError::UnsupportedModel(s.to_string()))?
-                    .to_string();
-                Ok(Self::MaaS(publisher, s.to_string()))
-            }
-            // Generic models based on prefix matching
-            _ if s.starts_with("claude-") => {
-                Ok(Self::Claude(ClaudeVersion::Generic(s.to_string())))
-            }
-            _ if s.starts_with("gemini-") => {
-                Ok(Self::Gemini(GeminiVersion::Generic(s.to_string())))
-            }
-            _ => Err(ModelError::UnsupportedModel(s.to_string())),
+        if s.starts_with("claude-") {
+            Ok(Self::Claude(s.to_string()))
+        } else if s.starts_with("gemini-") {
+            Ok(Self::Gemini(s.to_string()))
+        } else if s.ends_with("-maas") {
+            let publisher = s
+                .split('-')
+                .next()
+                .ok_or_else(|| ModelError::UnsupportedModel(s.to_string()))?
+                .to_string();
+            Ok(Self::MaaS(publisher, s.to_string()))
+        } else {
+            Err(ModelError::UnsupportedModel(s.to_string()))
         }
     }
 }
@@ -397,21 +353,16 @@ mod tests {
 
     #[test]
     fn test_model_parsing() -> Result<()> {
-        let valid_models = [
-            "claude-sonnet-4-20250514",
-            "claude-sonnet-4@20250514",
-            "gemini-1.5-pro-002",
-            "gemini-2.0-flash-001",
-            "gemini-2.0-pro-exp-02-05",
-            "gemini-2.5-pro-exp-03-25",
-            "gemini-2.5-flash-preview-05-20",
-            "gemini-2.5-pro-preview-05-06",
-        ];
+        let claude = GcpVertexAIModel::try_from("claude-sonnet-4@20250514")?;
+        assert!(matches!(claude, GcpVertexAIModel::Claude(_)));
+        assert_eq!(claude.to_string(), "claude-sonnet-4@20250514");
 
-        for model_id in valid_models {
-            let model = GcpVertexAIModel::try_from(model_id)?;
-            assert_eq!(model.to_string(), model_id);
-        }
+        let gemini = GcpVertexAIModel::try_from("gemini-2.5-flash")?;
+        assert!(matches!(gemini, GcpVertexAIModel::Gemini(_)));
+        assert_eq!(gemini.to_string(), "gemini-2.5-flash");
+
+        let maas = GcpVertexAIModel::try_from("qwen-maas")?;
+        assert!(matches!(maas, GcpVertexAIModel::MaaS(_, _)));
 
         assert!(GcpVertexAIModel::try_from("unsupported-model").is_err());
         Ok(())
@@ -419,71 +370,24 @@ mod tests {
 
     #[test]
     fn test_default_locations() -> Result<()> {
-        let test_cases = [
-            ("claude-sonnet-4-20250514", GcpLocation::Ohio),
-            ("claude-sonnet-4@20250514", GcpLocation::Ohio),
-            ("gemini-1.5-pro-002", GcpLocation::Iowa),
-            ("gemini-2.0-flash-001", GcpLocation::Iowa),
-            ("gemini-2.0-pro-exp-02-05", GcpLocation::Iowa),
-            ("gemini-2.5-pro-exp-03-25", GcpLocation::Iowa),
-            ("gemini-2.5-flash-preview-05-20", GcpLocation::Iowa),
-            ("gemini-2.5-pro-preview-05-06", GcpLocation::Iowa),
-        ];
+        let claude_model = GcpVertexAIModel::try_from("claude-sonnet-4@20250514")?;
+        assert_eq!(claude_model.known_location(), GcpLocation::Ohio);
 
-        for (model_id, expected_location) in test_cases {
-            let model = GcpVertexAIModel::try_from(model_id)?;
-            assert_eq!(
-                model.known_location(),
-                expected_location,
-                "Model {model_id} should have default location {expected_location:?}",
-            );
-
-            let context = RequestContext::new(model_id)?;
-            assert_eq!(
-                context.model.known_location(),
-                expected_location,
-                "RequestContext for {model_id} should have default location {expected_location:?}",
-            );
-        }
+        let gemini_model = GcpVertexAIModel::try_from("gemini-2.5-flash")?;
+        assert_eq!(gemini_model.known_location(), GcpLocation::Iowa);
 
         Ok(())
     }
 
     #[test]
-    fn test_generic_model_parsing() -> Result<()> {
-        // Test generic Claude models
-        let claude_models = [
-            "claude-3-8-apex@20250301",
-            "claude-new-version",
-            "claude-experimental",
-        ];
+    fn test_unknown_model_parsing() -> Result<()> {
+        let model = GcpVertexAIModel::try_from("claude-future-version")?;
+        assert!(matches!(model, GcpVertexAIModel::Claude(_)));
+        assert_eq!(model.to_string(), "claude-future-version");
 
-        for model_id in claude_models {
-            let model = GcpVertexAIModel::try_from(model_id)?;
-            match model {
-                GcpVertexAIModel::Claude(ClaudeVersion::Generic(ref name)) => {
-                    assert_eq!(name, model_id);
-                }
-                _ => panic!("Expected Claude generic model for {model_id}"),
-            }
-            assert_eq!(model.to_string(), model_id);
-            assert_eq!(model.known_location(), GcpLocation::Ohio);
-        }
-
-        // Test generic Gemini models
-        let gemini_models = ["gemini-3-pro", "gemini-2.0-flash", "gemini-experimental"];
-
-        for model_id in gemini_models {
-            let model = GcpVertexAIModel::try_from(model_id)?;
-            match model {
-                GcpVertexAIModel::Gemini(GeminiVersion::Generic(ref name)) => {
-                    assert_eq!(name, model_id);
-                }
-                _ => panic!("Expected Gemini generic model for {model_id}"),
-            }
-            assert_eq!(model.to_string(), model_id);
-            assert_eq!(model.known_location(), GcpLocation::Iowa);
-        }
+        let model = GcpVertexAIModel::try_from("gemini-4.0-ultra")?;
+        assert!(matches!(model, GcpVertexAIModel::Gemini(_)));
+        assert_eq!(model.to_string(), "gemini-4.0-ultra");
 
         Ok(())
     }

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -114,6 +114,7 @@ impl ProviderRegistry {
             known_models,
             model_doc_link: base_metadata.model_doc_link,
             config_keys,
+            allows_unlisted_models: false,
         };
 
         self.entries.insert(

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -397,6 +397,7 @@ mod tests {
                     known_models: vec![],
                     model_doc_link: "".to_string(),
                     config_keys: vec![],
+                    allows_unlisted_models: false,
                 }
             }
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -4735,6 +4735,10 @@
           "config_keys"
         ],
         "properties": {
+          "allows_unlisted_models": {
+            "type": "boolean",
+            "description": "Whether this provider allows entering model names not in the fetched list"
+          },
           "config_keys": {
             "type": "array",
             "items": {

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -631,6 +631,10 @@ export type ProviderEngine = 'openai' | 'ollama' | 'anthropic';
  */
 export type ProviderMetadata = {
     /**
+     * Whether this provider allows entering model names not in the fetched list
+     */
+    allows_unlisted_models?: boolean;
+    /**
      * Required configuration keys
      */
     config_keys: Array<ConfigKey>;

--- a/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/LeadWorkerSettings.tsx
@@ -119,11 +119,16 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                 });
               });
             }
+            // Add custom model option for all non-Custom providers
+            if (p.provider_type !== 'Custom') {
+              options.push({
+                value: `__custom__:${p.name}`,
+                label: 'Enter a model not listed...',
+                provider: p.name,
+              });
+            }
           });
         }
-
-        // Append a simple "custom" option to enable free-text entry
-        options.push({ value: '__custom__', label: 'Use custom model…', provider: '' });
 
         setModelOptions(options);
       } catch (error) {
@@ -241,9 +246,10 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                   onChange={(newValue: unknown) => {
                     const option = newValue as { value: string; provider: string } | null;
                     if (option) {
-                      if (option.value === '__custom__') {
+                      if (option.value.startsWith('__custom__')) {
                         setIsLeadCustomModel(true);
                         setLeadModel('');
+                        setLeadProvider(option.provider);
                         return;
                       }
                       setLeadModel(option.value);
@@ -294,9 +300,10 @@ export function LeadWorkerSettings({ isOpen, onClose }: LeadWorkerSettingsProps)
                   onChange={(newValue: unknown) => {
                     const option = newValue as { value: string; provider: string } | null;
                     if (option) {
-                      if (option.value === '__custom__') {
+                      if (option.value.startsWith('__custom__')) {
                         setIsWorkerCustomModel(true);
                         setWorkerModel('');
+                        setWorkerProvider(option.provider);
                         return;
                       }
                       setWorkerModel(option.value);

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -213,28 +213,33 @@ export const SwitchModelModal = ({
         const errors: string[] = [];
 
         results.forEach(({ provider: p, models, error }) => {
+          const modelList = error
+            ? (p.metadata.known_models?.map(({ name }) => name) || [])
+            : (models || []);
+
           if (error) {
             errors.push(error);
-            // Fallback to metadata known_models on error
-            if (p.metadata.known_models && p.metadata.known_models.length > 0) {
-              groupedOptions.push({
-                options: p.metadata.known_models.map(({ name }) => ({
-                  value: name,
-                  label: name,
-                  providerType: p.provider_type,
-                  provider: p.name,
-                })),
-              });
-            }
-          } else if (models && models.length > 0) {
-            groupedOptions.push({
-              options: models.map((m) => ({
-                value: m,
-                label: m,
-                provider: p.name,
-                providerType: p.provider_type,
-              })),
+          }
+
+          const options: { value: string; label: string; provider: string; providerType: ProviderType }[] =
+            modelList.map((m) => ({
+              value: m,
+              label: m,
+              provider: p.name,
+              providerType: p.provider_type,
+            }));
+
+          if (p.metadata.allows_unlisted_models && p.provider_type !== 'Custom') {
+            options.push({
+              value: 'custom',
+              label: 'Enter a model not listed...',
+              provider: p.name,
+              providerType: p.provider_type,
             });
+          }
+
+          if (options.length > 0) {
+            groupedOptions.push({ options });
           }
         });
 
@@ -242,20 +247,6 @@ export const SwitchModelModal = ({
         if (errors.length > 0) {
           console.error('Provider model fetch errors:', errors);
         }
-
-        // Add the "Custom model" option to each provider group
-        groupedOptions.forEach((group) => {
-          const option = group.options[0];
-          const providerName = option?.provider;
-          if (providerName && option?.providerType !== 'Custom') {
-            group.options.push({
-              value: 'custom',
-              label: 'Use custom model',
-              provider: providerName,
-              providerType: option?.providerType,
-            });
-          }
-        });
 
         setModelOptions(groupedOptions);
         setOriginalModelOptions(groupedOptions);
@@ -293,6 +284,7 @@ export const SwitchModelModal = ({
     if (selectedOption?.value === 'custom') {
       setIsCustomModel(true);
       setModel('');
+      setProvider(selectedOption.provider);
       setUserClearedModel(false);
     } else if (selectedOption === null) {
       // User cleared the selection
@@ -302,6 +294,7 @@ export const SwitchModelModal = ({
     } else {
       setIsCustomModel(false);
       setModel(selectedOption?.value || '');
+      setProvider(selectedOption?.provider || '');
       setUserClearedModel(false);
     }
   };


### PR DESCRIPTION
## Summary
- Add static KNOWN_MODELS list for Claude and Gemini models
- Filter models by GCP org policy (constraints/vertexai.allowedModels)
- Preserve unlisted model entry via allows_unlisted_models flag
- Replace ClaudeVersion/GeminiVersion enums with simple string storage

Note: Vertex AI does not provide a public REST API to list available foundation/publisher models, hence the static KNOWN_MODELS approach.

### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance

- [x] This PR was created or reviewed with AI assistance

### Testing
Unit tests and tested with Vertex AI.