### PR TITLE
fix: apply subrecipes when using slash commands

### DIFF
--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -358,8 +358,6 @@ impl Agent {
             Err(e) => return Err(anyhow!("Failed to build recipe: {}", e)),
         };
 
-        // Apply recipe components (subrecipes, response schema) to the agent
-        // This ensures subrecipes are available when the LLM processes the recipe
         self.apply_recipe_components(recipe.sub_recipes.clone(), recipe.response.clone(), true)
             .await;
 


### PR DESCRIPTION
## Summary

When invoking a recipe via slash command, the recipe's subrecipes and response schema were not being registered with the agent. This caused 'Unknown subrecipe' errors when goose tried to use subrecipes defined in the recipe.

## Problem

The `handle_recipe_command` function in `execute_commands.rs` was only extracting the `instructions` and `prompt` text from the recipe and returning it as a user message. It never called `apply_recipe_components()` to register subrecipes with the agent.

This meant that when a recipe defined `sub_recipes`, they were completely ignored in the slash command flow.

Comparing the different recipe invocation paths:

| Path | Subrecipes Loaded? |
|------|-------------------|
| CLI (`goose run --recipe`) | ✅ Yes |
| Desktop (recipe picker) | ✅ Yes |
| Subagent | ✅ Yes |
| **Slash command** | ❌ **No** (bug) |

## Fix

Added a call to `apply_recipe_components()` in `handle_recipe_command()` after building the recipe, matching the behavior of other recipe invocation paths.

## Testing

- Verified the code compiles
- Ran existing subagent and recipe tests - all pass
- This is a targeted fix that only affects the slash command path

<img width="655" height="443" alt="image" src="https://github.com/user-attachments/assets/e17731ef-bd70-4c97-999d-18709d8fa663" />
