### PR TITLE
fix: capitalize Rust in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,8 +41,8 @@ If you use Goose, Copilot, Claude, or other AI tools to help with your PRs:
 
 ## Prerequisites
 
-goose includes rust binaries alongside an electron app for the GUI. To work
-on the rust backend, you will need to [install rust and cargo][rustup]. To work
+goose includes Rust binaries alongside an electron app for the GUI. To work
+on the Rust backend, you will need to [install Rust and cargo][rustup]. To work
 on the App, you will also need to [install node and npm][nvm] - we recommend through nvm.
 
 We provide a shortcut to standard commands using [just][just] in our `justfile`.


### PR DESCRIPTION
Fixed capitalization of 'rust' to 'Rust' in the Prerequisites section, as Rust is a proper noun referring to the programming language.

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

