### PR TITLE
fix: migrate tables if they are missing things

### DIFF
--- a/.gooseignore
+++ b/.gooseignore
@@ -1,0 +1,18 @@
+# This file is created automatically if no .gooseignore exists.
+# Customize or uncomment the patterns below instead of deleting the file.
+# Removing it will simply cause goose to recreate it on the next start.
+#
+# Suggested patterns you can uncomment if desired:
+# **/.ssh/**        # block SSH keys and configs
+# **/*.key         # block loose private keys
+# **/*.pem         # block certificates/private keys
+# **/.git/**        # block git metadata entirely
+# **/target/**     # block Rust build artifacts
+# **/node_modules/** # block JS/TS dependencies
+# **/*.db          # block local database files
+# **/*.sqlite      # block SQLite databases
+#
+
+**/.env
+**/.env.*
+**/secrets.*


### PR DESCRIPTION
This is a sensitive one - but I got into a state where somehow my db was missing a migration and I had to have goose manually add it. 

This is an attempt to automate that so the schema can be repaired. Not sure if this is a terrible idea but @zanesq @jamadeo @DOsinga if you think it is - worth consideration (not easy how to test this TBH)