### PR TITLE
fix slash and @ keyboard navigation popover background color

### DIFF
--- a/ui/desktop/src/components/MentionPopover.tsx
+++ b/ui/desktop/src/components/MentionPopover.tsx
@@ -553,10 +553,9 @@ const MentionPopover = forwardRef<
                   <div
                     key={item.extra}
                     onClick={() => handleItemClick(index)}
+                    data-selected={index === selectedIndex}
                     className={`flex items-center gap-3 p-2 rounded-md cursor-pointer transition-colors ${
-                      index === selectedIndex
-                        ? 'bg-bgProminent text-textProminentInverse'
-                        : 'hover:bg-bgSubtle'
+                      index === selectedIndex ? 'bg-sidebar-accent' : 'hover:bg-sidebar-accent/50'
                     }`}
                   >
                     <div className="flex-shrink-0 text-textSubtle">
@@ -564,7 +563,7 @@ const MentionPopover = forwardRef<
                     </div>
                     <div className="flex-1 min-w-0">
                       <div className="text-sm truncate text-textStandard">{item.name}</div>
-                      <div className="text-xs text-textSubtle truncate">{item.extra}</div>
+                      <div className="text-xs truncate text-textSubtle">{item.extra}</div>
                     </div>
                   </div>
                 ))}


### PR DESCRIPTION
## Summary
the background color wasn't visible when using keyboard navigation in the mention popover, this fixes that.

<img width="550" height="390" alt="Screenshot 2026-01-16 at 1 51 48 PM" src="https://github.com/user-attachments/assets/292c7da1-a515-4de2-8a25-bd0f4b9e4d7a" />
<img width="466" height="406" alt="Screenshot 2026-01-16 at 1 51 36 PM" src="https://github.com/user-attachments/assets/71838cf5-63cd-4655-a49a-5398144aa202" />

closes https://github.com/block/goose/issues/6730

  

