### PR TITLE
fixed 0 token in openrouter steaming

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -609,8 +609,6 @@ where
                     msg = msg.with_id(id);
                 }
 
-                // Always yield usage when present - OpenRouter sends usage in a separate
-                // chunk that may have empty content and no finish_reason
                 yield (
                     Some(msg),
                     usage,


### PR DESCRIPTION
## Summary
Fix Issue  https://github.com/block/goose/issues/5907

**Root Cause**
When sending api request to openrouter via streaming mode, the response chunks with usage comes in the chunk without finish_reason. Example

```
- choices: [(content=Some(""), finish_reason=None, has_usage=true)], usage: Some({prompt_tokens: 5897, ...}
```

**Fix**
Skip the check for `finish_reason` to get the usage

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [X] This PR was created or reviewed with AI assistance

### Testing
Manual testing and also tested open_ai, databricks and github copilot provider using the same open_ai logic
