### PR TITLE
feat(providers): add custom headers support to Anthropic provider

### DIFF
--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -91,8 +91,19 @@ impl AnthropicProvider {
             key: api_key,
         };
 
-        let api_client = ApiClient::new(config.base_url, auth)?
+        let mut api_client = ApiClient::new(config.base_url, auth)?
             .with_header("anthropic-version", ANTHROPIC_API_VERSION)?;
+
+        // Add custom headers if present
+        if let Some(headers) = &config.headers {
+            let mut header_map = reqwest::header::HeaderMap::new();
+            for (key, value) in headers {
+                let header_name = reqwest::header::HeaderName::from_bytes(key.as_bytes())?;
+                let header_value = reqwest::header::HeaderValue::from_str(value)?;
+                header_map.insert(header_name, header_value);
+            }
+            api_client = api_client.with_headers(header_map)?;
+        }
 
         Ok(Self {
             api_client,


### PR DESCRIPTION
## Summary

- Adds custom headers support to `AnthropicProvider::from_custom_config`
- Enables Anthropic-compatible proxies (like Portkey) that require custom headers for authentication
- Mirrors the existing implementation in `OpenAiProvider::from_custom_config`

## Test plan

- [x] `cargo check` passes
- [x] `cargo test -p goose --lib anthropic` - all 8 tests pass
- [x] `cargo clippy` - no new warnings
- [ ] Manual testing with Portkey proxy

🤖 Generated with [Claude Code](https://claude.com/claude-code)