### PR TITLE
Session manager fixes

### DIFF
--- a/crates/goose/src/session/session_manager.rs
+++ b/crates/goose/src/session/session_manager.rs
@@ -783,10 +783,7 @@ impl SessionStorage {
     }
 
     #[allow(clippy::too_many_lines)]
-    async fn apply_migration(
-        tx: &mut sqlx::Transaction<'_, Sqlite>,
-        version: i32,
-    ) -> Result<()> {
+    async fn apply_migration(tx: &mut sqlx::Transaction<'_, Sqlite>, version: i32) -> Result<()> {
         match version {
             1 => {
                 sqlx::query(


### PR DESCRIPTION
## Summary

This fixes two issues:

* We weren't running migration inside of a transaction, which means that if you had a large number of messages and had goose running twice, we could have both upgrading, both failing and we're broken
* A true merge conflict about inserting messages for fork.
