### PR TITLE
fix(goose): only send agent-session-id when a session exists

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -17,7 +17,6 @@ use goose::config::{
     configure_tetrate, Config, ConfigError, ExperimentManager, ExtensionEntry, GooseMode,
     PermissionManager,
 };
-use goose::conversation::message::Message;
 use goose::model::ModelConfig;
 use goose::posthog::{get_telemetry_choice, TELEMETRY_ENABLED_KEY};
 use goose::providers::provider_test::test_provider_configuration;
@@ -25,7 +24,6 @@ use goose::providers::{create, providers, retry_operation, RetryConfig};
 use goose::session::SessionType;
 use serde_json::Value;
 use std::collections::HashMap;
-use uuid::Uuid;
 
 // useful for light themes where there is no dicernible colour contrast between
 // cursor-selected and cursor-unselected items.
@@ -683,10 +681,8 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     let models_res = {
         let temp_model_config = ModelConfig::new(&provider_meta.default_model)?;
         let temp_provider = create(provider_name, temp_model_config).await?;
-        // Provider setup runs before any user session exists; use an ephemeral id.
-        let session_id = Uuid::new_v4().to_string();
         retry_operation(&RetryConfig::default(), || async {
-            temp_provider.fetch_recommended_models(&session_id).await
+            temp_provider.fetch_recommended_models().await
         })
         .await
     };
@@ -1658,11 +1654,11 @@ pub async fn handle_openrouter_auth() -> anyhow::Result<()> {
 
     match create("openrouter", model_config).await {
         Ok(provider) => {
-            // Config verification runs before any user session exists; use an ephemeral id.
-            let session_id = Uuid::new_v4().to_string();
+            let model_config = provider.get_model_config();
             let test_result = provider
-                .complete(
-                    &session_id,
+                .complete_with_model(
+                    None,
+                    &model_config,
                     "You are goose, an AI assistant.",
                     &[Message::user().with_text("Say 'Configuration test successful!'")],
                     &[],
@@ -1738,16 +1734,7 @@ pub async fn handle_tetrate_auth() -> anyhow::Result<()> {
 
     match create("tetrate", model_config).await {
         Ok(provider) => {
-            // Config verification runs before any user session exists; use an ephemeral id.
-            let session_id = Uuid::new_v4().to_string();
-            let test_result = provider
-                .complete(
-                    &session_id,
-                    "You are goose, an AI assistant.",
-                    &[Message::user().with_text("Say 'Configuration test successful!'")],
-                    &[],
-                )
-                .await;
+            let test_result = provider.fetch_supported_models().await;
 
             match test_result {
                 Ok(_) => {

--- a/crates/goose/examples/image_tool.rs
+++ b/crates/goose/examples/image_tool.rs
@@ -10,7 +10,6 @@ use rmcp::model::{CallToolRequestParams, Content, Tool};
 use rmcp::object;
 use std::fs;
 use std::sync::Arc;
-use uuid::Uuid;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -63,10 +62,10 @@ async fn main() -> Result<()> {
                 },
             }
         });
-        let session_id = Uuid::new_v4().to_string();
         let (response, usage) = provider
-            .complete(
-                &session_id,
+            .complete_with_model(
+                None,
+                &provider.get_model_config(),
                 "You are a helpful assistant. Please describe any text you see in the image.",
                 &messages,
                 &[Tool::new("view_image", "View an image", input_schema)],

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -435,7 +435,7 @@ mod tests {
 
         async fn complete_with_model(
             &self,
-            _session_id: &str,
+            _session_id: Option<&str>,
             _model_config: &ModelConfig,
             _system: &str,
             _messages: &[Message],

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -473,7 +473,7 @@ mod tests {
 
         async fn complete_with_model(
             &self,
-            _session_id: &str,
+            _session_id: Option<&str>,
             _model_config: &ModelConfig,
             _system: &str,
             messages: &[Message],

--- a/crates/goose/src/providers/api_client.rs
+++ b/crates/goose/src/providers/api_client.rs
@@ -196,7 +196,7 @@ pub struct ApiRequestBuilder<'a> {
     client: &'a ApiClient,
     path: &'a str,
     headers: HeaderMap,
-    session_id: &'a str,
+    session_id: Option<&'a str>,
 }
 
 impl ApiClient {
@@ -273,10 +273,15 @@ impl ApiClient {
         Ok(self)
     }
 
-    pub fn request<'a>(&'a self, session_id: &'a str, path: &'a str) -> ApiRequestBuilder<'a> {
+    /// - `session_id`: Use `None` only for configuration or pre-session tasks.
+    pub fn request<'a>(
+        &'a self,
+        session_id: Option<&'a str>,
+        path: &'a str,
+    ) -> ApiRequestBuilder<'a> {
         ApiRequestBuilder {
             client: self,
-            session_id,
+            session_id: session_id.filter(|id| !id.is_empty()),
             path,
             headers: HeaderMap::new(),
         }
@@ -284,7 +289,7 @@ impl ApiClient {
 
     pub async fn api_post(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         path: &str,
         payload: &Value,
     ) -> Result<ApiResponse> {
@@ -293,18 +298,18 @@ impl ApiClient {
 
     pub async fn response_post(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         path: &str,
         payload: &Value,
     ) -> Result<Response> {
         self.request(session_id, path).response_post(payload).await
     }
 
-    pub async fn api_get(&self, session_id: &str, path: &str) -> Result<ApiResponse> {
+    pub async fn api_get(&self, session_id: Option<&str>, path: &str) -> Result<ApiResponse> {
         self.request(session_id, path).api_get().await
     }
 
-    pub async fn response_get(&self, session_id: &str, path: &str) -> Result<Response> {
+    pub async fn response_get(&self, session_id: Option<&str>, path: &str) -> Result<Response> {
         self.request(session_id, path).response_get().await
     }
 
@@ -373,10 +378,16 @@ impl<'a> ApiRequestBuilder<'a> {
         F: FnOnce(url::Url, &Client) -> reqwest::RequestBuilder,
     {
         let url = self.client.build_url(self.path)?;
-        let mut request = request_builder(url, &self.client.client);
-        request = request.headers(self.headers.clone());
+        let mut headers = self.headers.clone();
+        headers.remove(SESSION_ID_HEADER);
+        if let Some(session_id) = self.session_id {
+            let header_name = HeaderName::from_static(SESSION_ID_HEADER);
+            let header_value = HeaderValue::from_str(session_id)?;
+            headers.insert(header_name, header_value);
+        }
 
-        request = request.header(SESSION_ID_HEADER, self.session_id);
+        let mut request = request_builder(url, &self.client.client);
+        request = request.headers(headers);
 
         request = match &self.client.auth {
             AuthMethod::BearerToken(token) => {
@@ -411,69 +422,40 @@ impl fmt::Debug for ApiClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use test_case::test_case;
 
-    #[tokio::test]
-    async fn test_session_id_header_injection() {
-        let client = ApiClient::new(
-            "http://localhost:8080".to_string(),
-            AuthMethod::BearerToken("test-token".to_string()),
-        )
-        .unwrap();
-
-        let builder = client.request("test-session_id-456", "/test");
-        let request = builder
-            .send_request(|url, client| client.get(url))
-            .await
+    #[test_case(Some("test-session_id-456"), None, Some("test-session_id-456"); "header set")]
+    #[test_case(Some("new-session"), Some(("Agent-Session-Id", "old-session")), Some("new-session"); "replaces existing")]
+    #[test_case(None, Some(("Agent-Session-Id", "old-session")), None; "removes existing on none")]
+    #[test_case(Some(""), Some(("agent-session-id", "old-session")), None; "removes existing on empty")]
+    fn test_session_id_header(
+        session_id: Option<&str>,
+        existing_header: Option<(&str, &str)>,
+        expected: Option<&str>,
+    ) {
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        runtime.block_on(async {
+            let client = ApiClient::new(
+                "http://localhost:8080".to_string(),
+                AuthMethod::BearerToken("test-token".to_string()),
+            )
             .unwrap();
 
-        let headers = request.build().unwrap().headers().clone();
+            let mut builder = client.request(session_id, "/test");
+            if let Some((key, value)) = existing_header {
+                builder = builder.header(key, value).unwrap();
+            }
+            let request = builder
+                .send_request(|url, client| client.get(url))
+                .await
+                .unwrap();
 
-        assert!(headers.contains_key(SESSION_ID_HEADER));
-        assert_eq!(
-            headers.get(SESSION_ID_HEADER).unwrap().to_str().unwrap(),
-            "test-session_id-456"
-        );
-    }
+            let headers = request.build().unwrap().headers().clone();
 
-    #[tokio::test]
-    async fn test_session_id_header_with_different_id() {
-        let client = ApiClient::new(
-            "http://localhost:8080".to_string(),
-            AuthMethod::BearerToken("test-token".to_string()),
-        )
-        .unwrap();
-
-        let builder = client.request("another-session_id-789", "/test");
-        let request = builder
-            .send_request(|url, client| client.get(url))
-            .await
-            .unwrap();
-
-        let headers = request.build().unwrap().headers().clone();
-
-        assert!(headers.contains_key(SESSION_ID_HEADER));
-        assert_eq!(
-            headers.get(SESSION_ID_HEADER).unwrap().to_str().unwrap(),
-            "another-session_id-789"
-        );
-    }
-
-    #[tokio::test]
-    async fn test_session_id_header_always_present() {
-        let client = ApiClient::new(
-            "http://localhost:8080".to_string(),
-            AuthMethod::BearerToken("test-token".to_string()),
-        )
-        .unwrap();
-
-        let builder = client.request("required-session_id", "/test");
-        let request = builder
-            .send_request(|url, client| client.get(url))
-            .await
-            .unwrap();
-
-        let headers = request.build().unwrap().headers().clone();
-
-        assert!(headers.contains_key(SESSION_ID_HEADER));
+            let actual = headers
+                .get(SESSION_ID_HEADER)
+                .and_then(|value| value.to_str().ok());
+            assert_eq!(actual, expected);
+        });
     }
 }

--- a/crates/goose/src/providers/auto_detect.rs
+++ b/crates/goose/src/providers/auto_detect.rs
@@ -1,10 +1,7 @@
 use crate::model::ModelConfig;
 use crate::providers::retry::{retry_operation, RetryConfig};
 
-pub async fn detect_provider_from_api_key(
-    session_id: &str,
-    api_key: &str,
-) -> Option<(String, Vec<String>)> {
+pub async fn detect_provider_from_api_key(api_key: &str) -> Option<(String, Vec<String>)> {
     let provider_tests = vec![
         ("anthropic", "ANTHROPIC_API_KEY"),
         ("openai", "OPENAI_API_KEY"),
@@ -18,7 +15,6 @@ pub async fn detect_provider_from_api_key(
         .into_iter()
         .map(|(provider_name, env_key)| {
             let api_key = api_key.to_string();
-            let session_id = session_id.to_string();
             tokio::spawn(async move {
                 let original_value = std::env::var(env_key).ok();
                 std::env::set_var(env_key, &api_key);
@@ -31,7 +27,7 @@ pub async fn detect_provider_from_api_key(
                 {
                     Ok(provider) => {
                         match retry_operation(&RetryConfig::default(), || async {
-                            provider.fetch_supported_models(&session_id).await
+                            provider.fetch_supported_models().await
                         })
                         .await
                         {

--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -99,7 +99,11 @@ impl AzureProvider {
         })
     }
 
-    async fn post(&self, session_id: &str, payload: &Value) -> Result<Value, ProviderError> {
+    async fn post(
+        &self,
+        session_id: Option<&str>,
+        payload: &Value,
+    ) -> Result<Value, ProviderError> {
         // Build the path for Azure OpenAI
         let path = format!(
             "openai/deployments/{}/chat/completions?api-version={}",
@@ -147,7 +151,7 @@ impl Provider for AzureProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],

--- a/crates/goose/src/providers/canonical/build_canonical_models.rs
+++ b/crates/goose/src/providers/canonical/build_canonical_models.rs
@@ -550,9 +550,7 @@ async fn check_provider(
         }
     };
 
-    // Provider probe runs outside any user session; use an ephemeral id.
-    let session_id = uuid::Uuid::new_v4().to_string();
-    let fetched_models = match provider.fetch_supported_models(&session_id).await {
+    let fetched_models = match provider.fetch_supported_models().await {
         Ok(Some(models)) => {
             println!("  ✓ Fetched {} models", models.len());
             models

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -417,7 +417,7 @@ impl Provider for ClaudeCodeProvider {
     )]
     async fn complete_with_model(
         &self,
-        _session_id: &str,
+        _session_id: Option<&str>, // create_session == YYYYMMDD_N, but --session-id requires a UUID
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -507,7 +507,7 @@ impl Provider for CodexProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        _session_id: Option<&str>, // CLI has no external session-id flag to propagate.
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -352,7 +352,7 @@ impl Provider for CursorAgentProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        _session_id: Option<&str>, // CLI has no external session-id flag to propagate.
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -264,7 +264,7 @@ impl Provider for GeminiCliProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        _session_id: Option<&str>, // CLI has no external session-id flag to propagate.
         _model_config: &ModelConfig,
         system: &str,
         messages: &[Message],

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -169,7 +169,11 @@ impl GithubCopilotProvider {
         })
     }
 
-    async fn post(&self, session_id: &str, payload: &mut Value) -> Result<Response, ProviderError> {
+    async fn post(
+        &self,
+        session_id: Option<&str>,
+        payload: &mut Value,
+    ) -> Result<Response, ProviderError> {
         let (endpoint, token) = self.get_api_info().await?;
         let auth = AuthMethod::BearerToken(token);
         let mut headers = self.get_github_headers();
@@ -411,7 +415,7 @@ impl Provider for GithubCopilotProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],
@@ -469,7 +473,7 @@ impl Provider for GithubCopilotProvider {
         let response = self
             .with_retry(|| async {
                 let mut payload_clone = payload.clone();
-                let resp = self.post(session_id, &mut payload_clone).await?;
+                let resp = self.post(Some(session_id), &mut payload_clone).await?;
                 handle_status_openai_compat(resp).await
             })
             .await
@@ -480,10 +484,7 @@ impl Provider for GithubCopilotProvider {
         stream_openai_compat(response, log)
     }
 
-    async fn fetch_supported_models(
-        &self,
-        _session_id: &str,
-    ) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
         let (endpoint, token) = self.get_api_info().await?;
         let url = format!("{}/models", endpoint);
 

--- a/crates/goose/src/providers/sagemaker_tgi.rs
+++ b/crates/goose/src/providers/sagemaker_tgi.rs
@@ -14,6 +14,7 @@ use super::errors::ProviderError;
 use super::retry::ProviderRetry;
 use super::utils::RequestLog;
 use crate::conversation::message::{Message, MessageContent};
+use crate::session_context::SESSION_ID_HEADER;
 
 use crate::model::ModelConfig;
 use chrono::Utc;
@@ -154,17 +155,27 @@ impl SageMakerTgiProvider {
         Ok(request)
     }
 
-    async fn invoke_endpoint(&self, payload: Value) -> Result<Value, ProviderError> {
+    async fn invoke_endpoint(
+        &self,
+        session_id: Option<&str>,
+        payload: Value,
+    ) -> Result<Value, ProviderError> {
         let body = serde_json::to_string(&payload).map_err(|e| {
             ProviderError::RequestFailed(format!("Failed to serialize request: {}", e))
         })?;
 
-        let response = self
+        let mut request = self
             .sagemaker_client
             .invoke_endpoint()
             .endpoint_name(&self.endpoint_name)
             .content_type("application/json")
-            .body(body.into_bytes().into())
+            .body(body.into_bytes().into());
+
+        if let Some(session_id) = session_id.filter(|id| !id.is_empty()) {
+            request = request.custom_attributes(format!("{SESSION_ID_HEADER}={session_id}"));
+        }
+
+        let response = request
             .send()
             .await
             .map_err(|e| ProviderError::RequestFailed(format!("SageMaker invoke failed: {}", e)))?;
@@ -289,7 +300,7 @@ impl Provider for SageMakerTgiProvider {
     )]
     async fn complete_with_model(
         &self,
-        _session_id: &str,
+        session_id: Option<&str>,
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],
@@ -302,7 +313,7 @@ impl Provider for SageMakerTgiProvider {
         })?;
 
         let response = self
-            .with_retry(|| self.invoke_endpoint(request_payload.clone()))
+            .with_retry(|| self.invoke_endpoint(session_id, request_payload.clone()))
             .await?;
 
         let message = self.parse_tgi_response(response)?;

--- a/crates/goose/src/providers/snowflake.rs
+++ b/crates/goose/src/providers/snowflake.rs
@@ -107,7 +107,11 @@ impl SnowflakeProvider {
         })
     }
 
-    async fn post(&self, session_id: &str, payload: &Value) -> Result<Value, ProviderError> {
+    async fn post(
+        &self,
+        session_id: Option<&str>,
+        payload: &Value,
+    ) -> Result<Value, ProviderError> {
         let response = self
             .api_client
             .response_post(session_id, "api/v2/cortex/inference:complete", payload)
@@ -319,7 +323,7 @@ impl Provider for SnowflakeProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],

--- a/crates/goose/src/providers/testprovider.rs
+++ b/crates/goose/src/providers/testprovider.rs
@@ -121,7 +121,7 @@ impl Provider for TestProvider {
 
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         _model_config: &ModelConfig,
         system: &str,
         messages: &[Message],
@@ -130,7 +130,10 @@ impl Provider for TestProvider {
         let hash = Self::hash_input(messages);
 
         if let Some(inner) = &self.inner {
-            let (message, usage) = inner.complete(session_id, system, messages, tools).await?;
+            let model_config = inner.get_model_config();
+            let (message, usage) = inner
+                .complete_with_model(session_id, &model_config, system, messages, tools)
+                .await?;
 
             let record = TestRecord {
                 input: TestInput {
@@ -203,7 +206,7 @@ mod tests {
 
         async fn complete_with_model(
             &self,
-            _session_id: &str,
+            _session_id: Option<&str>,
             _model_config: &ModelConfig,
             _system: &str,
             _messages: &[Message],

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -63,7 +63,11 @@ impl TetrateProvider {
         })
     }
 
-    async fn post(&self, session_id: &str, payload: &Value) -> Result<Value, ProviderError> {
+    async fn post(
+        &self,
+        session_id: Option<&str>,
+        payload: &Value,
+    ) -> Result<Value, ProviderError> {
         let response = self
             .api_client
             .response_post(session_id, "v1/chat/completions", payload)
@@ -158,7 +162,7 @@ impl Provider for TetrateProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],
@@ -215,7 +219,7 @@ impl Provider for TetrateProvider {
             .with_retry(|| async {
                 let resp = self
                     .api_client
-                    .response_post(session_id, "v1/chat/completions", &payload)
+                    .response_post(Some(session_id), "v1/chat/completions", &payload)
                     .await?;
                 handle_status_openai_compat(resp).await
             })
@@ -228,12 +232,14 @@ impl Provider for TetrateProvider {
     }
 
     /// Fetch supported models from Tetrate Agent Router Service API (only models with tool support)
-    async fn fetch_supported_models(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
         // Use the existing api_client which already has authentication configured
-        let response = match self.api_client.response_get(session_id, "v1/models").await {
+        let response = match self
+            .api_client
+            .request(None, "v1/models")
+            .response_get()
+            .await
+        {
             Ok(response) => response,
             Err(e) => {
                 tracing::warn!("Failed to fetch models from Tetrate Agent Router Service API: {}, falling back to manual model entry", e);

--- a/crates/goose/src/providers/venice.rs
+++ b/crates/goose/src/providers/venice.rs
@@ -115,7 +115,7 @@ impl VeniceProvider {
 
     async fn post(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         path: &str,
         payload: &Value,
     ) -> Result<Value, ProviderError> {
@@ -229,13 +229,11 @@ impl Provider for VeniceProvider {
         self.model.clone()
     }
 
-    async fn fetch_supported_models(
-        &self,
-        session_id: &str,
-    ) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
         let response = self
             .api_client
-            .response_get(session_id, &self.models_path)
+            .request(None, &self.models_path)
+            .response_get()
             .await?;
         let json: serde_json::Value = response.json().await?;
 
@@ -265,7 +263,7 @@ impl Provider for VeniceProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],

--- a/crates/goose/src/providers/xai.rs
+++ b/crates/goose/src/providers/xai.rs
@@ -69,7 +69,7 @@ impl XaiProvider {
         })
     }
 
-    async fn post(&self, session_id: &str, payload: Value) -> Result<Value, ProviderError> {
+    async fn post(&self, session_id: Option<&str>, payload: Value) -> Result<Value, ProviderError> {
         let response = self
             .api_client
             .response_post(session_id, "chat/completions", &payload)
@@ -110,7 +110,7 @@ impl Provider for XaiProvider {
     )]
     async fn complete_with_model(
         &self,
-        session_id: &str,
+        session_id: Option<&str>,
         model_config: &ModelConfig,
         system: &str,
         messages: &[Message],
@@ -165,7 +165,7 @@ impl Provider for XaiProvider {
             .with_retry(|| async {
                 let resp = self
                     .api_client
-                    .response_post(session_id, "chat/completions", &payload)
+                    .response_post(Some(session_id), "chat/completions", &payload)
                     .await?;
                 handle_status_openai_compat(resp).await
             })

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -378,12 +378,14 @@ mod tests {
 
             async fn complete_with_model(
                 &self,
-                session_id: &str,
+                session_id: Option<&str>,
                 _model_config: &ModelConfig,
                 system_prompt: &str,
                 messages: &[Message],
                 tools: &[Tool],
             ) -> anyhow::Result<(Message, ProviderUsage), ProviderError> {
+                // Test-only: coerce missing session_id to empty so complete() can be reused.
+                let session_id = session_id.unwrap_or("");
                 self.complete(session_id, system_prompt, messages, tools)
                     .await
             }

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -94,9 +94,10 @@ impl MockCompactionProvider {
 
 #[async_trait]
 impl Provider for MockCompactionProvider {
-    async fn complete(
+    async fn complete_with_model(
         &self,
-        _session_id: &str,
+        _session_id: Option<&str>,
+        _model_config: &ModelConfig,
         system_prompt: &str,
         messages: &[Message],
         _tools: &[Tool],
@@ -163,30 +164,6 @@ impl Provider for MockCompactionProvider {
         );
 
         Ok((message, usage))
-    }
-
-    async fn complete_with_model(
-        &self,
-        session_id: &str,
-        _model_config: &ModelConfig,
-        system_prompt: &str,
-        messages: &[Message],
-        tools: &[Tool],
-    ) -> Result<(Message, ProviderUsage), ProviderError> {
-        self.complete(session_id, system_prompt, messages, tools)
-            .await
-    }
-
-    async fn complete_fast(
-        &self,
-        session_id: &str,
-        system_prompt: &str,
-        messages: &[Message],
-        tools: &[Tool],
-    ) -> Result<(Message, ProviderUsage), ProviderError> {
-        // Compaction uses complete_fast, so delegate to complete
-        self.complete(session_id, system_prompt, messages, tools)
-            .await
     }
 
     fn get_model_config(&self) -> ModelConfig {

--- a/crates/goose/tests/mcp_integration_test.rs
+++ b/crates/goose/tests/mcp_integration_test.rs
@@ -59,7 +59,7 @@ impl Provider for MockProvider {
 
     async fn complete_with_model(
         &self,
-        _session_id: &str,
+        _session_id: Option<&str>,
         _model_config: &ModelConfig,
         _system: &str,
         _messages: &[Message],


### PR DESCRIPTION
## Summary
Stop adding the `agent-session-id` header unless there is a current session. This keeps headers 1:1 with session manager records and avoids confusing or conflicting session IDs.

`None` is for configuration or pre-session paths (model discovery, provider detection, auth probes, canonical model checks).

This also backfills propagation of non-basic OpenAI apis so they can also see `agent-session-id` (e.g., Anthropic, Bedrock, Vertex etc). This is important because proxies like Envoy AI Gateway and Ollama started supporting non-OpenAI endpoints recently. With this, they can do log correlation on goose session ID.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [x] Refactor / Code quality
- [x] Tests
- [ ] Performance improvement
- [ ] Documentation
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Added some edge case tests.

### Related Issues
Tuneup of #6626
