### PR TITLE
fix: add gap between buttons in MacDesktopInstallButtons.js

### DIFF
--- a/documentation/src/components/MacDesktopInstallButtons.js
+++ b/documentation/src/components/MacDesktopInstallButtons.js
@@ -5,7 +5,7 @@ const DesktopInstallButtons = () => {
   return (
     <div>
       <p>Click one of the buttons below to download goose Desktop for macOS:</p>
-      <div className="pill-button">
+      <div className="pill-button" style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
         <Link
           className="button button--primary button--lg"
           to="https://github.com/block/goose/releases/download/stable/Goose.zip"


### PR DESCRIPTION
## Summary
Added gap between buttons in the MacDesktopIinstallButtons.js. The gap matches the one in the Linux install buttons. Very simple change :slightly_smiling_face: 
Closes #6451

### Type of Change
- [x] Bug fix

### AI Assistance
- [ ] This PR was created or reviewed with AI assistance

### Testing
Manually.

### Related Issues
Relates to #6451.
Discussion: https://discord.com/channels/1287729918100246654/1408153538537721966/1460363266789212323

### Screenshots/Demos (for UX changes)
Before:  
<img width="510" height="421" alt="image" src="https://github.com/user-attachments/assets/68a15451-70ad-470e-9ccd-98e762f87d3f" />

After:   
<img width="506" height="418" alt="image" src="https://github.com/user-attachments/assets/9ebd54f8-102d-4641-858c-31b0e03fbb5e" />