### PR TITLE
fix: omit structured_content when None instead of serializing as null

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -131,6 +131,7 @@ pub struct CallToolRequest {
 #[derive(Serialize, utoipa::ToSchema)]
 pub struct CallToolResponse {
     content: Vec<Content>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     structured_content: Option<Value>,
     is_error: bool,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

The MCP spec defines `structuredContent` as optional (field may be absent), not nullable:

```typescript
structuredContent?: { [key: string]: unknown }
```

Without `skip_serializing_if`, serde serializes `Option::None` as `null` in JSON, but Zod's `.optional()` schema accepts `undefined` (field absent) and rejects `null`.

This was causing Zod validation errors in MCP Apps when calling tools that don't return structured content.

## Changes

Added `#[serde(skip_serializing_if = "Option::is_none")]` to `structured_content` field in `CallToolResponse` so the field is omitted from JSON when `None`, aligning with the MCP spec.

## Related

Fixes #6454

See: https://github.com/block/goose/issues/6454#issuecomment-3746760600