### PR TITLE
CLI show extension errors

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -484,6 +484,15 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
     spinner.clear();
 
     for (name, err) in offer_debug {
+        eprintln!(
+            "{}",
+            style(format!(
+                "Warning: Failed to start extension '{}' ({}), continuing without it",
+                name, err
+            ))
+            .yellow()
+        );
+
         if let Err(debug_err) = offer_extension_debugging_help(
             &name,
             &err.to_string(),


### PR DESCRIPTION
## Summary
We offered help to fix but didn't show what was broken when an extension didn't load in the CLI

Before:
<img width="533" height="62" alt="image" src="https://github.com/user-attachments/assets/c7162b01-632b-499d-843a-dfac2a624c27" />

After:
<img width="521" height="121" alt="image" src="https://github.com/user-attachments/assets/d4ffc0ca-85bc-49f9-92d8-91f043407f1c" />


Fixes:
#6395