### PR TITLE
Fix: Recipe Extensions Not Loading in Desktop

### DIFF
--- a/ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx
+++ b/ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useForm } from '@tanstack/react-form';
-import { Recipe, generateDeepLink, Parameter, stripEmptyExtensions } from '../../recipe';
+import { Recipe, generateDeepLink, Parameter } from '../../recipe';
 import { Check, ExternalLink, Play, Save, X } from 'lucide-react';
 import { Geese } from '../icons/Geese';
 import Copy from '../icons/Copy';
@@ -81,12 +81,8 @@ export default function CreateEditRecipeModal({
   const [copied, setCopied] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
 
-  // Initialize selected extensions for the recipe
-  const [recipeExtensions] = useState<ExtensionConfig[]>(() => {
-    if (recipe?.extensions) {
-      return recipe.extensions;
-    }
-    return [];
+  const [recipeExtensions] = useState<ExtensionConfig[] | undefined>(() => {
+    return recipe?.extensions ?? undefined;
   });
 
   // Reset form when recipe changes
@@ -132,14 +128,11 @@ export default function CreateEditRecipeModal({
       }
     }
 
-    // Strip envs to avoid leaking secrets
-    const extensionsWithoutEnvs = recipeExtensions.map((extension) =>
+    const extensions = recipeExtensions?.map((extension) =>
       'envs' in extension ? { ...extension, envs: undefined } : extension
-    ) as ExtensionConfig[];
+    ) as ExtensionConfig[] | undefined;
 
-    // Use stripEmptyExtensions to avoid saving empty extensions array
-    // Empty extensions array would prevent default extensions from loading
-    return stripEmptyExtensions({
+    return {
       ...recipe,
       title,
       description,
@@ -148,8 +141,8 @@ export default function CreateEditRecipeModal({
       prompt: prompt || undefined,
       parameters: formattedParameters,
       response: responseConfig,
-      extensions: extensionsWithoutEnvs,
-    }) as Recipe;
+      extensions,
+    };
   }, [
     recipe,
     title,

--- a/ui/desktop/src/components/recipes/CreateRecipeFromSessionModal.tsx
+++ b/ui/desktop/src/components/recipes/CreateRecipeFromSessionModal.tsx
@@ -156,8 +156,6 @@ export default function CreateRecipeFromSessionModal({
 
     setIsCreating(true);
     try {
-      // Create the recipe object from form data
-      // Don't set extensions - let the recipe use default enabled extensions
       const recipe: Recipe = {
         title: formData.title,
         description: formData.description,

--- a/ui/desktop/src/components/schedule/ScheduleModal.tsx
+++ b/ui/desktop/src/components/schedule/ScheduleModal.tsx
@@ -4,7 +4,7 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { ScheduledJob } from '../../schedule';
 import { CronPicker } from './CronPicker';
-import { Recipe, decodeRecipe, stripEmptyExtensions } from '../../recipe';
+import { Recipe, decodeRecipe } from '../../recipe';
 import { getStorageDirectory } from '../../recipe/recipe_management';
 import ClockIcon from '../../assets/clock-icon.svg';
 import * as yaml from 'yaml';
@@ -80,28 +80,25 @@ async function parseDeepLink(deepLink: string): Promise<Recipe | null> {
 }
 
 function recipeToYaml(recipe: Recipe): string {
-  // Strip empty extensions to ensure scheduled recipes use default enabled extensions
-  const processedRecipe = stripEmptyExtensions(recipe) as Recipe;
-
   const cleanRecipe: CleanRecipe = {
-    title: processedRecipe.title,
-    description: processedRecipe.description,
+    title: recipe.title,
+    description: recipe.description,
   };
 
-  if (processedRecipe.instructions) {
-    cleanRecipe.instructions = processedRecipe.instructions;
+  if (recipe.instructions) {
+    cleanRecipe.instructions = recipe.instructions;
   }
 
-  if (processedRecipe.prompt) {
-    cleanRecipe.prompt = processedRecipe.prompt;
+  if (recipe.prompt) {
+    cleanRecipe.prompt = recipe.prompt;
   }
 
-  if (processedRecipe.activities && processedRecipe.activities.length > 0) {
-    cleanRecipe.activities = processedRecipe.activities;
+  if (recipe.activities && recipe.activities.length > 0) {
+    cleanRecipe.activities = recipe.activities;
   }
 
-  if (processedRecipe.extensions && processedRecipe.extensions.length > 0) {
-    cleanRecipe.extensions = processedRecipe.extensions.map((ext) => {
+  if (recipe.extensions && recipe.extensions.length > 0) {
+    cleanRecipe.extensions = recipe.extensions.map((ext) => {
       const cleanExt: CleanExtension = {
         name: ext.name,
         type: 'builtin',
@@ -181,15 +178,15 @@ function recipeToYaml(recipe: Recipe): string {
     });
   }
 
-  if (processedRecipe.author) {
+  if (recipe.author) {
     cleanRecipe.author = {
-      contact: processedRecipe.author.contact || undefined,
-      metadata: processedRecipe.author.metadata || undefined,
+      contact: recipe.author.contact || undefined,
+      metadata: recipe.author.metadata || undefined,
     };
   }
 
   cleanRecipe.schedule = {
-    window_title: `${processedRecipe.title} - Scheduled`,
+    window_title: `${recipe.title} - Scheduled`,
   };
 
   return yaml.stringify(cleanRecipe);

--- a/ui/desktop/src/recipe/index.ts
+++ b/ui/desktop/src/recipe/index.ts
@@ -77,15 +77,10 @@ export async function generateDeepLink(recipe: Recipe): Promise<string> {
   return `goose://recipe?config=${encoded}`;
 }
 
-/**
- * Strips empty extensions array from a recipe.
- * This ensures recipes without explicit extensions will use the default enabled extensions
- * from the user's config in the desktop rather than loading with no extensions.
- */
-export function stripEmptyExtensions<T extends { extensions?: unknown[] | null }>(recipe: T): T {
+export function stripEmptyExtensions(recipe: Recipe): Recipe {
   if (Array.isArray(recipe.extensions) && recipe.extensions.length === 0) {
     const { extensions: _, ...rest } = recipe;
-    return rest as T;
+    return rest as Recipe;
   }
   return recipe;
 }


### PR DESCRIPTION
## Summary: Fix desktop recipes not using default extensions

### Problem
Recipes with an empty `extensions: []` array would cause `resolve_extensions_for_new_session` 
to return no extensions, instead of falling back to the user's default enabled extensions.

### Solution
Strip empty extension arrays in the frontend before saving/running recipes.

### Files Changed

**ui/desktop/src/recipe/index.ts**
- Added `stripEmptyExtensions()` utility function that removes the `extensions` property 
  if it's an empty array

**ui/desktop/src/components/recipes/RecipesView.tsx**
- `handleStartRecipeChat()`: Strip empty extensions in memory before running a recipe
- Removed unused `recipeId` parameter

**ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx**
- `getCurrentRecipe()`: Use `stripEmptyExtensions()` when building recipe to save

**ui/desktop/src/components/recipes/CreateRecipeFromSessionModal.tsx**
- `handleCreateRecipe()`: Simply don't set `extensions` at all (instead of setting `[]`)

**ui/desktop/src/components/schedule/ScheduleModal.tsx**
- `recipeToYaml()`: Strip empty extensions before converting recipe to YAML for scheduling

### How it works
- If a recipe has `extensions: []`, it gets stripped to `extensions: undefined`
- Backend's `resolve_extensions_for_new_session(None, override_extensions)` then falls 
  through to use the UI's enabled extensions (desktop) or `get_enabled_extensions()` (scheduler)