### PR TITLE
fix: correct Cloudinary extension command and env variable

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -121,25 +121,15 @@
     "id": "cloudinary-asset-management-mcp",
     "name": "Cloudinary Asset Management",
     "description": "Cloud-based image and video management",
-    "command": "npx -y cloudinary-asset-management-mcp",
+    "command": "npx -y --package @cloudinary/asset-management -- mcp start",
     "link": "https://github.com/cloudinary/asset-management-js",
-    "installation_notes": "Install using npx package manager.",
+    "installation_notes": "Requires Node.js v20 or greater. Get your Cloudinary URL from the Cloudinary Console (https://console.cloudinary.com/settings/api-keys).",
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": [
       {
-        "name": "CLOUDINARY_CLOUD_NAME",
-        "description": "Required environment variable",
-        "required": true
-      },
-      {
-        "name": "CLOUDINARY_API_KEY",
-        "description": "Required environment variable",
-        "required": true
-      },
-      {
-        "name": "CLOUDINARY_API_SECRET",
-        "description": "Required environment variable",
+        "name": "CLOUDINARY_URL",
+        "description": "Your Cloudinary URL (cloudinary://api_key:api_secret@cloud_name)",
         "required": true
       }
     ]


### PR DESCRIPTION
## Summary

Debbie pointed out that this was an issue when she tried to install the cloudinary MCP off the extensions page. 
Fixes the Cloudinary Asset Management extension configuration in the extensions registry.

## Changes
- **Command**: Changed from `npx -y cloudinary-asset-management-mcp` (non-existent package) to `npx -y --package @cloudinary/asset-management -- mcp start` (correct package and subcommand)
- **Environment Variable**: Changed from three separate variables (`CLOUDINARY_CLOUD_NAME`, `CLOUDINARY_API_KEY`, `CLOUDINARY_API_SECRET`) to single `CLOUDINARY_URL` to match the tutorial documentation
- **Installation Notes**: Updated to mention Node.js v20 requirement

## Testing
Verified locally that the extensions page at `/goose/extensions/detail?id=cloudinary-asset-management-mcp` now shows the correct command and environment variable.

## Related
- Tutorial: https://block.github.io/goose/docs/mcp/cloudinary-asset-management-mcp/
- Extensions page: https://block.github.io/goose/extensions/detail?id=cloudinary-asset-management-mcp