### PR TITLE
fix: enable custom model entry for OpenRouter provider

### DIFF
--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -248,6 +248,7 @@ impl Provider for OpenRouterProvider {
                 ),
             ],
         )
+        .with_unlisted_models()
     }
 
     fn get_name(&self) -> &str {


### PR DESCRIPTION
## Summary
OpenRouter filters its model list to only show models with tool support, but users may need to enter models that work but aren't marked as supporting tools. This enables the "Enter a model not listed..." option in the cli/ui for OpenRouter.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

Closes: #6760 