### PR TITLE
Install goose-mcp crate dependencies

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -53,6 +53,11 @@ jobs:
           exit 1
         fi
 
+    - name: install dependencies
+      run: |
+        sudo apt update -y
+        sudo apt install -y libdbus-1-dev gnome-keyring libxcb1-dev
+
     - name: create release branch
       env:
         ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
The goose crate depends on goose-mcp now, so to run build_canonical_models, we need to install this. Looking into removing this dependency after this.