### PR TITLE
feat(ui): format large token counts in billions for readability

### DIFF
--- a/ui/desktop/src/components/sessions/SessionsInsights.tsx
+++ b/ui/desktop/src/components/sessions/SessionsInsights.tsx
@@ -109,6 +109,22 @@ export function SessionInsights() {
       .replace(/\//g, '/');
   };
 
+  const formatTokens = (tokens: number | undefined): string => {
+    if (!tokens) {
+      return '0';
+    }
+    if (tokens >= 1_000_000_000) {
+      return `${(tokens / 1_000_000_000).toFixed(2)}B`;
+    }
+    if (tokens >= 1_000_000) {
+      return `${(tokens / 1_000_000).toFixed(2)}M`;
+    }
+    if (tokens >= 1_000) {
+      return `${(tokens / 1_000).toFixed(1)}K`;
+    }
+    return tokens.toString();
+  };
+
   // Render skeleton loader while data is loading
   const renderSkeleton = () => (
     <div className="bg-background-muted flex flex-col h-full">
@@ -262,9 +278,7 @@ export function SessionInsights() {
             <CardContent className="page-transition flex flex-col justify-end h-full p-0">
               <div className="flex flex-col justify-end">
                 <p className="text-4xl font-mono font-light flex items-end">
-                  {insights?.totalTokens && insights.totalTokens > 0
-                    ? `${(insights.totalTokens / 1000000).toFixed(2)}M`
-                    : '0.00M'}
+                  {formatTokens(insights?.totalTokens)}
                 </p>
                 <span className="text-xs text-text-muted">Total tokens</span>
               </div>


### PR DESCRIPTION
## Summary

Improves the display of token counts in the Sessions Insights view by formatting values with appropriate units (B, M, K) for better readability.


<img src="https://media2.giphy.com/media/v1.Y2lkPTc5MGI3NjExYWhrdW1hb3cyYjdrcm03Y2J0emQ1MjRjZ28xdWUwdnN1bTdpZGl6dCZlcD12MV9pbnRlcm5hbF9naWZfYnlfaWQmY3Q9Zw/BZlNhp9L5WINi/giphy.gif" />

## Problem
<img width="486" height="265" alt="image" src="https://github.com/user-attachments/assets/17836956-6dd3-4fc0-a244-0c800e73afc9"/> 


When token counts exceed 1 billion, displaying them in millions becomes less readable. For example, `1234M` is harder to quickly parse than `1.23B`.

## Solution

Added a `formatTokens` helper function that formats token counts with human-readable units:
- `>= 1B`: `1.23B`
- `>= 1M`: `1.23M`
- `>= 1K`: `1.5K`
- `< 1K`: raw number

## Testing

Manual testing in the Sessions Insights view.