### PR TITLE
docs: frameDomains and baseUriDomains for mcp apps

### DIFF
--- a/documentation/docs/tutorials/building-mcp-apps.md
+++ b/documentation/docs/tutorials/building-mcp-apps.md
@@ -169,6 +169,8 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
               csp: {
                 connectDomains: [],
                 resourceDomains: [],
+                frameDomains: [],
+                baseUriDomains: [],
               },
               prefersBorder: true,
             },
@@ -532,6 +534,60 @@ Try:
 
 Your server returns a `ui://` resource URI, goose fetches the HTML and renders it in an iframe. The app communicates back via `postMessage`—requesting theme info, sending messages to chat, or resizing itself.
 
-MCP Apps run sandboxed with CSP restrictions. See the [MCP Apps Specification](https://github.com/modelcontextprotocol/ext-apps) for details on security and the full protocol.
+MCP Apps run in a sandboxed iframe with strict Content Security Policy restrictions.
+
+### Content Security Policy Configuration
+
+By default, apps can only load resources from their own origin. If your app needs to interact with external domains—such as loading resources from a CDN, making API calls, or embedding maps—you can configure which domains are allowed through the `csp` object in the resource's `_meta.ui` section.
+
+```javascript
+_meta: {
+  ui: {
+    csp: {
+      connectDomains: [],      // Domains for fetch/XHR requests
+      resourceDomains: [],     // Domains for scripts, styles, images, fonts, media
+      frameDomains: [],        // Origins allowed for nested iframes
+      baseUriDomains: [],      // Additional allowed base URIs
+    },
+  },
+}
+```
+
+| Option | CSP Directive | Purpose | Default |
+|--------|---------------|---------|---------|
+| `connectDomains` | `connect-src` | Domains your app can make network requests to | Same-origin only |
+| `resourceDomains` | `script-src`, `style-src`, `img-src`, `font-src`, `media-src` | Domains for loading external resources | Same-origin only |
+| `frameDomains` | `frame-src` | Origins allowed for nested `<iframe>` elements | `'none'` (no iframes) |
+| `baseUriDomains` | `base-uri` | Additional domains allowed for `<base>` element | `'self'` only |
+
+<details>
+<summary>Examples</summary>
+
+**Embedding a map:**
+
+```javascript
+csp: {
+  frameDomains: ['https://www.openstreetmap.org'],
+  resourceDomains: ['https://tile.openstreetmap.org'],
+}
+```
+
+**Loading resources from a CDN:**
+
+```javascript
+csp: {
+  resourceDomains: ['https://cdn.jsdelivr.net', 'https://unpkg.com'],
+  connectDomains: ['https://api.example.com'],
+}
+```
+
+</details>
+
+See the [MCP Apps Specification](https://github.com/modelcontextprotocol/ext-apps) for details on security and the full protocol.
+
+:::warning Security Consideration
+Only add domains you trust. Each domain you add expands what external content can be loaded or embedded in your app. Keep the list minimal and specific to reduce security risks.
+:::
+
 
 


### PR DESCRIPTION
## Summary
This PR documents `frameDomains` and `baseUriDomains` CSP configuration options for MCP Apps.

Documentation updates:
- `documentation/docs/tutorials/building-mcp-apps.md`: 
  - Add `frameDomains` and `baseUriDomains` to CSP configuration example
  - Add Content Security Policy Configuration section with table, examples, and security warning

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Manually tested CSP configuration with OpenStreetMap iframe embedding

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212876692483681