### PR TITLE
Remove codex skills flag support

### DIFF
--- a/documentation/docs/guides/cli-providers.md
+++ b/documentation/docs/guides/cli-providers.md
@@ -68,6 +68,7 @@ The Codex provider integrates with OpenAI's [Codex CLI tool](https://developers.
 **Features:**
 - Uses OpenAI's GPT-5 series models (gpt-5.2-codex, gpt-5.2, gpt-5.1-codex-max, gpt-5.1-codex-mini)
 - Configurable reasoning effort levels (low, medium, high)
+- Optional skills support for enhanced capabilities
 - JSON output parsing for structured responses
 - Automatic filtering of goose extensions from system prompts
 
@@ -310,6 +311,7 @@ The following models are recognized and passed to the Claude CLI via the `--mode
 | `GOOSE_MODEL` | Model to use (only known models are passed to CLI) | `gpt-5.2-codex` |
 | `CODEX_COMMAND` | Path to the Codex CLI command | `codex` |
 | `CODEX_REASONING_EFFORT` | Reasoning effort level: `low`, `medium`, or `high` | `high` |
+| `CODEX_ENABLE_SKILLS` | Enable Codex skills: `true` or `false` | `true` |
 | `CODEX_SKIP_GIT_CHECK` | Skip git repository requirement: `true` or `false` | `false` |
 
 **Known Models:**


### PR DESCRIPTION
alternative for: https://github.com/block/goose/pull/6520/changes

The Codex CLI has removed the skills feature flag in newer versions, making skills always enabled. This change removes the flag handling from the goose codex provider to simplify the code.

Changes:
- Remove enable_skills field from CodexProvider struct
- Remove --enable/--disable skills CLI flag usage
- Remove CODEX_ENABLE_SKILLS config key from metadata
- Update documentation to remove skills flag references
- Update all tests to remove enable_skills field

Skills are now always enabled in Codex CLI, so there's no need for backwards compatibility with older CLI versions that supported the flag.


