### PR TITLE
allow --with-builtin extension on cli resume

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -204,14 +204,13 @@ async fn offer_extension_debugging_help(
 
 fn check_missing_extensions_or_exit(
     saved_extensions: &[ExtensionConfig],
-    cli_extension_names: &HashSet<String>,
+    cli_builtin_names: &HashSet<String>,
     interactive: bool,
 ) {
     let missing: Vec<_> = saved_extensions
         .iter()
         .filter(|ext| {
-            !cli_extension_names.contains(&ext.name())
-                && get_extension_by_name(&ext.name()).is_none()
+            !cli_builtin_names.contains(&ext.name()) && get_extension_by_name(&ext.name()).is_none()
         })
         .cloned()
         .collect();
@@ -454,8 +453,8 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
         eprintln!("{}", style(format!("Warning: {}", warning)).yellow());
     }
 
-    // Collect CLI-provided extension names to avoid false "missing" warnings on resume
-    let cli_extension_names: HashSet<String> = session_config.builtins.iter().cloned().collect();
+    // Collect CLI-provided builtin names to avoid false "missing" warnings on resume
+    let cli_builtin_names: HashSet<String> = session_config.builtins.iter().cloned().collect();
 
     // If we get extensions_override, only run those extensions and none other
     let extensions_to_run: Vec<_> = if let Some(extensions) = session_config.extensions_override {
@@ -468,7 +467,7 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
                 {
                     check_missing_extensions_or_exit(
                         &saved_state.extensions,
-                        &cli_extension_names,
+                        &cli_builtin_names,
                         session_config.interactive,
                     );
                     saved_state.extensions


### PR DESCRIPTION
## Summary
Included builtin extension names in the check_missing_extensions_or_exit check, so that you can add `--with-builtin` to cli call while also including `--resume`

The problem:

`goose run --with-builtin developer --output-format stream-json --name session1 -t "read the readme"`
`goose run --with-builtin developer --output-format stream-json --name session1 -t "summarize our convo" --resume`
results in: "Extension(s) developer from previous session are no longer available. Restore for this session?"

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ x ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ x ] This PR was created or reviewed with AI assistance

### Testing
Yes, I verified this works by running the flow locally from ./target/debug/goose, and the interative cli prompt did not showup

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

