### PR TITLE
feat(google): add configurable thinking level for Gemini 3 models

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -707,6 +707,14 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
         }
     };
 
+    if model.to_lowercase().starts_with("gemini-3") {
+        let thinking_level: &str = cliclack::select("Select thinking level for Gemini 3:")
+            .item("low", "Low - Better latency, lighter reasoning", "")
+            .item("high", "High - Deeper reasoning, higher latency", "")
+            .interact()?;
+        config.set_gemini3_thinking_level(thinking_level)?;
+    }
+
     // Test the configuration
     let spin = spinner();
     spin.start("Checking your configuration...");

--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -968,6 +968,7 @@ config_value!(GOOSE_PROVIDER, String);
 config_value!(GOOSE_MODEL, String);
 config_value!(GOOSE_PROMPT_EDITOR, Option<String>);
 config_value!(GOOSE_MAX_ACTIVE_AGENTS, usize);
+config_value!(GEMINI3_THINKING_LEVEL, String);
 
 /// Load init-config.yaml from workspace root if it exists.
 /// This function is shared between the config recovery and the init_config endpoint.

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -21,6 +21,11 @@ import { getPredefinedModelsFromEnv, shouldShowPredefinedModels } from '../prede
 import { ProviderType } from '../../../../api';
 import { trackModelChanged } from '../../../../utils/analytics';
 
+const THINKING_LEVEL_OPTIONS = [
+  { value: 'low', label: 'Low - Better latency, lighter reasoning' },
+  { value: 'high', label: 'High - Deeper reasoning, higher latency' },
+];
+
 const PREFERRED_MODEL_PATTERNS = [
   /claude-sonnet-4/i,
   /claude-4/i,
@@ -101,6 +106,10 @@ export const SwitchModelModal = ({
   const [loadingModels, setLoadingModels] = useState<boolean>(false);
   const [userClearedModel, setUserClearedModel] = useState(false);
   const [providerErrors, setProviderErrors] = useState<Record<string, string>>({});
+  const [thinkingLevel, setThinkingLevel] = useState<string>('low');
+
+  const modelName = usePredefinedModels ? selectedPredefinedModel?.name : model;
+  const isGemini3Model = modelName?.toLowerCase().startsWith('gemini-3') ?? false;
 
   // Validate form data
   const validateForm = useCallback(() => {
@@ -148,7 +157,18 @@ export const SwitchModelModal = ({
       } else {
         const providerMetaData = await getProviderMetadata(provider || '', getProviders);
         const providerDisplayName = providerMetaData.display_name;
-        modelObj = { name: model, provider: provider, subtext: providerDisplayName } as Model;
+        modelObj = {
+          name: model,
+          provider: provider,
+          subtext: providerDisplayName,
+        } as Model;
+      }
+
+      if (isGemini3Model) {
+        modelObj = {
+          ...modelObj,
+          request_params: { ...modelObj.request_params, thinking_level: thinkingLevel },
+        };
       }
 
       await changeModel(sessionId, modelObj);
@@ -410,7 +430,7 @@ export const SwitchModelModal = ({
                           className="peer sr-only"
                         />
                         <div
-                          className="h-4 w-4 rounded-full border border-border-default 
+                          className="h-4 w-4 rounded-full border border-border-default
                                 peer-checked:border-[6px] peer-checked:border-black dark:peer-checked:border-white
                                 peer-checked:bg-white dark:peer-checked:bg-black
                                 transition-all duration-200 ease-in-out group-hover:border-border-default"
@@ -423,6 +443,24 @@ export const SwitchModelModal = ({
 
               {attemptedSubmit && validationErrors.model && (
                 <div className="text-red-500 text-sm mt-1">{validationErrors.model}</div>
+              )}
+
+              {isGemini3Model && (
+                <div className="mt-2">
+                  <label className="text-sm text-textSubtle mb-1 block">
+                    Thinking Level
+                    <span className="text-xs text-textMuted ml-2">(Gemini 3 models only)</span>
+                  </label>
+                  <Select
+                    options={THINKING_LEVEL_OPTIONS}
+                    value={THINKING_LEVEL_OPTIONS.find((o) => o.value === thinkingLevel)}
+                    onChange={(newValue: unknown) => {
+                      const option = newValue as { value: string; label: string } | null;
+                      setThinkingLevel(option?.value || 'low');
+                    }}
+                    placeholder="Select thinking level"
+                  />
+                </div>
               )}
             </div>
           ) : (
@@ -520,6 +558,24 @@ export const SwitchModelModal = ({
                       {attemptedSubmit && validationErrors.model && (
                         <div className="text-red-500 text-sm mt-1">{validationErrors.model}</div>
                       )}
+                    </div>
+                  )}
+
+                  {isGemini3Model && (
+                    <div className="mt-2">
+                      <label className="text-sm text-textSubtle mb-1 block">
+                        Thinking Level
+                        <span className="text-xs text-textMuted ml-2">(Gemini 3 models only)</span>
+                      </label>
+                      <Select
+                        options={THINKING_LEVEL_OPTIONS}
+                        value={THINKING_LEVEL_OPTIONS.find((o) => o.value === thinkingLevel)}
+                        onChange={(newValue: unknown) => {
+                          const option = newValue as { value: string; label: string } | null;
+                          setThinkingLevel(option?.value || 'low');
+                        }}
+                        placeholder="Select thinking level"
+                      />
                     </div>
                   )}
                 </>


### PR DESCRIPTION
## Summary

- Defaults to 'low' instead of Google's default 'high' for better latency
- Supports 'low' and 'high' levels for Gemini 3 models

### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Unit testing and local testing with gemini3 models.