### PR TITLE
ACP get working dir from args.cwd

### DIFF
--- a/crates/goose-acp/src/server.rs
+++ b/crates/goose-acp/src/server.rs
@@ -49,7 +49,6 @@ pub struct GooseAcpAgent {
 pub struct GooseAcpConfig {
     pub provider: Arc<dyn goose::providers::base::Provider>,
     pub builtins: Vec<String>,
-    pub work_dir: std::path::PathBuf,
     pub data_dir: std::path::PathBuf,
     pub config_dir: std::path::PathBuf,
     pub goose_mode: goose::config::GooseMode,
@@ -308,7 +307,6 @@ impl GooseAcpAgent {
         Self::with_config(GooseAcpConfig {
             provider,
             builtins,
-            work_dir: std::env::current_dir().unwrap_or_default(),
             data_dir: Paths::data_dir(),
             config_dir: Paths::config_dir(),
             goose_mode,
@@ -689,7 +687,7 @@ impl GooseAcpAgent {
         let manager = self.agent.config.session_manager.clone();
         let goose_session = manager
             .create_session(
-                std::env::current_dir().unwrap_or_default(),
+                args.cwd.clone(),
                 "ACP Session".to_string(), // just an initial name - may be replaced by maybe_update_name
                 SessionType::User,
             )

--- a/crates/goose-acp/tests/server_test.rs
+++ b/crates/goose-acp/tests/server_test.rs
@@ -260,7 +260,6 @@ async fn spawn_server_in_process(
     let config = GooseAcpConfig {
         provider: Arc::new(provider),
         builtins: builtins.iter().map(|s| s.to_string()).collect(),
-        work_dir: data_root.to_path_buf(),
         data_dir: data_root.to_path_buf(),
         config_dir: data_root.to_path_buf(),
         goose_mode,


### PR DESCRIPTION
## Summary

Goose found and fixed the bug in the ACP client's `working_dir` handling:

### The Problem
In `crates/goose-acp/src/server.rs`, the `on_new_session` function was ignoring the `cwd` field from the `NewSessionRequest` and instead using `std::env::current_dir()`:

```rust
// Before (buggy):
let goose_session = manager
    .create_session(
        std::env::current_dir().unwrap_or_default(),  // Wrong!
        "ACP Session".to_string(),
        SessionType::User,
    )
```

### The Fix
Changed it to use `args.cwd` from the ACP request:

```rust
// After (fixed):
let goose_session = manager
    .create_session(
        args.cwd.clone(),  // Correct - uses the cwd from the ACP client
        "ACP Session".to_string(),
        SessionType::User,
    )
```

### Additional Cleanup
I also removed the unused `work_dir` field from `GooseAcpConfig` since:
1. It was never used anywhere in the code
2. The working directory should come from the ACP protocol's `NewSessionRequest.cwd` field, not from a config
3. The `on_load_session` function was already correctly using `args.cwd` to update the working directory