### PR TITLE
docs: fix extensions page

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -357,6 +357,8 @@
     "id": "jetbrains",
     "name": "JetBrains",
     "description": "Integrate with any JetBrains IDE (requires local setup, dependent on your IDE version)",
+    "command": "",
+    "show_install_command": false,
     "link": "https://github.com/JetBrains/mcp-jetbrains",
     "installation_notes": "Requires IDE v2025.2+. Use STDIO from Settings > Tools > MCP Server.",
     "is_builtin": false,


### PR DESCRIPTION
## Summary
This PR fixes an issue that causes an "Cannot read properties of undefined (reading 'split')" error loading the Extensions library. The root cause is that the jetbrains extension didn't have the `command` field. For this fix, we're (temporarily) ignoring it while looking into an issue about how `goose session --with-extension` is handling the command.

Documentation updates:
- `documentation/static/servers.json`:
  - Set `"show_install_command": false` to hide the command on the extension cards
  
<img width="891" height="555" alt="Screenshot 2026-01-13 at 2 00 36 PM" src="https://github.com/user-attachments/assets/69efd548-a73b-4343-a15e-aa0eb5c0398b" />
<img width="508" height="270" alt="Screenshot 2026-01-13 at 2 00 26 PM" src="https://github.com/user-attachments/assets/67535ac5-2e4b-4b61-a34f-b2f79d576690" />

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Manual testing