### PR TITLE
copilot instruction to flag prelease docs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -45,7 +45,7 @@
 - See HOWTOAI.md for AI-assisted code standards
 - MCP protocol implementations require extra scrutiny
 - Naming convention: In `documentation/docs` and `documentation/blog`, always refer to the project as "goose" (lowercase), never "Goose" (even at the start of sentences)
-- No prerelease docs: PRs should not contain updates in `/documentation` that correspond to code changes in the PR if they cause the public documentation to be ahead of the latest release version
+- No prerelease docs: PRs should not contain updates in `/documentation` that correspond to code changes in the PR so that the public docs stay in sync with the latest released version. New topics should be marked with `unlisted: true`; other content should be removed or hidden from public view.
 
 ## CI Pipeline Context
 


### PR DESCRIPTION
## Summary
This PR adds a "No prerelease docs" instruction to help Copilot flag documentation changes that apply to unreleased features during the PR review. Doc changes become public shortly after merging but code changes are gated by release, so there can be a days-long lag.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [x] Other (specify below)
  - PR review workflow

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212882395343141