### PR TITLE
fix(cli): incorrect bin name in shell completions

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -854,6 +854,9 @@ enum Command {
     Completion {
         #[arg(value_enum)]
         shell: ClapShell,
+
+        #[arg(long, default_value = "goose", help = "Provide a custom binary name")]
+        bin_name: String,
     },
 }
 
@@ -1438,9 +1441,8 @@ pub async fn cli() -> anyhow::Result<()> {
     );
 
     match cli.command {
-        Some(Command::Completion { shell }) => {
+        Some(Command::Completion { shell, bin_name }) => {
             let mut cmd = Cli::command();
-            let bin_name = cmd.get_name().to_string();
             generate(shell, &mut cmd, bin_name, &mut std::io::stdout());
             Ok(())
         }


### PR DESCRIPTION

## Summary
This patch fixes the incorrect binary name (default is the crate name i.e `goose-cli`) in the generated shell completions  introduced in https://github.com/block/goose/pull/6313

Also added a new flag to customize the binary name `--bin-name` to the `completions` sub command instead of hard coding it, as some distributions _might_ ship with a different bin name.


### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Tested locally 

### Related Issues
Closes #6432


### Screenshots/Demos (for UX changes)
```bash
goose completion --help

Usage: goose completion [OPTIONS] <SHELL>

Arguments:
  <SHELL>  [possible values: bash, elvish, fish, powershell, zsh]

Options:
      --bin-name <BIN_NAME>  Provide a custom binary name [default: goose]
  -h, --help                 Print help

   

