### PR TITLE
fix(ci): temporarily skip gh-pages checkout to fix disk space issue

### DIFF
--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -53,24 +53,26 @@ jobs:
         working-directory: ./documentation
         run: ./scripts/verify-build.sh
 
-      - name: Checkout gh-pages branch
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        continue-on-error: true      # Branch may not exist on first deploy or in forks
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
-        with:
-          ref: gh-pages
-          path: gh-pages-current
+      # TODO: Re-enable after cleaning up gh-pages branch (currently ~7.4GB causing disk space issues)
+      # See: https://github.com/block/goose/issues/XXXX
+      # - name: Checkout gh-pages branch
+      #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      #   continue-on-error: true      # Branch may not exist on first deploy or in forks
+      #   uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
+      #   with:
+      #     ref: gh-pages
+      #     path: gh-pages-current
 
-      - name: Preserve pr-preview directory
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-        run: |
-          # Copy pr-preview from current gh-pages to the new build (if it exists)
-          if [ -d "gh-pages-current/pr-preview" ]; then
-            cp -r gh-pages-current/pr-preview documentation/build/pr-preview
-            echo "Preserved pr-preview directory with $(ls gh-pages-current/pr-preview | wc -l) PR previews"
-          else
-            echo "No pr-preview directory to preserve"
-          fi
+      # - name: Preserve pr-preview directory
+      #   if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+      #   run: |
+      #     # Copy pr-preview from current gh-pages to the new build (if it exists)
+      #     if [ -d "gh-pages-current/pr-preview" ]; then
+      #       cp -r gh-pages-current/pr-preview documentation/build/pr-preview
+      #       echo "Preserved pr-preview directory with $(ls gh-pages-current/pr-preview | wc -l) PR previews"
+      #     else
+      #       echo "No pr-preview directory to preserve"
+      #     fi
 
       - name: Deploy to /gh-pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## Summary
Temporarily disables the gh-pages checkout steps to unblock documentation deployments.

## Problem
The gh-pages branch has grown to **~7.4GB** (large images duplicated across PR previews), causing `No space left on device` errors during the deploy step:

```
System.IO.IOException: No space left on device
```

See failed run: https://github.com/block/goose/actions/runs/21258828347

## Fix
Comments out the `Checkout gh-pages branch` and `Preserve pr-preview directory` steps temporarily.

**Trade-off:** Existing PR previews will be lost on next deploy, but they can be regenerated by re-running PR preview workflows.

## Follow-up needed
- [ ] Clean up gh-pages branch (remove old PR previews, optimize large images)
- [ ] Re-enable the preservation steps

## Related
- Unblocks deploys for #6635, #6636, #6639, #6624, #6043