### PR TITLE
fix chat input text going under action buttons at certain widths

### DIFF
--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1236,8 +1236,9 @@ export default function ChatInput({
               maxHeight: `${maxHeight}px`,
               overflowY: 'auto',
               opacity: isRecording ? 0 : 1,
+              paddingRight: dictationSettings?.enabled ? '180px' : '120px',
             }}
-            className="w-full outline-none border-none focus:ring-0 bg-transparent px-3 pt-3 pb-1.5 pr-32 text-sm resize-none text-textStandard placeholder:text-textPlaceholder"
+            className="w-full outline-none border-none focus:ring-0 bg-transparent px-3 pt-3 pb-1.5 text-sm resize-none text-textStandard placeholder:text-textPlaceholder"
           />
           {isRecording && (
             <div className="absolute inset-0 flex items-center pl-4 pr-32 pt-3 pb-1.5">


### PR DESCRIPTION
## Summary
Noticed at some app widths long chat input text is going under the submit / action buttons.

Top is existing version
Bottom is new with fix applied

<img width="770" height="378" alt="Screenshot 2026-01-27 at 11 56 01 AM" src="https://github.com/user-attachments/assets/058a2e7a-1526-4ec8-b2ed-1429ff88b3e8" />

