### PR TITLE
fix(codex): propagate extended PATH to codex subprocess

### DIFF
--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -176,6 +176,13 @@ impl CodexProvider {
         let mut cmd = Command::new(&self.command);
         configure_command_no_window(&mut cmd);
 
+        // Propagate extended PATH so the codex subprocess can find Node.js
+        // and other dependencies (especially when launched from the desktop app
+        // where the inherited PATH is limited).
+        if let Ok(path) = SearchPaths::builder().with_npm().path() {
+            cmd.env("PATH", path);
+        }
+
         // Use 'exec' subcommand for non-interactive mode
         cmd.arg("exec");
 


### PR DESCRIPTION
## Summary

When the Codex CLI provider spawns `codex exec`, the subprocess inherits the parent process's PATH. When goose is launched from the desktop app (Electron), this PATH is significantly more limited than a terminal session -- it lacks paths added by nvm, volta, pnpm, fnm, and other Node version managers. This causes the codex subprocess to fail finding Node.js and other dependencies.

This fix adds PATH propagation using `SearchPaths::builder().with_npm().path()`, matching the existing pattern already used by `gemini_cli.rs`. The subprocess now gets access to common binary locations (`~/.local/bin`, `/opt/homebrew/bin`, `~/.npm-global/bin`, etc.) plus the system PATH.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
- All 30 existing codex provider unit tests pass
- `cargo fmt`, `cargo clippy -D warnings` clean
- Manual testing: verified `codex exec` works with the extended PATH
- The fix is a 4-line addition following an established pattern (gemini_cli.rs)

### Related Issues
Relates to #6263
Reported by @Aerasyn: https://github.com/block/goose/pull/6263#issuecomment-3812629554
Also noted by @michaelneale during original review: "I had some issues with my codex install and the desktop - might have to have a follow on, but ran out of time for it. Something to do with path maybe."