### PR TITLE
fix(docs): use named import for globby v13

### DIFF
--- a/documentation/plugins/markdown-export.cjs
+++ b/documentation/plugins/markdown-export.cjs
@@ -17,7 +17,7 @@ module.exports = function markdownExportPlugin(context, options) {
 
       console.log('[markdown-export] Starting markdown export...');
       
-      const globby = (await import('globby')).default;
+      const { globby } = await import('globby');
       
       const docsDir = path.join(context.siteDir, 'docs');
       const outputDir = path.join(outDir, 'docs');

--- a/documentation/scripts/generate-docs-map.js
+++ b/documentation/scripts/generate-docs-map.js
@@ -41,7 +41,7 @@ function getHeadings(content) {
 }
 
 async function main() {
-  const globby = (await import('globby')).default;
+  const { globby } = await import('globby');
   
   const sections = [
     { name: 'Getting Started', pattern: 'getting-started/*.{md,mdx}' },


### PR DESCRIPTION
## Summary
Fixes the docs build failure introduced by the previous globby fix (#6636).

## Problem
The previous fix used:
```js
const globby = (await import('globby')).default;
```

But **globby v13 has no default export** - it uses named exports:
```js
export const globby = ...  // named export, not default
```

This worked locally because some environments had globby v11 cached (which does have a default export), but CI installs v13 fresh.

## Fix
```js
const { globby } = await import('globby');
```

## Files Changed
- `documentation/scripts/generate-docs-map.js`
- `documentation/plugins/markdown-export.cjs`