### PR TITLE
fix(docs): use dynamic import for globby ESM module

### DIFF
--- a/documentation/plugins/markdown-export.cjs
+++ b/documentation/plugins/markdown-export.cjs
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const { globby } = require('globby');
 
 module.exports = function markdownExportPlugin(context, options) {
   const pluginOptions = {
@@ -17,6 +16,8 @@ module.exports = function markdownExportPlugin(context, options) {
       }
 
       console.log('[markdown-export] Starting markdown export...');
+      
+      const globby = (await import('globby')).default;
       
       const docsDir = path.join(context.siteDir, 'docs');
       const outputDir = path.join(outDir, 'docs');

--- a/documentation/scripts/generate-docs-map.js
+++ b/documentation/scripts/generate-docs-map.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const { globby } = require('globby');
 const matter = require('gray-matter');
 
 const DOCS_DIR = path.join(__dirname, '..', 'docs');
@@ -42,6 +41,8 @@ function getHeadings(content) {
 }
 
 async function main() {
+  const globby = (await import('globby')).default;
+  
   const sections = [
     { name: 'Getting Started', pattern: 'getting-started/*.{md,mdx}' },
     { name: 'Guides', pattern: 'guides/**/*.{md,mdx}' },


### PR DESCRIPTION
## Summary
`globby` v13+ is ESM-only and cannot be imported with `require()` in CommonJS files. This causes `npm run build` to fail with:

```
TypeError: globby is not a function
```

## Root Cause
- CI uses **Node 20** where ESM interop still allows this to partially work
- Local development with **Node 22+** (e.g., Node 25) is stricter about ESM/CJS boundaries and throws the error

## Fix
Use dynamic import instead of `require()`:
```js
const globby = (await import('globby')).default;
```

## Files Changed
- `documentation/scripts/generate-docs-map.js`
- `documentation/plugins/markdown-export.cjs`

## Testing
- `npm run build` now succeeds on Node 25