### PR TITLE
feat: exclude subagent tool from code_execution filtering

### DIFF
--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -17,6 +17,7 @@ use crate::providers::toolshim::{
 };
 
 use crate::agents::code_execution_extension::EXTENSION_NAME as CODE_EXECUTION_EXTENSION;
+use crate::agents::subagent_tool::SUBAGENT_TOOL_NAME;
 #[cfg(test)]
 use crate::session::SessionType;
 use rmcp::model::Tool;
@@ -128,7 +129,9 @@ impl Agent {
             .await;
         if code_execution_active {
             let code_exec_prefix = format!("{CODE_EXECUTION_EXTENSION}__");
-            tools.retain(|tool| tool.name.starts_with(&code_exec_prefix));
+            tools.retain(|tool| {
+                tool.name.starts_with(&code_exec_prefix) || tool.name == SUBAGENT_TOOL_NAME
+            });
         }
 
         // Stable tool ordering is important for multi session prompt caching.


### PR DESCRIPTION
## Summary
- Retain subagent tool even when code_execution mode is active
- Allows subagent to be called directly without going through code_execution


### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested locally.

```
( O)> check ~/.config/goose/config.yaml and list the extensions enabled.

─── 1 tool call | execute_code ──────────────────────────
  1. developer/shell: Read the goose config file using cat to handle home directory expansion


─── 1 tool call | execute_code ──────────────────────────
  1. developer/shell: Read the first 50 lines of the config file to check for missed extensions

Based on the configuration file at `~/.config/goose/config.yaml`, the following extensions are currently enabled:

*   **developer**: Code editing and shell access
*   **skills**: Load and use skills from .claude/skills or .goose/skills directories
*   **extensionmanager**: Enable extension management tools
*   **chatrecall**: Search past conversations and load session summaries
*   **autovisualiser**: Data visualization and UI generation tools
*   **memory**: Teach goose your preferences as you go
*   **code_execution**: Execute JavaScript code in a sandboxed environment
*   **github**: github extension

The following extensions are present but **disabled**:
*   todo
*   computercontroller
*   tutorial
*   jira
*   kiteextension
*   kiwitravel

( O)> Use a subagent with google provider and gemini-3-pro-preview model to fetch last 10 PRs from vllm-project/vllm and another subagent with gcp_vertex_ai provider and claude-opus-4-5@20251101 model to fetch last 10 PRs from sgl-project/sglang and then present them together

─── subagent |  ──────────────────────────
instructions: Fetch the last 10 Pull Requests from the repository 'vllm-project/vllm' using the GitHub tool. Li...
settings:
    model: gemini-3-pro-preview
    provider: google


─── subagent |  ──────────────────────────
instructions: Fetch the last 10 Pull Requests from the repository 'sgl-project/sglang' using the GitHub tool. L...
settings:
    model: claude-opus-4-5@20251101
    provider: gcp_vertex_ai

Here are the last 10 Pull Requests for **vllm-project/vllm** and **sgl-project/sglang**.
.....
```