### PR TITLE
chore(maintenance): make GitHub repo configurable for auto-updater and publisher

### DIFF
--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -43,8 +43,8 @@ module.exports = {
       name: '@electron-forge/publisher-github',
       config: {
         repository: {
-          owner: 'block',
-          name: 'goose',
+          owner: process.env.GITHUB_OWNER || 'block',
+          name: process.env.GITHUB_REPO || 'goose',
         },
         prerelease: false,
         draft: true,

--- a/ui/desktop/src/utils/githubUpdater.ts
+++ b/ui/desktop/src/utils/githubUpdater.ts
@@ -27,8 +27,8 @@ interface UpdateCheckResult {
 }
 
 export class GitHubUpdater {
-  private readonly owner = 'block';
-  private readonly repo = 'goose';
+  private readonly owner = process.env.GITHUB_OWNER || 'block';
+  private readonly repo = process.env.GITHUB_REPO || 'goose';
   private readonly apiUrl = `https://api.github.com/repos/${this.owner}/${this.repo}/releases/latest`;
 
   async checkForUpdates(): Promise<UpdateCheckResult> {

--- a/ui/desktop/vite.main.config.mts
+++ b/ui/desktop/vite.main.config.mts
@@ -1,4 +1,9 @@
 import { defineConfig } from 'vite';
 
 // https://vitejs.dev/config
-export default defineConfig({});
+export default defineConfig({
+  define: {
+    'process.env.GITHUB_OWNER': JSON.stringify(process.env.GITHUB_OWNER || 'block'),
+    'process.env.GITHUB_REPO': JSON.stringify(process.env.GITHUB_REPO || 'goose'),
+  },
+});


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
Based on my understanding from related issue and AI assistance:  
The auto-updated has hard-coded string for the repo path. This is an issue because it would cause friction would repo migration.  
  
This PR:  
Replaces hard-coded 'block/goose' repository path with environment
variables (GITHUB_OWNER, GITHUB_REPO) that default to 'block/goose'.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [x] Other (specify below)
Chore ?  

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
```
cargo check \
&& cargo test \
&& cargo fmt \
&& ./scripts/clippy-lint.sh
```  
  
### Related Issues
Relates to #6136  