### PR TITLE
fix: address compilation issue in main

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -30,7 +30,7 @@ fn truncate_with_ellipsis(s: &str, max_len: usize) -> String {
 
 fn parse_cli_flag_extensions(
     extensions: &[String],
-    streamable_http_extensions: &[String],
+    streamable_http_extensions: &[StreamableHttpOptions],
     builtins: &[String],
 ) -> Vec<(String, ExtensionConfig)> {
     let mut extensions_to_load = Vec::new();
@@ -55,9 +55,9 @@ fn parse_cli_flag_extensions(
         }
     }
 
-    for (idx, ext_str) in streamable_http_extensions.iter().enumerate() {
-        let config = CliSession::parse_streamable_http_extension(ext_str);
-        let hint = truncate_with_ellipsis(ext_str, EXTENSION_HINT_MAX_LEN);
+    for (idx, opts) in streamable_http_extensions.iter().enumerate() {
+        let config = CliSession::parse_streamable_http_extension(&opts.url, opts.timeout);
+        let hint = truncate_with_ellipsis(&opts.url, EXTENSION_HINT_MAX_LEN);
         let label = format!("http #{}({})", idx + 1, hint);
         extensions_to_load.push((label, config));
     }
@@ -579,7 +579,6 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
         session_config.output_format.clone(),
     )
     .await;
-
 
     if let Err(e) = session
         .agent

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -9,7 +9,6 @@ mod prompt;
 mod task_execution_display;
 mod thinking;
 
-use crate::cli::StreamableHttpOptions;
 use crate::session::task_execution_display::{
     format_task_execution_notification, TASK_EXECUTION_NOTIFICATION_TYPE,
 };
@@ -292,7 +291,7 @@ impl CliSession {
         })
     }
 
-    pub fn parse_streamable_http_extension(extension_url: &str) -> ExtensionConfig {
+    pub fn parse_streamable_http_extension(extension_url: &str, timeout: u64) -> ExtensionConfig {
         ExtensionConfig::StreamableHttp {
             name: String::new(),
             uri: extension_url.to_string(),
@@ -300,7 +299,7 @@ impl CliSession {
             env_keys: Vec::new(),
             headers: HashMap::new(),
             description: goose::config::DEFAULT_EXTENSION_DESCRIPTION.to_string(),
-            timeout: Some(goose::config::DEFAULT_EXTENSION_TIMEOUT),
+            timeout: Some(timeout),
             bundled: None,
             available_tools: Vec::new(),
         }
@@ -357,7 +356,10 @@ impl CliSession {
     }
 
     pub async fn add_streamable_http_extension(&mut self, extension_url: String) -> Result<()> {
-        let config = Self::parse_streamable_http_extension(&extension_url);
+        let config = Self::parse_streamable_http_extension(
+            &extension_url,
+            goose::config::DEFAULT_EXTENSION_TIMEOUT,
+        );
         self.add_and_persist_extensions(vec![config]).await
     }
 


### PR DESCRIPTION
`cargo build` is broken at the moment. this addresses it by using `StreamableHttpOptions` where it should be used, and also using the new `timeout` attr available