### PR TITLE
Update version to 1.22.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,7 +2896,7 @@ dependencies = [
 
 [[package]]
 name = "goose"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "ahash",
  "anyhow",
@@ -2982,7 +2982,7 @@ dependencies = [
 
 [[package]]
 name = "goose-acp"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "assert-json-diff",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "goose-bench"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3028,7 +3028,7 @@ dependencies = [
 
 [[package]]
 name = "goose-cli"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anstream",
  "anyhow",
@@ -3075,7 +3075,7 @@ dependencies = [
 
 [[package]]
 name = "goose-mcp"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -3124,7 +3124,7 @@ dependencies = [
 
 [[package]]
 name = "goose-server"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -3168,7 +3168,7 @@ dependencies = [
 
 [[package]]
 name = "goose-test"
-version = "1.21.0"
+version = "1.22.0"
 dependencies = [
  "clap",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2021"
-version = "1.21.0"
+version = "1.22.0"
 authors = ["Block <ai-oss-tools@block.xyz>"]
 license = "Apache-2.0"
 repository = "https://github.com/block/goose"

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -10,7 +10,7 @@
     "license": {
       "name": "Apache-2.0"
     },
-    "version": "1.21.0"
+    "version": "1.22.0"
   },
   "paths": {
     "/action-required/tool-confirmation": {

--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "goose-app",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "goose-app",
-      "version": "1.21.0",
+      "version": "1.22.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mcp-ui/client": "^5.17.3",

--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "goose-app",
   "productName": "Goose",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "Goose App",
   "engines": {
     "node": "^24.10.0",


### PR DESCRIPTION
We cannot merge https://github.com/block/goose/pull/6813 after the release, so this will update the version in `main`