### PR TITLE
increase worker threads for ci

### DIFF
--- a/crates/goose-acp/tests/server_test.rs
+++ b/crates/goose-acp/tests/server_test.rs
@@ -22,7 +22,7 @@ use test_case::test_case;
 use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 use wiremock::MockServer;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_acp_basic_completion() {
     let temp_dir = tempfile::tempdir().unwrap();
     let prompt = "what is 1+1";
@@ -62,7 +62,7 @@ async fn test_acp_basic_completion() {
     .await;
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_acp_with_mcp_http_server() {
     let temp_dir = tempfile::tempdir().unwrap();
     let prompt = "Use the get_code tool and output only its result.";
@@ -344,7 +344,7 @@ async fn run_acp_session<F, Fut>(
 #[test_case(Some(PermissionOptionKind::RejectAlways), ToolCallStatus::Failed, "user:\n  always_allow: []\n  ask_before: []\n  never_allow:\n  - lookup__get_code\n"; "reject_always")]
 #[test_case(Some(PermissionOptionKind::RejectOnce), ToolCallStatus::Failed, ""; "reject_once")]
 #[test_case(None, ToolCallStatus::Failed, ""; "cancelled")]
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_permission_persistence(
     kind: Option<PermissionOptionKind>,
     expected_status: ToolCallStatus,


### PR DESCRIPTION
## Summary
fix failing tests for goose-acp
```
thread 'test_permission_persistence::allow_always' (4774) has overflowed its stack
fatal runtime error: stack overflow, aborting
error: test failed, to rerun pass `-p goose-acp --test server_test`

Caused by:
  process didn't exit successfully: `/home/runner/work/goose/goose/target/debug/deps/server_test-d0cb26eab9d9a4eb --skip 'scenario_tests::scenarios::tests'` (signal: 6, SIGABRT: process abort signal)
Error: Process completed with exit code 101.
```
