### PR TITLE
Set up direnv and update flake inputs

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,8 @@ crates/goose/tests/mcp_replays/*errors.txt
 # Nix build output
 result
 
+# direnv
+.direnv/
+
 # Goose self-test artifacts
 gooseselftest/

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1755186698,
-        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "lastModified": 1768305791,
+        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
         "type": "github"
       },
       "original": {
@@ -47,11 +47,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1755571033,
-        "narHash": "sha256-V8gmZBfMiFGCyGJQx/yO81LFJ4d/I5Jxs2id96rLxrM=",
+        "lastModified": 1768445213,
+        "narHash": "sha256-y0BglISgDr61vvdb35m0O4npuqh1pojlBNDILo9j8AI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "95487740bb7ac11553445e9249041a6fa4b5eccf",
+        "rev": "1cd63408e71cc0e6a89ff2cb7c4107214e2523cc",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -30,9 +30,7 @@
         
         darwinInputs = with pkgs; [
           libiconv
-          darwin.apple_sdk.frameworks.Security
-          darwin.apple_sdk.frameworks.SystemConfiguration
-          darwin.apple_sdk.frameworks.CoreServices
+          apple-sdk
         ];
         
         buildInputs = commonInputs


### PR DESCRIPTION
## Summary
Fixes the build environment by updating flake inputs to resolve the Rust 1.92 error and adding direnv support for automatic devshell activation. 
 It also simplifies macOS dependencies by refactoring flake.nix to use the unified apple-sdk.
### Type of Change

* [ ] Feature
* [x] Bug fix
* [x] Refactor / Code quality
* [ ] Performance improvement
* [ ] Documentation
* [ ] Tests
* [ ] Security fix
* [x] Build / Release
* [ ] Other (specify below)

### AI Assistance

* [x] This PR was created or reviewed with AI assistance

### Testing

**Manual testing:**

* **Before:** `nix develop` failed with `error: No stable 1.92.* is available`.
* **After:**
* `nix develop` successfully enters the environment; `rustc 1.92.0` is available.
* `direnv allow` successfully activates the environment automatically upon entering the directory.



(CI/Unit/Integration tests: Not run — config-only change)

### Related Issues

Relates to: N/A
Discussion: N/A

### Screenshots/Demos (for UX changes)

Before: N/A

After: N/A