### PR TITLE
fix(ui): preserve working directory when creating new chat

### DIFF
--- a/ui/desktop/src/components/bottom_menu/DirSwitcher.tsx
+++ b/ui/desktop/src/components/bottom_menu/DirSwitcher.tsx
@@ -3,6 +3,7 @@ import { FolderDot } from 'lucide-react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/Tooltip';
 import { updateWorkingDir } from '../../api';
 import { toast } from 'react-toastify';
+import { setCurrentWorkingDir } from '../../utils/workingDir';
 
 interface DirSwitcherProps {
   className: string;
@@ -42,6 +43,7 @@ export const DirSwitcher: React.FC<DirSwitcherProps> = ({
     const newDir = result.filePaths[0];
 
     window.electron.addRecentDir(newDir);
+    setCurrentWorkingDir(newDir);
 
     if (sessionId) {
       onWorkingDirChange?.(newDir);

--- a/ui/desktop/src/utils/workingDir.ts
+++ b/ui/desktop/src/utils/workingDir.ts
@@ -1,3 +1,11 @@
+// Track the current working dir for this window (updated when user changes it)
+let currentWorkingDir: string | null = null;
+
+export const setCurrentWorkingDir = (dir: string): void => {
+  currentWorkingDir = dir;
+};
+
 export const getInitialWorkingDir = (): string => {
-  return (window.appConfig?.get('GOOSE_WORKING_DIR') as string) || '';
+  // Use the current dir if set, otherwise fall back to initial config
+  return currentWorkingDir ?? (window.appConfig?.get('GOOSE_WORKING_DIR') as string) ?? '';
 };


### PR DESCRIPTION
## Summary
Track the current working directory in module-level state so that creating a new chat uses the user's most recent directory choice, not the original directory from window creation

hard refresh (command + shift + R) still causes a reset to the original directory


### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
These changes were tested manually by running the application locally using `just run-ui`

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

