### PR TITLE
fix(mistral): add devstral models with correct 262K context length

### DIFF
--- a/crates/goose/src/providers/declarative/mistral.json
+++ b/crates/goose/src/providers/declarative/mistral.json
@@ -27,6 +27,14 @@
       "context_limit": 256000
     },
     {
+      "name": "devstral-2512",
+      "context_limit": 262144
+    },
+    {
+      "name": "devstral-small-2505",
+      "context_limit": 262144
+    },
+    {
       "name": "pixtral-large-2411",
       "context_limit": 128000
     },


### PR DESCRIPTION
## Summary
Fixes #6185

## Problem
Devstral models (`devstral-2512` and `devstral-small-2505`) were missing from the Mistral provider's declarative model list, causing Goose to fall back to the default 128K context limit instead of the actual 262144 tokens supported by these models.

## Solution
Added both devstral models to `mistral.json` with their correct `context_limit` values (262144) as confirmed by the Mistral API:

```bash
curl -s https://api.mistral.ai/v1/models -H "Authorization: Bearer $MISTRAL_API_KEY" \
  | jq '.data[] | select(.id == "devstral-2512") | {id, max_context_length}'
# Returns: {"id": "devstral-2512", "max_context_length": 262144}
```

## Changes
- Added `devstral-2512` with `context_limit: 262144`
- Added `devstral-small-2505` with `context_limit: 262144`

## Testing
- Verified the context values match Mistral's official API documentation
- The canonical_models.json already had these models with correct context limits for OpenRouter