### PR TITLE
feat: add native structured output support for providers

### DIFF
--- a/crates/goose-acp/src/server.rs
+++ b/crates/goose-acp/src/server.rs
@@ -297,6 +297,7 @@ impl GooseAcpAgent {
             toolshim_model: None,
             fast_model: None,
             request_params: None,
+            response_schema: None,
         };
         let provider = create(&provider_name, model_config).await?;
         let goose_mode = config

--- a/crates/goose-acp/src/server_factory.rs
+++ b/crates/goose-acp/src/server_factory.rs
@@ -53,6 +53,7 @@ impl AcpServer {
             toolshim: false,
             toolshim_model: None,
             fast_model: None,
+            response_schema: None,
         };
 
         let provider = create(&provider_name, model_config).await?;

--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1911,6 +1911,7 @@ fn add_provider() -> anyhow::Result<()> {
         api_key,
         models,
         supports_streaming: Some(supports_streaming),
+        supports_structured_output: None,
         headers,
         requires_auth,
     })?;

--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -399,14 +399,6 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
             .with_temperature(temperature)
     };
 
-    agent
-        .apply_recipe_components(
-            recipe.and_then(|r| r.sub_recipes.clone()),
-            recipe.and_then(|r| r.response.clone()),
-            true,
-        )
-        .await;
-
     let new_provider = match create(&provider_name, model_config).await {
         Ok(provider) => provider,
         Err(e) => {
@@ -420,6 +412,15 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
             process::exit(1);
         }
     };
+
+    agent
+        .apply_recipe_components(
+            recipe.and_then(|r| r.sub_recipes.clone()),
+            recipe.and_then(|r| r.response.clone()),
+            true,
+            new_provider.supports_structured_output(),
+        )
+        .await;
     let provider_for_display = Arc::clone(&new_provider);
 
     if let Some(lead_worker) = new_provider.as_lead_worker() {

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -91,6 +91,7 @@ pub struct UpdateCustomProviderRequest {
     pub api_key: String,
     pub models: Vec<String>,
     pub supports_streaming: Option<bool>,
+    pub supports_structured_output: Option<bool>,
     pub headers: Option<std::collections::HashMap<String, String>>,
     #[serde(default = "default_requires_auth")]
     pub requires_auth: bool,
@@ -673,6 +674,7 @@ pub async fn create_custom_provider(
             api_key: request.api_key,
             models: request.models,
             supports_streaming: request.supports_streaming,
+            supports_structured_output: request.supports_structured_output,
             headers: request.headers,
             requires_auth: request.requires_auth,
         },
@@ -743,6 +745,7 @@ pub async fn update_custom_provider(
             api_key: request.api_key,
             models: request.models,
             supports_streaming: request.supports_streaming,
+            supports_structured_output: request.supports_structured_output,
             headers: request.headers,
             requires_auth: request.requires_auth,
         },

--- a/crates/goose-server/src/routes/recipe_utils.rs
+++ b/crates/goose-server/src/routes/recipe_utils.rs
@@ -162,11 +162,17 @@ pub async fn apply_recipe_to_agent(
     recipe: &Recipe,
     include_final_output_tool: bool,
 ) -> Option<String> {
+    let provider_supports_structured_output = agent
+        .provider()
+        .await
+        .map(|p| p.supports_structured_output())
+        .unwrap_or(false);
     agent
         .apply_recipe_components(
             recipe.sub_recipes.clone(),
             recipe.response.clone(),
             include_final_output_tool,
+            provider_supports_structured_output,
         )
         .await;
 

--- a/crates/goose/src/agents/execute_commands.rs
+++ b/crates/goose/src/agents/execute_commands.rs
@@ -278,6 +278,7 @@ impl Agent {
         }
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn handle_recipe_command(
         &self,
         command: &str,
@@ -378,8 +379,18 @@ impl Agent {
             Err(e) => return Err(anyhow!("Failed to build recipe: {}", e)),
         };
 
-        self.apply_recipe_components(recipe.sub_recipes.clone(), recipe.response.clone(), true)
-            .await;
+        let provider_supports_structured_output = self
+            .provider()
+            .await
+            .map(|p| p.supports_structured_output())
+            .unwrap_or(false);
+        self.apply_recipe_components(
+            recipe.sub_recipes.clone(),
+            recipe.response.clone(),
+            true,
+            provider_supports_structured_output,
+        )
+        .await;
 
         let prompt = [recipe.instructions.as_deref(), recipe.prompt.as_deref()]
             .into_iter()

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -173,8 +173,18 @@ fn get_agent_messages_with_notifications(
         }
 
         let has_response_schema = recipe.response.is_some();
+        let provider_supports_structured_output = agent
+            .provider()
+            .await
+            .map(|p| p.supports_structured_output())
+            .unwrap_or(false);
         agent
-            .apply_recipe_components(recipe.sub_recipes.clone(), recipe.response.clone(), true)
+            .apply_recipe_components(
+                recipe.sub_recipes.clone(),
+                recipe.response.clone(),
+                true,
+                provider_supports_structured_output,
+            )
             .await;
 
         let subagent_prompt =

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -40,6 +40,7 @@ pub struct DeclarativeProviderConfig {
     pub headers: Option<HashMap<String, String>>,
     pub timeout_seconds: Option<u64>,
     pub supports_streaming: Option<bool>,
+    pub supports_structured_output: Option<bool>,
     #[serde(default = "default_requires_auth")]
     pub requires_auth: bool,
 }
@@ -100,6 +101,7 @@ pub struct CreateCustomProviderParams {
     pub api_key: String,
     pub models: Vec<String>,
     pub supports_streaming: Option<bool>,
+    pub supports_structured_output: Option<bool>,
     pub headers: Option<HashMap<String, String>>,
     pub requires_auth: bool,
 }
@@ -113,6 +115,7 @@ pub struct UpdateCustomProviderParams {
     pub api_key: String,
     pub models: Vec<String>,
     pub supports_streaming: Option<bool>,
+    pub supports_structured_output: Option<bool>,
     pub headers: Option<HashMap<String, String>>,
     pub requires_auth: bool,
 }
@@ -153,6 +156,7 @@ pub fn create_custom_provider(
         headers: params.headers,
         timeout_seconds: None,
         supports_streaming: params.supports_streaming,
+        supports_structured_output: params.supports_structured_output,
         requires_auth: params.requires_auth,
     };
 
@@ -210,6 +214,7 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             headers: params.headers.or(existing_config.headers),
             timeout_seconds: existing_config.timeout_seconds,
             supports_streaming: params.supports_streaming,
+            supports_structured_output: params.supports_structured_output,
             requires_auth: params.requires_auth,
         };
 

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -550,6 +550,7 @@ mod tests {
                     toolshim_model: None,
                     fast_model: None,
                     request_params: None,
+                    response_schema: None,
                 },
                 max_tool_responses: None,
             }

--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -115,6 +115,8 @@ pub struct ModelConfig {
     /// Provider-specific request parameters (e.g., anthropic_beta headers)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub request_params: Option<HashMap<String, Value>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_schema: Option<Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -166,6 +168,7 @@ impl ModelConfig {
             toolshim_model,
             fast_model: None,
             request_params,
+            response_schema: None,
         })
     }
 

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -386,6 +386,7 @@ pub fn create_request(
     system: &str,
     messages: &[Message],
     tools: &[Tool],
+    response_schema: Option<&Value>,
 ) -> Result<Value> {
     let anthropic_messages = format_messages(messages);
     let tool_specs = format_tools(tools);
@@ -413,6 +414,16 @@ pub fn create_request(
         "messages": anthropic_messages,
         "max_tokens": max_tokens,
     });
+
+    if let Some(schema) = response_schema {
+        payload.as_object_mut().unwrap().insert(
+            "output_format".to_string(),
+            json!({
+                "type": "json_schema",
+                "schema": schema
+            }),
+        );
+    }
 
     // Add system message if present
     if !system.is_empty() {

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -1042,6 +1042,7 @@ mod tests {
             toolshim_model: None,
             fast_model: None,
             request_params: None,
+            response_schema: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
         let obj = request.as_object().unwrap();
@@ -1074,6 +1075,7 @@ mod tests {
             toolshim_model: None,
             fast_model: None,
             request_params: None,
+            response_schema: None,
         };
         let request = create_request(&model_config, "system", &[], &[], &ImageFormat::OpenAi)?;
         assert_eq!(request["reasoning_effort"], "high");
@@ -1393,6 +1395,7 @@ mod tests {
             toolshim_model: None,
             fast_model: None,
             request_params: None,
+            response_schema: None,
         };
 
         let messages = vec![
@@ -1445,6 +1448,7 @@ mod tests {
             toolshim_model: None,
             fast_model: None,
             request_params: None,
+            response_schema: None,
         };
 
         let messages = vec![Message::user().with_text("Hello")];

--- a/crates/goose/src/providers/formats/gcpvertexai.rs
+++ b/crates/goose/src/providers/formats/gcpvertexai.rs
@@ -218,7 +218,8 @@ fn create_anthropic_request(
     messages: &[Message],
     tools: &[Tool],
 ) -> Result<Value> {
-    let mut request = anthropic::create_request(model_config, system, messages, tools)?;
+    // Vertex AI Claude doesn't support structured output (beta header not available)
+    let mut request = anthropic::create_request(model_config, system, messages, tools, None)?;
 
     let obj = request
         .as_object_mut()
@@ -251,7 +252,13 @@ fn create_google_request(
     messages: &[Message],
     tools: &[Tool],
 ) -> Result<Value> {
-    google::create_request(model_config, system, messages, tools)
+    google::create_request(
+        model_config,
+        system,
+        messages,
+        tools,
+        model_config.response_schema.as_ref(),
+    )
 }
 
 /// Creates a provider-specific request payload and context.

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -648,6 +648,13 @@ impl Provider for GcpVertexAIProvider {
         true
     }
 
+    fn supports_structured_output(&self) -> bool {
+        let model = &self.model.model_name;
+        // Only Gemini 3+ tested - Gemini 2.x can't use tools + structured output together
+        // Open models (DeepSeek, Llama) via Vertex AI not tested yet
+        model.starts_with("gemini-3")
+    }
+
     async fn stream(
         &self,
         session_id: &str,

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -3739,6 +3739,10 @@
             "type": "boolean",
             "nullable": true
           },
+          "supports_structured_output": {
+            "type": "boolean",
+            "nullable": true
+          },
           "timeout_seconds": {
             "type": "integer",
             "format": "int64",
@@ -5161,6 +5165,9 @@
             "type": "object",
             "description": "Provider-specific request parameters (e.g., anthropic_beta headers)",
             "additionalProperties": {},
+            "nullable": true
+          },
+          "response_schema": {
             "nullable": true
           },
           "temperature": {
@@ -7092,6 +7099,10 @@
             "type": "boolean"
           },
           "supports_streaming": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "supports_structured_output": {
             "type": "boolean",
             "nullable": true
           }

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -166,6 +166,7 @@ export type DeclarativeProviderConfig = {
     name: string;
     requires_auth?: boolean;
     supports_streaming?: boolean | null;
+    supports_structured_output?: boolean | null;
     timeout_seconds?: number | null;
 };
 
@@ -619,6 +620,7 @@ export type ModelConfig = {
     request_params?: {
         [key: string]: unknown;
     } | null;
+    response_schema?: unknown;
     temperature?: number | null;
     toolshim: boolean;
     toolshim_model?: string | null;
@@ -1315,6 +1317,7 @@ export type UpdateCustomProviderRequest = {
     models: Array<string>;
     requires_auth?: boolean;
     supports_streaming?: boolean | null;
+    supports_structured_output?: boolean | null;
 };
 
 export type UpdateFromSessionRequest = {


### PR DESCRIPTION
## Summary
Implements native structured output at the provider level, saving LLM roundtrips with tool calls.

- Add supports_structured_output() trait method to Provider
- Implement for OpenAI (gpt-4o, gpt-4.x, o1/o3/o4 models)
- Implement for Anthropic (Claude 4.x models)
- Implement for Google (Gemini 3.x models)
- Pass recipe json_schema to provider's response_format when supported
- Add CustomProviderParams struct to simplify provider config APIs
- Add supports_structured_output field to DeclarativeProviderConfig

### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Tested locally with google provider.