### PR TITLE
fix(windows): prevent console window flickering when spawning subproc…

### DIFF
--- a/crates/goose-mcp/src/computercontroller/platform/windows.rs
+++ b/crates/goose-mcp/src/computercontroller/platform/windows.rs
@@ -2,6 +2,9 @@ use super::SystemAutomation;
 use std::path::PathBuf;
 use std::process::Command;
 
+use std::os::windows::process::CommandExt;
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 pub struct WindowsAutomation;
 
 impl SystemAutomation for WindowsAutomation {
@@ -12,6 +15,7 @@ impl SystemAutomation for WindowsAutomation {
             .arg("-Command")
             .arg(script)
             .env("GOOSE_TERMINAL", "1")
+            .creation_flags(CREATE_NO_WINDOW)
             .output()?;
 
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())

--- a/crates/goose-mcp/src/developer/shell.rs
+++ b/crates/goose-mcp/src/developer/shell.rs
@@ -4,6 +4,12 @@ use std::{env, ffi::OsString, process::Stdio};
 #[allow(unused_imports)] // False positive: trait is used for process_group method
 use std::os::unix::process::CommandExt;
 
+#[cfg(windows)]
+use std::os::windows::process::CommandExt;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x08000000;
+
 #[derive(Debug, Clone)]
 pub struct ShellConfig {
     pub executable: String,
@@ -132,6 +138,11 @@ pub fn configure_shell_command(
         .args(&shell_config.args)
         .arg(command);
 
+    #[cfg(windows)]
+    {
+        command_builder.creation_flags(CREATE_NO_WINDOW);
+    }
+
     // On Unix systems, create a new process group so we can kill child processes
     #[cfg(unix)]
     {
@@ -170,10 +181,10 @@ pub async fn kill_process_group(
     {
         if let Some(pid) = pid {
             // Use taskkill to kill the process tree on Windows
-            let _kill_result = tokio::process::Command::new("taskkill")
-                .args(&["/F", "/T", "/PID", &pid.to_string()])
-                .output()
-                .await;
+            let mut kill_cmd = tokio::process::Command::new("taskkill")
+                .args(["/F", "/T", "/PID", &pid.to_string()])
+                .creation_flags(CREATE_NO_WINDOW);
+            let _kill_result = kill_cmd.output().await;
         }
 
         // Return the result of tokio's kill


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
From my understanding of discord discussion, what other devs have shared, and AI assisted debugging, my understanding is:  
  
On Windows, shell commands were causing PowerShell/Command Prompt
windows to briefly flash on screen. This was a regression where the
`CREATE_NO_WINDOW flag (0x08000000)` was not being applied when spawning
subprocesses.

Apply the flag to all subprocess creation points in goose-mcp

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Unable to test: On linux.  

### Related Issues
Discussion: [LINK](https://canary.discord.com/channels/1287729918100246654/1466492193484046538)


### Screenshots/Demos (for UX changes)
Before:  

After:   

