### PR TITLE
Use Intl.NumberFormat for token formatting in SessionsInsights

### DIFF
--- a/ui/desktop/src/components/sessions/SessionsInsights.tsx
+++ b/ui/desktop/src/components/sessions/SessionsInsights.tsx
@@ -110,19 +110,9 @@ export function SessionInsights() {
   };
 
   const formatTokens = (tokens: number | undefined): string => {
-    if (!tokens) {
-      return '0';
-    }
-    if (tokens >= 1_000_000_000) {
-      return `${(tokens / 1_000_000_000).toFixed(2)}B`;
-    }
-    if (tokens >= 1_000_000) {
-      return `${(tokens / 1_000_000).toFixed(2)}M`;
-    }
-    if (tokens >= 1_000) {
-      return `${(tokens / 1_000).toFixed(1)}K`;
-    }
-    return tokens.toString();
+    return new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 2 }).format(
+      tokens || 0
+    );
   };
 
   // Render skeleton loader while data is loading


### PR DESCRIPTION
Addresses feedback from #6449

Replaces custom token formatting logic with `Intl.NumberFormat` using compact notation as suggested by @DOsinga.

**Before:**
```typescript
const formatTokens = (tokens: number | undefined): string => {
  if (!tokens) return '0';
  if (tokens >= 1_000_000_000) return `${(tokens / 1_000_000_000).toFixed(2)}B`;
  if (tokens >= 1_000_000) return `${(tokens / 1_000_000).toFixed(2)}M`;
  if (tokens >= 1_000) return `${(tokens / 1_000).toFixed(1)}K`;
  return tokens.toString();
};
```

**After:**
```typescript
const formatTokens = (tokens: number | undefined): string => {
  return new Intl.NumberFormat('en', { notation: 'compact', maximumFractionDigits: 2 }).format(
    tokens || 0
  );
};
```

This is cleaner, more maintainable, and leverages the browser's native formatting capabilities.