### PR TITLE
fix: recipe extensions ignored when run from UI and scheduler

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -221,8 +221,16 @@ async fn start_agent(
             })?;
 
     // Initialize session with extensions (either overrides from hub or global defaults)
-    let extensions_to_use =
+    let mut extensions_to_use =
         extension_overrides.unwrap_or_else(goose::config::get_enabled_extensions);
+
+    // If recipe has extensions, merge them with the global/override extensions
+    if let Some(ref recipe) = original_recipe {
+        if let Some(ref recipe_extensions) = recipe.extensions {
+            extensions_to_use.extend(recipe_extensions.clone());
+        }
+    }
+
     let mut extension_data = session.extension_data.clone();
     let extensions_state = EnabledExtensionsState::new(extensions_to_use);
     if let Err(e) = extensions_state.to_extension_data(&mut extension_data) {


### PR DESCRIPTION
Closes: #6023 

## PR Description 

This PR fixes a bug where recipe extensions were being ignored when recipes were run from the UI and scheduler. The fix ensures that recipe extensions are properly saved to the session's extension_data so they can be loaded correctly.

### Type of Change
- [x] Bug fix

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Screenshots/Demos (for UX changes)
Before:  

After:   

