### PR TITLE
feat: display subagent tool calls in CLI and UI

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -21,6 +21,7 @@ use tokio_util::task::AbortOnDropHandle;
 pub use self::export::message_to_markdown;
 pub use builder::{build_session, SessionBuilderConfig};
 use console::Color;
+use goose::agents::subagent_handler::SUBAGENT_TOOL_REQUEST_TYPE;
 use goose::agents::AgentEvent;
 use goose::permission::permission_confirmation::PrincipalType;
 use goose::permission::Permission;
@@ -1524,6 +1525,49 @@ fn handle_mcp_notification(
 ) {
     match notification {
         ServerNotification::LoggingMessageNotification(log_notif) => {
+            if let Some(obj) = log_notif.params.data.as_object() {
+                if obj.get("type").and_then(|v| v.as_str()) == Some(SUBAGENT_TOOL_REQUEST_TYPE) {
+                    if let (Some(subagent_id), Some(tool_call)) = (
+                        obj.get("subagent_id").and_then(|v| v.as_str()),
+                        obj.get("tool_call").and_then(|v| v.as_object()),
+                    ) {
+                        let tool_name = tool_call
+                            .get("name")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("unknown");
+                        let arguments = tool_call
+                            .get("arguments")
+                            .and_then(|v| v.as_object())
+                            .cloned();
+
+                        if interactive {
+                            let _ = progress_bars.hide();
+                        }
+                        if is_stream_json_mode {
+                            emit_stream_event(&StreamEvent::Notification {
+                                extension_id: extension_id.to_string(),
+                                data: NotificationData::Log {
+                                    message: output::format_subagent_tool_call_message(
+                                        subagent_id,
+                                        tool_name,
+                                    ),
+                                },
+                            });
+                            return;
+                        }
+                        if !is_json_mode {
+                            output::render_subagent_tool_call(
+                                subagent_id,
+                                tool_name,
+                                arguments.as_ref(),
+                                debug,
+                            );
+                            return;
+                        }
+                    }
+                }
+            }
+
             let (formatted, subagent_id, notif_type) =
                 format_logging_notification(&log_notif.params.data, debug);
 

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -602,21 +602,108 @@ fn render_default_request(call: &CallToolRequestParams, debug: bool) {
     println!();
 }
 
+fn split_tool_name(tool_name: &str) -> (String, String) {
+    let parts: Vec<_> = tool_name.rsplit("__").collect();
+    let tool = parts.first().copied().unwrap_or("unknown");
+    let extension = parts
+        .split_first()
+        .map(|(_, s)| s.iter().rev().copied().collect::<Vec<_>>().join("__"))
+        .unwrap_or_default();
+    (tool.to_string(), extension)
+}
+
+pub fn format_subagent_tool_call_message(subagent_id: &str, tool_name: &str) -> String {
+    let short_id = subagent_id.rsplit('_').next().unwrap_or(subagent_id);
+    let (tool, extension) = split_tool_name(tool_name);
+
+    if extension.is_empty() {
+        format!("[subagent:{}] {}", short_id, tool)
+    } else {
+        format!("[subagent:{}] {} | {}", short_id, tool, extension)
+    }
+}
+
+pub fn render_subagent_tool_call(
+    subagent_id: &str,
+    tool_name: &str,
+    arguments: Option<&JsonObject>,
+    debug: bool,
+) {
+    if tool_name == "code_execution__execute_code" {
+        let tool_graph = arguments
+            .and_then(|args| args.get("tool_graph"))
+            .and_then(Value::as_array)
+            .filter(|arr| !arr.is_empty());
+        if let Some(tool_graph) = tool_graph {
+            return render_subagent_tool_graph(subagent_id, tool_graph);
+        }
+    }
+    let tool_header = format!(
+        "─── {} ──────────────────────────",
+        style(format_subagent_tool_call_message(subagent_id, tool_name))
+            .magenta()
+            .dim()
+    );
+    println!();
+    println!("{}", tool_header);
+    print_params(&arguments.cloned(), 0, debug);
+    println!();
+}
+
+fn render_subagent_tool_graph(subagent_id: &str, tool_graph: &[Value]) {
+    let short_id = subagent_id.rsplit('_').next().unwrap_or(subagent_id);
+    let count = tool_graph.len();
+    let plural = if count == 1 { "" } else { "s" };
+    println!();
+    println!(
+        "─── {} {} tool call{} | {} ──────────────────────────",
+        style(format!("[subagent:{}]", short_id)).cyan(),
+        style(count).cyan(),
+        plural,
+        style("execute_code").magenta().dim()
+    );
+
+    for (i, node) in tool_graph.iter().filter_map(Value::as_object).enumerate() {
+        let tool = node
+            .get("tool")
+            .and_then(Value::as_str)
+            .unwrap_or("unknown");
+        let desc = node
+            .get("description")
+            .and_then(Value::as_str)
+            .unwrap_or("");
+        let deps: Vec<_> = node
+            .get("depends_on")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(Value::as_u64)
+            .map(|d| (d + 1).to_string())
+            .collect();
+        let deps_str = if deps.is_empty() {
+            String::new()
+        } else {
+            format!(" (uses {})", deps.join(", "))
+        };
+        println!(
+            "  {}. {}: {}{}",
+            style(i + 1).dim(),
+            style(tool).cyan(),
+            style(desc).green(),
+            style(deps_str).dim()
+        );
+    }
+    println!();
+}
+
 // Helper functions
 
 fn print_tool_header(call: &CallToolRequestParams) {
-    let parts: Vec<_> = call.name.rsplit("__").collect();
+    let (tool, extension) = split_tool_name(&call.name);
     let tool_header = format!(
         "─── {} | {} ──────────────────────────",
-        style(parts.first().unwrap_or(&"unknown")),
-        style(
-            parts
-                .split_first()
-                .map(|(_, s)| s.iter().rev().copied().collect::<Vec<_>>().join("__"))
-                .unwrap_or_else(|| "unknown".to_string())
-        )
-        .magenta()
-        .dim(),
+        style(tool),
+        style(extension).magenta().dim(),
     );
     println!();
     println!("{}", tool_header);

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -1,12 +1,18 @@
 use crate::{
     agents::{subagent_task_config::TaskConfig, Agent, AgentConfig, AgentEvent, SessionConfig},
-    conversation::{message::Message, Conversation},
+    conversation::{
+        message::{Message, MessageContent},
+        Conversation,
+    },
     prompt_template::render_template,
     recipe::Recipe,
 };
 use anyhow::{anyhow, Result};
 use futures::StreamExt;
-use rmcp::model::{ErrorCode, ErrorData};
+use rmcp::model::{
+    ErrorCode, ErrorData, LoggingLevel, LoggingMessageNotification,
+    LoggingMessageNotificationMethod, LoggingMessageNotificationParam, ServerNotification,
+};
 use serde::Serialize;
 use std::future::Future;
 use std::pin::Pin;
@@ -15,18 +21,17 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, info};
 
 #[derive(Serialize)]
-struct SubagentPromptContext {
-    max_turns: usize,
-    subagent_id: String,
-    task_instructions: String,
-    tool_count: usize,
-    available_tools: String,
+pub struct SubagentPromptContext {
+    pub max_turns: usize,
+    pub subagent_id: String,
+    pub task_instructions: String,
+    pub tool_count: usize,
+    pub available_tools: String,
 }
 
 type AgentMessagesFuture =
     Pin<Box<dyn Future<Output = Result<(Conversation, Option<String>)>> + Send>>;
 
-/// Standalone function to run a complete subagent task with output options
 pub async fn run_complete_subagent_task(
     config: AgentConfig,
     recipe: Recipe,
@@ -35,16 +40,43 @@ pub async fn run_complete_subagent_task(
     session_id: String,
     cancellation_token: Option<CancellationToken>,
 ) -> Result<String, anyhow::Error> {
-    let (messages, final_output) =
-        get_agent_messages(config, recipe, task_config, session_id, cancellation_token)
-            .await
-            .map_err(|e| {
-                ErrorData::new(
-                    ErrorCode::INTERNAL_ERROR,
-                    format!("Failed to execute task: {}", e),
-                    None,
-                )
-            })?;
+    run_complete_subagent_task_with_notifications(
+        config,
+        recipe,
+        task_config,
+        return_last_only,
+        session_id,
+        cancellation_token,
+        None,
+    )
+    .await
+}
+
+pub async fn run_complete_subagent_task_with_notifications(
+    config: AgentConfig,
+    recipe: Recipe,
+    task_config: TaskConfig,
+    return_last_only: bool,
+    session_id: String,
+    cancellation_token: Option<CancellationToken>,
+    notification_tx: Option<tokio::sync::mpsc::UnboundedSender<rmcp::model::ServerNotification>>,
+) -> Result<String, anyhow::Error> {
+    let (messages, final_output) = get_agent_messages_with_notifications(
+        config,
+        recipe,
+        task_config,
+        session_id,
+        cancellation_token,
+        notification_tx,
+    )
+    .await
+    .map_err(|e| {
+        ErrorData::new(
+            ErrorCode::INTERNAL_ERROR,
+            format!("Failed to execute task: {}", e),
+            None,
+        )
+    })?;
 
     if let Some(output) = final_output {
         return Ok(output);
@@ -67,40 +99,35 @@ pub async fn run_complete_subagent_task(
         let all_text_content: Vec<String> = messages
             .iter()
             .flat_map(|message| {
-                message.content.iter().filter_map(|content| {
-                    match content {
-                        crate::conversation::message::MessageContent::Text(text_content) => {
-                            Some(text_content.text.clone())
-                        }
-                        crate::conversation::message::MessageContent::ToolResponse(
-                            tool_response,
-                        ) => {
-                            // Extract text from tool response
-                            if let Ok(result) = &tool_response.tool_result {
-                                let texts: Vec<String> = result
-                                    .content
-                                    .iter()
-                                    .filter_map(|content| {
-                                        if let rmcp::model::RawContent::Text(raw_text_content) =
-                                            &content.raw
-                                        {
-                                            Some(raw_text_content.text.clone())
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .collect();
-                                if !texts.is_empty() {
-                                    Some(format!("Tool result: {}", texts.join("\n")))
-                                } else {
-                                    None
-                                }
+                message.content.iter().filter_map(|content| match content {
+                    crate::conversation::message::MessageContent::Text(text_content) => {
+                        Some(text_content.text.clone())
+                    }
+                    crate::conversation::message::MessageContent::ToolResponse(tool_response) => {
+                        if let Ok(result) = &tool_response.tool_result {
+                            let texts: Vec<String> = result
+                                .content
+                                .iter()
+                                .filter_map(|content| {
+                                    if let rmcp::model::RawContent::Text(raw_text_content) =
+                                        &content.raw
+                                    {
+                                        Some(raw_text_content.text.clone())
+                                    } else {
+                                        None
+                                    }
+                                })
+                                .collect();
+                            if !texts.is_empty() {
+                                Some(format!("Tool result: {}", texts.join("\n")))
                             } else {
                                 None
                             }
+                        } else {
+                            None
                         }
-                        _ => None,
                     }
+                    _ => None,
                 })
             })
             .collect();
@@ -111,12 +138,15 @@ pub async fn run_complete_subagent_task(
     Ok(response_text)
 }
 
-fn get_agent_messages(
+pub const SUBAGENT_TOOL_REQUEST_TYPE: &str = "subagent_tool_request";
+
+fn get_agent_messages_with_notifications(
     config: AgentConfig,
     recipe: Recipe,
     task_config: TaskConfig,
     session_id: String,
     cancellation_token: Option<CancellationToken>,
+    notification_tx: Option<tokio::sync::mpsc::UnboundedSender<rmcp::model::ServerNotification>>,
 ) -> AgentMessagesFuture {
     Box::pin(async move {
         let system_instructions = recipe.instructions.clone().unwrap_or_default();
@@ -128,11 +158,11 @@ fn get_agent_messages(
         let agent = Arc::new(Agent::with_config(config));
 
         agent
-            .update_provider(task_config.provider, &session_id)
+            .update_provider(task_config.provider.clone(), &session_id)
             .await
             .map_err(|e| anyhow!("Failed to set provider on sub agent: {}", e))?;
 
-        for extension in task_config.extensions {
+        for extension in &task_config.extensions {
             if let Err(e) = agent.add_extension(extension.clone(), &session_id).await {
                 debug!(
                     "Failed to add extension '{}' to subagent: {}",
@@ -147,24 +177,8 @@ fn get_agent_messages(
             .apply_recipe_components(recipe.sub_recipes.clone(), recipe.response.clone(), true)
             .await;
 
-        let tools = agent.list_tools(&session_id, None).await;
-        let subagent_prompt = render_template(
-            "subagent_system.md",
-            &SubagentPromptContext {
-                max_turns: task_config
-                    .max_turns
-                    .expect("TaskConfig always sets max_turns"),
-                subagent_id: session_id.clone(),
-                task_instructions: system_instructions,
-                tool_count: tools.len(),
-                available_tools: tools
-                    .iter()
-                    .map(|t| t.name.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", "),
-            },
-        )
-        .map_err(|e| anyhow!("Failed to render subagent system prompt: {}", e))?;
+        let subagent_prompt =
+            build_subagent_prompt(&agent, &task_config, &session_id, system_instructions).await?;
         agent.override_system_prompt(subagent_prompt).await;
 
         let user_message = Message::user().with_text(user_task);
@@ -182,35 +196,186 @@ fn get_agent_messages(
             retry_config: recipe.retry,
         };
 
-        let mut stream = agent
-            .reply(user_message, session_config, cancellation_token)
-            .await
-            .map_err(|e| anyhow!("Failed to get reply from agent: {}", e))?;
-        while let Some(message_result) = stream.next().await {
-            match message_result {
-                Ok(AgentEvent::Message(msg)) => conversation.push(msg),
-                Ok(AgentEvent::McpNotification(_)) | Ok(AgentEvent::ModelChange { .. }) => {}
-                Ok(AgentEvent::HistoryReplaced(updated_conversation)) => {
-                    conversation = updated_conversation;
-                }
-                Err(e) => {
-                    tracing::error!("Error receiving message from subagent: {}", e);
-                    break;
-                }
-            }
-        }
+        conversation = run_subagent_stream(
+            agent.clone(),
+            user_message,
+            session_config,
+            cancellation_token,
+            &session_id,
+            &notification_tx,
+            conversation,
+        )
+        .await?;
 
-        let final_output = if has_response_schema {
-            agent
-                .final_output_tool
-                .lock()
-                .await
-                .as_ref()
-                .and_then(|tool| tool.final_output.clone())
-        } else {
-            None
-        };
+        let final_output = get_final_output(&agent, has_response_schema).await;
 
         Ok((conversation, final_output))
     })
+}
+
+async fn build_subagent_prompt(
+    agent: &Agent,
+    task_config: &TaskConfig,
+    session_id: &str,
+    system_instructions: String,
+) -> Result<String> {
+    let tools = agent.list_tools(session_id, None).await;
+    render_template(
+        "subagent_system.md",
+        &SubagentPromptContext {
+            max_turns: task_config
+                .max_turns
+                .expect("TaskConfig always sets max_turns"),
+            subagent_id: session_id.to_string(),
+            task_instructions: system_instructions,
+            tool_count: tools.len(),
+            available_tools: tools
+                .iter()
+                .map(|t| t.name.to_string())
+                .collect::<Vec<_>>()
+                .join(", "),
+        },
+    )
+    .map_err(|e| anyhow!("Failed to render subagent system prompt: {}", e))
+}
+
+async fn run_subagent_stream(
+    agent: Arc<Agent>,
+    user_message: Message,
+    session_config: SessionConfig,
+    cancellation_token: Option<CancellationToken>,
+    session_id: &str,
+    notification_tx: &Option<tokio::sync::mpsc::UnboundedSender<rmcp::model::ServerNotification>>,
+    mut conversation: Conversation,
+) -> Result<Conversation> {
+    let mut stream = crate::session_context::with_session_id(Some(session_id.to_string()), async {
+        agent
+            .reply(user_message, session_config, cancellation_token)
+            .await
+    })
+    .await
+    .map_err(|e| anyhow!("Failed to get reply from agent: {}", e))?;
+
+    while let Some(message_result) = stream.next().await {
+        match message_result {
+            Ok(AgentEvent::Message(msg)) => {
+                if let Some(ref tx) = notification_tx {
+                    for content in &msg.content {
+                        if let Some(notif) = create_tool_notification(content, session_id) {
+                            if tx.send(notif).is_err() {
+                                debug!("Notification receiver dropped for subagent {}", session_id);
+                            }
+                        }
+                    }
+                }
+                conversation.push(msg);
+            }
+            Ok(AgentEvent::McpNotification(_)) => {}
+            Ok(AgentEvent::ModelChange { .. }) => {}
+            Ok(AgentEvent::HistoryReplaced(updated_conversation)) => {
+                conversation = updated_conversation;
+            }
+            Err(e) => {
+                tracing::error!("Error receiving message from subagent: {}", e);
+                break;
+            }
+        }
+    }
+
+    Ok(conversation)
+}
+
+async fn get_final_output(agent: &Agent, has_response_schema: bool) -> Option<String> {
+    if has_response_schema {
+        agent
+            .final_output_tool
+            .lock()
+            .await
+            .as_ref()
+            .and_then(|tool| tool.final_output.clone())
+    } else {
+        None
+    }
+}
+
+fn create_tool_notification(
+    content: &MessageContent,
+    subagent_id: &str,
+) -> Option<ServerNotification> {
+    if let MessageContent::ToolRequest(req) = content {
+        let tool_call = req.tool_call.as_ref().ok()?;
+
+        Some(ServerNotification::LoggingMessageNotification(
+            LoggingMessageNotification {
+                method: LoggingMessageNotificationMethod,
+                params: LoggingMessageNotificationParam {
+                    level: LoggingLevel::Info,
+                    logger: Some(format!("subagent:{}", subagent_id)),
+                    data: serde_json::json!({
+                        "type": SUBAGENT_TOOL_REQUEST_TYPE,
+                        "subagent_id": subagent_id,
+                        "tool_call": {
+                            "name": tool_call.name,
+                            "arguments": tool_call.arguments
+                        }
+                    }),
+                },
+                extensions: Default::default(),
+            },
+        ))
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{create_tool_notification, SUBAGENT_TOOL_REQUEST_TYPE};
+    use crate::conversation::message::MessageContent;
+    use rmcp::model::{CallToolRequestParams, ServerNotification};
+    use serde_json::json;
+
+    #[test]
+    fn create_tool_notification_for_tool_request() {
+        let tool_call = CallToolRequestParams {
+            meta: None,
+            task: None,
+            name: "developer__shell".to_string().into(),
+            arguments: Some(json!({"command": "ls"}).as_object().unwrap().clone()),
+        };
+        let content = MessageContent::tool_request("req1", Ok(tool_call));
+        let notification =
+            create_tool_notification(&content, "session_1").expect("expected notification");
+
+        let ServerNotification::LoggingMessageNotification(log_notif) = notification else {
+            panic!("expected logging notification");
+        };
+        let data = log_notif
+            .params
+            .data
+            .as_object()
+            .expect("expected object data");
+        assert_eq!(
+            data.get("type").and_then(|v| v.as_str()),
+            Some(SUBAGENT_TOOL_REQUEST_TYPE)
+        );
+        assert_eq!(
+            data.get("subagent_id").and_then(|v| v.as_str()),
+            Some("session_1")
+        );
+        let tool_call = data
+            .get("tool_call")
+            .and_then(|v| v.as_object())
+            .expect("expected tool_call object");
+        assert_eq!(
+            tool_call.get("name").and_then(|v| v.as_str()),
+            Some("developer__shell")
+        );
+    }
+
+    #[test]
+    fn create_tool_notification_ignores_non_tool_request() {
+        let content = MessageContent::text("hello");
+        assert!(create_tool_notification(&content, "session_1").is_none());
+    }
 }


### PR DESCRIPTION
## Summary
- Add notification forwarding from subagent to parent agent
- Create tool call notifications for subagent ToolRequest messages
- Add render_subagent_tool_call() to display tool headers in CLI
- Add formatSubagentToolCall() helper in UI for consistent display
- Use session ID suffix for unique subagent identification

### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Tested locally with both cli and ui.

```
Context: ○○○○○○○○○○ 0% (0/128000 tokens)
( O)> Use a subagent with google provider and gemini-2.5-pro model to fetch last 10 PRs from vllm-project/vllm and another subagent with gcp_vertex_ai provider and claude-opus-4-5@20251101 model to fetch last 10 PRs from sgl-project/sglang and then output them together in a tabular format

─── subagent |  ──────────────────────────
instructions: Fetch the last 10 Pull Requests from the repository 'vllm-project/vllm'. Return the details inclu...
extensions: github
settings:
    model: gemini-2.5-pro
    provider: google


─── [subagent:53] list_pull_requests | github ──────────────────────────
direction: desc
owner: vllm-project
perPage: 10
repo: vllm
sort: created
state: all


─── subagent |  ──────────────────────────
instructions: Fetch the last 10 Pull Requests from the repository 'sgl-project/sglang'. Return the details incl...
extensions: github
settings:
    model: claude-opus-4-5@20251101
    provider: gcp_vertex_ai


─── [subagent:54] list_pull_requests | github ──────────────────────────
owner: sgl-project
perPage: 10
repo: sglang


─── [subagent:54] get_file_contents | github ──────────────────────────
owner: sgl-project
path: /tmp/goose_mcp_responses/mcp_response_20260116_090422.774994.txt
repo: sglang


─── [subagent:54] search_pull_requests | github ──────────────────────────
order: desc
owner: sgl-project
perPage: 10
query: is:pr
repo: sglang
sort: created

Here are the last 10 Pull Requests from both `vllm-project/vllm` and `sgl-project/sglang` combined into a single table:

```