### PR TITLE
Add frameDomains and baseUriDomains CSP support for MCP Apps

### DIFF
--- a/ui/desktop/src/components/McpApps/utils.ts
+++ b/ui/desktop/src/components/McpApps/utils.ts
@@ -9,6 +9,8 @@ export async function fetchMcpAppProxyUrl(
   csp?: {
     connectDomains?: string[] | null;
     resourceDomains?: string[] | null;
+    frameDomains?: string[] | null;
+    baseUriDomains?: string[] | null;
   } | null
 ): Promise<string | null> {
   try {
@@ -27,6 +29,12 @@ export async function fetchMcpAppProxyUrl(
     }
     if (csp?.resourceDomains?.length) {
       params.set('resource_domains', csp.resourceDomains.join(','));
+    }
+    if (csp?.frameDomains?.length) {
+      params.set('frame_domains', csp.frameDomains.join(','));
+    }
+    if (csp?.baseUriDomains?.length) {
+      params.set('base_uri_domains', csp.baseUriDomains.join(','));
     }
 
     return `${baseUrl}/mcp-app-proxy?${params.toString()}`;


### PR DESCRIPTION
## Summary

Implements early support for proposed CSP extensions to the MCP Apps specification:

- **`frameDomains`**: Controls the `frame-src` CSP directive for nested iframes
  - Empty/omitted → `frame-src 'none'` (no nested iframes allowed)
  - With values → `frame-src <origins>`

- **`baseUriDomains`**: Controls the `base-uri` CSP directive
  - Empty/omitted → `base-uri 'self'`
  - With values → `base-uri 'self' <domains>`

## Context

This PR anticipates changes proposed in the MCP Apps spec:
**https://github.com/modelcontextprotocol/ext-apps/pull/158**

> ⚠️ **Note**: The upstream spec PR is not yet merged. We're implementing early to validate the approach and ensure it works well for Goose users. The final implementation may need adjustments once the spec is finalized.

## Why?

Enables MCP App experiences like this Svelte playground, where the app injects an iframe into itself.

1. Add this MCP server in goose https://mcp-git-mcp-apps-playground-link-svelte.vercel.app/mcp
2. Ask to create a playground link with a simple svelte 5 counter component

<img width="1703" height="1538" alt="image" src="https://github.com/user-attachments/assets/30dd47e1-e0cd-4ce1-a1b1-a55c9b6bf9f9" />


## Changes

- `crates/goose-server/src/routes/mcp_app_proxy.rs`: Added `frame_domains` and `base_uri_domains` query parameters and CSP generation logic
- `ui/desktop/src/components/McpApps/utils.ts`: Added `frameDomains` and `baseUriDomains` to the CSP type and URL builder