### PR TITLE
fix: macOS keychain infinite prompt loop   

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -547,7 +547,6 @@ impl Config {
         let mut cache = self.secrets_cache.lock().unwrap();
 
         let values = if let Some(ref cached_secrets) = *cache {
-            tracing::debug!("secrets cache hit");
             cached_secrets.clone()
         } else {
             tracing::debug!("secrets cache miss, fetching from storage");
@@ -578,7 +577,6 @@ impl Config {
             };
 
             *cache = Some(loaded.clone());
-            tracing::debug!("secrets cached");
             loaded
         };
 
@@ -888,7 +886,6 @@ impl Config {
     fn invalidate_secrets_cache(&self) {
         let mut cache = self.secrets_cache.lock().unwrap();
         *cache = None;
-        tracing::debug!("secrets cache invalidated");
     }
 
     /// Check if an error string indicates a keyring availability issue that should trigger fallback


### PR DESCRIPTION
## Summary
**Problem**: Each call to `get_secret()` hits keychain separately, causing multiple prompts when loading provider config with multiple secret parameters. 
**Solution**: Add in-memory cache to `all_secrets()` so keychain is accessed once per config load.
 - Before: N keychain prompts for N secret parameters when loading provider config
 - After: 1 keychain prompt per config load, cached for subsequent reads in same session

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Related Issues
Fixes #6595 