### PR TITLE
feat(ui): support prefersBorder option for MCP Apps

### DIFF
--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -193,16 +193,6 @@ export default function McpAppRenderer({
     );
   }
 
-  if (!resource.html) {
-    return (
-      <div className={cn('p-4 bg-bgApp border border-borderSubtle rounded-lg')}>
-        <div className="flex items-center justify-center" style={{ minHeight: '200px' }}>
-          Loading MCP app...
-        </div>
-      </div>
-    );
-  }
-
   return (
     <div
       className={cn(
@@ -210,7 +200,7 @@ export default function McpAppRenderer({
         resource.prefersBorder ? 'border border-borderSubtle rounded-lg' : 'my-6'
       )}
     >
-      {proxyUrl ? (
+      {resource.html && proxyUrl ? (
         <iframe
           ref={iframeRef}
           src={proxyUrl}
@@ -223,16 +213,8 @@ export default function McpAppRenderer({
           sandbox="allow-scripts allow-same-origin"
         />
       ) : (
-        <div
-          style={{
-            width: '100%',
-            minHeight: '200px',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-          }}
-        >
-          Loading...
+        <div className="flex items-center justify-center p-4" style={{ minHeight: '200px' }}>
+          Loading MCP app...
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Adds support for the `_meta.ui.prefersBorder` option in MCP App resources. When an MCP App returns `prefersBorder: false` in its resource metadata, the UI wrapper border and rounded corners are removed, allowing the app to render edge-to-edge.

## Changes

- Read `prefersBorder` from `_meta.ui` in the resource response (defaults to `true`)
- Conditionally apply border/rounded styling based on this preference
- Refactored resource state into a single `ResourceData` object for cleaner code

## Usage

MCP Apps can now specify border preference in their resource response:

```json
{
  "uri": "ui://widget/example.html",
  "mimeType": "text/html;profile=mcp-app",
  "_meta": {
    "ui": {
      "prefersBorder": false
    }
  },
  "text": "<!doctype html>..."
}
```

## Before / After

| Before | After |
|--------|-------|
| <img width="1240" height="950" alt="image" src="https://github.com/user-attachments/assets/ffc4da39-c4f6-4977-9d6d-30e17f48d42b" /> | <img width="1237" height="951" alt="image" src="https://github.com/user-attachments/assets/2ba18f3c-65a2-4dfa-86ea-94607f67e92c" /> |

*Before: MCP App with default border and rounded corners*
*After: MCP App with `prefersBorder: false` - no wrapper border*
