### PR TITLE
fix: improve code execution mode tool handling

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -236,7 +236,8 @@ impl Agent {
         )));
 
         // Add repetition inspector (lower priority - basic repetition checking)
-        tool_inspection_manager.add_inspector(Box::new(RepetitionInspector::new(None)));
+        // Limit to 5 repetitions to allow model self-correction while preventing infinite loops
+        tool_inspection_manager.add_inspector(Box::new(RepetitionInspector::new(Some(5))));
 
         tool_inspection_manager
     }

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
@@ -9,7 +9,6 @@ goose uses LLM providers with tool calling capability. You can be used with diff
 claude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).
 These models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10
 months prior to the current date.
-
 # Extensions
 
 Extensions allow other applications to provide context to goose. Extensions connect goose to different data sources and

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
@@ -9,7 +9,6 @@ goose uses LLM providers with tool calling capability. You can be used with diff
 claude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).
 These models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10
 months prior to the current date.
-
 # Extensions
 
 Extensions allow other applications to provide context to goose. Extensions connect goose to different data sources and

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
@@ -9,7 +9,6 @@ goose uses LLM providers with tool calling capability. You can be used with diff
 claude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).
 These models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10
 months prior to the current date.
-
 # Extensions
 
 Extensions allow other applications to provide context to goose. Extensions connect goose to different data sources and

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -5,8 +5,6 @@ goose uses LLM providers with tool calling capability. You can be used with diff
 claude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).
 These models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10
 months prior to the current date.
-{% if not code_execution_mode %}
-
 # Extensions
 
 Extensions allow other applications to provide context to goose. Extensions connect goose to different data sources and
@@ -40,7 +38,6 @@ and extensionmanager__list_resources on this extension.
 
 {% else %}
 No extensions are defined. You should let the user know that they should add extensions.
-{% endif %}
 {% endif %}
 
 {% if extension_tool_limits is defined and not code_execution_mode %}


### PR DESCRIPTION
## Summary
- Surface extension server instructions in system prompt by removing conditional code_execution_mode block from system.md
- Use prefixed tool names (code_execution__*) consistently in MOIM, server instructions, and tool descriptions to prevent model confusion
- Add explicit "NEVER use JSON.parse()" warnings since tool results are already parsed JavaScript objects
- Set RepetitionInspector limit to 5 to prevent infinite loops when model repeatedly calls same tools

### Type of Change
- [ ] Feature
- [x] Bug fix
- [x] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Tested locally with Gemini and hybrid models like Nemotron.