### PR TITLE
feat: add generic HTTP LLM provider support

### DIFF
--- a/crates/goose/examples/generic_http_provider.json
+++ b/crates/goose/examples/generic_http_provider.json
@@ -1,0 +1,56 @@
+{
+  "name": "custom_llm",
+  "display_name": "Custom LLM Provider",
+  "description": "Custom LLM provider using generic HTTP provider",
+  "engine": "generic_http",
+  "env_prefix": "CUSTOM_LLM",
+  "endpoint": {
+    "url_template": "http://localhost:8765/v1/chat/messages",
+    "method": "POST",
+    "timeout_seconds": 120,
+    "skip_ssl_verify": false
+  },
+  "auth": {
+    "type": "header",
+    "header_name": "Authorization",
+    "value_template": "Bearer ${TOKEN}"
+  },
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "request": {
+    "template": {
+      "model": "${MODEL}",
+      "messages": [{"role": "user", "content": "${PROMPT}"}],
+      "stream": "${IS_STREAM:bool}"
+    }
+  },
+  "response": {
+    "content_path": "$.content",
+    "error_path": "$.error"
+  },
+  "streaming": {
+    "enabled": true,
+    "format": "sse",
+    "content_path": "$.content"
+  },
+  "tool_injection": {
+    "enabled": true,
+    "format": "markdown_codeblock",
+    "block_name": "tool_call"
+  },
+  "config_keys": [
+    {
+      "name": "TOKEN",
+      "required": true,
+      "secret": true,
+      "description": "API authentication token"
+    }
+  ],
+  "models": [
+    {
+      "name": "custom-model-v1",
+      "context_limit": 8000
+    }
+  ]
+}

--- a/crates/goose/src/config/generic_provider_config.rs
+++ b/crates/goose/src/config/generic_provider_config.rs
@@ -1,0 +1,480 @@
+//! Configuration schema for Generic HTTP LLM Provider
+//!
+//! This module defines the configuration structure for connecting to arbitrary LLM APIs
+//! that don't follow standard OpenAI/Anthropic formats.
+
+use crate::providers::base::ModelInfo;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
+use utoipa::ToSchema;
+
+/// Configuration for a generic HTTP LLM provider
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct GenericProviderConfig {
+    /// Unique identifier for this provider (e.g., "custom_my_llm")
+    pub name: String,
+
+    /// Display name shown in UI (e.g., "My Company LLM")
+    pub display_name: String,
+
+    /// Description of the provider
+    pub description: String,
+
+    /// Engine type - must be "generic_http" for this provider type
+    #[serde(default = "default_engine")]
+    pub engine: String,
+
+    /// Endpoint configuration
+    pub endpoint: EndpointConfig,
+
+    /// Authentication configuration
+    pub auth: AuthConfig,
+
+    /// Additional headers to include in requests
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+
+    /// Request format configuration
+    pub request: RequestConfig,
+
+    /// Response parsing configuration
+    pub response: ResponseConfig,
+
+    /// Streaming configuration (optional)
+    #[serde(default)]
+    pub streaming: Option<StreamingConfig>,
+
+    /// Tool injection configuration for LLMs that don't support native tool calling
+    #[serde(default)]
+    pub tool_injection: Option<ToolInjectionConfig>,
+
+    /// Configuration keys that users need to provide
+    pub config_keys: Vec<ConfigKeyDef>,
+
+    /// Available models
+    pub models: Vec<ModelInfo>,
+
+    /// Environment variable prefix for config keys (optional)
+    /// If not specified, uses provider name in uppercase (e.g., "MY_LLM" -> "MY_LLM_TOKEN")
+    /// Example: "GOOSE_CUSTOM" -> "GOOSE_CUSTOM_TOKEN"
+    #[serde(default)]
+    pub env_prefix: Option<String>,
+}
+
+fn default_engine() -> String {
+    "generic_http".to_string()
+}
+
+impl GenericProviderConfig {
+    /// Check if this config is for generic HTTP provider
+    pub fn is_generic_http(&self) -> bool {
+        self.engine == "generic_http"
+    }
+
+    /// Get the provider ID
+    pub fn id(&self) -> &str {
+        &self.name
+    }
+
+    /// Get the display name
+    pub fn display_name(&self) -> &str {
+        &self.display_name
+    }
+
+    /// Get available models
+    pub fn models(&self) -> &[ModelInfo] {
+        &self.models
+    }
+
+    /// Get default model name
+    pub fn default_model(&self) -> Option<&str> {
+        self.models.first().map(|m| m.name.as_str())
+    }
+
+    /// Get environment variable prefix for config keys
+    /// Returns env_prefix if specified, otherwise uses provider name in uppercase
+    pub fn get_env_prefix(&self) -> String {
+        self.env_prefix
+            .clone()
+            .unwrap_or_else(|| self.name.to_uppercase().replace('-', "_"))
+    }
+}
+
+/// Endpoint configuration
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct EndpointConfig {
+    /// URL template with variable substitution support
+    /// Example: "https://${DOMAIN}/api/v1/chat"
+    pub url_template: String,
+
+    /// HTTP method (default: POST)
+    #[serde(default = "default_method")]
+    pub method: String,
+
+    /// Request timeout in seconds
+    #[serde(default = "default_timeout")]
+    pub timeout_seconds: u64,
+
+    /// Skip SSL certificate verification (equivalent to curl -k)
+    /// Use with caution - only for self-signed certificates or testing
+    #[serde(default)]
+    pub skip_ssl_verify: bool,
+}
+
+fn default_method() -> String {
+    "POST".to_string()
+}
+
+fn default_timeout() -> u64 {
+    120
+}
+
+/// Authentication configuration
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum AuthConfig {
+    /// Custom header authentication
+    /// Example: x-openapi-token: Bearer ${TOKEN}
+    Header {
+        header_name: String,
+        value_template: String,
+    },
+
+    /// Bearer token authentication (Authorization: Bearer ${TOKEN})
+    Bearer { token_template: String },
+
+    /// Basic authentication
+    Basic {
+        username_template: String,
+        password_template: String,
+    },
+
+    /// Query parameter authentication
+    Query {
+        param_name: String,
+        value_template: String,
+    },
+
+    /// No authentication required
+    #[default]
+    None,
+}
+
+/// Request format configuration
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RequestConfig {
+    /// JSON template for request body
+    /// Supports variable substitution: ${PROMPT}, ${MODEL}, ${IS_STREAM}, etc.
+    pub template: Value,
+
+    /// Custom prompt format (optional)
+    /// Default: "${SYSTEM}\n\n${HISTORY}\n\nUser: ${USER_QUERY}"
+    #[serde(default)]
+    pub prompt_format: Option<String>,
+
+    /// Message history format (optional)
+    /// Default: "${ROLE}: ${CONTENT}"
+    #[serde(default)]
+    pub message_format: Option<String>,
+
+    /// Role name mappings (optional)
+    #[serde(default)]
+    pub role_mappings: Option<RoleMappings>,
+}
+
+/// Role name mappings for message formatting
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+pub struct RoleMappings {
+    #[serde(default = "default_user_role")]
+    pub user: String,
+    #[serde(default = "default_assistant_role")]
+    pub assistant: String,
+    #[serde(default = "default_system_role")]
+    pub system: String,
+}
+
+fn default_user_role() -> String {
+    "User".to_string()
+}
+
+fn default_assistant_role() -> String {
+    "Assistant".to_string()
+}
+
+fn default_system_role() -> String {
+    "System".to_string()
+}
+
+/// Response parsing configuration
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ResponseConfig {
+    /// JSONPath to extract content from response
+    /// Example: "$.content" or "$.choices[0].message.content"
+    pub content_path: String,
+
+    /// JSONPath to extract error message (optional)
+    #[serde(default)]
+    pub error_path: Option<String>,
+
+    /// Usage/token counting configuration (optional)
+    #[serde(default)]
+    pub usage: Option<UsageConfig>,
+}
+
+/// Token usage extraction configuration
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct UsageConfig {
+    /// JSONPath for input token count
+    #[serde(default)]
+    pub input_tokens_path: Option<String>,
+
+    /// JSONPath for output token count
+    #[serde(default)]
+    pub output_tokens_path: Option<String>,
+
+    /// JSONPath for total token count
+    #[serde(default)]
+    pub total_tokens_path: Option<String>,
+}
+
+/// Streaming configuration
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct StreamingConfig {
+    /// Whether streaming is supported
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Streaming format
+    #[serde(default)]
+    pub format: StreamingFormat,
+
+    /// JSONPath to extract content from each chunk
+    #[serde(default)]
+    pub content_path: Option<String>,
+
+    /// JSONPath to detect end of stream
+    #[serde(default)]
+    pub done_path: Option<String>,
+
+    /// Usage/token counting configuration for streaming (optional)
+    /// Token usage is typically included in the final chunk when done=true
+    #[serde(default)]
+    pub usage: Option<UsageConfig>,
+}
+
+/// Streaming response format
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum StreamingFormat {
+    /// Server-Sent Events (data: {...}\n\n)
+    #[default]
+    Sse,
+    /// Newline-delimited JSON
+    Ndjson,
+    /// Raw chunked transfer
+    Chunked,
+}
+
+/// Tool injection configuration for LLMs without native tool support
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ToolInjectionConfig {
+    /// Whether tool injection is enabled
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Format for tool call output
+    #[serde(default)]
+    pub format: ToolInjectionFormat,
+
+    /// Block name for markdown format (default: "tool_call")
+    #[serde(default = "default_block_name")]
+    pub block_name: String,
+
+    /// Custom system prompt template for tool injection
+    #[serde(default)]
+    pub system_template: Option<String>,
+}
+
+fn default_block_name() -> String {
+    "tool_call".to_string()
+}
+
+impl Default for ToolInjectionConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            format: ToolInjectionFormat::default(),
+            block_name: default_block_name(),
+            system_template: None,
+        }
+    }
+}
+
+/// Tool injection output format
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ToolInjectionFormat {
+    /// Markdown code block: ```tool_call\n{...}\n```
+    #[default]
+    MarkdownCodeblock,
+    /// XML format: <tool_call>...</tool_call>
+    Xml,
+    /// Plain JSON object
+    Json,
+}
+
+/// Configuration key definition
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct ConfigKeyDef {
+    /// Key name (e.g., "TOKEN", "DOMAIN")
+    pub name: String,
+
+    /// Whether this key is required
+    #[serde(default)]
+    pub required: bool,
+
+    /// Whether this should be stored securely (in keyring)
+    #[serde(default)]
+    pub secret: bool,
+
+    /// Default value (optional)
+    #[serde(default)]
+    pub default: Option<String>,
+
+    /// Human-readable description
+    #[serde(default)]
+    pub description: Option<String>,
+}
+
+impl ConfigKeyDef {
+    /// Convert to provider ConfigKey with custom prefix
+    pub fn to_config_key_with_prefix(&self, env_prefix: &str) -> crate::providers::base::ConfigKey {
+        let prefixed_name = format!("{}_{}", env_prefix, self.name.to_uppercase());
+        crate::providers::base::ConfigKey {
+            name: prefixed_name,
+            required: self.required,
+            secret: self.secret,
+            default: self.default.clone(),
+            oauth_flow: false,
+        }
+    }
+
+    /// Convert to provider ConfigKey with prefixed name (uses provider name as prefix)
+    pub fn to_config_key(&self, provider_name: &str) -> crate::providers::base::ConfigKey {
+        let env_prefix = provider_name.to_uppercase().replace('-', "_");
+        self.to_config_key_with_prefix(&env_prefix)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_deserialize_config() {
+        let json = r#"{
+            "name": "custom_test",
+            "display_name": "Test Provider",
+            "description": "A test provider",
+            "engine": "generic_http",
+            "endpoint": {
+                "url_template": "https://${DOMAIN}/api/chat"
+            },
+            "auth": {
+                "type": "bearer",
+                "token_template": "${TOKEN}"
+            },
+            "request": {
+                "template": {
+                    "prompt": "${PROMPT}",
+                    "model": "${MODEL}"
+                }
+            },
+            "response": {
+                "content_path": "$.content"
+            },
+            "config_keys": [
+                {"name": "DOMAIN", "required": true, "secret": false},
+                {"name": "TOKEN", "required": true, "secret": true}
+            ],
+            "models": [
+                {"name": "default-model", "context_limit": 8000}
+            ]
+        }"#;
+
+        let config: GenericProviderConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.name, "custom_test");
+        assert!(config.is_generic_http());
+        assert_eq!(config.config_keys.len(), 2);
+    }
+
+    #[test]
+    fn test_config_key_prefix() {
+        let key_def = ConfigKeyDef {
+            name: "TOKEN".to_string(),
+            required: true,
+            secret: true,
+            default: None,
+            description: Some("API Token".to_string()),
+        };
+
+        let config_key = key_def.to_config_key("custom_my_llm");
+        assert_eq!(config_key.name, "CUSTOM_MY_LLM_TOKEN");
+        assert!(config_key.required);
+        assert!(config_key.secret);
+    }
+
+    #[test]
+    fn test_generic_http_provider_config() {
+        let json = r#"{
+            "name": "custom_llm",
+            "display_name": "Custom LLM Provider",
+            "description": "Custom LLM provider for testing generic HTTP provider",
+            "engine": "generic_http",
+            "endpoint": {
+                "url_template": "http://localhost:8765/v1/chat/messages",
+                "method": "POST",
+                "timeout_seconds": 120
+            },
+            "auth": {
+                "type": "bearer",
+                "token_template": "${TOKEN}"
+            },
+            "headers": {
+                "Content-Type": "application/json"
+            },
+            "request": {
+                "template": {
+                    "model": "${MODEL}",
+                    "messages": [{"role": "user", "content": "${PROMPT}"}],
+                    "stream": "${IS_STREAM:bool}"
+                }
+            },
+            "response": {
+                "content_path": "$.content",
+                "error_path": "$.error",
+                "usage": {
+                    "input_tokens_path": "$.usage.input_tokens",
+                    "output_tokens_path": "$.usage.output_tokens",
+                    "total_tokens_path": "$.usage.total_tokens"
+                }
+            },
+            "tool_injection": {
+                "enabled": true,
+                "format": "markdown_codeblock",
+                "block_name": "tool_call"
+            },
+            "config_keys": [
+                {"name": "TOKEN", "required": true, "secret": true, "description": "API authentication token"}
+            ],
+            "models": [{"name": "custom-model-v1", "context_limit": 8000}]
+        }"#;
+
+        let config: GenericProviderConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.name, "custom_llm");
+        assert!(config.is_generic_http());
+        assert_eq!(config.models.len(), 1);
+        assert_eq!(config.models[0].name, "custom-model-v1");
+    }
+}

--- a/crates/goose/src/config/mod.rs
+++ b/crates/goose/src/config/mod.rs
@@ -2,6 +2,7 @@ pub mod base;
 pub mod declarative_providers;
 mod experiments;
 pub mod extensions;
+pub mod generic_provider_config;
 pub mod goose_mode;
 pub mod paths;
 pub mod permission;

--- a/crates/goose/src/providers/formats/generic_http.rs
+++ b/crates/goose/src/providers/formats/generic_http.rs
@@ -1,0 +1,639 @@
+//! Template engine and formatters for Generic HTTP LLM Provider
+//!
+//! This module provides:
+//! - Template variable substitution
+//! - Message history formatting
+//! - Tool injection prompt generation
+//! - Response parsing with JSONPath
+//! - Tool call extraction from responses
+
+use crate::config::generic_provider_config::{
+    RoleMappings, ToolInjectionConfig, ToolInjectionFormat,
+};
+use crate::conversation::message::{Message, MessageContent};
+use crate::providers::base::Usage;
+use anyhow::{anyhow, Result};
+use regex::Regex;
+use rmcp::model::{Role, Tool};
+use serde_json::Value;
+use std::collections::HashMap;
+
+/// Parsed tool call from LLM response
+#[derive(Debug, Clone)]
+pub struct ParsedToolCall {
+    pub id: String,
+    pub name: String,
+    pub arguments: Value,
+}
+
+/// Substitute variables in a template string
+///
+/// Supported formats:
+/// - `${VAR}` - simple substitution
+/// - `${VAR:number}` - parse as number
+/// - `${VAR:bool}` - parse as boolean (true/false)
+/// - `${VAR:bool_string}` - boolean as string ("True"/"False")
+/// - `${VAR:json}` - parse as JSON
+pub fn substitute_template(template: &str, variables: &HashMap<String, String>) -> Result<String> {
+    let re = Regex::new(r"\$\{([^}:]+)(?::([^}]+))?\}")?;
+
+    let mut result = template.to_string();
+    let mut replacements = Vec::new();
+
+    for cap in re.captures_iter(template) {
+        let full_match = cap.get(0).unwrap().as_str();
+        let var_name = cap.get(1).unwrap().as_str();
+        let type_hint = cap.get(2).map(|m| m.as_str());
+
+        let value = variables
+            .get(var_name)
+            .ok_or_else(|| anyhow!("Variable not found: {}", var_name))?;
+
+        let replacement = match type_hint {
+            Some("bool_string") => {
+                let bool_val = value.parse::<bool>().unwrap_or(false);
+                if bool_val { "True" } else { "False" }.to_string()
+            }
+            _ => value.clone(),
+        };
+
+        replacements.push((full_match.to_string(), replacement));
+    }
+
+    for (pattern, replacement) in replacements {
+        result = result.replace(&pattern, &replacement);
+    }
+
+    Ok(result)
+}
+
+/// Substitute variables in a JSON template
+///
+/// Recursively processes all string values in the JSON structure
+pub fn substitute_json_template(
+    template: &Value,
+    variables: &HashMap<String, String>,
+) -> Result<Value> {
+    match template {
+        Value::String(s) => {
+            let substituted = substitute_template(s, variables)?;
+
+            // Check for type hints and convert accordingly
+            let re = Regex::new(r"\$\{([^}:]+):([^}]+)\}")?;
+            if let Some(cap) = re.captures(s) {
+                let var_name = cap.get(1).unwrap().as_str();
+                let type_hint = cap.get(2).unwrap().as_str();
+
+                if let Some(value) = variables.get(var_name) {
+                    return match type_hint {
+                        "number" => {
+                            if let Ok(n) = value.parse::<i64>() {
+                                Ok(Value::Number(n.into()))
+                            } else if let Ok(n) = value.parse::<f64>() {
+                                Ok(serde_json::Number::from_f64(n)
+                                    .map(Value::Number)
+                                    .unwrap_or(Value::String(substituted)))
+                            } else {
+                                Ok(Value::String(substituted))
+                            }
+                        }
+                        "bool" => {
+                            let bool_val = value.parse::<bool>().unwrap_or(false);
+                            Ok(Value::Bool(bool_val))
+                        }
+                        "json" => serde_json::from_str(value)
+                            .map_err(|e| anyhow!("Failed to parse JSON: {}", e)),
+                        _ => Ok(Value::String(substituted)),
+                    };
+                }
+            }
+
+            Ok(Value::String(substituted))
+        }
+        Value::Array(arr) => {
+            let new_arr: Result<Vec<Value>> = arr
+                .iter()
+                .map(|v| substitute_json_template(v, variables))
+                .collect();
+            Ok(Value::Array(new_arr?))
+        }
+        Value::Object(obj) => {
+            let mut new_obj = serde_json::Map::new();
+            for (k, v) in obj {
+                let new_key = substitute_template(k, variables)?;
+                let new_val = substitute_json_template(v, variables)?;
+                new_obj.insert(new_key, new_val);
+            }
+            Ok(Value::Object(new_obj))
+        }
+        _ => Ok(template.clone()),
+    }
+}
+
+/// Extract a value from JSON using a simple JSONPath-like syntax
+///
+/// Supported syntax:
+/// - `$.field` - access object field
+/// - `$.field.nested` - nested field access
+/// - `$.array[0]` - array index access
+/// - `$.array[0].field` - combined access
+pub fn extract_by_path(json: &Value, path: &str) -> Option<Value> {
+    let path = path.strip_prefix("$.").unwrap_or(path);
+    if path.is_empty() {
+        return Some(json.clone());
+    }
+
+    let mut current = json;
+
+    for part in split_path(path) {
+        current = match &part {
+            PathPart::Field(name) => current.get(name)?,
+            PathPart::Index(idx) => current.get(*idx)?,
+        };
+    }
+
+    Some(current.clone())
+}
+
+enum PathPart {
+    Field(String),
+    Index(usize),
+}
+
+fn split_path(path: &str) -> Vec<PathPart> {
+    let mut parts = Vec::new();
+    let re = Regex::new(r"([^\.\[\]]+)|\[(\d+)\]").unwrap();
+
+    for cap in re.captures_iter(path) {
+        if let Some(field) = cap.get(1) {
+            parts.push(PathPart::Field(field.as_str().to_string()));
+        } else if let Some(idx) = cap.get(2) {
+            if let Ok(i) = idx.as_str().parse::<usize>() {
+                parts.push(PathPart::Index(i));
+            }
+        }
+    }
+
+    parts
+}
+
+/// Extract full message content including tool requests and responses
+/// This is different from as_concat_text() which only extracts Text content
+fn extract_message_content(message: &Message) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    for content in &message.content {
+        match content {
+            MessageContent::Text(text) => {
+                parts.push(text.text.clone());
+            }
+            MessageContent::ToolRequest(request) => {
+                // Format tool request as the LLM originally output it
+                if let Ok(call) = &request.tool_call {
+                    let tool_json = serde_json::json!({
+                        "name": call.name,
+                        "arguments": call.arguments
+                    });
+                    parts.push(format!(
+                        "```tool_call\n{}\n```",
+                        serde_json::to_string_pretty(&tool_json).unwrap_or_default()
+                    ));
+                }
+            }
+            MessageContent::ToolResponse(response) => {
+                // Format tool response so LLM knows the result
+                match &response.tool_result {
+                    Ok(result) => {
+                        let result_text: Vec<String> = result
+                            .content
+                            .iter()
+                            .filter_map(|c| c.as_text().map(|t| t.text.clone()))
+                            .collect();
+                        if !result_text.is_empty() {
+                            parts.push(format!(
+                                "[Tool Result for {}]:\n{}",
+                                response.id,
+                                result_text.join("\n")
+                            ));
+                        } else {
+                            parts.push(format!("[Tool {} completed successfully]", response.id));
+                        }
+                    }
+                    Err(err) => {
+                        parts.push(format!("[Tool Error for {}]: {}", response.id, err.message));
+                    }
+                }
+            }
+            // Skip other content types (Image, Thinking, etc.)
+            _ => {}
+        }
+    }
+
+    parts.join("\n")
+}
+
+/// Format message history into a single string
+pub fn format_messages(
+    system: &str,
+    messages: &[Message],
+    prompt_format: Option<&str>,
+    message_format: Option<&str>,
+    role_mappings: Option<&RoleMappings>,
+) -> String {
+    let default_mappings = RoleMappings::default();
+    let mappings = role_mappings.unwrap_or(&default_mappings);
+
+    let msg_fmt = message_format.unwrap_or("${ROLE}: ${CONTENT}");
+
+    // Format each message
+    let history: Vec<String> = messages
+        .iter()
+        .take(messages.len().saturating_sub(1))
+        .filter_map(|msg| {
+            let role = match msg.role {
+                Role::User => &mappings.user,
+                Role::Assistant => &mappings.assistant,
+            };
+            let content = extract_message_content(msg);
+
+            // Skip empty messages
+            if content.trim().is_empty() {
+                return None;
+            }
+
+            Some(
+                msg_fmt
+                    .replace("${ROLE}", role)
+                    .replace("${CONTENT}", &content),
+            )
+        })
+        .collect();
+
+    let history_str = history.join("\n\n");
+
+    // Get current user query (last message)
+    let user_query = messages
+        .last()
+        .map(extract_message_content)
+        .unwrap_or_default();
+
+    // Apply prompt format
+    let default_format = "${SYSTEM}\n\n${HISTORY}\n\n${ROLE}: ${USER_QUERY}";
+    let fmt = prompt_format.unwrap_or(default_format);
+
+    fmt.replace("${SYSTEM}", system)
+        .replace("${HISTORY}", &history_str)
+        .replace("${USER_QUERY}", &user_query)
+        .replace("${ROLE}", &mappings.user)
+}
+
+/// Generate tool injection prompt to append to system prompt
+pub fn generate_tool_injection(tools: &[Tool], config: &ToolInjectionConfig) -> String {
+    if !config.enabled || tools.is_empty() {
+        return String::new();
+    }
+
+    // Use custom template if provided
+    if let Some(template) = &config.system_template {
+        let tools_json = serde_json::to_string_pretty(tools).unwrap_or_default();
+        return template.replace("${TOOLS}", &tools_json);
+    }
+
+    // Default template based on format
+    let mut injection = String::new();
+
+    injection.push_str("\n\n## Available Tools\n\n");
+    injection.push_str("You have access to the following tools. ");
+
+    match config.format {
+        ToolInjectionFormat::MarkdownCodeblock => {
+            injection.push_str(&format!(
+                "To use a tool, respond with a JSON block in this EXACT format:\n\n```{}\n",
+                config.block_name
+            ));
+            injection.push_str(r#"{"name": "tool_name", "arguments": {"param1": "value1"}}"#);
+            injection.push_str("\n```\n\n");
+        }
+        ToolInjectionFormat::Xml => {
+            injection.push_str("To use a tool, respond with XML in this EXACT format:\n\n");
+            injection.push_str(&format!("<{}>\n", config.block_name));
+            injection.push_str("<name>tool_name</name>\n");
+            injection.push_str(r#"<arguments>{"param1": "value1"}</arguments>"#);
+            injection.push_str(&format!("\n</{}>\n\n", config.block_name));
+        }
+        ToolInjectionFormat::Json => {
+            injection
+                .push_str("To use a tool, respond with a JSON object in this EXACT format:\n\n");
+            injection.push_str(&format!(
+                r#"{{"{block_name}": {{"name": "tool_name", "arguments": {{"param1": "value1"}}}}}}"#,
+                block_name = config.block_name
+            ));
+            injection.push_str("\n\n");
+        }
+    }
+
+    injection.push_str("### Available tools:\n\n");
+
+    for tool in tools {
+        injection.push_str(&format!("#### {}\n", tool.name));
+        if let Some(desc) = &tool.description {
+            injection.push_str(&format!("{}\n", desc));
+        }
+        injection.push_str(&format!(
+            "Parameters: {}\n\n",
+            serde_json::to_string(&tool.input_schema).unwrap_or_default()
+        ));
+    }
+
+    injection.push_str("### Rules:\n");
+    injection.push_str("- When you need to use a tool, output ONLY the tool call block\n");
+    injection.push_str("- Do not explain that you're using a tool, just use it\n");
+    injection.push_str("- After receiving tool results, continue your response normally\n");
+    injection.push_str("- You can call multiple tools by outputting multiple tool call blocks\n");
+
+    injection
+}
+
+/// Parse tool calls from LLM response based on injection format
+pub fn parse_tool_calls(
+    content: &str,
+    config: &ToolInjectionConfig,
+) -> (String, Vec<ParsedToolCall>) {
+    if !config.enabled {
+        return (content.to_string(), Vec::new());
+    }
+
+    match config.format {
+        ToolInjectionFormat::MarkdownCodeblock => {
+            parse_markdown_tool_calls(content, &config.block_name)
+        }
+        ToolInjectionFormat::Xml => parse_xml_tool_calls(content, &config.block_name),
+        ToolInjectionFormat::Json => parse_json_tool_calls(content, &config.block_name),
+    }
+}
+
+fn parse_markdown_tool_calls(content: &str, block_name: &str) -> (String, Vec<ParsedToolCall>) {
+    let pattern = format!(r"```{}\s*\n?([\s\S]*?)```", regex::escape(block_name));
+    let re = Regex::new(&pattern).unwrap();
+
+    let mut tool_calls = Vec::new();
+    let mut remaining = content.to_string();
+
+    for cap in re.captures_iter(content) {
+        if let Some(json_str) = cap.get(1) {
+            if let Ok(parsed) = serde_json::from_str::<Value>(json_str.as_str().trim()) {
+                if let (Some(name), Some(args)) = (
+                    parsed.get("name").and_then(|v| v.as_str()),
+                    parsed.get("arguments"),
+                ) {
+                    tool_calls.push(ParsedToolCall {
+                        id: format!("call_{}", uuid::Uuid::new_v4()),
+                        name: name.to_string(),
+                        arguments: args.clone(),
+                    });
+                }
+            }
+        }
+    }
+
+    remaining = re.replace_all(&remaining, "").to_string();
+    (remaining.trim().to_string(), tool_calls)
+}
+
+fn parse_xml_tool_calls(content: &str, block_name: &str) -> (String, Vec<ParsedToolCall>) {
+    let pattern = format!(
+        r"<{}>\s*<name>([^<]+)</name>\s*<arguments>([\s\S]*?)</arguments>\s*</{}>",
+        regex::escape(block_name),
+        regex::escape(block_name)
+    );
+    let re = Regex::new(&pattern).unwrap();
+
+    let mut tool_calls = Vec::new();
+    let mut remaining = content.to_string();
+
+    for cap in re.captures_iter(content) {
+        if let (Some(name), Some(args_str)) = (cap.get(1), cap.get(2)) {
+            if let Ok(args) = serde_json::from_str::<Value>(args_str.as_str().trim()) {
+                tool_calls.push(ParsedToolCall {
+                    id: format!("call_{}", uuid::Uuid::new_v4()),
+                    name: name.as_str().trim().to_string(),
+                    arguments: args,
+                });
+            }
+        }
+    }
+
+    let full_pattern = format!(
+        r"<{}>\s*<name>[^<]+</name>\s*<arguments>[\s\S]*?</arguments>\s*</{}>",
+        regex::escape(block_name),
+        regex::escape(block_name)
+    );
+    let full_re = Regex::new(&full_pattern).unwrap();
+    remaining = full_re.replace_all(&remaining, "").to_string();
+
+    (remaining.trim().to_string(), tool_calls)
+}
+
+fn parse_json_tool_calls(content: &str, block_name: &str) -> (String, Vec<ParsedToolCall>) {
+    // Try to find JSON objects with the block_name key
+    let mut tool_calls = Vec::new();
+    let mut remaining = content.to_string();
+
+    // Simple approach: try to parse each line as JSON
+    let json_pattern = Regex::new(r"\{[^{}]*\{[^{}]*\}[^{}]*\}").unwrap();
+
+    for cap in json_pattern.find_iter(content) {
+        if let Ok(parsed) = serde_json::from_str::<Value>(cap.as_str()) {
+            if let Some(tool_call) = parsed.get(block_name) {
+                if let (Some(name), Some(args)) = (
+                    tool_call.get("name").and_then(|v| v.as_str()),
+                    tool_call.get("arguments"),
+                ) {
+                    tool_calls.push(ParsedToolCall {
+                        id: format!("call_{}", uuid::Uuid::new_v4()),
+                        name: name.to_string(),
+                        arguments: args.clone(),
+                    });
+                    remaining = remaining.replace(cap.as_str(), "");
+                }
+            }
+        }
+    }
+
+    (remaining.trim().to_string(), tool_calls)
+}
+
+/// Extract usage information from response
+pub fn extract_usage(
+    response: &Value,
+    input_path: Option<&str>,
+    output_path: Option<&str>,
+    total_path: Option<&str>,
+) -> Usage {
+    let input_tokens = input_path
+        .and_then(|p| extract_by_path(response, p))
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
+    let output_tokens = output_path
+        .and_then(|p| extract_by_path(response, p))
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
+    let total_tokens = total_path
+        .and_then(|p| extract_by_path(response, p))
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
+
+    Usage::new(input_tokens, output_tokens, total_tokens)
+}
+
+/// Build variables map for template substitution
+#[allow(clippy::too_many_arguments)]
+pub fn build_variables(
+    system: &str,
+    messages: &[Message],
+    model: &str,
+    is_stream: bool,
+    config_values: &HashMap<String, String>,
+    prompt_format: Option<&str>,
+    message_format: Option<&str>,
+    role_mappings: Option<&RoleMappings>,
+) -> HashMap<String, String> {
+    let mut vars = config_values.clone();
+
+    // Add system variables
+    vars.insert("SYSTEM".to_string(), system.to_string());
+    vars.insert("MODEL".to_string(), model.to_string());
+    vars.insert("IS_STREAM".to_string(), is_stream.to_string());
+
+    // Format history
+    let history: Vec<String> = messages
+        .iter()
+        .take(messages.len().saturating_sub(1))
+        .map(|msg| {
+            let role = match msg.role {
+                Role::User => "User",
+                Role::Assistant => "Assistant",
+            };
+            format!("{}: {}", role, msg.as_concat_text())
+        })
+        .collect();
+    vars.insert("HISTORY".to_string(), history.join("\n\n"));
+
+    // Get current query
+    let user_query = messages
+        .last()
+        .map(|m| m.as_concat_text())
+        .unwrap_or_default();
+    vars.insert("USER_QUERY".to_string(), user_query);
+
+    // Build full prompt
+    let prompt = format_messages(
+        system,
+        messages,
+        prompt_format,
+        message_format,
+        role_mappings,
+    );
+    vars.insert("PROMPT".to_string(), prompt);
+
+    vars
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn test_substitute_simple() {
+        let mut vars = HashMap::new();
+        vars.insert("NAME".to_string(), "test".to_string());
+        vars.insert("VALUE".to_string(), "123".to_string());
+
+        let result = substitute_template("Hello ${NAME}, value is ${VALUE}", &vars).unwrap();
+        assert_eq!(result, "Hello test, value is 123");
+    }
+
+    #[test]
+    fn test_substitute_bool_string() {
+        let mut vars = HashMap::new();
+        vars.insert("FLAG".to_string(), "true".to_string());
+
+        let result = substitute_template("${FLAG:bool_string}", &vars).unwrap();
+        assert_eq!(result, "True");
+    }
+
+    #[test]
+    fn test_substitute_json_number() {
+        let mut vars = HashMap::new();
+        vars.insert("ID".to_string(), "123".to_string());
+
+        let template = json!({"id": "${ID:number}"});
+        let result = substitute_json_template(&template, &vars).unwrap();
+        assert_eq!(result, json!({"id": 123}));
+    }
+
+    #[test]
+    fn test_extract_by_path() {
+        let json = json!({
+            "response": {
+                "content": "Hello",
+                "items": [{"id": 1}, {"id": 2}]
+            }
+        });
+
+        assert_eq!(
+            extract_by_path(&json, "$.response.content"),
+            Some(json!("Hello"))
+        );
+        assert_eq!(
+            extract_by_path(&json, "$.response.items[0].id"),
+            Some(json!(1))
+        );
+    }
+
+    #[test]
+    fn test_parse_markdown_tool_calls() {
+        let content = r#"I'll read the file for you.
+
+```tool_call
+{"name": "read_file", "arguments": {"path": "/tmp/test.txt"}}
+```
+
+Done!"#;
+
+        let config = ToolInjectionConfig {
+            enabled: true,
+            format: ToolInjectionFormat::MarkdownCodeblock,
+            block_name: "tool_call".to_string(),
+            system_template: None,
+        };
+
+        let (remaining, calls) = parse_tool_calls(content, &config);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read_file");
+        assert!(remaining.contains("I'll read the file"));
+        assert!(remaining.contains("Done!"));
+    }
+
+    #[test]
+    fn test_parse_xml_tool_calls() {
+        let content = r#"<tool_call>
+<name>read_file</name>
+<arguments>{"path": "/tmp/test.txt"}</arguments>
+</tool_call>"#;
+
+        let config = ToolInjectionConfig {
+            enabled: true,
+            format: ToolInjectionFormat::Xml,
+            block_name: "tool_call".to_string(),
+            system_template: None,
+        };
+
+        let (_, calls) = parse_tool_calls(content, &config);
+        assert_eq!(calls.len(), 1);
+        assert_eq!(calls[0].name, "read_file");
+    }
+}

--- a/crates/goose/src/providers/formats/mod.rs
+++ b/crates/goose/src/providers/formats/mod.rs
@@ -2,6 +2,7 @@ pub mod anthropic;
 pub mod bedrock;
 pub mod databricks;
 pub mod gcpvertexai;
+pub mod generic_http;
 pub mod google;
 pub mod openai;
 pub mod openai_responses;

--- a/crates/goose/src/providers/generic_http.rs
+++ b/crates/goose/src/providers/generic_http.rs
@@ -1,0 +1,651 @@
+//! Generic HTTP LLM Provider
+//!
+//! A flexible provider that can connect to any HTTP-based LLM API using
+//! configuration-driven request/response mapping.
+
+use super::base::{ConfigKey, MessageStream, Provider, ProviderMetadata, ProviderUsage, Usage};
+use super::errors::ProviderError;
+use super::formats::generic_http::{
+    build_variables, extract_by_path, extract_usage, generate_tool_injection, parse_tool_calls,
+    substitute_json_template, substitute_template, ParsedToolCall,
+};
+use crate::config::generic_provider_config::{AuthConfig, GenericProviderConfig, StreamingFormat};
+use crate::config::Config;
+use crate::conversation::message::Message;
+use crate::model::ModelConfig;
+use anyhow::Result;
+use async_stream::try_stream;
+use async_trait::async_trait;
+use futures::{StreamExt, TryStreamExt};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use rmcp::model::{object, CallToolRequestParam, Tool};
+use serde_json::Value;
+use std::collections::HashMap;
+use std::io;
+use std::time::Duration;
+use tokio_util::codec::{FramedRead, LinesCodec};
+use tokio_util::io::StreamReader;
+
+/// Generic HTTP LLM Provider
+///
+/// This provider can connect to any HTTP-based LLM API by using
+/// a configuration file that defines:
+/// - Endpoint URL and authentication
+/// - Request format (with template substitution)
+/// - Response parsing (with JSONPath)
+/// - Optional tool injection for LLMs without native tool support
+#[derive(Debug)]
+pub struct GenericHttpProvider {
+    /// The provider configuration
+    config: GenericProviderConfig,
+    /// HTTP client
+    client: reqwest::Client,
+    /// Resolved configuration values
+    resolved_values: HashMap<String, String>,
+    /// Model configuration
+    model: ModelConfig,
+    /// Cached provider name
+    name: String,
+}
+
+impl GenericHttpProvider {
+    /// Create a new GenericHttpProvider from configuration
+    pub fn from_config(config: GenericProviderConfig, model: ModelConfig) -> Result<Self> {
+        let global_config = Config::global();
+
+        // Resolve all config keys
+        let mut resolved_values = HashMap::new();
+        let env_prefix = config.get_env_prefix();
+        for key_def in &config.config_keys {
+            let prefixed_name = format!("{}_{}", env_prefix, key_def.name.to_uppercase());
+
+            let value = if key_def.secret {
+                global_config.get_secret(&prefixed_name).ok()
+            } else {
+                global_config.get_param::<String>(&prefixed_name).ok()
+            };
+
+            let value = value
+                .or_else(|| key_def.default.clone())
+                .ok_or_else(|| anyhow::anyhow!("Missing required config: {}", prefixed_name))?;
+
+            resolved_values.insert(key_def.name.clone(), value);
+        }
+
+        // Build HTTP client
+        let timeout = Duration::from_secs(config.endpoint.timeout_seconds);
+        let mut client_builder = reqwest::Client::builder().timeout(timeout);
+
+        // Skip SSL verification if configured (equivalent to curl -k)
+        if config.endpoint.skip_ssl_verify {
+            client_builder = client_builder.danger_accept_invalid_certs(true);
+        }
+
+        let client = client_builder.build()?;
+
+        let name = config.name.clone();
+
+        Ok(Self {
+            config,
+            client,
+            resolved_values,
+            model,
+            name,
+        })
+    }
+
+    /// Build the request URL from template
+    fn build_url(&self) -> Result<String> {
+        substitute_template(&self.config.endpoint.url_template, &self.resolved_values)
+    }
+
+    /// Build authentication header
+    fn build_auth_header(&self) -> Result<Option<(String, String)>> {
+        match &self.config.auth {
+            AuthConfig::Header {
+                header_name,
+                value_template,
+            } => {
+                let value = substitute_template(value_template, &self.resolved_values)?;
+                Ok(Some((header_name.clone(), value)))
+            }
+            AuthConfig::Bearer { token_template } => {
+                let token = substitute_template(token_template, &self.resolved_values)?;
+                Ok(Some((
+                    "Authorization".to_string(),
+                    format!("Bearer {}", token),
+                )))
+            }
+            AuthConfig::Basic {
+                username_template,
+                password_template,
+            } => {
+                let username = substitute_template(username_template, &self.resolved_values)?;
+                let password = substitute_template(password_template, &self.resolved_values)?;
+                let credentials = base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    format!("{}:{}", username, password),
+                );
+                Ok(Some((
+                    "Authorization".to_string(),
+                    format!("Basic {}", credentials),
+                )))
+            }
+            AuthConfig::Query { .. } => {
+                // Query params are handled in URL building
+                Ok(None)
+            }
+            AuthConfig::None => Ok(None),
+        }
+    }
+
+    /// Build additional headers from config
+    fn build_headers(&self) -> Result<HeaderMap> {
+        let mut headers = HeaderMap::new();
+
+        for (key, value_template) in &self.config.headers {
+            let value = substitute_template(value_template, &self.resolved_values)?;
+            let header_name = HeaderName::from_bytes(key.as_bytes())
+                .map_err(|e| anyhow::anyhow!("Invalid header name '{}': {}", key, e))?;
+            let header_value = HeaderValue::from_str(&value)
+                .map_err(|e| anyhow::anyhow!("Invalid header value for '{}': {}", key, e))?;
+            headers.insert(header_name, header_value);
+        }
+
+        Ok(headers)
+    }
+
+    /// Build request body from template
+    fn build_request_body(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+        is_stream: bool,
+    ) -> Result<Value> {
+        // Build system prompt with tool injection if enabled
+        let tool_injection = self
+            .config
+            .tool_injection
+            .as_ref()
+            .map(|cfg| generate_tool_injection(tools, cfg))
+            .unwrap_or_default();
+
+        let full_system = if tool_injection.is_empty() {
+            system.to_string()
+        } else {
+            format!("{}{}", system, tool_injection)
+        };
+
+        // Build variables for template substitution
+        let variables = build_variables(
+            &full_system,
+            messages,
+            &self.model.model_name,
+            is_stream,
+            &self.resolved_values,
+            self.config.request.prompt_format.as_deref(),
+            self.config.request.message_format.as_deref(),
+            self.config.request.role_mappings.as_ref(),
+        );
+
+        // Substitute template
+        substitute_json_template(&self.config.request.template, &variables)
+    }
+
+    /// Parse response to extract content
+    fn parse_response(
+        &self,
+        response: &Value,
+    ) -> Result<(String, Vec<ParsedToolCall>), ProviderError> {
+        // Check for error first
+        if let Some(error_path) = &self.config.response.error_path {
+            if let Some(error) = extract_by_path(response, error_path) {
+                if !error.is_null() {
+                    let error_msg = match error {
+                        Value::String(s) => s,
+                        Value::Array(arr) => {
+                            // Handle array of error objects
+                            arr.iter()
+                                .map(|e| {
+                                    let error_type =
+                                        e.get("type").and_then(|v| v.as_str()).unwrap_or("error");
+                                    let msg = e.get("msg").and_then(|v| v.as_str()).unwrap_or("");
+                                    format!("[{}] {}", error_type, msg)
+                                })
+                                .collect::<Vec<_>>()
+                                .join("; ")
+                        }
+                        _ => serde_json::to_string(&error).unwrap_or_default(),
+                    };
+                    return Err(ProviderError::RequestFailed(error_msg));
+                }
+            }
+        }
+
+        // Extract content
+        let content = extract_by_path(response, &self.config.response.content_path)
+            .map(|v| match v {
+                Value::String(s) => s,
+                _ => v.to_string(),
+            })
+            .ok_or_else(|| {
+                ProviderError::RequestFailed(format!(
+                    "Failed to extract content from response using path: {}",
+                    self.config.response.content_path
+                ))
+            })?;
+
+        // Parse tool calls if injection is enabled
+        let (remaining_content, tool_calls) = if let Some(tool_config) = &self.config.tool_injection
+        {
+            parse_tool_calls(&content, tool_config)
+        } else {
+            (content, Vec::new())
+        };
+
+        Ok((remaining_content, tool_calls))
+    }
+
+    /// Extract usage information from response
+    fn extract_usage(&self, response: &Value) -> Usage {
+        if let Some(usage_config) = &self.config.response.usage {
+            extract_usage(
+                response,
+                usage_config.input_tokens_path.as_deref(),
+                usage_config.output_tokens_path.as_deref(),
+                usage_config.total_tokens_path.as_deref(),
+            )
+        } else {
+            Usage::default()
+        }
+    }
+
+    /// Build a request and return the reqwest::RequestBuilder
+    fn build_request(&self, body: &Value) -> Result<reqwest::RequestBuilder, ProviderError> {
+        let url = self
+            .build_url()
+            .map_err(|e| ProviderError::RequestFailed(format!("Failed to build URL: {}", e)))?;
+
+        let headers = self
+            .build_headers()
+            .map_err(|e| ProviderError::RequestFailed(format!("Failed to build headers: {}", e)))?;
+
+        let mut request = self.client.post(&url).headers(headers).json(body);
+
+        // Add auth header
+        if let Some((header_name, header_value)) = self.build_auth_header().map_err(|e| {
+            ProviderError::Authentication(format!("Failed to build auth header: {}", e))
+        })? {
+            request = request.header(&header_name, &header_value);
+        }
+
+        // Add query auth if configured
+        if let AuthConfig::Query {
+            param_name,
+            value_template,
+        } = &self.config.auth
+        {
+            let value = substitute_template(value_template, &self.resolved_values)
+                .map_err(|e| ProviderError::Authentication(e.to_string()))?;
+            request = request.query(&[(param_name, value)]);
+        }
+
+        Ok(request)
+    }
+}
+
+#[async_trait]
+impl Provider for GenericHttpProvider {
+    fn metadata() -> ProviderMetadata
+    where
+        Self: Sized,
+    {
+        // This is a placeholder - actual metadata comes from config
+        ProviderMetadata::empty()
+    }
+
+    fn get_name(&self) -> &str {
+        &self.name
+    }
+
+    fn get_model_config(&self) -> ModelConfig {
+        self.model.clone()
+    }
+
+    async fn complete_with_model(
+        &self,
+        model_config: &ModelConfig,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+    ) -> Result<(Message, ProviderUsage), ProviderError> {
+        let body = self
+            .build_request_body(system, messages, tools, false)
+            .map_err(|e| {
+                ProviderError::RequestFailed(format!("Failed to build request body: {}", e))
+            })?;
+
+        let request = self.build_request(&body)?;
+
+        // Log request
+        tracing::debug!(
+            "GenericHttpProvider request: {}",
+            serde_json::to_string(&body).unwrap_or_default()
+        );
+
+        // Send request
+        let response = request
+            .send()
+            .await
+            .map_err(|e| ProviderError::RequestFailed(format!("HTTP request failed: {}", e)))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            return Err(match status.as_u16() {
+                401 | 403 => ProviderError::Authentication(format!(
+                    "Authentication failed ({}): {}",
+                    status, error_body
+                )),
+                429 => ProviderError::RateLimitExceeded {
+                    details: error_body,
+                    retry_delay: None,
+                },
+                500..=599 => {
+                    ProviderError::ServerError(format!("Server error ({}): {}", status, error_body))
+                }
+                _ => ProviderError::RequestFailed(format!(
+                    "Request failed ({}): {}",
+                    status, error_body
+                )),
+            });
+        }
+
+        // Parse response
+        let response_body: Value = response.json().await.map_err(|e| {
+            ProviderError::RequestFailed(format!("Failed to parse response JSON: {}", e))
+        })?;
+
+        tracing::debug!(
+            "GenericHttpProvider response: {}",
+            serde_json::to_string(&response_body).unwrap_or_default()
+        );
+
+        let (content, tool_calls) = self.parse_response(&response_body)?;
+        let usage = self.extract_usage(&response_body);
+
+        // Build message
+        let mut message = Message::assistant();
+
+        if !content.is_empty() {
+            message = message.with_text(&content);
+        }
+
+        for tc in tool_calls {
+            message = message.with_tool_request(
+                tc.id,
+                Ok(CallToolRequestParam {
+                    name: tc.name.into(),
+                    arguments: Some(object(tc.arguments)),
+                }),
+            );
+        }
+
+        Ok((
+            message,
+            ProviderUsage::new(model_config.model_name.clone(), usage),
+        ))
+    }
+
+    fn supports_streaming(&self) -> bool {
+        self.config
+            .streaming
+            .as_ref()
+            .map(|s| s.enabled)
+            .unwrap_or(false)
+    }
+
+    async fn stream(
+        &self,
+        system: &str,
+        messages: &[Message],
+        tools: &[Tool],
+    ) -> Result<MessageStream, ProviderError> {
+        let body = self
+            .build_request_body(system, messages, tools, true)
+            .map_err(|e| {
+                ProviderError::RequestFailed(format!("Failed to build request body: {}", e))
+            })?;
+
+        let request = self.build_request(&body)?;
+
+        tracing::debug!(
+            "GenericHttpProvider streaming request: {}",
+            serde_json::to_string(&body).unwrap_or_default()
+        );
+
+        let response = request
+            .send()
+            .await
+            .map_err(|e| ProviderError::RequestFailed(format!("HTTP request failed: {}", e)))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let error_body = response.text().await.unwrap_or_default();
+            return Err(match status.as_u16() {
+                401 | 403 => ProviderError::Authentication(format!(
+                    "Authentication failed ({}): {}",
+                    status, error_body
+                )),
+                429 => ProviderError::RateLimitExceeded {
+                    details: error_body,
+                    retry_delay: None,
+                },
+                500..=599 => {
+                    ProviderError::ServerError(format!("Server error ({}): {}", status, error_body))
+                }
+                _ => ProviderError::RequestFailed(format!(
+                    "Request failed ({}): {}",
+                    status, error_body
+                )),
+            });
+        }
+
+        // Get streaming config and validate format
+        let streaming_config = self.config.streaming.clone();
+
+        // Only SSE and Chunked formats are supported for streaming
+        if let Some(ref cfg) = streaming_config {
+            match cfg.format {
+                StreamingFormat::Sse | StreamingFormat::Chunked => {} // OK
+                StreamingFormat::Ndjson => {
+                    return Err(ProviderError::RequestFailed(
+                        "NDJSON streaming format is not supported.".to_string(),
+                    ));
+                }
+            }
+        }
+
+        let response_config = self.config.response.clone();
+        let tool_injection_config = self.config.tool_injection.clone();
+        let model_name = self.model.model_name.clone();
+
+        // Convert response to byte stream
+        let byte_stream = response.bytes_stream().map_err(io::Error::other);
+
+        Ok(Box::pin(try_stream! {
+            let stream_reader = StreamReader::new(byte_stream);
+            let mut framed = FramedRead::new(stream_reader, LinesCodec::new())
+                .map_err(anyhow::Error::from);
+
+            let mut accumulated_content = String::new();
+            let mut final_usage = Usage::default();
+
+            while let Some(line_result) = framed.next().await {
+                let line = line_result.map_err(|e| {
+                    ProviderError::RequestFailed(format!("Stream read error: {}", e))
+                })?;
+
+                // Skip empty lines
+                if line.trim().is_empty() {
+                    continue;
+                }
+
+                // Handle SSE format: data: {...}
+                let data_str = if line.starts_with("data: ") {
+                    line.strip_prefix("data: ").unwrap_or(&line)
+                } else {
+                    continue;
+                };
+
+                // Handle end of stream markers
+                if data_str.trim() == "[DONE]" {
+                    break;
+                }
+
+                // Parse JSON chunk
+                let chunk: Value = match serde_json::from_str(data_str) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        tracing::debug!("Failed to parse streaming chunk: {} - {}", e, data_str);
+                        continue;
+                    }
+                };
+
+                // Extract content using streaming config path or response config path
+                let content_path = streaming_config.as_ref()
+                    .and_then(|s| s.content_path.as_deref())
+                    .unwrap_or(&response_config.content_path);
+
+                let content = extract_by_path(&chunk, content_path)
+                    .map(|v| match v {
+                        Value::String(s) => s,
+                        _ => v.to_string(),
+                    })
+                    .unwrap_or_default();
+
+                // Check if done
+                let done = streaming_config.as_ref()
+                    .and_then(|s| s.done_path.as_ref())
+                    .and_then(|done_path| extract_by_path(&chunk, done_path))
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                // Extract usage from streaming chunk (typically in the final chunk when done=true)
+                if let Some(ref stream_cfg) = streaming_config {
+                    if let Some(ref usage_cfg) = stream_cfg.usage {
+                        let usage = extract_usage(
+                            &chunk,
+                            usage_cfg.input_tokens_path.as_deref(),
+                            usage_cfg.output_tokens_path.as_deref(),
+                            usage_cfg.total_tokens_path.as_deref(),
+                        );
+                        // Update final_usage if we got valid token counts
+                        if usage.input_tokens.is_some() || usage.output_tokens.is_some() {
+                            final_usage = usage;
+                        }
+                    }
+                }
+
+                if !content.is_empty() {
+                    accumulated_content.push_str(&content);
+
+                    // Yield text message for each chunk
+                    let message = Message::assistant().with_text(&content);
+                    yield (Some(message), None);
+                }
+
+                if done {
+                    break;
+                }
+            }
+
+            // Parse tool calls from accumulated content if tool injection is enabled
+            if let Some(tool_config) = &tool_injection_config {
+                let (_remaining_content, tool_calls) = parse_tool_calls(&accumulated_content, tool_config);
+
+                if !tool_calls.is_empty() {
+                    let mut final_message = Message::assistant();
+
+                    for tc in tool_calls {
+                        final_message = final_message.with_tool_request(
+                            tc.id,
+                            Ok(CallToolRequestParam {
+                                name: tc.name.into(),
+                                arguments: Some(object(tc.arguments)),
+                            }),
+                        );
+                    }
+
+                    yield (Some(final_message), Some(ProviderUsage::new(model_name.clone(), final_usage)));
+                }
+            }
+
+            // Yield final usage if we have it
+            if final_usage.input_tokens.is_some() || final_usage.output_tokens.is_some() {
+                yield (None, Some(ProviderUsage::new(model_name, final_usage)));
+            }
+
+        }))
+    }
+}
+
+/// Create ProviderMetadata from GenericProviderConfig
+pub fn metadata_from_config(config: &GenericProviderConfig) -> ProviderMetadata {
+    let env_prefix = config.get_env_prefix();
+    let config_keys: Vec<ConfigKey> = config
+        .config_keys
+        .iter()
+        .map(|k| k.to_config_key_with_prefix(&env_prefix))
+        .collect();
+
+    ProviderMetadata::with_models(
+        &config.name,
+        &config.display_name,
+        &config.description,
+        config.default_model().unwrap_or("default"),
+        config.models.clone(),
+        "",
+        config_keys,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_build_url() {
+        let config_json = r#"{
+            "name": "test_provider",
+            "display_name": "Test",
+            "description": "Test provider",
+            "endpoint": {
+                "url_template": "https://api.example.com/v1/chat"
+            },
+            "auth": {"type": "none"},
+            "request": {
+                "template": {"prompt": "${PROMPT}"}
+            },
+            "response": {
+                "content_path": "$.content"
+            },
+            "config_keys": [],
+            "models": [{"name": "test-model", "context_limit": 8000}]
+        }"#;
+
+        let config: GenericProviderConfig = serde_json::from_str(config_json).unwrap();
+        let model = ModelConfig::new("test-model").unwrap();
+        let provider = GenericHttpProvider {
+            config,
+            client: reqwest::Client::new(),
+            resolved_values: HashMap::new(),
+            model,
+            name: "test_provider".to_string(),
+        };
+
+        let url = provider.build_url().unwrap();
+        assert_eq!(url, "https://api.example.com/v1/chat");
+    }
+}

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -17,6 +17,7 @@ pub mod formats;
 mod gcpauth;
 pub mod gcpvertexai;
 pub mod gemini_cli;
+pub mod generic_http;
 pub mod githubcopilot;
 pub mod google;
 pub mod lead_worker;

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -159,4 +159,24 @@ impl ProviderRegistry {
     pub fn remove_custom_providers(&mut self) {
         self.entries.retain(|name, _| !name.starts_with("custom_"));
     }
+
+    /// Register a provider with custom metadata (for generic HTTP providers)
+    pub fn register_with_metadata<F>(
+        &mut self,
+        name: &str,
+        metadata: ProviderMetadata,
+        provider_type: ProviderType,
+        constructor: F,
+    ) where
+        F: Fn(ModelConfig) -> BoxFuture<'static, Result<Arc<dyn Provider>>> + Send + Sync + 'static,
+    {
+        self.entries.insert(
+            name.to_string(),
+            ProviderEntry {
+                metadata,
+                constructor: Arc::new(constructor),
+                provider_type,
+            },
+        );
+    }
 }


### PR DESCRIPTION
Add a flexible provider that can connect to any HTTP-based LLM API using configuration-driven request/response mapping.

Features:
- JSON configuration schema for defining custom LLM API integrations
- Template variable substitution for requests (${VAR}, ${VAR:number}, etc.)
- JSONPath-based response parsing ($.content, $.error, etc.)
- Multiple authentication methods (Bearer, Header, Basic, Query)
- SSE/Chunked streaming support
- Tool injection for LLMs without native tool calling support
- Skip SSL verification option for self-signed certificates
- Custom environment variable prefix support

Usage:
1. Create a JSON config file in ~/.config/goose/custom_providers/
2. Define endpoint, auth, request template, and response parsing
3. Run `goose configure` to set up the provider

Example config: crates/goose/examples/generic_http_provider.json

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

