### PR TITLE
Fix: Update session name in UI in real-time

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -59,6 +59,7 @@ interface BaseChatProps {
 }
 
 function BaseChatContent({
+  setChat,
   renderHeader,
   customChatInputProps = {},
   customMainLayoutProps = {},
@@ -300,6 +301,18 @@ function BaseChatContent({
     sessionId,
     name: session?.name || 'No Session',
   };
+
+  // Update the global chat context when session changes
+  useEffect(() => {
+    if (session) {
+      setChat({
+        messages,
+        recipe,
+        sessionId,
+        name: session.name,
+      });
+    }
+  }, [session?.name, sessionId, messages, recipe, setChat]);
 
   // Only use initialMessage for the prompt if it hasn't been submitted yet
   // If we have a recipe prompt and user recipe values, substitute parameters

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { ChatState } from '../types/chatState';
 
 import {
+  getSession,
   Message,
   MessageEvent,
   reply,
@@ -209,10 +210,35 @@ export function useChatStream({
         window.dispatchEvent(new CustomEvent('message-stream-finished'));
       }
 
+      // Refresh session name after each reply for the first 3 user messages
+      // The backend regenerates the name after each of the first 3 user messages
+      // to refine it as more context becomes available
+      if (!error && sessionId && session) {
+        const userMessageCount = messagesRef.current.filter(
+          (m) => m.role === 'user'
+        ).length;
+        
+        // Only refresh for the first 3 user messages
+        if (userMessageCount <= 3) {
+          try {
+            const response = await getSession({
+              path: { session_id: sessionId },
+              throwOnError: true,
+            });
+            if (response.data?.name && response.data.name !== session.name) {
+              setSession((prev) => (prev ? { ...prev, name: response.data.name } : prev));
+            }
+          } catch (refreshError) {
+            // Silently fail - this is a nice-to-have feature
+            console.warn('Failed to refresh session name:', refreshError);
+          }
+        }
+      }
+
       setChatState(ChatState.Idle);
       onStreamFinish();
     },
-    [onStreamFinish, sessionId]
+    [onStreamFinish, sessionId, session]
   );
 
   // Load session on mount or sessionId change


### PR DESCRIPTION
# Fix: Session Name Not Updating in UI Until Session Closed

## Problem

Goose has a built-in feature that automatically generates descriptive session names after the first 3 user messages. However, **the UI doesn't update to show these names until you close and reopen the session**.

This creates a poor user experience because:
- Users see "New session 1", "New session 1", "New session 1", etc. in their window titles even after the backend has generated meaningful names
- **The only way to see the actual session name is to close the session**, which completely defeats the value of being able to work with multiple sessions simultaneously
- Users can't easily distinguish between active sessions when switching between them

### Before This Fix

The window title remains stuck on "New session 1" even after the backend has generated a meaningful name:

**Before - Window title stuck on generic name:**

![Before Screenshot](screenshot-before.png)
*Window title shows "Goose - New session 1" even after multiple messages have been sent*

This breaks the multi-session workflow because you can't tell what each session is about without closing and reopening them.

## Root Cause

The session data is loaded once via `resumeAgent` when the session starts, and the UI never refreshes it. The backend's `maybe_update_name()` function runs in a background task and updates the database, but there's no mechanism to notify the frontend that the name has changed.

## Solution

This PR adds a **smart refresh mechanism** that updates the window title in real-time as the backend generates and refines the session name.

### How It Works

The backend has an interesting behavior: it **regenerates the session name after each of the first 3 user messages** to refine it as more context becomes available:

1. **After 1st message**: Backend generates initial name based on limited context
2. **After 2nd message**: Backend regenerates name with more context (more specific)
3. **After 3rd message**: Backend regenerates name one final time with full context (most specific)
4. **After 4th+ messages**: Backend stops updating the name

This PR makes the UI **match this backend behavior** by:

1. **Counting user messages** in the current conversation
2. **Refreshing the session name after each reply** for the first 3 user messages
3. **Stopping after the 3rd message** to avoid unnecessary API calls
4. **Propagating the name to the global ChatContext** so the window title updates immediately

### After This Fix - Name Evolution in Action

The window title now updates in real-time as the backend refines the session name:

**After 1st message** - "My queries are really slow":

![After 1st Message](screenshot-after-1.png)
*Window title updates to "Goose - Query performance optimization"*

**After 2nd message** - "I'm using PostgreSQL with a table that has 50 million rows":

![After 2nd Message](screenshot-after-2.png)
*Window title refines to "Goose - PostgreSQL large table performance"*

**After 3rd message** - "The slow query is doing a full table scan because I forgot to add an index on the user_id column":

![After 3rd Message](screenshot-after-3.png)
*Window title refines to "Goose - PostgreSQL missing index fix" (final, most specific name)*

**After 4th message** - "Can you show me the exact SQL command to create the index with the best performance settings?":

![After 4th Message](screenshot-after-4.png)
*Window title remains "Goose - PostgreSQL missing index fix" (no change - stops after 3 messages)*

The name becomes **more specific and accurate** with each of the first 3 messages as the backend gains more context. After the 3rd message, the name is finalized and no more API calls are made.

### Why This Approach is Optimal

- ✅ **Matches backend behavior**: Refreshes exactly when the backend updates the name (after 1st, 2nd, 3rd messages)
- ✅ **Minimal overhead**: Only 3 API calls per session, then stops permanently
- ✅ **Better UX**: Name appears immediately after 1st message and refines with more context
- ✅ **No ongoing cost**: Stops checking after 3rd message
- ✅ **Frontend-only change**: No backend modifications required
- ✅ **Self-limiting**: Counts user messages to know when to stop

### Alternative Approaches Considered

1. **Polling**: Would work but wasteful (constant requests even after name is set)
2. **Event-based system**: Most elegant but requires significant backend changes (new WebSocket/SSE event system)
3. **Refresh on every reply**: Would work but makes unnecessary API calls after the 3rd message
4. **Check name prefix**: Initial implementation, but broke after first update (name no longer starts with "New session")

## Changes

### Modified Files
1. `ui/desktop/src/hooks/useChatStream.ts`: Added session name refresh logic to the `onFinish` callback
2. `ui/desktop/src/components/BaseChat.tsx`: Added useEffect to propagate session name to global ChatContext

### Key Code Changes

**In `useChatStream.ts` - Smart refresh based on user message count:**

```typescript
// Refresh session name after each reply for the first 3 user messages
// The backend regenerates the name after each of the first 3 user messages
// to refine it as more context becomes available
if (!error && sessionId && session) {
  const userMessageCount = messagesRef.current.filter(
    (m) => m.role === 'user'
  ).length;
  
  // Only refresh for the first 3 user messages
  if (userMessageCount <= 3) {
    try {
      const response = await getSession({
        path: { session_id: sessionId },
        throwOnError: true,
      });
      if (response.data?.name && response.data.name !== session.name) {
        setSession((prev) => (prev ? { ...prev, name: response.data.name } : prev));
      }
    } catch (refreshError) {
      // Silently fail - this is a nice-to-have feature
      console.warn('Failed to refresh session name:', refreshError);
    }
  }
}
```

**In `BaseChat.tsx` - Propagate to global context:**

```typescript
// Update the global chat context when session changes
useEffect(() => {
  if (session) {
    setChat({
      messages,
      recipe,
      sessionId,
      name: session.name,
    });
  }
}, [session?.name, sessionId, messages, recipe, setChat]);
```

## Testing

### Manual Testing Steps

1. Start a new Goose session
2. Send 3 messages (e.g., "Help me debug this code", "Check the logs", "What's the error?")
3. **Verify the window title updates automatically** after the 3rd message completes
4. Send more messages → **Verify no additional API calls are made** (check network tab)

### Expected Behavior

- Window title should update from "New session 1" to a descriptive name (e.g., "Code debugging assistance") after the 3rd message
- No need to close and reopen the session
- Session name should be visible immediately in the UI

## Impact

- **User Experience**: Users can now see meaningful session names while working, making it much easier to manage multiple sessions
- **Performance**: Negligible impact - see detailed analysis above
- **Multi-Session Workflow**: Users can now effectively work with multiple sessions simultaneously without losing track of what each one is about


