### PR TITLE
fix scrollbar flicker in sidebar animation

### DIFF
--- a/ui/desktop/src/components/ui/sidebar.tsx
+++ b/ui/desktop/src/components/ui/sidebar.tsx
@@ -185,7 +185,7 @@ function Sidebar({
             <SheetTitle>Sidebar</SheetTitle>
             <SheetDescription>Displays the mobile sidebar.</SheetDescription>
           </SheetHeader>
-          <div className="flex h-full w-full flex-col">{children}</div>
+          <div className="flex h-full w-full flex-col overflow-hidden">{children}</div>
         </SheetContent>
       </Sheet>
     );
@@ -233,7 +233,7 @@ function Sidebar({
         <div
           data-sidebar="sidebar"
           data-slot="sidebar-inner"
-          className="bg-sidebar flex h-full w-full flex-col group-data-[variant=floating]:rounded-2xl group-data-[variant=floating]:border"
+          className="bg-sidebar flex h-full w-full flex-col overflow-hidden group-data-[variant=floating]:rounded-2xl group-data-[variant=floating]:border"
         >
           {children}
         </div>
@@ -359,7 +359,7 @@ function SidebarContent({ className, ...props }: React.ComponentProps<'div'>) {
       data-slot="sidebar-content"
       data-sidebar="content"
       className={cn(
-        'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        'flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto overflow-x-hidden group-data-[collapsible=icon]:overflow-hidden',
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary
When opening the sidebar when it's in the “mobile” state (the window is narrow), there's a temporary flicker caused by a scrollbar appearing unnecessarily. I think this is caused by the sidebar items animating in from the left; however, since no overflow is needed on the x-axis, the overflow-x can be hidden.

### Type of Change
- [x] Bug fix

### AI Assistance
- [ ] This PR was created or reviewed with AI assistance

### Testing
Manually.

### Screenshots/Demos (for UX changes)
Before:

[Screencast_20260118_133331.webm](https://github.com/user-attachments/assets/4ddd1206-a5e5-4a8d-8119-f811c4d40926)

After:   

[Screencast_20260118_135917.webm](https://github.com/user-attachments/assets/9c1fdc7b-e477-4332-b245-8f0d3a9a4c4e)
