### PR TITLE
fix(codex): correct codex reasoning effort conversion

### DIFF
--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -56,7 +56,7 @@ impl CodexProvider {
         // Get reasoning effort from config, default to "high"
         let reasoning_effort = config
             .get_codex_reasoning_effort()
-            .map(|r| r.to_string())
+            .map(String::from)
             .unwrap_or_else(|_| "high".to_string());
 
         // Validate reasoning effort


### PR DESCRIPTION
## Summary

Use inner String conversion so CODEX_REASONING_EFFORT parses correctly and doesn’t warn/fallback.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance

- [x] This PR was created or reviewed with AI assistance

### Testing

Manual testing

### Related Issues
Relates to #6515 
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

