### PR TITLE
fix(1785): enable lto and codegen-units in release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,7 @@ reqwest = { version = "0.12.28", default-features = false }
 tower = "0.5.2"
 tower-http = "0.6.8"
 url = "2.5.8"
+
+[profile.release]
+codegen-units = 1
+lto = true


### PR DESCRIPTION
## Summary
<!-- Describe your change -->

binary size:

- release：goose 126M，goosed 113M
- release + lto + codegen-units：goose 90M，goosed 81M

build time:

- release: 6m26.735s
- relase + lto + codegen-units: 12m29.807s


Fix: https://github.com/block/goose/issues/1785

### Type of Change
<!-- Select all that apply -->
- [x] Feature

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

