### PR TITLE
fix(code_execution): update test after PlatformExtensionContext API change

### DIFF
--- a/crates/goose/src/agents/code_execution_extension.rs
+++ b/crates/goose/src/agents/code_execution_extension.rs
@@ -925,9 +925,13 @@ mod tests {
 
     #[tokio::test]
     async fn test_record_result_outputs_valid_json() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let session_manager = Arc::new(crate::session::SessionManager::new(
+            temp_dir.path().to_path_buf(),
+        ));
         let context = PlatformExtensionContext {
-            session_id: None,
             extension_manager: None,
+            session_manager,
         };
         let client = CodeExecutionClient::new(context).unwrap();
 
@@ -939,7 +943,12 @@ mod tests {
         );
 
         let result = client
-            .call_tool("execute_code", Some(args), CancellationToken::new())
+            .call_tool(
+                "execute_code",
+                Some(args),
+                McpMeta::new("test-session-id"),
+                CancellationToken::new(),
+            )
             .await
             .unwrap();
 


### PR DESCRIPTION
## Summary
PR #6392 changed PlatformExtensionContext to use session_manager instead of session_id, and updated call_tool to require McpMeta parameter. This commit fixes test_record_result_outputs_valid_json to match the new API signatures.


### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)
