### PR TITLE
Fallback to latest version during failed install

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -202,7 +202,7 @@ if ! curl -sLf "$DOWNLOAD_URL" --output "$FILE"; then
     LATEST_TAG=$(curl -s https://api.github.com/repos/block/goose/releases/latest | \
       grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
     if [ -z "$LATEST_TAG" ]; then
-      echo "Error: Failed to download $DOWNLOAD_URL"
+      echo "Error: Failed to download $DOWNLOAD_URL and latest tag unavailable"
       exit 1
     fi
 
@@ -211,7 +211,7 @@ if ! curl -sLf "$DOWNLOAD_URL" --output "$FILE"; then
       # Fallback succeeded
       :
     else
-      echo "Error: Failed to download $DOWNLOAD_URL"
+      echo "Error: Failed to download from fallback url $DOWNLOAD_URL using latest tag $LATEST_TAG"
       exit 1
     fi
   else


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
Fix for https://github.com/block/goose/issues/6858

Installs fail because sometime `goose-x86_64-unknown-linux-gnu.tar.bz2` doesn't exist at `github.com/block/goose/releases/download/stable` but it exists at `/goose/releases/download/<version_number>`.

Now, if the download fails and a GOOSE_VERSION isn't specified, it will get the latest version from github and retry with that version explicitly. This avoids a failure when the `stable` tag is missing its download files.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [X] This PR was created or reviewed with AI assistance

### Testing
Script is working locally for me and there isn't a download file on the stable tag right now.

### Related Issues
Relates to #6858 

