### PR TITLE
fix[desktop]: Improve UX for ExtensionItem component

### DIFF
--- a/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
+++ b/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
@@ -85,7 +85,7 @@ export default function ExtensionItem({
             {editable && (
               <button
                 className="text-textSubtle hover:text-textStandard"
-                aria-label={`Configure ${getFriendlyTitle} Extension`}
+                aria-label={`Configure ${getFriendlyTitle(extension)} Extension`}
                 onClick={() => onConfigure?.(extension)}
               >
                 <Gear className="w-4 h-4" />


### PR DESCRIPTION
## Summary
<!-- Describe your change -->

Fixes accessibility issues in the ExtensionItem component where the entire card was clickable, causing accidental toggles and poor accessibility.

### Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

---
- Removed `onClick` handler from Card component
- Removed `hover:cursor-pointer` and `hover:shadow-default` from Card (no longer clickable)
- Removed `e.stopPropagation()` from CardAction (no longer needed)
- Added `aria-label` attributes to the Settings button and Switch for screen reader support
----
### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual testing - observed expected changes. 
  
- [x] Verified clicking on card area no longer toggles extension
- [x] Verified Switch toggle still works correctly
- [x] Verified Settings button still works correctly
- [x] Verified keyboard navigation works (Tab to focus, Enter/Space to activate)
  

### Related Issues
Relates to: fixes #6311  


### Screenshots/Demos (for UX changes)
Before:  


![531284767-575c1aad-1117-40c1-88b4-c11f192605b1](https://github.com/user-attachments/assets/c7ea2572-6bf8-45f3-855c-ac1ce49fb05d)


After:   

https://github.com/user-attachments/assets/d52322a4-2750-49ba-ba59-80582712c8ae


