### PR TITLE
nit: don't spit out compaction when in term mode as it fills up the screen

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -220,6 +220,7 @@ pub fn render_message(message: &Message, debug: bool) {
                         set_thinking_message(&notification.msg);
                     }
                     SystemNotificationType::InlineMessage => {
+                        hide_thinking();
                         println!("\n{}", style(&notification.msg).yellow());
                     }
                 }


### PR DESCRIPTION
<img width="429" height="192" alt="image" src="https://github.com/user-attachments/assets/ea7793be-7957-4514-8cd5-04c2a1416020" />

this should stop that