### PR TITLE
[Fix] autovisualizer not working with code execution enabled

### DIFF
--- a/crates/goose/src/agents/code_execution_extension.rs
+++ b/crates/goose/src/agents/code_execution_extension.rs
@@ -448,6 +448,7 @@ impl CodeExecutionClient {
                 completions: None,
                 experimental: None,
                 logging: None,
+                tasks: None,
             },
             server_info: Implementation {
                 name: EXTENSION_NAME.to_string(),
@@ -709,6 +710,7 @@ impl CodeExecutionClient {
                     let tool_call = CallToolRequestParam {
                         name: tool_name.into(),
                         arguments: serde_json::from_str(&arguments).ok(),
+                        task: None,
                     };
                     match manager
                         .dispatch_tool_call(&session_id, tool_call, CancellationToken::new())


### PR DESCRIPTION
## Problem
This bug was reported in [this issue](https://github.com/block/goose/issues/6583). When code execution was enabled, autovisualizer visualizations were not rendering in the UI. The visualizations would return empty strings instead of displaying charts/graphs. 

## Root Cause
The code execution extension was stripping out resource contents (HTML visualizations) from tool call results, only keeping text content. When autovisualizer created visualizations as `BlobResourceContents (base64-encoded HTML)`, these resources were being discarded during JavaScript execution.

## Solution
Modified `crates/goose/src/agents/code_execution_extension.rs` to properly collect and return resource contents:

1. Added resource collection: Created `Arc<Mutex<Vec<CallToolResult>>>` to collect all tool call results during JavaScript execution
2. Updated `run_tool_handler`: Modified to accept and store `CallToolResult objects` in the collection
3. Extract resources in `handle_execute_code`: After JS execution completes, iterate through collected results and extract resource contents with `Role::User` audience
4. Return combined content: Return both text results AND resources so the UI's `MCPUIResourceRenderer `component can display visualizations

### Testing
Verified that visualizations (bar charts, etc.) now render correctly in the Electron app when code execution is enabled.
<img width="1376" height="822" alt="Screenshot 2026-01-21 at 1 56 18 PM" src="https://github.com/user-attachments/assets/10af26d7-8875-45de-b3a9-97993fa77bbb" />


