### PR TITLE
fix: respect GOOSE_CLI_MIN_PRIORITY for shell streaming output

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1558,7 +1558,7 @@ fn format_logging_notification(
                         let min_priority = config
                             .get_param::<f32>("GOOSE_CLI_MIN_PRIORITY")
                             .ok()
-                            .unwrap_or(0.5);
+                            .unwrap_or(output::DEFAULT_MIN_PRIORITY);
 
                         if min_priority > 0.1 && !debug {
                             if let Some(response_content) = msg.strip_prefix("Responded: ") {
@@ -1618,11 +1618,19 @@ fn display_log_notification(
                 std::io::stdout().flush().unwrap();
             }
         } else if ntype == "shell_output" {
-            if interactive {
-                let _ = progress_bars.hide();
-            }
-            if !is_json_mode {
-                println!("{}", formatted_message);
+            let config = Config::global();
+            let min_priority = config
+                .get_param::<f32>("GOOSE_CLI_MIN_PRIORITY")
+                .ok()
+                .unwrap_or(output::DEFAULT_MIN_PRIORITY);
+
+            if min_priority < 0.1 {
+                if interactive {
+                    let _ = progress_bars.hide();
+                }
+                if !is_json_mode {
+                    println!("{}", formatted_message);
+                }
             }
         }
     } else if output::is_showing_thinking() {

--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -17,6 +17,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::time::Duration;
 
+pub const DEFAULT_MIN_PRIORITY: f32 = 0.0;
+
 // Re-export theme for use in main
 #[derive(Clone, Copy)]
 pub enum Theme {
@@ -308,7 +310,7 @@ fn render_tool_response(resp: &ToolResponse, theme: Theme, debug: bool) {
                 let min_priority = config
                     .get_param::<f32>("GOOSE_CLI_MIN_PRIORITY")
                     .ok()
-                    .unwrap_or(0.5);
+                    .unwrap_or(DEFAULT_MIN_PRIORITY);
 
                 if content
                     .priority()


### PR DESCRIPTION
## Summary
Shell output was being streamed via MCP logging notifications without respecting the GOOSE_CLI_MIN_PRIORITY setting.

Now shell streaming output only displays when min_priority is default (0.0).

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

Closes: #6733