### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -252,7 +252,7 @@ jobs:
           echo "ARTIFACT=target/${TARGET}/release/goose-${TARGET}.zip" >> $GITHUB_ENV
 
       - name: Upload CLI artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: goose-${{ matrix.architecture }}-${{ matrix.target-suffix }}
           path: ${{ env.ARTIFACT }}

--- a/.github/workflows/bundle-desktop-intel.yml
+++ b/.github/workflows/bundle-desktop-intel.yml
@@ -44,7 +44,7 @@ jobs:
         run: df -h
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           # Only pass ref if it's explicitly set, otherwise let checkout action use its default behavior
           ref: ${{ inputs.ref != '' && inputs.ref || '' }}
@@ -96,7 +96,7 @@ jobs:
           cp target/x86_64-apple-darwin/release/goosed ui/desktop/src/bin/goosed
 
       - name: Cache npm dependencies
-        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: |
             ui/desktop/node_modules
@@ -220,7 +220,7 @@ jobs:
           df -h
 
       - name: Upload Desktop artifact
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-darwin-x64
           path: ui/desktop/out/Goose-darwin-x64/Goose_intel_mac.zip

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -25,7 +25,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
@@ -122,7 +122,7 @@ jobs:
           ls -la ui/desktop/src/bin/
 
       - name: Cache npm dependencies
-        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: |
             ui/desktop/node_modules
@@ -164,28 +164,28 @@ jobs:
           find ui/desktop/out/ -name "*.deb" -o -name "*.rpm" -o -name "*.flatpak" -exec ls -lh {} \;
 
       - name: Upload .deb package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-linux-x64-deb
           path: ui/desktop/out/make/deb/x64/*.deb
           if-no-files-found: error
 
       - name: Upload .rpm package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-linux-x64-rpm
           path: ui/desktop/out/make/rpm/x64/*.rpm
           if-no-files-found: error
 
       - name: Upload .flatpak package
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-linux-x64-flatpak
           path: ui/desktop/out/make/flatpak/**/*.flatpak
           if-no-files-found: error
 
       - name: Upload combined Linux packages
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-linux-x64
           path: |

--- a/.github/workflows/bundle-desktop-windows.yml
+++ b/.github/workflows/bundle-desktop-windows.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ inputs.ref != '' && inputs.ref || '' }}
           fetch-depth: 0
@@ -55,12 +55,12 @@ jobs:
           aws-region: us-west-2
 
       - name: Set up Node.js
-        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # pin@v3
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
         with:
           node-version: 22
 
       - name: Cache node_modules
-        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: |
             node_modules
@@ -326,7 +326,7 @@ jobs:
           cp Goose-win32-x64.zip out/Goose-win32-x64/
 
       - name: Upload Windows build artifacts
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-win32-x64
           path: ui/desktop/out/Goose-win32-x64/Goose-win32-x64.zip

--- a/.github/workflows/bundle-desktop.yml
+++ b/.github/workflows/bundle-desktop.yml
@@ -72,7 +72,7 @@ jobs:
         run: df -h
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           # Only pass ref if it's explicitly set, otherwise let checkout action use its default behavior
           ref: ${{ inputs.ref != '' && inputs.ref || '' }}
@@ -133,7 +133,7 @@ jobs:
           cp target/release/goosed ui/desktop/src/bin/goosed
 
       - name: Cache npm dependencies
-        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: |
             ui/desktop/node_modules
@@ -251,7 +251,7 @@ jobs:
 
       - name: Upload Desktop artifact
         id: upload-app-bundle
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-darwin-arm64
           path: ui/desktop/out/Goose-darwin-arm64/Goose.zip

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -26,7 +26,7 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
     steps:
       # checkout code so we can read the Cargo.toml
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Generate a canary version
         id: set-version
         run: |
@@ -53,8 +53,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-cli]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: download_cli.sh
           path: download_cli.sh
@@ -103,7 +103,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           merge-multiple: true
 

--- a/.github/workflows/check-release-pr.yaml
+++ b/.github/workflows/check-release-pr.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.head_ref, 'release/')
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       with:
         ref: ${{ github.head_ref }}
         fetch-depth: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Check for file changes
         uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # pin@v3
@@ -39,7 +39,7 @@ jobs:
     if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -53,7 +53,7 @@ jobs:
     if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -82,7 +82,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -104,7 +104,7 @@ jobs:
     if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -133,13 +133,13 @@ jobs:
     if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       # Temporarily disabled due to GitHub Actions bug on macOS runners
       # https://github.com/actions/runner-images/issues/13341
       # https://github.com/actions/runner/issues/4134
       # - name: Cache npm dependencies
-      #   uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
+      #   uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
       #   with:
       #     path: |
       #       ui/desktop/node_modules

--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -38,7 +38,7 @@ jobs:
       TARGET_BRANCH: ${{ inputs.target_branch }}
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       with:
         ref: ${{ inputs.target_branch }}
         fetch-depth: 0 # to generate complete release log

--- a/.github/workflows/deploy-docs-and-extensions.yml
+++ b/.github/workflows/deploy-docs-and-extensions.yml
@@ -23,15 +23,15 @@ jobs:
 
     steps:
       - name: Checkout the branch
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Setup Node.js
-        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # pin@v3
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
         with:
           node-version: 20 
 
       - name: Cache Node.js modules (documentation)
-        uses: actions/cache@2f8e54208210a422b2efd51efaa6bd6d7ca8920f # pin@v3
+        uses: actions/cache@8b402f58fbc84540c8b491a91e594a4576fec3d7  # v5.0.2
         with:
           path: ./documentation/node_modules
           key: ${{ runner.os }}-documentation-${{ hashFiles('./documentation/package-lock.json') }}
@@ -56,7 +56,7 @@ jobs:
       - name: Checkout gh-pages branch
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         continue-on-error: true      # Branch may not exist on first deploy or in forks
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # pin@v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: gh-pages
           path: gh-pages-current

--- a/.github/workflows/docs-update-recipe-ref.yml
+++ b/.github/workflows/docs-update-recipe-ref.yml
@@ -41,7 +41,7 @@ jobs:
     
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 0  # Fetch all history for version comparison
           fetch-tags: true  # Fetch all tags so we can checkout version tags
@@ -61,7 +61,7 @@ jobs:
           sudo apt-get install -y jq ripgrep
       
       - name: Set up Node.js
-        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # pin@v3
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
         with:
           node-version: '20'
       
@@ -178,7 +178,7 @@ jobs:
       
       - name: Upload automation outputs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: recipe-docs-update-${{ steps.versions.outputs.old_version }}-to-${{ steps.versions.outputs.new_version }}
           path: |

--- a/.github/workflows/goose-issue-solver.yml
+++ b/.github/workflows/goose-issue-solver.yml
@@ -150,7 +150,7 @@ jobs:
             -d '{"content":"eyes"}'
 
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/goose-pr-reviewer.yml
+++ b/.github/workflows/goose-pr-reviewer.yml
@@ -241,7 +241,7 @@ jobs:
             -d '{"content":"eyes"}'
 
       - name: Checkout PR
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: refs/pull/${{ github.event.issue.number }}/head
           fetch-depth: 1

--- a/.github/workflows/merge-release-pr-on-tag.yaml
+++ b/.github/workflows/merge-release-pr-on-tag.yaml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
     - name: Extract version from tag
       id: version

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
       version: ${{ steps.set-version.outputs.version }}
       commit_sha: ${{ steps.get-commit.outputs.commit_sha }}
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: main  # Ensure we're building from latest main
           fetch-depth: 0
@@ -60,8 +60,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-cli]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: download_cli.sh
           path: download_cli.sh
@@ -102,10 +102,10 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Download all artifacts
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           merge-multiple: true
 

--- a/.github/workflows/pr-comment-build-cli.yml
+++ b/.github/workflows/pr-comment-build-cli.yml
@@ -42,7 +42,7 @@ jobs:
           allowed_contexts: pull_request
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         
       - name: Get PR head SHA with gh
         id: set_head_sha
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Download CLI artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           pattern: goose-*
           path: cli-dist

--- a/.github/workflows/pr-comment-bundle-intel.yml
+++ b/.github/workflows/pr-comment-bundle-intel.yml
@@ -45,7 +45,7 @@ jobs:
           allowed_contexts: pull_request
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         
       - name: Get PR head SHA with gh
         id: set_head_sha
@@ -79,7 +79,7 @@ jobs:
 
     steps:
       - name: Download Intel artifact
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: Goose-darwin-x64
           path: intel-dist

--- a/.github/workflows/pr-comment-bundle-windows.yml
+++ b/.github/workflows/pr-comment-bundle-windows.yml
@@ -48,7 +48,7 @@ jobs:
           allowed_contexts: pull_request
 
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         
       - name: Get PR head SHA with gh
         id: set_head_sha
@@ -80,7 +80,7 @@ jobs:
 
     steps:
       - name: Download Windows artifact
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: Goose-win32-x64
           path: windows-dist

--- a/.github/workflows/pr-comment-bundle.yml
+++ b/.github/workflows/pr-comment-bundle.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Get PR info
         id: get_pr_info
         if: ${{ steps.command.outputs.continue == 'true' || github.event_name == 'workflow_dispatch' }}
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           script: |
             let prNumber;
@@ -121,7 +121,7 @@ jobs:
 
     steps:
       - name: Download ARM64 artifact
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: Goose-darwin-arm64
           path: arm64-dist

--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -30,7 +30,7 @@ jobs:
       code: ${{ steps.filter.outputs.code }}
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
           fetch-depth: 0
@@ -51,7 +51,7 @@ jobs:
     if: needs.changes.outputs.code == 'true' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
@@ -70,7 +70,7 @@ jobs:
           cargo build --release
 
       - name: Upload Binary for Smoke Tests
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: goose-binary
           path: target/release/goose
@@ -82,12 +82,12 @@ jobs:
     needs: build-binary
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Download Binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: goose-binary
           path: target/release
@@ -144,7 +144,7 @@ jobs:
           bash scripts/test_subrecipes.sh
 
       - name: Set up Python (for error proxy)
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.12'
 
@@ -168,12 +168,12 @@ jobs:
     needs: build-binary
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
       - name: Download Binary
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           name: goose-binary
           path: target/release

--- a/.github/workflows/pr-website-preview.yml
+++ b/.github/workflows/pr-website-preview.yml
@@ -19,11 +19,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the branch
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Setup Node.js
         if: github.event.action != 'closed'
-        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238  # v6.2.0
         with:
           node-version: 20
 
@@ -52,7 +52,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # pin@v3.11.1

--- a/.github/workflows/quarantine.yml
+++ b/.github/workflows/quarantine.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       - name: Check PR Author
         run: |
           # Get PR author

--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -26,7 +26,7 @@ jobs:
           egress-policy: audit
       
       - name: Checkout PR
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
@@ -226,7 +226,7 @@ jobs:
 
       - name: Upload scan artifacts
         if: always() && steps.find_recipes.outputs.has_recipes == 'true' && steps.recipe_changes.outputs.recipe_files_changed == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: security-scan
           path: ${{ runner.temp }}/security-scan/**
@@ -235,7 +235,7 @@ jobs:
 
       - name: Post scan results to PR
         if: always() && steps.find_recipes.outputs.has_recipes == 'true' && steps.recipe_changes.outputs.recipe_files_changed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           WORKSPACE: ${{ github.workspace }}
           RUNNER_TEMP: ${{ runner.temp }}
@@ -330,7 +330,7 @@ jobs:
 
       - name: Set GitHub status check
         if: always() && steps.find_recipes.outputs.has_recipes == 'true' && steps.recipe_changes.outputs.recipe_files_changed == 'true'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         env:
           RUNNER_TEMP: ${{ runner.temp }}
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,8 +33,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-cli]
     steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
-      - uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # pin@v4
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
+      - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: download_cli.sh
           path: download_cli.sh
@@ -94,7 +94,7 @@ jobs:
       contents: write
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@cc203385981b70ca67e1cc392babf9cc229d5806 # pin@v4
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131  # v7.0.0
         with:
           merge-multiple: true
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: "Checkout code"
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           persist-credentials: false
 
@@ -64,7 +64,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4.6.1
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       # Use the official stale action from GitHub
       - name: 'Close Stale PRs'
-        uses: actions/stale@v10
+        uses: actions/stale@997185467fa4f803885201cee163a9f38240193d  # v10.1.1
         with:
           # Authentication token with required permissions
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test-finder.yml
+++ b/.github/workflows/test-finder.yml
@@ -30,7 +30,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pin@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
         with:
           fetch-depth: 0
 

--- a/.github/workflows/update-hacktoberfest-leaderboard.yml
+++ b/.github/workflows/update-hacktoberfest-leaderboard.yml
@@ -15,10 +15,10 @@ jobs:
       issues: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
 
       - name: Update Leaderboard
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/update-health-dashboard.yml
+++ b/.github/workflows/update-health-dashboard.yml
@@ -34,7 +34,7 @@ jobs:
           if_no_artifact_found: ignore
         
       - name: 'Update Dashboard'
-        uses: actions/github-script@v7
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd  # v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -222,7 +222,7 @@ jobs:
             console.log(`Successfully updated discussion #${discussionNumber}`);
       
       - name: 'Upload metrics artifact'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: health-metrics
           path: health-metrics.json

--- a/.github/workflows/update-release-pr.yaml
+++ b/.github/workflows/update-release-pr.yaml
@@ -17,11 +17,11 @@ jobs:
     runs-on: ubuntu-latest
     if: startsWith(github.event.pull_request.head.ref, 'release/') && github.event.pull_request.user.login == 'github-actions[bot]'
     steps:
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       with:
         fetch-depth: 0 # to generate complete release log
 
-    - uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955 # v4
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1
       with:
         ref: ${{ github.base_ref }}
         path: './prior-version'


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions to ensure compatibility with Node 24, as Node 20 will reach end-of-life in April 2026.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `actions/cache` | [`2f8e542`](https://github.com/actions/cache/commit/2f8e54208210a422b2efd51efaa6bd6d7ca8920f) | [`8b402f5`](https://github.com/actions/cache/commit/8b402f58fbc84540c8b491a91e594a4576fec3d7) | [Release](https://github.com/actions/cache/releases/tag/v5) | bundle-desktop-intel.yml, bundle-desktop-linux.yml, bundle-desktop-windows.yml, bundle-desktop.yml, ci.yml, deploy-docs-and-extensions.yml |
| `actions/checkout` | [`08eba0b`](https://github.com/actions/checkout/commit/08eba0b27e820071cde6df949e0beb9ba4906955), [`11bd719`](https://github.com/actions/checkout/commit/11bd71901bbe5b1630ceea73d27597364c9af683), [`93cb6ef`](https://github.com/actions/checkout/commit/93cb6efe18208431cddfb8368fd83d5badbf9bfd), [`f43a0e5`](https://github.com/actions/checkout/commit/f43a0e5ff2bd294095638e18286ca9a3d1956744), [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`8e8c483`](https://github.com/actions/checkout/commit/8e8c483db84b4bee98b60c0593521ed34d9990e8) | [Release](https://github.com/actions/checkout/releases/tag/v6) | build-cli.yml, bundle-desktop-intel.yml, bundle-desktop-linux.yml, bundle-desktop-windows.yml, bundle-desktop.yml, canary.yml, check-release-pr.yaml, ci.yml, create-release-pr.yaml, deploy-docs-and-extensions.yml, docs-update-recipe-ref.yml, goose-issue-solver.yml, goose-pr-reviewer.yml, merge-release-pr-on-tag.yaml, nightly.yml, pr-comment-build-cli.yml, pr-comment-bundle-intel.yml, pr-comment-bundle-windows.yml, pr-smoke-test.yml, pr-website-preview.yml, publish-docker.yml, quarantine.yml, recipe-security-scanner.yml, release.yml, scorecard.yml, test-finder.yml, update-hacktoberfest-leaderboard.yml, update-release-pr.yaml |
| `actions/download-artifact` | [`cc20338`](https://github.com/actions/download-artifact/commit/cc203385981b70ca67e1cc392babf9cc229d5806), [`v4`](https://github.com/actions/download-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/download-artifact/releases/tag/v7) | [Release](https://github.com/actions/download-artifact/releases/tag/v7) | canary.yml, nightly.yml, pr-comment-build-cli.yml, pr-comment-bundle-intel.yml, pr-comment-bundle-windows.yml, pr-comment-bundle.yml, pr-smoke-test.yml, release.yml |
| `actions/github-script` | [`v7`](https://github.com/actions/github-script/releases/tag/v7) | [`v8`](https://github.com/actions/github-script/releases/tag/v8) | [Release](https://github.com/actions/github-script/releases/tag/v8) | pr-comment-bundle.yml, recipe-security-scanner.yml, update-hacktoberfest-leaderboard.yml, update-health-dashboard.yml |
| `actions/setup-node` | [`1a4442c`](https://github.com/actions/setup-node/commit/1a4442cacd436585916779262731d5b162bc6ec7), [`3235b87`](https://github.com/actions/setup-node/commit/3235b876344d2a9aa001b8d1453c930bba69e610) | [`6044e13`](https://github.com/actions/setup-node/commit/6044e13b5dc448c55e2357c09f80417699197238) | [Release](https://github.com/actions/setup-node/releases/tag/v6) | bundle-desktop-windows.yml, deploy-docs-and-extensions.yml, docs-update-recipe-ref.yml, pr-website-preview.yml |
| `actions/setup-python` | [`v5`](https://github.com/actions/setup-python/releases/tag/v5) | [`v6`](https://github.com/actions/setup-python/releases/tag/v6) | [Release](https://github.com/actions/setup-python/releases/tag/v6) | pr-smoke-test.yml |
| `actions/upload-artifact` | [`4cec3d8`](https://github.com/actions/upload-artifact/commit/4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1), [`ea165f8`](https://github.com/actions/upload-artifact/commit/ea165f8d65b6e75b540449e92b4886f43607fa02), [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`b7c566a`](https://github.com/actions/upload-artifact/commit/b7c566a772e6b6bfb58ed0dc250532a479d7789f) | [Release](https://github.com/actions/upload-artifact/releases/tag/v6) | build-cli.yml, bundle-desktop-intel.yml, bundle-desktop-linux.yml, bundle-desktop-windows.yml, bundle-desktop.yml, canary.yml, docs-update-recipe-ref.yml, nightly.yml, pr-smoke-test.yml, recipe-security-scanner.yml, release.yml, scorecard.yml, update-health-dashboard.yml |

## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will begin using Node 24 by default starting March 4th, 2026.

### Why this matters

- **Node 20 EOL**: April 2026
- **Node 24 default**: March 4th, 2026
- **Action**: Update to latest action versions that support Node 24

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
