### PR TITLE
feat: add requires_auth flag for custom providers without authentication

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -5,7 +5,9 @@ use goose::agents::extension::ToolInfo;
 use goose::agents::extension_manager::get_parameter_names;
 use goose::agents::Agent;
 use goose::agents::{extension::Envs, ExtensionConfig};
-use goose::config::declarative_providers::{create_custom_provider, remove_custom_provider};
+use goose::config::declarative_providers::{
+    create_custom_provider, remove_custom_provider, CreateCustomProviderParams,
+};
 use goose::config::extensions::{
     get_all_extension_names, get_all_extensions, get_enabled_extensions, get_extension_by_name,
     name_to_key, remove_extension, set_extension, set_extension_enabled,
@@ -1877,10 +1879,15 @@ fn add_provider() -> anyhow::Result<()> {
         })
         .interact()?;
 
-    let api_key: String = cliclack::password("API key:")
-        .allow_empty()
-        .mask('▪')
+    let requires_auth = cliclack::confirm("Does this provider require authentication?")
+        .initial_value(true)
         .interact()?;
+
+    let api_key: String = if requires_auth {
+        cliclack::password("API key:").mask('▪').interact()?
+    } else {
+        String::new()
+    };
 
     let models_input: String = cliclack::input("Available models (separate with commas):")
         .placeholder("model-a, model-b, model-c")
@@ -1910,15 +1917,16 @@ fn add_provider() -> anyhow::Result<()> {
         None
     };
 
-    create_custom_provider(
-        provider_type,
-        display_name.clone(),
+    create_custom_provider(CreateCustomProviderParams {
+        engine: provider_type.to_string(),
+        display_name: display_name.clone(),
         api_url,
         api_key,
         models,
-        Some(supports_streaming),
+        supports_streaming: Some(supports_streaming),
         headers,
-    )?;
+        requires_auth,
+    })?;
 
     cliclack::outro(format!("Custom provider added: {}", display_name))?;
     Ok(())

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -95,6 +95,12 @@ pub struct UpdateCustomProviderRequest {
     pub models: Vec<String>,
     pub supports_streaming: Option<bool>,
     pub headers: Option<std::collections::HashMap<String, String>>,
+    #[serde(default = "default_requires_auth")]
+    pub requires_auth: bool,
+}
+
+fn default_requires_auth() -> bool {
+    true
 }
 
 #[derive(Deserialize, ToSchema)]
@@ -708,13 +714,16 @@ pub async fn create_custom_provider(
     Json(request): Json<UpdateCustomProviderRequest>,
 ) -> Result<Json<String>, StatusCode> {
     let config = goose::config::declarative_providers::create_custom_provider(
-        &request.engine,
-        request.display_name,
-        request.api_url,
-        request.api_key,
-        request.models,
-        request.supports_streaming,
-        request.headers,
+        goose::config::declarative_providers::CreateCustomProviderParams {
+            engine: request.engine,
+            display_name: request.display_name,
+            api_url: request.api_url,
+            api_key: request.api_key,
+            models: request.models,
+            supports_streaming: request.supports_streaming,
+            headers: request.headers,
+            requires_auth: request.requires_auth,
+        },
     )
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 
@@ -778,13 +787,17 @@ pub async fn update_custom_provider(
     Json(request): Json<UpdateCustomProviderRequest>,
 ) -> Result<Json<String>, StatusCode> {
     goose::config::declarative_providers::update_custom_provider(
-        &id,
-        &request.engine,
-        request.display_name,
-        request.api_url,
-        request.api_key,
-        request.models,
-        request.supports_streaming,
+        goose::config::declarative_providers::UpdateCustomProviderParams {
+            id: id.clone(),
+            engine: request.engine,
+            display_name: request.display_name,
+            api_url: request.api_url,
+            api_key: request.api_key,
+            models: request.models,
+            supports_streaming: request.supports_streaming,
+            headers: request.headers,
+            requires_auth: request.requires_auth,
+        },
     )
     .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
 

--- a/crates/goose/src/providers/api_client.rs
+++ b/crates/goose/src/providers/api_client.rs
@@ -21,6 +21,7 @@ pub struct ApiClient {
 }
 
 pub enum AuthMethod {
+    NoAuth,
     BearerToken(String),
     ApiKey {
         header_name: String,
@@ -172,6 +173,7 @@ pub struct ApiResponse {
 impl fmt::Debug for AuthMethod {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            AuthMethod::NoAuth => f.debug_tuple("NoAuth").finish(),
             AuthMethod::BearerToken(_) => f.debug_tuple("BearerToken").field(&"[hidden]").finish(),
             AuthMethod::ApiKey { header_name, .. } => f
                 .debug_struct("ApiKey")
@@ -379,6 +381,7 @@ impl<'a> ApiRequestBuilder<'a> {
         request = request.header(SESSION_ID_HEADER, self.session_id);
 
         request = match &self.client.auth {
+            AuthMethod::NoAuth => request,
             AuthMethod::BearerToken(token) => {
                 request.header("Authorization", format!("Bearer {}", token))
             }

--- a/crates/goose/src/providers/factory.rs
+++ b/crates/goose/src/providers/factory.rs
@@ -316,13 +316,12 @@ mod tests {
     #[tokio::test]
     async fn test_openai_compatible_providers_config_keys() {
         let providers_list = providers().await;
-        let cases = vec![
-            ("openai", "OPENAI_API_KEY"),
+        let required_api_key_cases = vec![
             ("groq", "GROQ_API_KEY"),
             ("mistral", "MISTRAL_API_KEY"),
             ("custom_deepseek", "DEEPSEEK_API_KEY"),
         ];
-        for (name, expected_key) in cases {
+        for (name, expected_key) in required_api_key_cases {
             if let Some((meta, _)) = providers_list.iter().find(|(m, _)| m.name == name) {
                 assert!(
                     !meta.config_keys.is_empty(),
@@ -345,6 +344,25 @@ mod tests {
                 // Provider not registered; skip test for this provider
                 continue;
             }
+        }
+
+        if let Some((meta, _)) = providers_list.iter().find(|(m, _)| m.name == "openai") {
+            assert!(
+                !meta.config_keys.is_empty(),
+                "openai provider should have config keys"
+            );
+            assert_eq!(
+                meta.config_keys[0].name, "OPENAI_API_KEY",
+                "First config key for openai should be OPENAI_API_KEY"
+            );
+            assert!(
+                !meta.config_keys[0].required,
+                "OPENAI_API_KEY should be optional for local server support"
+            );
+            assert!(
+                meta.config_keys[0].secret,
+                "OPENAI_API_KEY should be secret"
+            );
         }
     }
 }

--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -47,7 +47,7 @@ impl LiteLLMProvider {
         let timeout_secs: u64 = config.get_param("LITELLM_TIMEOUT").unwrap_or(600);
 
         let auth = if api_key.is_empty() {
-            AuthMethod::Custom(Box::new(NoAuth))
+            AuthMethod::NoAuth
         } else {
             AuthMethod::BearerToken(api_key)
         };
@@ -118,17 +118,6 @@ impl LiteLLMProvider {
             .response_post(session_id, &self.base_path, payload)
             .await?;
         handle_response_openai_compat(response).await
-    }
-}
-
-// No authentication provider for LiteLLM when API key is not provided
-struct NoAuth;
-
-#[async_trait]
-impl super::api_client::AuthProvider for NoAuth {
-    async fn get_auth_header(&self) -> Result<(String, String)> {
-        // Return a dummy header that won't be used
-        Ok(("X-No-Auth".to_string(), "true".to_string()))
     }
 }
 

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -71,8 +71,8 @@ impl OllamaProvider {
                 .map_err(|_| anyhow::anyhow!("Failed to set default port"))?;
         }
 
-        let auth = AuthMethod::Custom(Box::new(NoAuth));
-        let api_client = ApiClient::with_timeout(base_url.to_string(), auth, timeout)?;
+        let api_client =
+            ApiClient::with_timeout(base_url.to_string(), AuthMethod::NoAuth, timeout)?;
 
         Ok(Self {
             api_client,
@@ -108,8 +108,8 @@ impl OllamaProvider {
                 .map_err(|_| anyhow::anyhow!("Failed to set default port"))?;
         }
 
-        let auth = AuthMethod::Custom(Box::new(NoAuth));
-        let api_client = ApiClient::with_timeout(base_url.to_string(), auth, timeout)?;
+        let api_client =
+            ApiClient::with_timeout(base_url.to_string(), AuthMethod::NoAuth, timeout)?;
 
         Ok(Self {
             api_client,
@@ -125,15 +125,6 @@ impl OllamaProvider {
             .response_post(session_id, "v1/chat/completions", payload)
             .await?;
         handle_response_openai_compat(response).await
-    }
-}
-
-struct NoAuth;
-
-#[async_trait]
-impl super::api_client::AuthProvider for NoAuth {
-    async fn get_auth_header(&self) -> Result<(String, String)> {
-        Ok(("X-No-Auth".to_string(), "true".to_string()))
     }
 }
 

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -67,23 +67,27 @@ impl OpenAiProvider {
         let model = model.with_fast(OPEN_AI_DEFAULT_FAST_MODEL.to_string());
 
         let config = crate::config::Config::global();
-        let secrets = config.get_secrets("OPENAI_API_KEY", &["OPENAI_CUSTOM_HEADERS"])?;
-        let api_key = secrets.get("OPENAI_API_KEY").unwrap().clone();
         let host: String = config
             .get_param("OPENAI_HOST")
             .unwrap_or_else(|_| "https://api.openai.com".to_string());
+
+        let api_key: Option<String> = config.get_secret("OPENAI_API_KEY").ok();
+        let custom_headers: Option<HashMap<String, String>> = config
+            .get_secret::<String>("OPENAI_CUSTOM_HEADERS")
+            .ok()
+            .map(parse_custom_headers);
+
         let base_path: String = config
             .get_param("OPENAI_BASE_PATH")
             .unwrap_or_else(|_| "v1/chat/completions".to_string());
         let organization: Option<String> = config.get_param("OPENAI_ORGANIZATION").ok();
         let project: Option<String> = config.get_param("OPENAI_PROJECT").ok();
-        let custom_headers: Option<HashMap<String, String>> = secrets
-            .get("OPENAI_CUSTOM_HEADERS")
-            .cloned()
-            .map(parse_custom_headers);
         let timeout_secs: u64 = config.get_param("OPENAI_TIMEOUT").unwrap_or(600);
 
-        let auth = AuthMethod::BearerToken(api_key);
+        let auth = match api_key {
+            Some(key) if !key.is_empty() => AuthMethod::BearerToken(key),
+            _ => AuthMethod::NoAuth,
+        };
         let mut api_client =
             ApiClient::with_timeout(host, auth, std::time::Duration::from_secs(timeout_secs))?;
 
@@ -136,9 +140,12 @@ impl OpenAiProvider {
         config: DeclarativeProviderConfig,
     ) -> Result<Self> {
         let global_config = crate::config::Config::global();
-        let api_key: String = global_config
-            .get_secret(&config.api_key_env)
-            .map_err(|_e| anyhow::anyhow!("Missing API key: {}", config.api_key_env))?;
+
+        let api_key: Option<String> = if config.requires_auth && !config.api_key_env.is_empty() {
+            global_config.get_secret(&config.api_key_env).ok()
+        } else {
+            None
+        };
 
         let url = url::Url::parse(&config.base_url)
             .map_err(|e| anyhow::anyhow!("Invalid base URL '{}': {}", config.base_url, e))?;
@@ -161,7 +168,11 @@ impl OpenAiProvider {
         };
 
         let timeout_secs = config.timeout_seconds.unwrap_or(600);
-        let auth = AuthMethod::BearerToken(api_key);
+
+        let auth = match api_key {
+            Some(key) if !key.is_empty() => AuthMethod::BearerToken(key),
+            _ => AuthMethod::NoAuth,
+        };
         let mut api_client =
             ApiClient::with_timeout(host, auth, std::time::Duration::from_secs(timeout_secs))?;
 
@@ -228,7 +239,7 @@ impl Provider for OpenAiProvider {
             models,
             OPEN_AI_DOC_URL,
             vec![
-                ConfigKey::new("OPENAI_API_KEY", true, true, None),
+                ConfigKey::new("OPENAI_API_KEY", false, true, None),
                 ConfigKey::new("OPENAI_HOST", true, false, Some("https://api.openai.com")),
                 ConfigKey::new("OPENAI_BASE_PATH", true, false, Some("v1/chat/completions")),
                 ConfigKey::new("OPENAI_ORGANIZATION", false, false, None),

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -98,12 +98,14 @@ impl ProviderRegistry {
 
         let mut config_keys = base_metadata.config_keys.clone();
 
-        if let Some(api_key_index) = config_keys
-            .iter()
-            .position(|key| key.required && key.secret)
-        {
-            config_keys[api_key_index] =
-                super::base::ConfigKey::new(&config.api_key_env, true, true, None);
+        if let Some(api_key_index) = config_keys.iter().position(|key| key.secret) {
+            if !config.requires_auth {
+                config_keys.remove(api_key_index);
+            } else if !config.api_key_env.is_empty() {
+                let api_key_required = provider_type == ProviderType::Declarative;
+                config_keys[api_key_index] =
+                    super::base::ConfigKey::new(&config.api_key_env, api_key_required, true, None);
+            }
         }
 
         let custom_metadata = ProviderMetadata {

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -3480,7 +3480,6 @@
           "name",
           "engine",
           "display_name",
-          "api_key_env",
           "base_url",
           "models"
         ],
@@ -3516,6 +3515,9 @@
           },
           "name": {
             "type": "string"
+          },
+          "requires_auth": {
+            "type": "boolean"
           },
           "supports_streaming": {
             "type": "boolean",
@@ -6692,6 +6694,9 @@
             "items": {
               "type": "string"
             }
+          },
+          "requires_auth": {
+            "type": "boolean"
           },
           "supports_streaming": {
             "type": "boolean",

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -154,7 +154,7 @@ export type CspMetadata = {
 };
 
 export type DeclarativeProviderConfig = {
-    api_key_env: string;
+    api_key_env?: string;
     base_url: string;
     description?: string | null;
     display_name: string;
@@ -164,6 +164,7 @@ export type DeclarativeProviderConfig = {
     } | null;
     models: Array<ModelInfo>;
     name: string;
+    requires_auth?: boolean;
     supports_streaming?: boolean | null;
     timeout_seconds?: number | null;
 };
@@ -1203,6 +1204,7 @@ export type UpdateCustomProviderRequest = {
         [key: string]: string;
     } | null;
     models: Array<string>;
+    requires_auth?: boolean;
     supports_streaming?: boolean | null;
 };
 


### PR DESCRIPTION
## Summary
- Add AuthMethod::NoAuth variant for providers that don't need auth headers
- Add requires_auth field to DeclarativeProviderConfig
- Update CLI to prompt whether provider requires authentication
- Update UI CustomProviderForm with authentication toggle
- Refactor create_custom_provider to use CreateCustomProviderParams struct

This enables using local OpenAI-compatible servers (e.g., vLLM, Ollama) that may not require API keys without getting 401 Unauthorized errors.


### Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Tested locally

Closes: #6693