### PR TITLE
refactor: centralize audience filtering before providers receive messages

### DIFF
--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -182,11 +182,17 @@ impl Agent {
     ) -> Result<MessageStream, ProviderError> {
         let config = provider.get_model_config();
 
+        let filtered_messages: Vec<Message> = messages
+            .iter()
+            .filter(|m| m.is_agent_visible())
+            .map(|m| m.agent_visible_content())
+            .collect();
+
         // Convert tool messages to text if toolshim is enabled
         let messages_for_provider = if config.toolshim {
-            convert_tool_messages_to_text(messages)
+            convert_tool_messages_to_text(&filtered_messages)
         } else {
-            Conversation::new_unvalidated(messages.to_vec())
+            Conversation::new_unvalidated(filtered_messages)
         };
 
         // Clone owned data to move into the async stream

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -78,9 +78,8 @@ static CHATGPT_CODEX_AUTH_STATE: LazyLock<Arc<ChatGptCodexAuthState>> =
 fn build_input_items(messages: &[Message]) -> Result<Vec<Value>> {
     let mut items = Vec::new();
 
-    for message in messages.iter().filter(|m| m.is_agent_visible()) {
-        let filtered = message.agent_visible_content();
-        let role = match filtered.role {
+    for message in messages {
+        let role = match message.role {
             Role::User => Some("user"),
             Role::Assistant => Some("assistant"),
         };
@@ -96,7 +95,7 @@ fn build_input_items(messages: &[Message]) -> Result<Vec<Value>> {
             }
         };
 
-        for content in &filtered.content {
+        for content in &message.content {
             match content {
                 MessageContent::Text(text) => {
                     if !text.text.is_empty() {

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -64,15 +64,14 @@ impl CursorAgentProvider {
         full_prompt.push_str("\n\n");
 
         // Add conversation history
-        for message in messages.iter().filter(|m| m.is_agent_visible()) {
-            let filtered = message.agent_visible_content();
-            let role_prefix = match filtered.role {
+        for message in messages {
+            let role_prefix = match message.role {
                 Role::User => "Human: ",
                 Role::Assistant => "Assistant: ",
             };
             full_prompt.push_str(role_prefix);
 
-            for content in &filtered.content {
+            for content in &message.content {
                 match content {
                     MessageContent::Text(text_content) => {
                         full_prompt.push_str(&text_content.text);

--- a/crates/goose/src/providers/formats/anthropic.rs
+++ b/crates/goose/src/providers/formats/anthropic.rs
@@ -34,13 +34,7 @@ const DATA_FIELD: &str = "data";
 pub fn format_messages(messages: &[Message]) -> Vec<Value> {
     let mut anthropic_messages = Vec::new();
 
-    let filtered_messages: Vec<Message> = messages
-        .iter()
-        .filter(|m| m.is_agent_visible())
-        .map(|m| m.agent_visible_content())
-        .collect();
-
-    for message in &filtered_messages {
+    for message in messages {
         let role = match message.role {
             Role::User => USER_ROLE,
             Role::Assistant => ASSISTANT_ROLE,

--- a/crates/goose/src/providers/formats/bedrock.rs
+++ b/crates/goose/src/providers/formats/bedrock.rs
@@ -18,12 +18,10 @@ use super::super::base::Usage;
 use crate::conversation::message::{Message, MessageContent};
 
 pub fn to_bedrock_message(message: &Message) -> Result<bedrock::Message> {
-    let filtered = message.agent_visible_content();
-
     bedrock::Message::builder()
-        .role(to_bedrock_role(&filtered.role))
+        .role(to_bedrock_role(&message.role))
         .set_content(Some(
-            filtered
+            message
                 .content
                 .iter()
                 .map(to_bedrock_message_content)

--- a/crates/goose/src/providers/formats/databricks.rs
+++ b/crates/goose/src/providers/formats/databricks.rs
@@ -106,11 +106,10 @@ fn format_tool_response(
 ///   even though the message structure is otherwise following openai, the enum switches this
 fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<DatabricksMessage> {
     let mut result = Vec::new();
-    for message in messages.iter().filter(|m| m.is_agent_visible()) {
-        let filtered = message.agent_visible_content();
+    for message in messages {
         let mut converted = DatabricksMessage {
             content: Value::Null,
-            role: match filtered.role {
+            role: match message.role {
                 Role::User => "user".to_string(),
                 Role::Assistant => "assistant".to_string(),
             },
@@ -122,7 +121,7 @@ fn format_messages(messages: &[Message], image_format: &ImageFormat) -> Vec<Data
         let mut has_tool_calls = false;
         let mut has_multiple_content = false;
 
-        for content in &filtered.content {
+        for content in &message.content {
             match content {
                 MessageContent::Text(text) => {
                     if !text.text.is_empty() {

--- a/crates/goose/src/providers/formats/openai_responses.rs
+++ b/crates/goose/src/providers/formats/openai_responses.rs
@@ -306,9 +306,8 @@ fn add_function_calls(input_items: &mut Vec<Value>, messages: &[Message]) {
 }
 
 fn add_function_call_outputs(input_items: &mut Vec<Value>, messages: &[Message]) {
-    for message in messages.iter().filter(|m| m.is_agent_visible()) {
-        let filtered = message.agent_visible_content();
-        for content in &filtered.content {
+    for message in messages {
+        for content in &message.content {
             if let MessageContent::ToolResponse(response) = content {
                 match &response.tool_result {
                     Ok(contents) => {

--- a/crates/goose/src/providers/formats/snowflake.rs
+++ b/crates/goose/src/providers/formats/snowflake.rs
@@ -12,13 +12,7 @@ use std::collections::HashSet;
 pub fn format_messages(messages: &[Message]) -> Vec<Value> {
     let mut snowflake_messages = Vec::new();
 
-    let filtered_messages: Vec<Message> = messages
-        .iter()
-        .filter(|m| m.is_agent_visible())
-        .map(|m| m.agent_visible_content())
-        .collect();
-
-    for message in &filtered_messages {
+    for message in messages {
         let role = match message.role {
             Role::User => "user",
             Role::Assistant => "assistant",

--- a/crates/goose/src/providers/toolshim.rs
+++ b/crates/goose/src/providers/toolshim.rs
@@ -321,11 +321,10 @@ pub fn convert_tool_messages_to_text(messages: &[Message]) -> Conversation {
     let converted_messages: Vec<Message> = messages
         .iter()
         .map(|message| {
-            let filtered = message.agent_visible_content();
             let mut new_content = Vec::new();
             let mut has_tool_content = false;
 
-            for content in &filtered.content {
+            for content in &message.content {
                 match content {
                     MessageContent::ToolRequest(req) => {
                         has_tool_content = true;
@@ -370,9 +369,9 @@ pub fn convert_tool_messages_to_text(messages: &[Message]) -> Conversation {
             }
 
             if has_tool_content {
-                Message::new(filtered.role.clone(), filtered.created, new_content)
+                Message::new(message.role.clone(), message.created, new_content)
             } else {
-                filtered
+                message.clone()
             }
         })
         .collect();


### PR DESCRIPTION
## Summary
Move filtering to stream_response_from_provider() so providers receive pre-filtered messages.

### Type of Change
- [ ] Feature
- [] Bug fix
- [x] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested with anthropic provider.

```
Before the fix:

"content": "Linux ramishra-thinkpadp1gen7.rmtin.csb 6.18.5-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Sun Jan 11 17:09:32 UTC 2026 x86_64 GNU/Linux\n\nLinux ramishra-thinkpadp1gen7.rmtin.csb 6.18.5-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Sun Jan 11 17:09:32 UTC 2026 x86_64 GNU/Linux\n"
The uname -a output appeared twice (separated by a blank line).

After the fix:
"content": "Linux ramishra-thinkpadp1gen7.rmtin.csb 6.18.5-200.fc43.x86_64 #1 SMP PREEMPT_DYNAMIC Sun Jan 11 17:09:32 UTC 2026 x86_64 GNU/Linux\n"
The output appears only once.

```

Closes: #6703