### PR TITLE
Fix path for global agent skills

### DIFF
--- a/documentation/docs/guides/context-engineering/using-skills.md
+++ b/documentation/docs/guides/context-engineering/using-skills.md
@@ -28,7 +28,7 @@ goose skills are compatible with Claude Desktop and other [agents that support A
 Skills can be stored globally and/or per-project. goose checks all of these directories in order and combines what it finds. If the same skill name exists in multiple directories, later directories take priority:
 
 1. `~/.claude/skills/` — Global, shared with Claude Desktop
-2. `~/.config/agent/skills/` — Global, portable across AI coding agents (`~/.config/agents/skills` in goose v1.20.0 and later)
+2. `~/.config/agents/skills/` — Global, portable across AI coding agents
 3. `~/.config/goose/skills/` — Global, goose-specific
 4. `./.claude/skills/` — Project-level, shared with Claude Desktop
 5. `./.goose/skills/` — Project-level, goose-specific


### PR DESCRIPTION
## Summary
goose v1.20 was released- updating docs with correct global skills path.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
None
