### PR TITLE
docs: todo tutorial update

### DIFF
--- a/documentation/docs/mcp/todo-mcp.md
+++ b/documentation/docs/mcp/todo-mcp.md
@@ -10,9 +10,11 @@ import GooseBuiltinInstaller from '@site/src/components/GooseBuiltinInstaller';
 
 The Todo extension helps goose stay organized by breaking complex work into a series of steps and keeping you updated as it completes each step.
 
-goose automatically knows to use the Todo extension if it has to do tasks that have 2 or more steps, involve multiple files/components, or have an uncertain scope.
+goose automatically knows to use the Todo extension for tasks involving multiple files/components or uncertain scope. At the start of the task, goose will create an internal checklist, read and update progress as it works, and verify that all tasks are completed.
 
-At the start of the task, goose will create an internal checklist, read and update progress as it works, and verify that all tasks are completed.
+:::tip
+You can ask goose to "show me the current todo list" at any time to see what's being tracked.
+:::
 
 This tutorial will cover enabling and using the Todo extension.
 


### PR DESCRIPTION
## Summary
This PR updates the Todo tutorial to sync with a change to prompt to create the todo list and remove the "2 steps or more" threshold.

Documentation updates:
- `documentation/docs/mcp/todo-mcp.md`:
  - Remove the reference to 2 steps
  - Add tip that you can ask goose to show the list

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Manual testing

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212851198493199