### PR TITLE
Missed a couple of places that hard code J for the newline key

### DIFF
--- a/crates/goose-cli/src/session/completion.rs
+++ b/crates/goose-cli/src/session/completion.rs
@@ -390,7 +390,11 @@ impl Hinter for GooseCompleter {
     fn hint(&self, line: &str, _pos: usize, _ctx: &Context<'_>) -> Option<Self::Hint> {
         // Only show hint when line is empty
         if line.is_empty() {
-            Some("Press Enter to send, Ctrl-J for new line".to_string())
+            let newline_key = super::input::get_newline_key().to_ascii_uppercase();
+            Some(format!(
+                "Press Enter to send, Ctrl-{} for new line",
+                newline_key
+            ))
         } else {
             None
         }

--- a/crates/goose-cli/src/session/input.rs
+++ b/crates/goose-cli/src/session/input.rs
@@ -83,9 +83,12 @@ pub fn get_input(
         return Ok(InputResult::Message(message));
     }
 
-    // Ensure Ctrl-J binding is set for newlines
+    let newline_key = get_newline_key();
     editor.bind_sequence(
-        rustyline::KeyEvent(rustyline::KeyCode::Char('j'), rustyline::Modifiers::CTRL),
+        rustyline::KeyEvent(
+            rustyline::KeyCode::Char(newline_key),
+            rustyline::Modifiers::CTRL,
+        ),
         rustyline::EventHandler::Simple(rustyline::Cmd::Newline),
     );
 


### PR DESCRIPTION
## Summary
From https://github.com/block/goose/pull/5956 there were a couple spots that were missed and don't use the new configuration preventing this from working properly.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Manual testing locally

### Related Issues
Relates to #5956   
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

