### PR TITLE
fix: correctly parse extension name from tool call for MCP apps

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -96,10 +96,14 @@ function McpAppWrapper({
     }
   }
 
-  const extensionName =
-    requestWithMeta.toolCall.status === 'success'
-      ? requestWithMeta.toolCall.value.name.split('__')[0]
-      : '';
+  // Tool names are formatted as "{extension_name}__{tool_name}".
+  // Extension names can contain underscores (special chars like parentheses are normalized to "_"),
+  // so we must use lastIndexOf to find the delimiter.
+  // e.g., "my_server(local)" -> "my_server_local_" -> "my_server_local___get_time"
+  const toolCallName =
+    requestWithMeta.toolCall.status === 'success' ? requestWithMeta.toolCall.value.name : '';
+  const delimiterIndex = toolCallName.lastIndexOf('__');
+  const extensionName = delimiterIndex === -1 ? '' : toolCallName.substring(0, delimiterIndex);
 
   const toolArguments =
     requestWithMeta.toolCall.status === 'success'


### PR DESCRIPTION
## Summary

Fixes MCP app resource loading failures when extension names contain special characters that get normalized to underscores.

## Problem

When an extension name ends with a special character (like parentheses), it gets normalized to an underscore. For example:
- `my_server(local)` becomes `my_server_local_`

The previous code used `split('__')[0]` to extract the extension name from a tool call name. This incorrectly split on the **first** `__` occurrence instead of the **last** one (which is the actual delimiter).

For a tool call like `my_server_local___get_time`:
- **Before**: `split('__')[0]` → `my_server_local` (wrong - missing trailing `_`)
- **After**: `lastIndexOf('__')` → `my_server_local_` (correct)

This caused MCP app resource requests to fail with "Extension not found" errors because the extension name didn't match.

## Solution

Use `lastIndexOf('__')` to find the delimiter between extension name and tool name, which is consistent with how the server parses tool names.

## Testing

Tested with an MCP extension named `extappsbasicserverreach(local)` which normalizes to `extappsbasicserverreach_local_`. MCP app resources now load correctly.