### PR TITLE
fix(cli): sync all MCP prompt messages to session before agent reply

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1305,6 +1305,7 @@ impl CliSession {
                     let num_messages = messages.len();
                     for (i, prompt_message) in messages.into_iter().enumerate() {
                         let msg = Message::from(prompt_message);
+                        // ensure we get a User - Assistant - User type pattern
                         let expected_role = if i % 2 == 0 {
                             rmcp::model::Role::User
                         } else {
@@ -1317,6 +1318,7 @@ impl CliSession {
                                 expected_role, i, msg.role
                             ));
                             valid = false;
+                            // get rid of everything we added to messages
                             self.messages.truncate(start_len);
                             break;
                         }


### PR DESCRIPTION
## Summary

### Problem
When using `/prompt` in the CLI with multi-message MCP prompts (e.g., User → Assistant → User), only the final user message was being interpreted by the model.

### Root Cause
1. `handle_prompt_command` correctly added all prompt messages to `self.messages` (local conversation)
2. But `process_agent_response` only sent `self.messages.last()` to `agent.reply()`
3. `agent.reply()` added that single message to the session, then retrieved the conversation from the session
4. **Result**: Earlier messages from the prompt were never added to the session

### Fix
Before calling `process_agent_response`, we now sync all messages except the last one to the session via `session_manager.add_message()`. The last message is still added by `agent.reply()` as normal, ensuring the full conversation context is available to the agent.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [X] This PR was created or reviewed with AI assistance

### Testing

ran test suite. thought about adding a new test but testing `handle_prompt_command` directly is complex because it requires a full `CliSession` with `Agent`. I did temporarily implement it with mocking just to make sure the fix worked, but it added little value as a regression test. open to ideas if anyone thinks we need one

### Related Issues
fixes #6506  