### PR TITLE
removed the line number in the error message

### DIFF
--- a/crates/goose/src/agents/types.rs
+++ b/crates/goose/src/agents/types.rs
@@ -93,3 +93,68 @@ pub struct SessionConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub retry_config: Option<RetryConfig>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_retry_config_validate_success() {
+        let config = RetryConfig {
+            max_retries: 3,
+            checks: vec![],
+            on_failure: None,
+            timeout_seconds: Some(60),
+            on_failure_timeout_seconds: Some(120),
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_retry_config_validate_max_retries_zero() {
+        let config = RetryConfig {
+            max_retries: 0,
+            checks: vec![],
+            on_failure: None,
+            timeout_seconds: None,
+            on_failure_timeout_seconds: None,
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "max_retries must be greater than 0");
+    }
+
+    #[test]
+    fn test_retry_config_validate_timeout_zero() {
+        let config = RetryConfig {
+            max_retries: 3,
+            checks: vec![],
+            on_failure: None,
+            timeout_seconds: Some(0),
+            on_failure_timeout_seconds: None,
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "timeout_seconds must be greater than 0 if specified"
+        );
+    }
+
+    #[test]
+    fn test_retry_config_validate_on_failure_timeout_zero() {
+        let config = RetryConfig {
+            max_retries: 3,
+            checks: vec![],
+            on_failure: None,
+            timeout_seconds: None,
+            on_failure_timeout_seconds: Some(0),
+        };
+        let result = config.validate();
+        assert!(result.is_err());
+        assert_eq!(
+            result.unwrap_err(),
+            "on_failure_timeout_seconds must be greater than 0 if specified"
+        );
+    }
+}

--- a/crates/goose/src/recipe/build_recipe/tests.rs
+++ b/crates/goose/src/recipe/build_recipe/tests.rs
@@ -638,3 +638,29 @@ parameters:
         }
     }
 }
+
+#[test]
+fn test_build_recipe_from_template_invalid_retry_config() {
+    let instructions_and_parameters = r#"
+                "instructions": "Test instructions",
+                "retry": {
+                    "max_retries": 0,
+                    "checks": []
+                }"#;
+    let (_temp_dir, recipe_content, recipe_dir) = setup_recipe_file(instructions_and_parameters);
+
+    let build_recipe_result =
+        build_recipe_from_template(recipe_content, &recipe_dir, Vec::new(), NO_USER_PROMPT);
+    assert!(build_recipe_result.is_err());
+    let err = build_recipe_result.unwrap_err();
+
+    match err {
+        RecipeError::TemplateRendering { source } => {
+            assert_eq!(
+                source.to_string(),
+                "Invalid retry configuration: max_retries must be greater than 0"
+            );
+        }
+        _ => panic!("Expected TemplateRendering error, got: {:?}", err),
+    }
+}

--- a/crates/goose/src/recipe/template_recipe.rs
+++ b/crates/goose/src/recipe/template_recipe.rs
@@ -8,7 +8,7 @@ use anyhow::Result;
 use minijinja::{Environment, UndefinedBehavior};
 use regex::Regex;
 
-const CURRENT_TEMPLATE_NAME: &str = "current_template";
+const CURRENT_TEMPLATE_NAME: &str = "recipe_template";
 const OPEN_BRACE: &str = "{{";
 const CLOSE_BRACE: &str = "}}";
 

--- a/crates/goose/src/recipe/validate_recipe.rs
+++ b/crates/goose/src/recipe/validate_recipe.rs
@@ -44,6 +44,7 @@ pub fn validate_recipe_template_from_content(
     let (recipe, _) = parse_recipe_content(recipe_content, recipe_dir)?;
 
     validate_prompt_or_instructions(&recipe)?;
+    validate_retry_config(&recipe)?;
     if let Some(response) = &recipe.response {
         if let Some(json_schema) = &response.json_schema {
             validate_json_schema(json_schema)?;
@@ -51,6 +52,18 @@ pub fn validate_recipe_template_from_content(
     }
 
     Ok(recipe)
+}
+
+fn validate_retry_config(recipe: &Recipe) -> Result<()> {
+    if let Some(ref retry_config) = recipe.retry {
+        if let Err(validation_error) = retry_config.validate() {
+            return Err(anyhow::anyhow!(
+                "Invalid retry configuration: {}",
+                validation_error
+            ));
+        }
+    }
+    Ok(())
 }
 
 fn validate_prompt_or_instructions(recipe: &Recipe) -> Result<()> {


### PR DESCRIPTION
## Summary
Improved recipe error handling and validation to produce friendlier error messages (without line/column numbers) 

**Why**
When user saves or imports recipe, the goose server will deserialise the recipe in the request level and it will show the error of "missing field title: line1 column1".   Sometimes the recipe is not provided via a file to call these end points, it could be a deeplink or serialised UI form data,  so it does not make sense to include the line number, column number.  Even with a recipe file in CLI, since it already specifies the field name in the error message, we don't need the line number, column number. 

**What**
- Removed the line number related from error message via parsing (looking for ` at line`).  I was trying to find a better approach like using custom error message but seems the solution is creating a custom deserializer with all the validation. With the `custom deserializer`, we have to duplicate the logic of required field, type of data in default serde behaviour for each field.  Therefore, I chose to use the `parsing error message` approach which is simpler

- Renamed the internal template name from `current_template` to `recipe_template` so that it makes a bit more sense in the minininjia error message.  

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [X] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [X] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Unit test and manual test

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)