### PR TITLE
fix: prevent docs deploy from being cancelled by PR previews

### DIFF
--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -8,8 +8,12 @@ on:
       - 'documentation/**'
 
 # Use same concurrency group as PR preview workflow to prevent race conditions
-# when both workflows try to modify gh-pages branch simultaneously
-concurrency: pr-preview
+# when both workflows try to modify gh-pages branch simultaneously.
+# cancel-in-progress: false ensures production deploys queue and wait rather than
+# being cancelled by PR preview workflows.
+concurrency:
+  group: pr-preview
+  cancel-in-progress: false
 
 jobs:
   deploy:


### PR DESCRIPTION
## Problem

PR #6547 was merged but never deployed to the blog site. The deployment workflow was **cancelled** because it triggered at the same time as a PR preview workflow.

Both workflows share the `concurrency: pr-preview` group to prevent race conditions when writing to gh-pages. However, without `cancel-in-progress: false`, production deploys can be cancelled by PR previews.

## Solution

Add `cancel-in-progress: false` to the deploy workflow. This ensures:
- Production deploys will **queue and wait** rather than being cancelled
- PR previews can still cancel each other (that's fine)
- Both workflows still share the same concurrency group to avoid gh-pages conflicts

## Testing

This is a workflow configuration change. The behavior can be verified by:
1. Merging a docs change to main
2. Having a PR preview trigger at the same time
3. Confirming the production deploy queues instead of being cancelled