### PR TITLE
copilot instructions: Update "No prerelease docs" instruction

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,7 +34,8 @@
 - Async/await misuse or blocking operations in async contexts
 - Improper trait implementations
 
-
+### No Prerelease Docs
+- If the PR contains both code changes to features/functionality AND updates in `/documentation`: Documentation updates must be separated to keep public docs in sync with released versions. Either mark new topics with `unlisted: true` or remove/hide the documentation.
 
 ## Project-Specific Context
 
@@ -45,7 +46,6 @@
 - See HOWTOAI.md for AI-assisted code standards
 - MCP protocol implementations require extra scrutiny
 - Naming convention: In `documentation/docs` and `documentation/blog`, always refer to the project as "goose" (lowercase), never "Goose" (even at the start of sentences)
-- No prerelease docs: PRs should not contain updates in `/documentation` that correspond to code changes in the PR so that the public docs stay in sync with the latest released version. New topics should be marked with `unlisted: true`; other content should be removed or hidden from public view.
 
 ## CI Pipeline Context
 


### PR DESCRIPTION
## Summary
Copilot has been skipping this check on initial run and also applied it to a docs-only PR.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [x] Other (specify below)
  - PR review workflow

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
none