### PR TITLE
docs: clarify directory in /documentation readme

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,6 +2,8 @@
 
 This website is built using [Docusaurus](https://docusaurus.io/), a modern static website generator.
 
+Run all commands from the `documentation/` directory.
+
 ### Installation
 
 ```


### PR DESCRIPTION
## Summary
This PR updates `documentation/README.md` to clarify that the commands should be run from the /documentation directory.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Manual