### PR TITLE
fix(mcp-app): add wasm-unsafe-eval to outer CSP for WASM support

### DIFF
--- a/crates/goose-server/src/routes/mcp_app_proxy.rs
+++ b/crates/goose-server/src/routes/mcp_app_proxy.rs
@@ -62,8 +62,8 @@ fn build_outer_csp(
 
     format!(
         "default-src 'none'; \
-         script-src 'self' 'unsafe-inline'{resources}; \
-         script-src-elem 'self' 'unsafe-inline'{resources}; \
+         script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval'{resources};\
+         script-src-elem 'self' 'unsafe-inline' 'wasm-unsafe-eval'{resources};\
          style-src 'self' 'unsafe-inline'{resources}; \
          style-src-elem 'self' 'unsafe-inline'{resources}; \
          connect-src 'self'{connections}; \


### PR DESCRIPTION
MCP Apps that use WebAssembly fail to load because the outer sandbox CSP was missing the `wasm-unsafe-eval` directive. This prevents `WebAssembly.compile()` and `WebAssembly.instantiate()` from working.

## Summary

Add `wasm-unsafe-eval` to both `script-src` and `script-src-elem` directives to allow WASM-based MCP Apps to function properly.

### Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance

- [ ] This PR was created or reviewed with AI assistance

### Testing

This was manually tested using Goose Desktop.

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)

Before:  

<img width="1276" height="1383" alt="image" src="https://github.com/user-attachments/assets/f9ac3954-8ce5-445b-a389-2c768d0160fb" />

After:   

<img width="1270" height="1382" alt="image" src="https://github.com/user-attachments/assets/dd108dd7-408f-4d09-be33-007cffc4a474" />

