### PR TITLE
fix: correct tool support detection in Tetrate provider model fetching

### DIFF
--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -281,9 +281,8 @@ impl Provider for TetrateProvider {
 
                 // Check if the model supports computer_use (which indicates tool/function support)
                 // The Tetrate API uses "supports_computer_use" instead of "supported_parameters"
-                let supported_params = match model
-                    .get("supported_parameters")
-                    .and_then(|v| v.as_array()) {
+                let supported_params =
+                    match model.get("supported_parameters").and_then(|v| v.as_array()) {
                         Some(params) => params,
                         None => {
                             tracing::debug!(
@@ -301,10 +300,7 @@ impl Provider for TetrateProvider {
                 if has_tool_support {
                     Some(id.to_string())
                 } else {
-                    tracing::debug!(
-                        "Model '{}' does not support tools, skipping",
-                        id
-                    );
+                    tracing::debug!("Model '{}' does not support tools, skipping", id);
                     None
                 }
             })


### PR DESCRIPTION
The Tetrate provider was checking for 'supports_computer_use' boolean to determine tool support, but Tetrate API uses 'supported_parameters' array containing "tools" (same as OpenRouter). This caused all models to be filtered out, leading to model fetch failures.

Also added graceful fallback for missing 'data' field in API response to match the pattern used elsewhere in the function.

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
```
cargo check  
cargo test  
cargo fmt   
./scripts/clippy-lint.sh # run the linter

Finished `dev` profile [unoptimized + debuginfo] target(s) in 40.03s
  
✅ All baseline clippy checks passed!  
🔒 Checking for banned TLS crates... 
✓ No banned TLS crates found (native-tls, openssl, openssl-sys)  
✅ Done
```

### Related Issues  
Discussion: [LINK](https://canary.discord.com/channels/1287729918100246654/1466202034142445734)


### Screenshots/Demos (for UX changes)
Before:  
<img width="1278" height="716" alt="image" src="https://github.com/user-attachments/assets/d8548ac4-7f17-4e6b-91f4-8bc8ea1cdd8c" />
  

After:   
<img width="1278" height="716" alt="image" src="https://github.com/user-attachments/assets/e5c628d9-1797-4ef9-942f-1723094bc26a" />

