### PR TITLE
Add preferred microphone selection with dropdown z-index and settings propagation fixes

### DIFF
--- a/ui/desktop/src/components/settings/dictation/MicrophoneSelector.tsx
+++ b/ui/desktop/src/components/settings/dictation/MicrophoneSelector.tsx
@@ -1,0 +1,236 @@
+import { useState, useEffect, useCallback } from 'react';
+import { ChevronDown, RefreshCw, Mic, Check } from 'lucide-react';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuLabel,
+} from '../../ui/dropdown-menu';
+
+interface MicrophoneSelectorProps {
+  selectedDeviceId: string | null;
+  onDeviceChange: (deviceId: string | null) => void;
+}
+
+interface AudioDevice {
+  deviceId: string;
+  label: string;
+}
+
+export const MicrophoneSelector = ({
+  selectedDeviceId,
+  onDeviceChange,
+}: MicrophoneSelectorProps) => {
+  const [devices, setDevices] = useState<AudioDevice[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [permissionDenied, setPermissionDenied] = useState(false);
+  const [testingMic, setTestingMic] = useState(false);
+  const [micLevel, setMicLevel] = useState(0);
+
+  const loadDevices = useCallback(async () => {
+    if (!navigator.mediaDevices?.enumerateDevices) return;
+
+    setIsLoading(true);
+    try {
+      let deviceList = await navigator.mediaDevices.enumerateDevices();
+      let audioInputs = deviceList.filter((d) => d.kind === 'audioinput');
+
+      // If labels are empty, we need to request permission first
+      const hasLabels = audioInputs.some((d) => d.label);
+      if (!hasLabels && audioInputs.length > 0) {
+        try {
+          const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+          stream.getTracks().forEach((track) => track.stop());
+          // Re-enumerate after permission granted
+          deviceList = await navigator.mediaDevices.enumerateDevices();
+          audioInputs = deviceList.filter((d) => d.kind === 'audioinput');
+          setPermissionDenied(false);
+        } catch (err: unknown) {
+          const error = err as { name?: string };
+          if (error.name === 'NotAllowedError' || error.name === 'SecurityError') {
+            setPermissionDenied(true);
+          }
+        }
+      }
+
+      setDevices(
+        audioInputs.map((d, index) => ({
+          deviceId: d.deviceId,
+          label: d.label || `Microphone ${index + 1}`,
+        }))
+      );
+    } catch (err) {
+      console.error('Failed to enumerate audio devices:', err);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadDevices();
+
+    const handleDeviceChange = () => {
+      loadDevices();
+    };
+    navigator.mediaDevices?.addEventListener('devicechange', handleDeviceChange);
+    return () => {
+      navigator.mediaDevices?.removeEventListener('devicechange', handleDeviceChange);
+    };
+  }, [loadDevices]);
+
+  const getSelectedLabel = (): string => {
+    if (!selectedDeviceId) return 'System default';
+    const device = devices.find((d) => d.deviceId === selectedDeviceId);
+    return device?.label || 'System default';
+  };
+
+  const handleTestMicrophone = async () => {
+    if (testingMic) {
+      setTestingMic(false);
+      setMicLevel(0);
+      return;
+    }
+
+    setTestingMic(true);
+    try {
+      const constraints = selectedDeviceId
+        ? { audio: { deviceId: { exact: selectedDeviceId } } }
+        : { audio: true as const };
+
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
+      const audioContext = new AudioContext();
+      const source = audioContext.createMediaStreamSource(stream);
+      const analyser = audioContext.createAnalyser();
+      analyser.fftSize = 256;
+      source.connect(analyser);
+
+      const dataArray = new Uint8Array(analyser.frequencyBinCount);
+      let animationId: number;
+      let stopped = false;
+
+      const updateLevel = () => {
+        if (stopped) return;
+        analyser.getByteFrequencyData(dataArray);
+        const average = dataArray.reduce((sum, val) => sum + val, 0) / dataArray.length;
+        setMicLevel(Math.min(100, (average / 128) * 100));
+        animationId = requestAnimationFrame(updateLevel);
+      };
+      updateLevel();
+
+      // Auto-stop after 5 seconds
+      setTimeout(() => {
+        stopped = true;
+        cancelAnimationFrame(animationId);
+        stream.getTracks().forEach((track) => track.stop());
+        audioContext.close().catch(() => {});
+        setTestingMic(false);
+        setMicLevel(0);
+      }, 5000);
+    } catch (err) {
+      console.error('Failed to test microphone:', err);
+      setTestingMic(false);
+      setMicLevel(0);
+    }
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="py-2 px-2 hover:bg-background-muted rounded-lg transition-all">
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <h3 className="text-text-default">Preferred Microphone</h3>
+            <p className="text-xs text-text-muted mt-[2px]">
+              Select which microphone to use for voice dictation
+            </p>
+          </div>
+          <button
+            onClick={() => loadDevices()}
+            className="p-1.5 text-text-muted hover:text-text-default transition-colors rounded-md hover:bg-background-subtle flex-shrink-0"
+            title="Refresh device list"
+          >
+            <RefreshCw className={`w-3.5 h-3.5 ${isLoading ? 'animate-spin' : ''}`} />
+          </button>
+        </div>
+
+        <div className="mt-2 relative">
+          <DropdownMenu onOpenChange={(open) => open && loadDevices()}>
+            <DropdownMenuTrigger asChild>
+              <button className="flex items-center justify-between gap-2 w-full px-3 py-1.5 text-sm border border-border-subtle rounded-md hover:border-border-default transition-colors text-text-default bg-background-default">
+                <span className="truncate">{getSelectedLabel()}</span>
+                <ChevronDown className="w-4 h-4 flex-shrink-0" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent
+              align="start"
+              side="bottom"
+              sideOffset={4}
+              collisionPadding={16}
+              className="w-[var(--radix-dropdown-menu-trigger-width)] min-w-[200px] max-w-[calc(100vw-2rem)]"
+            >
+              <DropdownMenuLabel className="text-xs text-text-muted">
+                Audio Input Device
+              </DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              <DropdownMenuItem onClick={() => onDeviceChange(null)}>
+                <span className="flex-1">System default</span>
+                {!selectedDeviceId && <Check className="w-4 h-4 ml-2 flex-shrink-0" />}
+              </DropdownMenuItem>
+              <DropdownMenuSeparator />
+              {devices.map((device) => (
+                <DropdownMenuItem
+                  key={device.deviceId}
+                  onClick={() => onDeviceChange(device.deviceId)}
+                >
+                  <span className="flex-1 truncate">{device.label}</span>
+                  {selectedDeviceId === device.deviceId && (
+                    <Check className="w-4 h-4 ml-2 flex-shrink-0" />
+                  )}
+                </DropdownMenuItem>
+              ))}
+              {devices.length === 0 && !isLoading && (
+                <div className="px-2 py-1.5 text-sm text-text-muted">No microphones found</div>
+              )}
+              {isLoading && (
+                <div className="px-2 py-1.5 text-sm text-text-muted">Loading devices...</div>
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+
+      {permissionDenied && (
+        <div className="mx-2 p-2 bg-yellow-50 dark:bg-yellow-900/20 rounded-md">
+          <p className="text-xs text-yellow-700 dark:text-yellow-400">
+            Microphone access was denied. To see device names, allow microphone access in your OS
+            settings (macOS: System Settings → Privacy & Security → Microphone).
+          </p>
+        </div>
+      )}
+
+      <div className="flex items-center gap-2 px-2">
+        <button
+          onClick={handleTestMicrophone}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-xs border border-border-subtle rounded-md hover:border-border-default transition-colors text-text-muted hover:text-text-default bg-background-default"
+        >
+          <Mic className={`w-3.5 h-3.5 ${testingMic ? 'text-red-500' : ''}`} />
+          {testingMic ? 'Testing...' : 'Test microphone'}
+        </button>
+        {testingMic && (
+          <div className="flex-1 h-2 bg-background-subtle rounded-full overflow-hidden">
+            <div
+              className="h-full bg-green-500 rounded-full transition-all duration-75"
+              style={{ width: `${micLevel}%` }}
+            />
+          </div>
+        )}
+      </div>
+
+      <p className="text-xs text-text-muted px-2">
+        If you don&apos;t see your device, make sure the app is allowed to access the microphone in
+        your OS settings.
+      </p>
+    </div>
+  );
+};

--- a/ui/desktop/src/components/settings/dictation/ProviderSelector.tsx
+++ b/ui/desktop/src/components/settings/dictation/ProviderSelector.tsx
@@ -1,11 +1,17 @@
 import { useState, useEffect } from 'react';
-import { ChevronDown } from 'lucide-react';
+import { ChevronDown, Check } from 'lucide-react';
 import { DictationProvider, DictationSettings } from '../../../hooks/useDictationSettings';
 import { DICTATION_PROVIDER_ELEVENLABS } from '../../../hooks/dictationConstants';
 import { useConfig } from '../../ConfigContext';
 import { ElevenLabsKeyInput } from './ElevenLabsKeyInput';
 import { ProviderInfo } from './ProviderInfo';
 import { VOICE_DICTATION_ELEVENLABS_ENABLED } from '../../../updates';
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '../../ui/dropdown-menu';
 
 interface ProviderSelectorProps {
   settings: DictationSettings;
@@ -14,7 +20,6 @@ interface ProviderSelectorProps {
 
 export const ProviderSelector = ({ settings, onProviderChange }: ProviderSelectorProps) => {
   const [hasOpenAIKey, setHasOpenAIKey] = useState(false);
-  const [showProviderDropdown, setShowProviderDropdown] = useState(false);
   const { getProviders } = useConfig();
 
   useEffect(() => {
@@ -32,26 +37,17 @@ export const ProviderSelector = ({ settings, onProviderChange }: ProviderSelecto
     checkOpenAIKey();
   }, [getProviders]);
 
-  const handleDropdownToggle = async () => {
-    const newShowState = !showProviderDropdown;
-    setShowProviderDropdown(newShowState);
-
-    if (newShowState) {
+  const handleOpenChange = async (open: boolean) => {
+    if (open) {
       try {
         const providers = await getProviders(true);
         const openAIProvider = providers.find((p) => p.name === 'openai');
-        const isConfigured = !!openAIProvider?.is_configured;
-        setHasOpenAIKey(isConfigured);
+        setHasOpenAIKey(!!openAIProvider?.is_configured);
       } catch (error) {
         console.error('Error checking OpenAI configuration:', error);
         setHasOpenAIKey(false);
       }
     }
-  };
-
-  const handleProviderChange = (provider: DictationProvider) => {
-    onProviderChange(provider);
-    setShowProviderDropdown(false);
   };
 
   const getProviderLabel = (provider: DictationProvider): string => {
@@ -74,40 +70,36 @@ export const ProviderSelector = ({ settings, onProviderChange }: ProviderSelecto
             Choose how voice is converted to text
           </p>
         </div>
-        <div className="relative">
-          <button
-            onClick={handleDropdownToggle}
-            className="flex items-center gap-2 px-3 py-1.5 text-sm border border-border-subtle rounded-md hover:border-border-default transition-colors text-text-default bg-background-default"
-          >
-            {getProviderLabel(settings.provider)}
-            <ChevronDown className="w-4 h-4" />
-          </button>
-
-          {showProviderDropdown && (
-            <div className="absolute right-0 mt-1 w-48 bg-background-default border border-border-default rounded-md shadow-lg z-10">
-              <button
-                onClick={() => handleProviderChange('openai')}
-                className={`w-full px-3 py-2 text-left text-sm transition-colors hover:bg-background-subtle text-text-default ${!VOICE_DICTATION_ELEVENLABS_ENABLED ? 'first:rounded-t-md last:rounded-b-md' : 'first:rounded-t-md'}`}
-              >
+        <DropdownMenu onOpenChange={handleOpenChange}>
+          <DropdownMenuTrigger asChild>
+            <button className="flex items-center gap-2 px-3 py-1.5 text-sm border border-border-subtle rounded-md hover:border-border-default transition-colors text-text-default bg-background-default">
+              {getProviderLabel(settings.provider)}
+              <ChevronDown className="w-4 h-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-48">
+            <DropdownMenuItem onClick={() => onProviderChange('openai')}>
+              <span className="flex-1">
                 OpenAI Whisper
                 {!hasOpenAIKey && <span className="text-xs ml-1">(not configured)</span>}
-                {settings.provider === 'openai' && <span className="float-right">✓</span>}
-              </button>
-
-              {VOICE_DICTATION_ELEVENLABS_ENABLED && (
-                <button
-                  onClick={() => handleProviderChange(DICTATION_PROVIDER_ELEVENLABS)}
-                  className="w-full px-3 py-2 text-left text-sm hover:bg-background-subtle transition-colors text-text-default last:rounded-b-md"
-                >
-                  ElevenLabs
-                  {settings.provider === DICTATION_PROVIDER_ELEVENLABS && (
-                    <span className="float-right">✓</span>
-                  )}
-                </button>
+              </span>
+              {settings.provider === 'openai' && (
+                <Check className="w-4 h-4 ml-2 flex-shrink-0" />
               )}
-            </div>
-          )}
-        </div>
+            </DropdownMenuItem>
+
+            {VOICE_DICTATION_ELEVENLABS_ENABLED && (
+              <DropdownMenuItem
+                onClick={() => onProviderChange(DICTATION_PROVIDER_ELEVENLABS)}
+              >
+                <span className="flex-1">ElevenLabs</span>
+                {settings.provider === DICTATION_PROVIDER_ELEVENLABS && (
+                  <Check className="w-4 h-4 ml-2 flex-shrink-0" />
+                )}
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       </div>
 
       {VOICE_DICTATION_ELEVENLABS_ENABLED &&

--- a/ui/desktop/src/hooks/dictationConstants.ts
+++ b/ui/desktop/src/hooks/dictationConstants.ts
@@ -22,11 +22,13 @@ export const getDefaultDictationSettings = async (
     return {
       enabled: true,
       provider: 'openai' as DictationProvider,
+      preferredDeviceId: null,
     };
   } else {
     return {
       enabled: false,
       provider: null as DictationProvider,
+      preferredDeviceId: null,
     };
   }
 };

--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -490,7 +490,7 @@ body {
   position: fixed;
   top: 0;
   left: 0;
-  z-index: 50;
+  z-index: 40;
 }
 
 .no-drag {


### PR DESCRIPTION
## Summary

Adds a microphone input source selector to the voice dictation settings panel, allowing users to choose their preferred audio input device (e.g., AirPods, MacBook microphone, external mic). Also fixes two bugs: a z-index conflict causing the dropdown to render behind the titlebar, and settings changes not propagating immediately to the active chat session.

### Type of Change
- [x] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Manual testing performed:
- [x] Microphone selector dropdown opens and lists all available audio input devices
- [x] Selecting a different microphone persists the choice in localStorage
- [x] After changing the microphone in settings and returning to chat, dictation uses the newly selected device immediately
- [x] Dropdown renders above the titlebar drag region (z-index fix verified)
- [x] Dropdown properly portals to document.body and is not clipped by ScrollArea overflow
- [x] Voice dictation toggle still works correctly (enable/disable)
- [x] Settings panel animation (expand/collapse) does not interfere with dropdown positioning

### Related Issues
[N/A](https://github.com/block/goose/issues/6731)

### Screenshots/Demos (for UX changes)
Before:
That section was not available.

After:

1)
<img width="1253" height="470" alt="Screenshot 2026-01-27 at 11 56 39" src="https://github.com/user-attachments/assets/4063e2de-2196-41ca-b8c5-7b410f416753" />

2)
<img width="1248" height="572" alt="Screenshot 2026-01-27 at 11 56 49" src="https://github.com/user-attachments/assets/ca0078e3-1186-457d-92c5-aaafa87a082e" />


---

### Detailed Changes

**New Feature: Microphone Selector** (`MicrophoneSelector.tsx`)
- New component that enumerates audio input devices via `navigator.mediaDevices.enumerateDevices()`
- Dropdown menu showing all available microphones with the current selection indicated by a checkmark
- Persists selection to localStorage under the dictation settings key
- Handles permission prompts and device enumeration errors gracefully

**Bug Fix: Dropdown z-index** (`main.css`)
- Changed `.titlebar-drag-region` z-index from `50` to `40`
- Ensures portaled dropdown menus (`z-50`) render above the fixed titlebar
- Maintains correct stacking: titlebar (`z-40`) < dropdowns/modals (`z-50`)

**Bug Fix: Settings propagation** (`VoiceDictationToggle.tsx`, `useDictationSettings.ts`)
- Dispatches a `dictation-settings-changed` CustomEvent when settings are saved
- The `useDictationSettings` hook listens for this event to immediately pick up changes
- Fixes the issue where `window.storage` events only fire cross-tab, not within the same window