### PR TITLE
[NOT READY FOR REVIEW] Refactor session storage into unified storage module

### DIFF
--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -22,6 +22,7 @@ pub mod security;
 pub mod session;
 pub mod session_context;
 pub mod slash_commands;
+pub mod storage;
 pub mod subprocess;
 pub mod token_counter;
 pub mod tool_inspection;

--- a/crates/goose/src/posthog.rs
+++ b/crates/goose/src/posthog.rs
@@ -2,7 +2,7 @@
 
 use crate::config::paths::Paths;
 use crate::config::{get_enabled_extensions, Config};
-use crate::session::session_manager::CURRENT_SCHEMA_VERSION;
+use crate::storage::CURRENT_SCHEMA_VERSION;
 use crate::session::SessionManager;
 use chrono::{DateTime, Utc};
 use once_cell::sync::Lazy;

--- a/crates/goose/src/session/mod.rs
+++ b/crates/goose/src/session/mod.rs
@@ -1,7 +1,7 @@
 mod chat_history_search;
 mod diagnostics;
 pub mod extension_data;
-mod legacy;
+pub(crate) mod legacy;
 pub mod session_manager;
 
 pub use diagnostics::{generate_diagnostics, get_system_info, SystemInfo};

--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -1,27 +1,18 @@
-use crate::config::paths::Paths;
 use crate::conversation::message::Message;
 use crate::conversation::Conversation;
 use crate::model::ModelConfig;
 use crate::providers::base::{Provider, MSG_COUNT_FOR_SESSION_NAME_GENERATION};
 use crate::recipe::Recipe;
 use crate::session::extension_data::ExtensionData;
+use crate::storage::StorageManager;
 use anyhow::Result;
 use chrono::{DateTime, Utc};
 use rmcp::model::Role;
 use serde::{Deserialize, Serialize};
-use sqlx::sqlite::SqliteConnectOptions;
-use sqlx::{Pool, Sqlite};
 use std::collections::HashMap;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::OnceCell;
-use tracing::{info, warn};
 use utoipa::ToSchema;
-
-pub const CURRENT_SCHEMA_VERSION: i32 = 6;
-pub const SESSIONS_FOLDER: &str = "sessions";
-pub const DB_NAME: &str = "sessions.db";
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, ToSchema, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
@@ -61,7 +52,6 @@ impl std::str::FromStr for SessionType {
     }
 }
 
-static SESSION_STORAGE: OnceCell<Arc<SessionStorage>> = OnceCell::const_new();
 
 #[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
 pub struct Session {
@@ -93,23 +83,23 @@ pub struct Session {
 }
 
 pub struct SessionUpdateBuilder {
-    session_id: String,
-    name: Option<String>,
-    user_set_name: Option<bool>,
-    session_type: Option<SessionType>,
-    working_dir: Option<PathBuf>,
-    extension_data: Option<ExtensionData>,
-    total_tokens: Option<Option<i32>>,
-    input_tokens: Option<Option<i32>>,
-    output_tokens: Option<Option<i32>>,
-    accumulated_total_tokens: Option<Option<i32>>,
-    accumulated_input_tokens: Option<Option<i32>>,
-    accumulated_output_tokens: Option<Option<i32>>,
-    schedule_id: Option<Option<String>>,
-    recipe: Option<Option<Recipe>>,
-    user_recipe_values: Option<Option<HashMap<String, String>>>,
-    provider_name: Option<Option<String>>,
-    model_config: Option<Option<ModelConfig>>,
+    pub session_id: String,
+    pub name: Option<String>,
+    pub user_set_name: Option<bool>,
+    pub session_type: Option<SessionType>,
+    pub working_dir: Option<PathBuf>,
+    pub extension_data: Option<ExtensionData>,
+    pub total_tokens: Option<Option<i32>>,
+    pub input_tokens: Option<Option<i32>>,
+    pub output_tokens: Option<Option<i32>>,
+    pub accumulated_total_tokens: Option<Option<i32>>,
+    pub accumulated_input_tokens: Option<Option<i32>>,
+    pub accumulated_output_tokens: Option<Option<i32>>,
+    pub schedule_id: Option<Option<String>>,
+    pub recipe: Option<Option<Recipe>>,
+    pub user_recipe_values: Option<Option<HashMap<String, String>>>,
+    pub provider_name: Option<Option<String>>,
+    pub model_config: Option<Option<ModelConfig>>,
 }
 
 #[derive(Serialize, ToSchema, Debug)]
@@ -120,7 +110,7 @@ pub struct SessionInsights {
 }
 
 impl SessionUpdateBuilder {
-    fn new(session_id: String) -> Self {
+    pub fn new(session_id: String) -> Self {
         Self {
             session_id,
             name: None,
@@ -241,29 +231,22 @@ impl SessionUpdateBuilder {
 pub struct SessionManager;
 
 impl SessionManager {
-    pub async fn instance() -> Result<Arc<SessionStorage>> {
-        SESSION_STORAGE
-            .get_or_try_init(|| async { SessionStorage::new().await.map(Arc::new) })
-            .await
-            .map(Arc::clone)
-    }
-
     pub async fn create_session(
         working_dir: PathBuf,
         name: String,
         session_type: SessionType,
     ) -> Result<Session> {
-        Self::instance()
-            .await?
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage
             .create_session(working_dir, name, session_type)
             .await
     }
 
     pub async fn get_session(id: &str, include_messages: bool) -> Result<Session> {
-        Self::instance()
-            .await?
-            .get_session(id, include_messages)
-            .await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.get_session(id, include_messages).await
     }
 
     pub fn update_session(id: &str) -> SessionUpdateBuilder {
@@ -271,54 +254,71 @@ impl SessionManager {
     }
 
     async fn apply_update(builder: SessionUpdateBuilder) -> Result<()> {
-        Self::instance().await?.apply_update(builder).await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.apply_update(builder).await
     }
 
     pub async fn add_message(id: &str, message: &Message) -> Result<()> {
-        Self::instance().await?.add_message(id, message).await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.add_message(id, message).await
     }
 
     pub async fn replace_conversation(id: &str, conversation: &Conversation) -> Result<()> {
-        Self::instance()
-            .await?
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage
             .replace_conversation(id, conversation)
             .await
     }
 
     pub async fn list_sessions() -> Result<Vec<Session>> {
-        Self::instance().await?.list_sessions().await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.list_sessions().await
     }
 
     pub async fn list_sessions_by_types(types: &[SessionType]) -> Result<Vec<Session>> {
-        Self::instance().await?.list_sessions_by_types(types).await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.list_sessions_by_types(types).await
     }
 
     pub async fn delete_session(id: &str) -> Result<()> {
-        Self::instance().await?.delete_session(id).await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.delete_session(id).await
     }
 
     pub async fn get_insights() -> Result<SessionInsights> {
-        Self::instance().await?.get_insights().await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.get_insights().await
     }
 
     pub async fn export_session(id: &str) -> Result<String> {
-        Self::instance().await?.export_session(id).await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.export_session(id).await
     }
 
     pub async fn import_session(json: &str) -> Result<Session> {
-        Self::instance().await?.import_session(json).await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.import_session(json).await
     }
 
     pub async fn copy_session(session_id: &str, new_name: String) -> Result<Session> {
-        Self::instance()
-            .await?
-            .copy_session(session_id, new_name)
-            .await
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage.copy_session(session_id, new_name).await
     }
 
     pub async fn truncate_conversation(session_id: &str, timestamp: i64) -> Result<()> {
-        Self::instance()
-            .await?
+        let storage_manager = StorageManager::instance().await?;
+        let session_storage = storage_manager.session_storage().await?;
+        session_storage
             .truncate_conversation(session_id, timestamp)
             .await
     }
@@ -358,33 +358,74 @@ impl SessionManager {
         before_date: Option<chrono::DateTime<chrono::Utc>>,
         exclude_session_id: Option<String>,
     ) -> Result<crate::session::chat_history_search::ChatRecallResults> {
-        Self::instance()
-            .await?
-            .search_chat_history(query, limit, after_date, before_date, exclude_session_id)
-            .await
+        use crate::session::chat_history_search::ChatHistorySearch;
+
+        let storage_manager = StorageManager::instance().await?;
+        let pool = storage_manager.pool();
+
+        ChatHistorySearch::new(
+            pool,
+            query,
+            limit,
+            after_date,
+            before_date,
+            exclude_session_id,
+        )
+        .execute()
+        .await
+    }
+
+    pub async fn import_legacy_sessions(
+        session_dir: &PathBuf,
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+    ) -> Result<()> {
+        use crate::session::legacy;
+        use crate::storage::SessionStorage;
+        use tracing::{info, warn};
+
+        let sessions = match legacy::list_sessions(session_dir) {
+            Ok(sessions) => sessions,
+            Err(_) => {
+                warn!("No legacy sessions found to import");
+                return Ok(());
+            }
+        };
+
+        if sessions.is_empty() {
+            return Ok(());
+        }
+
+        let session_storage = SessionStorage::from_pool(pool.clone()).await?;
+        let mut imported_count = 0;
+        let mut failed_count = 0;
+
+        for (session_name, session_path) in sessions {
+            match legacy::load_session(&session_name, &session_path) {
+                Ok(session) => match session_storage.import_legacy_session(&session).await {
+                    Ok(_) => {
+                        imported_count += 1;
+                        info!("  ✓ Imported: {}", session_name);
+                    }
+                    Err(e) => {
+                        failed_count += 1;
+                        info!("  ✗ Failed to import {}: {}", session_name, e);
+                    }
+                },
+                Err(e) => {
+                    failed_count += 1;
+                    info!("  ✗ Failed to load {}: {}", session_name, e);
+                }
+            }
+        }
+
+        info!(
+            "Import complete: {} successful, {} failed",
+            imported_count, failed_count
+        );
+        Ok(())
     }
 }
 
-pub struct SessionStorage {
-    pool: Pool<Sqlite>,
-}
-
-pub fn ensure_session_dir() -> Result<PathBuf> {
-    let session_dir = Paths::data_dir().join(SESSIONS_FOLDER);
-
-    if !session_dir.exists() {
-        fs::create_dir_all(&session_dir)?;
-    }
-
-    Ok(session_dir)
-}
-
-fn role_to_string(role: &Role) -> &'static str {
-    match role {
-        Role::User => "user",
-        Role::Assistant => "assistant",
-    }
-}
 
 impl Default for Session {
     fn default() -> Self {
@@ -478,838 +519,12 @@ impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for Session {
     }
 }
 
-impl SessionStorage {
-    async fn new() -> Result<Self> {
-        let session_dir = ensure_session_dir()?;
-        let db_path = session_dir.join(DB_NAME);
-
-        let storage = if db_path.exists() {
-            Self::open(&db_path).await?
-        } else {
-            let storage = Self::create(&db_path).await?;
-
-            if let Err(e) = storage.import_legacy(&session_dir).await {
-                warn!("Failed to import some legacy sessions: {}", e);
-            }
-
-            storage
-        };
-
-        Ok(storage)
-    }
-
-    async fn get_pool(db_path: &Path, create_if_missing: bool) -> Result<Pool<Sqlite>> {
-        let options = SqliteConnectOptions::new()
-            .filename(db_path)
-            .create_if_missing(create_if_missing)
-            .busy_timeout(std::time::Duration::from_secs(5))
-            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
-
-        sqlx::SqlitePool::connect_with(options).await.map_err(|e| {
-            anyhow::anyhow!(
-                "Failed to open SQLite database at '{}': {}",
-                db_path.display(),
-                e
-            )
-        })
-    }
-
-    async fn open(db_path: &Path) -> Result<Self> {
-        let pool = Self::get_pool(db_path, false).await?;
-
-        let storage = Self { pool };
-        storage.run_migrations().await?;
-        Ok(storage)
-    }
-
-    async fn create(db_path: &Path) -> Result<Self> {
-        let pool = Self::get_pool(db_path, true).await?;
-
-        sqlx::query(
-            r#"
-            CREATE TABLE schema_version (
-                version INTEGER PRIMARY KEY,
-                applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-            )
-        "#,
-        )
-        .execute(&pool)
-        .await?;
-
-        sqlx::query("INSERT INTO schema_version (version) VALUES (?)")
-            .bind(CURRENT_SCHEMA_VERSION)
-            .execute(&pool)
-            .await?;
-
-        sqlx::query(
-            r#"
-            CREATE TABLE sessions (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL DEFAULT '',
-                description TEXT NOT NULL DEFAULT '',
-                user_set_name BOOLEAN DEFAULT FALSE,
-                session_type TEXT NOT NULL DEFAULT 'user',
-                working_dir TEXT NOT NULL,
-                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                extension_data TEXT DEFAULT '{}',
-                total_tokens INTEGER,
-                input_tokens INTEGER,
-                output_tokens INTEGER,
-                accumulated_total_tokens INTEGER,
-                accumulated_input_tokens INTEGER,
-                accumulated_output_tokens INTEGER,
-                schedule_id TEXT,
-                recipe_json TEXT,
-                user_recipe_values_json TEXT,
-                provider_name TEXT,
-                model_config_json TEXT
-            )
-        "#,
-        )
-        .execute(&pool)
-        .await?;
-
-        sqlx::query(
-            r#"
-            CREATE TABLE messages (
-                id INTEGER PRIMARY KEY AUTOINCREMENT,
-                session_id TEXT NOT NULL REFERENCES sessions(id),
-                role TEXT NOT NULL,
-                content_json TEXT NOT NULL,
-                created_timestamp INTEGER NOT NULL,
-                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-                tokens INTEGER,
-                metadata_json TEXT
-            )
-        "#,
-        )
-        .execute(&pool)
-        .await?;
-
-        sqlx::query("CREATE INDEX idx_messages_session ON messages(session_id)")
-            .execute(&pool)
-            .await?;
-        sqlx::query("CREATE INDEX idx_messages_timestamp ON messages(timestamp)")
-            .execute(&pool)
-            .await?;
-        sqlx::query("CREATE INDEX idx_sessions_updated ON sessions(updated_at DESC)")
-            .execute(&pool)
-            .await?;
-        sqlx::query("CREATE INDEX idx_sessions_type ON sessions(session_type)")
-            .execute(&pool)
-            .await?;
-
-        Ok(Self { pool })
-    }
-
-    async fn import_legacy(&self, session_dir: &PathBuf) -> Result<()> {
-        use crate::session::legacy;
-
-        let sessions = match legacy::list_sessions(session_dir) {
-            Ok(sessions) => sessions,
-            Err(_) => {
-                warn!("No legacy sessions found to import");
-                return Ok(());
-            }
-        };
-
-        if sessions.is_empty() {
-            return Ok(());
-        }
-
-        let mut imported_count = 0;
-        let mut failed_count = 0;
-
-        for (session_name, session_path) in sessions {
-            match legacy::load_session(&session_name, &session_path) {
-                Ok(session) => match self.import_legacy_session(&session).await {
-                    Ok(_) => {
-                        imported_count += 1;
-                        info!("  ✓ Imported: {}", session_name);
-                    }
-                    Err(e) => {
-                        failed_count += 1;
-                        info!("  ✗ Failed to import {}: {}", session_name, e);
-                    }
-                },
-                Err(e) => {
-                    failed_count += 1;
-                    info!("  ✗ Failed to load {}: {}", session_name, e);
-                }
-            }
-        }
-
-        info!(
-            "Import complete: {} successful, {} failed",
-            imported_count, failed_count
-        );
-        Ok(())
-    }
-
-    async fn import_legacy_session(&self, session: &Session) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
-
-        let recipe_json = match &session.recipe {
-            Some(recipe) => Some(serde_json::to_string(recipe)?),
-            None => None,
-        };
-
-        let user_recipe_values_json = match &session.user_recipe_values {
-            Some(user_recipe_values) => Some(serde_json::to_string(user_recipe_values)?),
-            None => None,
-        };
-
-        let model_config_json = match &session.model_config {
-            Some(model_config) => Some(serde_json::to_string(model_config)?),
-            None => None,
-        };
-
-        sqlx::query(
-            r#"
-        INSERT INTO sessions (
-            id, name, user_set_name, session_type, working_dir, created_at, updated_at, extension_data,
-            total_tokens, input_tokens, output_tokens,
-            accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens,
-            schedule_id, recipe_json, user_recipe_values_json,
-            provider_name, model_config_json
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        "#,
-        )
-            .bind(&session.id)
-            .bind(&session.name)
-            .bind(session.user_set_name)
-            .bind(session.session_type.to_string())
-            .bind(session.working_dir.to_string_lossy().as_ref())
-            .bind(session.created_at)
-            .bind(session.updated_at)
-            .bind(serde_json::to_string(&session.extension_data)?)
-            .bind(session.total_tokens)
-            .bind(session.input_tokens)
-            .bind(session.output_tokens)
-            .bind(session.accumulated_total_tokens)
-            .bind(session.accumulated_input_tokens)
-            .bind(session.accumulated_output_tokens)
-            .bind(&session.schedule_id)
-            .bind(recipe_json)
-            .bind(user_recipe_values_json)
-            .bind(&session.provider_name)
-            .bind(model_config_json)
-            .execute(&mut *tx)
-            .await?;
-
-        tx.commit().await?;
-
-        if let Some(conversation) = &session.conversation {
-            self.replace_conversation(&session.id, conversation).await?;
-        }
-        Ok(())
-    }
-
-    async fn run_migrations(&self) -> Result<()> {
-        let current_version = self.get_schema_version().await?;
-
-        if current_version < CURRENT_SCHEMA_VERSION {
-            info!(
-                "Running database migrations from v{} to v{}...",
-                current_version, CURRENT_SCHEMA_VERSION
-            );
-
-            for version in (current_version + 1)..=CURRENT_SCHEMA_VERSION {
-                info!("  Applying migration v{}...", version);
-                self.apply_migration(version).await?;
-                self.update_schema_version(version).await?;
-                info!("  ✓ Migration v{} complete", version);
-            }
-
-            info!("All migrations complete");
-        }
-
-        Ok(())
-    }
-
-    async fn get_schema_version(&self) -> Result<i32> {
-        let table_exists = sqlx::query_scalar::<_, bool>(
-            r#"
-            SELECT EXISTS (
-                SELECT name FROM sqlite_master
-                WHERE type='table' AND name='schema_version'
-            )
-        "#,
-        )
-        .fetch_one(&self.pool)
-        .await?;
-
-        if !table_exists {
-            return Ok(0);
-        }
-
-        let version = sqlx::query_scalar::<_, i32>("SELECT MAX(version) FROM schema_version")
-            .fetch_one(&self.pool)
-            .await?;
-
-        Ok(version)
-    }
-
-    async fn update_schema_version(&self, version: i32) -> Result<()> {
-        sqlx::query("INSERT INTO schema_version (version) VALUES (?)")
-            .bind(version)
-            .execute(&self.pool)
-            .await?;
-        Ok(())
-    }
-
-    async fn apply_migration(&self, version: i32) -> Result<()> {
-        match version {
-            1 => {
-                sqlx::query(
-                    r#"
-                    CREATE TABLE IF NOT EXISTS schema_version (
-                        version INTEGER PRIMARY KEY,
-                        applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
-                    )
-                "#,
-                )
-                .execute(&self.pool)
-                .await?;
-            }
-            2 => {
-                sqlx::query(
-                    r#"
-                    ALTER TABLE sessions ADD COLUMN user_recipe_values_json TEXT
-                "#,
-                )
-                .execute(&self.pool)
-                .await?;
-            }
-            3 => {
-                sqlx::query(
-                    r#"
-                    ALTER TABLE messages ADD COLUMN metadata_json TEXT
-                "#,
-                )
-                .execute(&self.pool)
-                .await?;
-            }
-            4 => {
-                sqlx::query(
-                    r#"
-                    ALTER TABLE sessions ADD COLUMN name TEXT DEFAULT ''
-                "#,
-                )
-                .execute(&self.pool)
-                .await?;
-
-                sqlx::query(
-                    r#"
-                    ALTER TABLE sessions ADD COLUMN user_set_name BOOLEAN DEFAULT FALSE
-                "#,
-                )
-                .execute(&self.pool)
-                .await?;
-            }
-            5 => {
-                sqlx::query(
-                    r#"
-                    ALTER TABLE sessions ADD COLUMN session_type TEXT NOT NULL DEFAULT 'user'
-                "#,
-                )
-                .execute(&self.pool)
-                .await?;
-
-                sqlx::query("CREATE INDEX idx_sessions_type ON sessions(session_type)")
-                    .execute(&self.pool)
-                    .await?;
-            }
-            6 => {
-                sqlx::query(
-                    r#"
-                    ALTER TABLE sessions ADD COLUMN provider_name TEXT
-                "#,
-                )
-                .execute(&self.pool)
-                .await?;
-
-                sqlx::query(
-                    r#"
-                    ALTER TABLE sessions ADD COLUMN model_config_json TEXT
-                "#,
-                )
-                .execute(&self.pool)
-                .await?;
-            }
-            _ => {
-                anyhow::bail!("Unknown migration version: {}", version);
-            }
-        }
-
-        Ok(())
-    }
-
-    async fn create_session(
-        &self,
-        working_dir: PathBuf,
-        name: String,
-        session_type: SessionType,
-    ) -> Result<Session> {
-        let mut tx = self.pool.begin().await?;
-
-        let today = chrono::Utc::now().format("%Y%m%d").to_string();
-        let session = sqlx::query_as(
-            r#"
-                INSERT INTO sessions (id, name, user_set_name, session_type, working_dir, extension_data)
-                VALUES (
-                    ? || '_' || CAST(COALESCE((
-                        SELECT MAX(CAST(SUBSTR(id, 10) AS INTEGER))
-                        FROM sessions
-                        WHERE id LIKE ? || '_%'
-                    ), 0) + 1 AS TEXT),
-                    ?,
-                    FALSE,
-                    ?,
-                    ?,
-                    '{}'
-                )
-                RETURNING *
-                "#,
-        )
-            .bind(&today)
-            .bind(&today)
-            .bind(&name)
-            .bind(session_type.to_string())
-            .bind(working_dir.to_string_lossy().as_ref())
-            .fetch_one(&mut *tx)
-            .await?;
-
-        tx.commit().await?;
-        crate::posthog::emit_session_started();
-        Ok(session)
-    }
-
-    async fn get_session(&self, id: &str, include_messages: bool) -> Result<Session> {
-        let mut session = sqlx::query_as::<_, Session>(
-            r#"
-        SELECT id, working_dir, name, description, user_set_name, session_type, created_at, updated_at, extension_data,
-               total_tokens, input_tokens, output_tokens,
-               accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens,
-               schedule_id, recipe_json, user_recipe_values_json,
-               provider_name, model_config_json
-        FROM sessions
-        WHERE id = ?
-    "#,
-        )
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?
-            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
-
-        if include_messages {
-            let conv = self.get_conversation(&session.id).await?;
-            session.message_count = conv.messages().len();
-            session.conversation = Some(conv);
-        } else {
-            let count =
-                sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM messages WHERE session_id = ?")
-                    .bind(&session.id)
-                    .fetch_one(&self.pool)
-                    .await? as usize;
-            session.message_count = count;
-        }
-
-        Ok(session)
-    }
-
-    #[allow(clippy::too_many_lines)]
-    async fn apply_update(&self, builder: SessionUpdateBuilder) -> Result<()> {
-        let mut updates = Vec::new();
-        let mut query = String::from("UPDATE sessions SET ");
-
-        macro_rules! add_update {
-            ($field:expr, $name:expr) => {
-                if $field.is_some() {
-                    if !updates.is_empty() {
-                        query.push_str(", ");
-                    }
-                    updates.push($name);
-                    query.push_str($name);
-                    query.push_str(" = ?");
-                }
-            };
-        }
-
-        add_update!(builder.name, "name");
-        add_update!(builder.user_set_name, "user_set_name");
-        add_update!(builder.session_type, "session_type");
-        add_update!(builder.working_dir, "working_dir");
-        add_update!(builder.extension_data, "extension_data");
-        add_update!(builder.total_tokens, "total_tokens");
-        add_update!(builder.input_tokens, "input_tokens");
-        add_update!(builder.output_tokens, "output_tokens");
-        add_update!(builder.accumulated_total_tokens, "accumulated_total_tokens");
-        add_update!(builder.accumulated_input_tokens, "accumulated_input_tokens");
-        add_update!(
-            builder.accumulated_output_tokens,
-            "accumulated_output_tokens"
-        );
-        add_update!(builder.schedule_id, "schedule_id");
-        add_update!(builder.recipe, "recipe_json");
-        add_update!(builder.user_recipe_values, "user_recipe_values_json");
-        add_update!(builder.provider_name, "provider_name");
-        add_update!(builder.model_config, "model_config_json");
-
-        if updates.is_empty() {
-            return Ok(());
-        }
-
-        query.push_str(", ");
-        query.push_str("updated_at = datetime('now') WHERE id = ?");
-
-        let mut q = sqlx::query(&query);
-
-        if let Some(name) = builder.name {
-            q = q.bind(name);
-        }
-        if let Some(user_set_name) = builder.user_set_name {
-            q = q.bind(user_set_name);
-        }
-        if let Some(session_type) = builder.session_type {
-            q = q.bind(session_type.to_string());
-        }
-        if let Some(wd) = builder.working_dir {
-            q = q.bind(wd.to_string_lossy().to_string());
-        }
-        if let Some(ed) = builder.extension_data {
-            q = q.bind(serde_json::to_string(&ed)?);
-        }
-        if let Some(tt) = builder.total_tokens {
-            q = q.bind(tt);
-        }
-        if let Some(it) = builder.input_tokens {
-            q = q.bind(it);
-        }
-        if let Some(ot) = builder.output_tokens {
-            q = q.bind(ot);
-        }
-        if let Some(att) = builder.accumulated_total_tokens {
-            q = q.bind(att);
-        }
-        if let Some(ait) = builder.accumulated_input_tokens {
-            q = q.bind(ait);
-        }
-        if let Some(aot) = builder.accumulated_output_tokens {
-            q = q.bind(aot);
-        }
-        if let Some(sid) = builder.schedule_id {
-            q = q.bind(sid);
-        }
-        if let Some(recipe) = builder.recipe {
-            let recipe_json = recipe.map(|r| serde_json::to_string(&r)).transpose()?;
-            q = q.bind(recipe_json);
-        }
-        if let Some(user_recipe_values) = builder.user_recipe_values {
-            let user_recipe_values_json = user_recipe_values
-                .map(|urv| serde_json::to_string(&urv))
-                .transpose()?;
-            q = q.bind(user_recipe_values_json);
-        }
-        if let Some(provider_name) = builder.provider_name {
-            q = q.bind(provider_name);
-        }
-        if let Some(model_config) = builder.model_config {
-            let model_config_json = model_config
-                .map(|mc| serde_json::to_string(&mc))
-                .transpose()?;
-            q = q.bind(model_config_json);
-        }
-
-        let mut tx = self.pool.begin().await?;
-        q = q.bind(&builder.session_id);
-        q.execute(&mut *tx).await?;
-
-        tx.commit().await?;
-        Ok(())
-    }
-
-    async fn get_conversation(&self, session_id: &str) -> Result<Conversation> {
-        let rows = sqlx::query_as::<_, (String, String, i64, Option<String>)>(
-            "SELECT role, content_json, created_timestamp, metadata_json FROM messages WHERE session_id = ? ORDER BY timestamp",
-        )
-            .bind(session_id)
-            .fetch_all(&self.pool)
-            .await?;
-
-        let mut messages = Vec::new();
-        for (idx, (role_str, content_json, created_timestamp, metadata_json)) in
-            rows.into_iter().enumerate()
-        {
-            let role = match role_str.as_str() {
-                "user" => Role::User,
-                "assistant" => Role::Assistant,
-                _ => continue,
-            };
-
-            let content = serde_json::from_str(&content_json)?;
-            let metadata = metadata_json
-                .and_then(|json| serde_json::from_str(&json).ok())
-                .unwrap_or_default();
-
-            let mut message = Message::new(role, created_timestamp, content);
-            message.metadata = metadata;
-            message = message.with_id(format!("msg_{}_{}", session_id, idx));
-            messages.push(message);
-        }
-
-        Ok(Conversation::new_unvalidated(messages))
-    }
-
-    async fn add_message(&self, session_id: &str, message: &Message) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
-
-        let metadata_json = serde_json::to_string(&message.metadata)?;
-
-        sqlx::query(
-            r#"
-            INSERT INTO messages (session_id, role, content_json, created_timestamp, metadata_json)
-            VALUES (?, ?, ?, ?, ?)
-        "#,
-        )
-        .bind(session_id)
-        .bind(role_to_string(&message.role))
-        .bind(serde_json::to_string(&message.content)?)
-        .bind(message.created)
-        .bind(metadata_json)
-        .execute(&mut *tx)
-        .await?;
-
-        sqlx::query("UPDATE sessions SET updated_at = datetime('now') WHERE id = ?")
-            .bind(session_id)
-            .execute(&mut *tx)
-            .await?;
-
-        tx.commit().await?;
-        Ok(())
-    }
-
-    async fn replace_conversation(
-        &self,
-        session_id: &str,
-        conversation: &Conversation,
-    ) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
-
-        sqlx::query("DELETE FROM messages WHERE session_id = ?")
-            .bind(session_id)
-            .execute(&mut *tx)
-            .await?;
-
-        for message in conversation.messages() {
-            let metadata_json = serde_json::to_string(&message.metadata)?;
-
-            sqlx::query(
-                r#"
-            INSERT INTO messages (session_id, role, content_json, created_timestamp, metadata_json)
-            VALUES (?, ?, ?, ?, ?)
-        "#,
-            )
-            .bind(session_id)
-            .bind(role_to_string(&message.role))
-            .bind(serde_json::to_string(&message.content)?)
-            .bind(message.created)
-            .bind(metadata_json)
-            .execute(&mut *tx)
-            .await?;
-        }
-
-        tx.commit().await?;
-        Ok(())
-    }
-
-    async fn list_sessions_by_types(&self, types: &[SessionType]) -> Result<Vec<Session>> {
-        if types.is_empty() {
-            return Ok(Vec::new());
-        }
-
-        let placeholders: String = types.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
-        let query = format!(
-            r#"
-            SELECT s.id, s.working_dir, s.name, s.description, s.user_set_name, s.session_type, s.created_at, s.updated_at, s.extension_data,
-                   s.total_tokens, s.input_tokens, s.output_tokens,
-                   s.accumulated_total_tokens, s.accumulated_input_tokens, s.accumulated_output_tokens,
-                   s.schedule_id, s.recipe_json, s.user_recipe_values_json,
-                   s.provider_name, s.model_config_json,
-                   COUNT(m.id) as message_count
-            FROM sessions s
-            INNER JOIN messages m ON s.id = m.session_id
-            WHERE s.session_type IN ({})
-            GROUP BY s.id
-            ORDER BY s.updated_at DESC
-            "#,
-            placeholders
-        );
-
-        let mut q = sqlx::query_as::<_, Session>(&query);
-        for t in types {
-            q = q.bind(t.to_string());
-        }
-
-        q.fetch_all(&self.pool).await.map_err(Into::into)
-    }
-
-    async fn list_sessions(&self) -> Result<Vec<Session>> {
-        self.list_sessions_by_types(&[SessionType::User, SessionType::Scheduled])
-            .await
-    }
-
-    async fn delete_session(&self, session_id: &str) -> Result<()> {
-        let mut tx = self.pool.begin().await?;
-
-        let exists =
-            sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM sessions WHERE id = ?)")
-                .bind(session_id)
-                .fetch_one(&mut *tx)
-                .await?;
-
-        if !exists {
-            return Err(anyhow::anyhow!("Session not found"));
-        }
-
-        sqlx::query("DELETE FROM messages WHERE session_id = ?")
-            .bind(session_id)
-            .execute(&mut *tx)
-            .await?;
-
-        sqlx::query("DELETE FROM sessions WHERE id = ?")
-            .bind(session_id)
-            .execute(&mut *tx)
-            .await?;
-
-        tx.commit().await?;
-        Ok(())
-    }
-
-    async fn get_insights(&self) -> Result<SessionInsights> {
-        let row = sqlx::query_as::<_, (i64, Option<i64>)>(
-            r#"
-            SELECT COUNT(*) as total_sessions,
-                   COALESCE(SUM(COALESCE(accumulated_total_tokens, total_tokens, 0)), 0) as total_tokens
-            FROM sessions
-            "#,
-        )
-            .fetch_one(&self.pool)
-            .await?;
-
-        Ok(SessionInsights {
-            total_sessions: row.0 as usize,
-            total_tokens: row.1.unwrap_or(0),
-        })
-    }
-
-    async fn export_session(&self, id: &str) -> Result<String> {
-        let session = self.get_session(id, true).await?;
-        serde_json::to_string_pretty(&session).map_err(Into::into)
-    }
-
-    async fn import_session(&self, json: &str) -> Result<Session> {
-        let import: Session = serde_json::from_str(json)?;
-
-        let session = self
-            .create_session(
-                import.working_dir.clone(),
-                import.name.clone(),
-                import.session_type,
-            )
-            .await?;
-
-        let mut builder = SessionUpdateBuilder::new(session.id.clone())
-            .extension_data(import.extension_data)
-            .total_tokens(import.total_tokens)
-            .input_tokens(import.input_tokens)
-            .output_tokens(import.output_tokens)
-            .accumulated_total_tokens(import.accumulated_total_tokens)
-            .accumulated_input_tokens(import.accumulated_input_tokens)
-            .accumulated_output_tokens(import.accumulated_output_tokens)
-            .schedule_id(import.schedule_id)
-            .recipe(import.recipe)
-            .user_recipe_values(import.user_recipe_values);
-
-        if import.user_set_name {
-            builder = builder.user_provided_name(import.name.clone());
-        }
-
-        self.apply_update(builder).await?;
-
-        if let Some(conversation) = import.conversation {
-            self.replace_conversation(&session.id, &conversation)
-                .await?;
-        }
-
-        self.get_session(&session.id, true).await
-    }
-
-    async fn copy_session(&self, session_id: &str, new_name: String) -> Result<Session> {
-        let original_session = self.get_session(session_id, true).await?;
-
-        let new_session = self
-            .create_session(
-                original_session.working_dir.clone(),
-                new_name,
-                original_session.session_type,
-            )
-            .await?;
-
-        let builder = SessionUpdateBuilder::new(new_session.id.clone())
-            .extension_data(original_session.extension_data)
-            .schedule_id(original_session.schedule_id)
-            .recipe(original_session.recipe)
-            .user_recipe_values(original_session.user_recipe_values);
-
-        self.apply_update(builder).await?;
-
-        if let Some(conversation) = original_session.conversation {
-            self.replace_conversation(&new_session.id, &conversation)
-                .await?;
-        }
-
-        self.get_session(&new_session.id, true).await
-    }
-
-    async fn truncate_conversation(&self, session_id: &str, timestamp: i64) -> Result<()> {
-        sqlx::query("DELETE FROM messages WHERE session_id = ? AND created_timestamp >= ?")
-            .bind(session_id)
-            .bind(timestamp)
-            .execute(&self.pool)
-            .await?;
-
-        Ok(())
-    }
-
-    async fn search_chat_history(
-        &self,
-        query: &str,
-        limit: Option<usize>,
-        after_date: Option<chrono::DateTime<chrono::Utc>>,
-        before_date: Option<chrono::DateTime<chrono::Utc>>,
-        exclude_session_id: Option<String>,
-    ) -> Result<crate::session::chat_history_search::ChatRecallResults> {
-        use crate::session::chat_history_search::ChatHistorySearch;
-
-        ChatHistorySearch::new(
-            &self.pool,
-            query,
-            limit,
-            after_date,
-            before_date,
-            exclude_session_id,
-        )
-        .execute()
-        .await
-    }
-}
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::conversation::message::{Message, MessageContent};
+    use crate::storage::session_storage::SessionStorage;
     use tempfile::TempDir;
 
     const NUM_CONCURRENT_SESSIONS: i32 = 10;

--- a/crates/goose/src/storage/manager.rs
+++ b/crates/goose/src/storage/manager.rs
@@ -1,0 +1,160 @@
+use anyhow::Result;
+use sqlx::sqlite::SqliteConnectOptions;
+use sqlx::{Pool, Sqlite};
+use std::path::Path;
+use std::sync::Arc;
+use tokio::sync::OnceCell;
+
+use super::migrations::run_migrations;
+use super::session_storage::SessionStorage;
+use super::DB_NAME;
+
+static STORAGE_MANAGER: OnceCell<Arc<StorageManager>> = OnceCell::const_new();
+
+pub struct StorageManager {
+    pool: Pool<Sqlite>,
+}
+
+impl StorageManager {
+    pub async fn instance() -> Result<Arc<StorageManager>> {
+        STORAGE_MANAGER
+            .get_or_try_init(|| async { Self::new().await.map(Arc::new) })
+            .await
+            .map(Arc::clone)
+    }
+
+    async fn new() -> Result<Self> {
+        let session_dir = crate::storage::session_storage::ensure_session_dir()?;
+        let db_path = session_dir.join(DB_NAME);
+
+        let is_new_database = !db_path.exists();
+
+        let pool = if is_new_database {
+            Self::create_database(&db_path).await?
+        } else {
+            Self::open_database(&db_path).await?
+        };
+
+        let manager = Self { pool: pool.clone() };
+
+        // Import legacy sessions if this is a new database
+        if is_new_database {
+            if let Err(e) = crate::session::SessionManager::import_legacy_sessions(&session_dir, &pool).await {
+                tracing::warn!("Failed to import some legacy sessions: {}", e);
+            }
+        }
+
+        Ok(manager)
+    }
+
+    async fn open_database(db_path: &Path) -> Result<Pool<Sqlite>> {
+        let pool = Self::get_pool(db_path, false).await?;
+        run_migrations(&pool).await?;
+        Ok(pool)
+    }
+
+    async fn create_database(db_path: &Path) -> Result<Pool<Sqlite>> {
+        let pool = Self::get_pool(db_path, true).await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        "#,
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query("INSERT INTO schema_version (version) VALUES (?)")
+            .bind(super::migrations::CURRENT_SCHEMA_VERSION)
+            .execute(&pool)
+            .await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL DEFAULT '',
+                description TEXT NOT NULL DEFAULT '',
+                user_set_name BOOLEAN DEFAULT FALSE,
+                session_type TEXT NOT NULL DEFAULT 'user',
+                working_dir TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                extension_data TEXT DEFAULT '{}',
+                total_tokens INTEGER,
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                accumulated_total_tokens INTEGER,
+                accumulated_input_tokens INTEGER,
+                accumulated_output_tokens INTEGER,
+                schedule_id TEXT,
+                recipe_json TEXT,
+                user_recipe_values_json TEXT,
+                provider_name TEXT,
+                model_config_json TEXT
+            )
+        "#,
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id),
+                role TEXT NOT NULL,
+                content_json TEXT NOT NULL,
+                created_timestamp INTEGER NOT NULL,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                tokens INTEGER,
+                metadata_json TEXT
+            )
+        "#,
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query("CREATE INDEX idx_messages_session ON messages(session_id)")
+            .execute(&pool)
+            .await?;
+        sqlx::query("CREATE INDEX idx_messages_timestamp ON messages(timestamp)")
+            .execute(&pool)
+            .await?;
+        sqlx::query("CREATE INDEX idx_sessions_updated ON sessions(updated_at DESC)")
+            .execute(&pool)
+            .await?;
+        sqlx::query("CREATE INDEX idx_sessions_type ON sessions(session_type)")
+            .execute(&pool)
+            .await?;
+
+        Ok(pool)
+    }
+
+    async fn get_pool(db_path: &Path, create_if_missing: bool) -> Result<Pool<Sqlite>> {
+        let options = SqliteConnectOptions::new()
+            .filename(db_path)
+            .create_if_missing(create_if_missing)
+            .busy_timeout(std::time::Duration::from_secs(5))
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+
+        sqlx::SqlitePool::connect_with(options).await.map_err(|e| {
+            anyhow::anyhow!(
+                "Failed to open SQLite database at '{}': {}",
+                db_path.display(),
+                e
+            )
+        })
+    }
+
+    pub fn pool(&self) -> &Pool<Sqlite> {
+        &self.pool
+    }
+
+    pub async fn session_storage(&self) -> Result<SessionStorage> {
+        SessionStorage::from_pool(self.pool.clone()).await
+    }
+}

--- a/crates/goose/src/storage/migrations.rs
+++ b/crates/goose/src/storage/migrations.rs
@@ -1,0 +1,145 @@
+use anyhow::Result;
+use sqlx::{Pool, Sqlite};
+use tracing::info;
+
+pub const CURRENT_SCHEMA_VERSION: i32 = 6;
+
+pub async fn run_migrations(pool: &Pool<Sqlite>) -> Result<()> {
+    let current_version = get_schema_version(pool).await?;
+
+    if current_version < CURRENT_SCHEMA_VERSION {
+        info!(
+            "Running database migrations from v{} to v{}...",
+            current_version, CURRENT_SCHEMA_VERSION
+        );
+
+        for version in (current_version + 1)..=CURRENT_SCHEMA_VERSION {
+            info!("  Applying migration v{}...", version);
+            apply_migration(pool, version).await?;
+            update_schema_version(pool, version).await?;
+            info!("  ✓ Migration v{} complete", version);
+        }
+
+        info!("All migrations complete");
+    }
+
+    Ok(())
+}
+
+async fn get_schema_version(pool: &Pool<Sqlite>) -> Result<i32> {
+    let table_exists = sqlx::query_scalar::<_, bool>(
+        r#"
+        SELECT EXISTS (
+            SELECT name FROM sqlite_master
+            WHERE type='table' AND name='schema_version'
+        )
+    "#,
+    )
+    .fetch_one(pool)
+    .await?;
+
+    if !table_exists {
+        return Ok(0);
+    }
+
+    let version = sqlx::query_scalar::<_, i32>("SELECT MAX(version) FROM schema_version")
+        .fetch_one(pool)
+        .await?;
+
+    Ok(version)
+}
+
+async fn update_schema_version(pool: &Pool<Sqlite>, version: i32) -> Result<()> {
+    sqlx::query("INSERT INTO schema_version (version) VALUES (?)")
+        .bind(version)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+async fn apply_migration(pool: &Pool<Sqlite>, version: i32) -> Result<()> {
+    match version {
+        1 => {
+            sqlx::query(
+                r#"
+                CREATE TABLE IF NOT EXISTS schema_version (
+                    version INTEGER PRIMARY KEY,
+                    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            "#,
+            )
+            .execute(pool)
+            .await?;
+        }
+        2 => {
+            sqlx::query(
+                r#"
+                ALTER TABLE sessions ADD COLUMN user_recipe_values_json TEXT
+            "#,
+            )
+            .execute(pool)
+            .await?;
+        }
+        3 => {
+            sqlx::query(
+                r#"
+                ALTER TABLE messages ADD COLUMN metadata_json TEXT
+            "#,
+            )
+            .execute(pool)
+            .await?;
+        }
+        4 => {
+            sqlx::query(
+                r#"
+                ALTER TABLE sessions ADD COLUMN name TEXT DEFAULT ''
+            "#,
+            )
+            .execute(pool)
+            .await?;
+
+            sqlx::query(
+                r#"
+                ALTER TABLE sessions ADD COLUMN user_set_name BOOLEAN DEFAULT FALSE
+            "#,
+            )
+            .execute(pool)
+            .await?;
+        }
+        5 => {
+            sqlx::query(
+                r#"
+                ALTER TABLE sessions ADD COLUMN session_type TEXT NOT NULL DEFAULT 'user'
+            "#,
+            )
+            .execute(pool)
+            .await?;
+
+            sqlx::query("CREATE INDEX idx_sessions_type ON sessions(session_type)")
+                .execute(pool)
+                .await?;
+        }
+        6 => {
+            sqlx::query(
+                r#"
+                ALTER TABLE sessions ADD COLUMN provider_name TEXT
+            "#,
+            )
+            .execute(pool)
+            .await?;
+
+            sqlx::query(
+                r#"
+                ALTER TABLE sessions ADD COLUMN model_config_json TEXT
+            "#,
+            )
+            .execute(pool)
+            .await?;
+        }
+        _ => {
+            anyhow::bail!("Unknown migration version: {}", version);
+        }
+    }
+
+    Ok(())
+}

--- a/crates/goose/src/storage/mod.rs
+++ b/crates/goose/src/storage/mod.rs
@@ -1,0 +1,10 @@
+mod manager;
+mod migrations;
+pub mod session_storage;
+
+pub use manager::StorageManager;
+pub use migrations::CURRENT_SCHEMA_VERSION;
+pub use session_storage::{SessionStorage, ensure_session_dir};
+
+pub const SESSIONS_FOLDER: &str = "sessions";
+pub const DB_NAME: &str = "sessions.db";

--- a/crates/goose/src/storage/session_storage.rs
+++ b/crates/goose/src/storage/session_storage.rs
@@ -1,0 +1,626 @@
+use anyhow::Result;
+use rmcp::model::Role;
+use sqlx::{Pool, Sqlite};
+use std::fs;
+use std::path::PathBuf;
+
+use crate::config::paths::Paths;
+use crate::conversation::message::Message;
+use crate::conversation::Conversation;
+use crate::session::session_manager::{Session, SessionInsights, SessionType, SessionUpdateBuilder};
+use super::SESSIONS_FOLDER;
+
+pub struct SessionStorage {
+    pool: Pool<Sqlite>,
+}
+
+pub fn ensure_session_dir() -> Result<PathBuf> {
+    let session_dir = Paths::data_dir().join(SESSIONS_FOLDER);
+
+    if !session_dir.exists() {
+        fs::create_dir_all(&session_dir)?;
+    }
+
+    Ok(session_dir)
+}
+
+fn role_to_string(role: &Role) -> &'static str {
+    match role {
+        Role::User => "user",
+        Role::Assistant => "assistant",
+    }
+}
+
+impl SessionStorage {
+    pub async fn from_pool(pool: Pool<Sqlite>) -> Result<Self> {
+        let storage = Self { pool };
+        Ok(storage)
+    }
+
+    #[cfg(test)]
+    pub async fn create(db_path: &Path) -> Result<Self> {
+        use sqlx::sqlite::SqliteConnectOptions;
+        use super::migrations::CURRENT_SCHEMA_VERSION;
+
+        let options = SqliteConnectOptions::new()
+            .filename(db_path)
+            .create_if_missing(true)
+            .busy_timeout(std::time::Duration::from_secs(5))
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+
+        let pool = sqlx::SqlitePool::connect_with(options).await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE schema_version (
+                version INTEGER PRIMARY KEY,
+                applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        "#,
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query("INSERT INTO schema_version (version) VALUES (?)")
+            .bind(CURRENT_SCHEMA_VERSION)
+            .execute(&pool)
+            .await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                name TEXT NOT NULL DEFAULT '',
+                description TEXT NOT NULL DEFAULT '',
+                user_set_name BOOLEAN DEFAULT FALSE,
+                session_type TEXT NOT NULL DEFAULT 'user',
+                working_dir TEXT NOT NULL,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                extension_data TEXT DEFAULT '{}',
+                total_tokens INTEGER,
+                input_tokens INTEGER,
+                output_tokens INTEGER,
+                accumulated_total_tokens INTEGER,
+                accumulated_input_tokens INTEGER,
+                accumulated_output_tokens INTEGER,
+                schedule_id TEXT,
+                recipe_json TEXT,
+                user_recipe_values_json TEXT,
+                provider_name TEXT,
+                model_config_json TEXT
+            )
+        "#,
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query(
+            r#"
+            CREATE TABLE messages (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL REFERENCES sessions(id),
+                role TEXT NOT NULL,
+                content_json TEXT NOT NULL,
+                created_timestamp INTEGER NOT NULL,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                tokens INTEGER,
+                metadata_json TEXT
+            )
+        "#,
+        )
+        .execute(&pool)
+        .await?;
+
+        sqlx::query("CREATE INDEX idx_messages_session ON messages(session_id)")
+            .execute(&pool)
+            .await?;
+        sqlx::query("CREATE INDEX idx_messages_timestamp ON messages(timestamp)")
+            .execute(&pool)
+            .await?;
+        sqlx::query("CREATE INDEX idx_sessions_updated ON sessions(updated_at DESC)")
+            .execute(&pool)
+            .await?;
+        sqlx::query("CREATE INDEX idx_sessions_type ON sessions(session_type)")
+            .execute(&pool)
+            .await?;
+
+        Ok(Self { pool })
+    }
+
+    pub async fn import_legacy_session(&self, session: &Session) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+
+        let recipe_json = match &session.recipe {
+            Some(recipe) => Some(serde_json::to_string(recipe)?),
+            None => None,
+        };
+
+        let user_recipe_values_json = match &session.user_recipe_values {
+            Some(user_recipe_values) => Some(serde_json::to_string(user_recipe_values)?),
+            None => None,
+        };
+
+        let model_config_json = match &session.model_config {
+            Some(model_config) => Some(serde_json::to_string(model_config)?),
+            None => None,
+        };
+
+        sqlx::query(
+            r#"
+        INSERT INTO sessions (
+            id, name, user_set_name, session_type, working_dir, created_at, updated_at, extension_data,
+            total_tokens, input_tokens, output_tokens,
+            accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens,
+            schedule_id, recipe_json, user_recipe_values_json,
+            provider_name, model_config_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        "#,
+        )
+            .bind(&session.id)
+            .bind(&session.name)
+            .bind(session.user_set_name)
+            .bind(session.session_type.to_string())
+            .bind(session.working_dir.to_string_lossy().as_ref())
+            .bind(session.created_at)
+            .bind(session.updated_at)
+            .bind(serde_json::to_string(&session.extension_data)?)
+            .bind(session.total_tokens)
+            .bind(session.input_tokens)
+            .bind(session.output_tokens)
+            .bind(session.accumulated_total_tokens)
+            .bind(session.accumulated_input_tokens)
+            .bind(session.accumulated_output_tokens)
+            .bind(&session.schedule_id)
+            .bind(recipe_json)
+            .bind(user_recipe_values_json)
+            .bind(&session.provider_name)
+            .bind(model_config_json)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+
+        if let Some(conversation) = &session.conversation {
+            self.replace_conversation(&session.id, conversation).await?;
+        }
+        Ok(())
+    }
+
+    pub async fn create_session(
+        &self,
+        working_dir: PathBuf,
+        name: String,
+        session_type: SessionType,
+    ) -> Result<Session> {
+        let mut tx = self.pool.begin().await?;
+
+        let today = chrono::Utc::now().format("%Y%m%d").to_string();
+        let session = sqlx::query_as(
+            r#"
+                INSERT INTO sessions (id, name, user_set_name, session_type, working_dir, extension_data)
+                VALUES (
+                    ? || '_' || CAST(COALESCE((
+                        SELECT MAX(CAST(SUBSTR(id, 10) AS INTEGER))
+                        FROM sessions
+                        WHERE id LIKE ? || '_%'
+                    ), 0) + 1 AS TEXT),
+                    ?,
+                    FALSE,
+                    ?,
+                    ?,
+                    '{}'
+                )
+                RETURNING *
+                "#,
+        )
+            .bind(&today)
+            .bind(&today)
+            .bind(&name)
+            .bind(session_type.to_string())
+            .bind(working_dir.to_string_lossy().as_ref())
+            .fetch_one(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        crate::posthog::emit_session_started();
+        Ok(session)
+    }
+
+    pub async fn get_session(&self, id: &str, include_messages: bool) -> Result<Session> {
+        let mut session = sqlx::query_as::<_, Session>(
+            r#"
+        SELECT id, working_dir, name, description, user_set_name, session_type, created_at, updated_at, extension_data,
+               total_tokens, input_tokens, output_tokens,
+               accumulated_total_tokens, accumulated_input_tokens, accumulated_output_tokens,
+               schedule_id, recipe_json, user_recipe_values_json,
+               provider_name, model_config_json
+        FROM sessions
+        WHERE id = ?
+    "#,
+        )
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Session not found"))?;
+
+        if include_messages {
+            let conv = self.get_conversation(&session.id).await?;
+            session.message_count = conv.messages().len();
+            session.conversation = Some(conv);
+        } else {
+            let count =
+                sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM messages WHERE session_id = ?")
+                    .bind(&session.id)
+                    .fetch_one(&self.pool)
+                    .await? as usize;
+            session.message_count = count;
+        }
+
+        Ok(session)
+    }
+
+    #[allow(clippy::too_many_lines)]
+    pub async fn apply_update(&self, builder: SessionUpdateBuilder) -> Result<()> {
+        let mut updates = Vec::new();
+        let mut query = String::from("UPDATE sessions SET ");
+
+        macro_rules! add_update {
+            ($field:expr, $name:expr) => {
+                if $field.is_some() {
+                    if !updates.is_empty() {
+                        query.push_str(", ");
+                    }
+                    updates.push($name);
+                    query.push_str($name);
+                    query.push_str(" = ?");
+                }
+            };
+        }
+
+        add_update!(builder.name, "name");
+        add_update!(builder.user_set_name, "user_set_name");
+        add_update!(builder.session_type, "session_type");
+        add_update!(builder.working_dir, "working_dir");
+        add_update!(builder.extension_data, "extension_data");
+        add_update!(builder.total_tokens, "total_tokens");
+        add_update!(builder.input_tokens, "input_tokens");
+        add_update!(builder.output_tokens, "output_tokens");
+        add_update!(builder.accumulated_total_tokens, "accumulated_total_tokens");
+        add_update!(builder.accumulated_input_tokens, "accumulated_input_tokens");
+        add_update!(
+            builder.accumulated_output_tokens,
+            "accumulated_output_tokens"
+        );
+        add_update!(builder.schedule_id, "schedule_id");
+        add_update!(builder.recipe, "recipe_json");
+        add_update!(builder.user_recipe_values, "user_recipe_values_json");
+        add_update!(builder.provider_name, "provider_name");
+        add_update!(builder.model_config, "model_config_json");
+
+        if updates.is_empty() {
+            return Ok(());
+        }
+
+        query.push_str(", ");
+        query.push_str("updated_at = datetime('now') WHERE id = ?");
+
+        let mut q = sqlx::query(&query);
+
+        if let Some(name) = builder.name {
+            q = q.bind(name);
+        }
+        if let Some(user_set_name) = builder.user_set_name {
+            q = q.bind(user_set_name);
+        }
+        if let Some(session_type) = builder.session_type {
+            q = q.bind(session_type.to_string());
+        }
+        if let Some(wd) = builder.working_dir {
+            q = q.bind(wd.to_string_lossy().to_string());
+        }
+        if let Some(ed) = builder.extension_data {
+            q = q.bind(serde_json::to_string(&ed)?);
+        }
+        if let Some(tt) = builder.total_tokens {
+            q = q.bind(tt);
+        }
+        if let Some(it) = builder.input_tokens {
+            q = q.bind(it);
+        }
+        if let Some(ot) = builder.output_tokens {
+            q = q.bind(ot);
+        }
+        if let Some(att) = builder.accumulated_total_tokens {
+            q = q.bind(att);
+        }
+        if let Some(ait) = builder.accumulated_input_tokens {
+            q = q.bind(ait);
+        }
+        if let Some(aot) = builder.accumulated_output_tokens {
+            q = q.bind(aot);
+        }
+        if let Some(sid) = builder.schedule_id {
+            q = q.bind(sid);
+        }
+        if let Some(recipe) = builder.recipe {
+            let recipe_json = recipe.map(|r| serde_json::to_string(&r)).transpose()?;
+            q = q.bind(recipe_json);
+        }
+        if let Some(user_recipe_values) = builder.user_recipe_values {
+            let user_recipe_values_json = user_recipe_values
+                .map(|urv| serde_json::to_string(&urv))
+                .transpose()?;
+            q = q.bind(user_recipe_values_json);
+        }
+        if let Some(provider_name) = builder.provider_name {
+            q = q.bind(provider_name);
+        }
+        if let Some(model_config) = builder.model_config {
+            let model_config_json = model_config
+                .map(|mc| serde_json::to_string(&mc))
+                .transpose()?;
+            q = q.bind(model_config_json);
+        }
+
+        let mut tx = self.pool.begin().await?;
+        q = q.bind(&builder.session_id);
+        q.execute(&mut *tx).await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    async fn get_conversation(&self, session_id: &str) -> Result<Conversation> {
+        let rows = sqlx::query_as::<_, (String, String, i64, Option<String>)>(
+            "SELECT role, content_json, created_timestamp, metadata_json FROM messages WHERE session_id = ? ORDER BY timestamp",
+        )
+            .bind(session_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+        let mut messages = Vec::new();
+        for (idx, (role_str, content_json, created_timestamp, metadata_json)) in
+            rows.into_iter().enumerate()
+        {
+            let role = match role_str.as_str() {
+                "user" => Role::User,
+                "assistant" => Role::Assistant,
+                _ => continue,
+            };
+
+            let content = serde_json::from_str(&content_json)?;
+            let metadata = metadata_json
+                .and_then(|json| serde_json::from_str(&json).ok())
+                .unwrap_or_default();
+
+            let mut message = Message::new(role, created_timestamp, content);
+            message.metadata = metadata;
+            message = message.with_id(format!("msg_{}_{}", session_id, idx));
+            messages.push(message);
+        }
+
+        Ok(Conversation::new_unvalidated(messages))
+    }
+
+    pub async fn add_message(&self, session_id: &str, message: &Message) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+
+        let metadata_json = serde_json::to_string(&message.metadata)?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO messages (session_id, role, content_json, created_timestamp, metadata_json)
+            VALUES (?, ?, ?, ?, ?)
+        "#,
+        )
+        .bind(session_id)
+        .bind(role_to_string(&message.role))
+        .bind(serde_json::to_string(&message.content)?)
+        .bind(message.created)
+        .bind(metadata_json)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query("UPDATE sessions SET updated_at = datetime('now') WHERE id = ?")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn replace_conversation(
+        &self,
+        session_id: &str,
+        conversation: &Conversation,
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+
+        sqlx::query("DELETE FROM messages WHERE session_id = ?")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+
+        for message in conversation.messages() {
+            let metadata_json = serde_json::to_string(&message.metadata)?;
+
+            sqlx::query(
+                r#"
+            INSERT INTO messages (session_id, role, content_json, created_timestamp, metadata_json)
+            VALUES (?, ?, ?, ?, ?)
+        "#,
+            )
+            .bind(session_id)
+            .bind(role_to_string(&message.role))
+            .bind(serde_json::to_string(&message.content)?)
+            .bind(message.created)
+            .bind(metadata_json)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn list_sessions_by_types(&self, types: &[SessionType]) -> Result<Vec<Session>> {
+        if types.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let placeholders: String = types.iter().map(|_| "?").collect::<Vec<_>>().join(", ");
+        let query = format!(
+            r#"
+            SELECT s.id, s.working_dir, s.name, s.description, s.user_set_name, s.session_type, s.created_at, s.updated_at, s.extension_data,
+                   s.total_tokens, s.input_tokens, s.output_tokens,
+                   s.accumulated_total_tokens, s.accumulated_input_tokens, s.accumulated_output_tokens,
+                   s.schedule_id, s.recipe_json, s.user_recipe_values_json,
+                   s.provider_name, s.model_config_json,
+                   COUNT(m.id) as message_count
+            FROM sessions s
+            INNER JOIN messages m ON s.id = m.session_id
+            WHERE s.session_type IN ({})
+            GROUP BY s.id
+            ORDER BY s.updated_at DESC
+            "#,
+            placeholders
+        );
+
+        let mut q = sqlx::query_as::<_, Session>(&query);
+        for t in types {
+            q = q.bind(t.to_string());
+        }
+
+        q.fetch_all(&self.pool).await.map_err(Into::into)
+    }
+
+    pub async fn list_sessions(&self) -> Result<Vec<Session>> {
+        self.list_sessions_by_types(&[SessionType::User, SessionType::Scheduled])
+            .await
+    }
+
+    pub async fn delete_session(&self, session_id: &str) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+
+        let exists =
+            sqlx::query_scalar::<_, bool>("SELECT EXISTS(SELECT 1 FROM sessions WHERE id = ?)")
+                .bind(session_id)
+                .fetch_one(&mut *tx)
+                .await?;
+
+        if !exists {
+            return Err(anyhow::anyhow!("Session not found"));
+        }
+
+        sqlx::query("DELETE FROM messages WHERE session_id = ?")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+
+        sqlx::query("DELETE FROM sessions WHERE id = ?")
+            .bind(session_id)
+            .execute(&mut *tx)
+            .await?;
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn get_insights(&self) -> Result<SessionInsights> {
+        let row = sqlx::query_as::<_, (i64, Option<i64>)>(
+            r#"
+            SELECT COUNT(*) as total_sessions,
+                   COALESCE(SUM(COALESCE(accumulated_total_tokens, total_tokens, 0)), 0) as total_tokens
+            FROM sessions
+            "#,
+        )
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok(SessionInsights {
+            total_sessions: row.0 as usize,
+            total_tokens: row.1.unwrap_or(0),
+        })
+    }
+
+    pub async fn export_session(&self, id: &str) -> Result<String> {
+        let session = self.get_session(id, true).await?;
+        serde_json::to_string_pretty(&session).map_err(Into::into)
+    }
+
+    pub async fn import_session(&self, json: &str) -> Result<Session> {
+        let import: Session = serde_json::from_str(json)?;
+
+        let session = self
+            .create_session(
+                import.working_dir.clone(),
+                import.name.clone(),
+                import.session_type,
+            )
+            .await?;
+
+        let mut builder = SessionUpdateBuilder::new(session.id.clone())
+            .extension_data(import.extension_data)
+            .total_tokens(import.total_tokens)
+            .input_tokens(import.input_tokens)
+            .output_tokens(import.output_tokens)
+            .accumulated_total_tokens(import.accumulated_total_tokens)
+            .accumulated_input_tokens(import.accumulated_input_tokens)
+            .accumulated_output_tokens(import.accumulated_output_tokens)
+            .schedule_id(import.schedule_id)
+            .recipe(import.recipe)
+            .user_recipe_values(import.user_recipe_values);
+
+        if import.user_set_name {
+            builder = builder.user_provided_name(import.name.clone());
+        }
+
+        self.apply_update(builder).await?;
+
+        if let Some(conversation) = import.conversation {
+            self.replace_conversation(&session.id, &conversation)
+                .await?;
+        }
+
+        self.get_session(&session.id, true).await
+    }
+
+    pub async fn copy_session(&self, session_id: &str, new_name: String) -> Result<Session> {
+        let original_session = self.get_session(session_id, true).await?;
+
+        let new_session = self
+            .create_session(
+                original_session.working_dir.clone(),
+                new_name,
+                original_session.session_type,
+            )
+            .await?;
+
+        let builder = SessionUpdateBuilder::new(new_session.id.clone())
+            .extension_data(original_session.extension_data)
+            .schedule_id(original_session.schedule_id)
+            .recipe(original_session.recipe)
+            .user_recipe_values(original_session.user_recipe_values);
+
+        self.apply_update(builder).await?;
+
+        if let Some(conversation) = original_session.conversation {
+            self.replace_conversation(&new_session.id, &conversation)
+                .await?;
+        }
+
+        self.get_session(&new_session.id, true).await
+    }
+
+    pub async fn truncate_conversation(&self, session_id: &str, timestamp: i64) -> Result<()> {
+        sqlx::query("DELETE FROM messages WHERE session_id = ? AND created_timestamp >= ?")
+            .bind(session_id)
+            .bind(timestamp)
+            .execute(&self.pool)
+            .await?;
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Overview (AI Generated but manually edited and stripped out unnecessary details)

Refactor session-specific storage into a unified `storage/` module that centralizes all database operations, enabling future extensibility and reducing code duplication.

## Current Architecture

```
session/
├── mod.rs
├── session_manager.rs           (1514 lines)
│   ├── SessionManager           (facade with static methods)
│   ├── SessionStorage           (actual DB operations)
│   ├── Pool<Sqlite>             (embedded connection pool)
│   └── migrations               (embedded migration logic)
└── ...other session files
```

## Proposed Architecture

```
storage/
├── mod.rs                       # Exports StorageManager + domain modules
├── manager.rs                   # StorageManager singleton with connection pool
├── migrations.rs                # Centralized migration logic
└── session_storage.rs           # SessionStorage - session DB operations

session/
├── mod.rs                       # Exports public API
├── manager.rs                   # SessionManager facade (unchanged public API)
└── ...other session files
```

## Benefits

- Single managed connection pool 
- SQL testing contained in one module
- Easier to add, test, and reuse additional storage domains

## Changes

- Create `storage/` module with manager.rs, migrations.rs, and session submodule
- Extract SessionStorage from `session_manager.rs` to `storage/session_storage.rs`
- Move migration logic to `storage/migrations.rs`
- Extract SQL connection pool to `StorageManager` singleton
- SessionManager stays the same, only imports change
- Run tests to verify no breaking changes
