### PR TITLE
fix: filter models by tool_choice support in addition to tools

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -350,9 +350,19 @@ impl Provider for OpenRouterProvider {
                     .iter()
                     .any(|param| param.as_str() == Some("tools"));
 
-                if has_tool_support {
+                let has_tool_choice_support = supported_params
+                    .iter()
+                    .any(|param| param.as_str() == Some("tool_choice"));
+
+                if has_tool_support && has_tool_choice_support {
                     Some(id.to_string())
                 } else {
+                    if has_tool_support && !has_tool_choice_support {
+                        tracing::debug!(
+                            "Model '{}' supports tools but not tool_choice, skipping",
+                            id
+                        );
+                    }
                     None
                 }
             })


### PR DESCRIPTION
Closes : #3054 

### PR description

PR aims to fix a 404 error caused by incompatible OpenRouter models by updating the model filtering logic to require support for both `tools` and `tool_choice`, ensuring only compatible models are selected.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Tested in desktop UI with `nvidia/nemotron-3-nano-30b-a3b:free` model to see if it works and it worked and didn't dropped the error 404

### Screenshots/Demos (for UX changes)

![testFreeSufix](https://github.com/user-attachments/assets/75775fd4-db48-4c57-9984-4631765833ac)

