### PR TITLE
feat: load provider/model specified inside the recipe config

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -254,18 +254,27 @@ async fn start_agent(
     }
 
     if let Some(recipe) = original_recipe {
-        manager
-            .update(&session.id)
-            .recipe(Some(recipe))
-            .apply()
-            .await
-            .map_err(|err| {
-                error!("Failed to update session with recipe: {}", err);
-                ErrorResponse {
-                    message: format!("Failed to update session with recipe: {}", err),
-                    status: StatusCode::INTERNAL_SERVER_ERROR,
+        let mut update = manager.update(&session.id).recipe(Some(recipe.clone()));
+
+        if let Some(ref settings) = recipe.settings {
+            if let Some(ref provider) = settings.goose_provider {
+                update = update.provider_name(provider);
+
+                if let Some(ref model) = settings.goose_model {
+                    if let Ok(model_config) = ModelConfig::new(model) {
+                        update = update.model_config(model_config);
+                    }
                 }
-            })?;
+            }
+        }
+
+        update.apply().await.map_err(|err| {
+            error!("Failed to update session with recipe: {}", err);
+            ErrorResponse {
+                message: format!("Failed to update session with recipe: {}", err),
+                status: StatusCode::INTERNAL_SERVER_ERROR,
+            }
+        })?;
     }
 
     // Refetch session to get all updates

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1566,30 +1566,18 @@ impl Agent {
     pub async fn restore_provider_from_session(&self, session: &Session) -> Result<()> {
         let config = Config::global();
 
-        let recipe_provider = session
-            .recipe
-            .as_ref()
-            .and_then(|r| r.settings.as_ref())
-            .and_then(|s| s.goose_provider.clone());
-
-        let recipe_model = session
-            .recipe
-            .as_ref()
-            .and_then(|r| r.settings.as_ref())
-            .and_then(|s| s.goose_model.clone());
-
         let provider_name = session
             .provider_name
             .clone()
-            .or(recipe_provider)
             .or_else(|| config.get_goose_provider().ok())
             .ok_or_else(|| anyhow!("Could not configure agent: missing provider"))?;
 
         let model_config = match session.model_config.clone() {
             Some(saved_config) => saved_config,
             None => {
-                let model_name = recipe_model
-                    .or_else(|| config.get_goose_model().ok())
+                let model_name = config
+                    .get_goose_model()
+                    .ok()
                     .ok_or_else(|| anyhow!("Could not configure agent: missing model"))?;
                 crate::model::ModelConfig::new(&model_name)
                     .map_err(|e| anyhow!("Could not configure agent: invalid model {}", e))?

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -35,6 +35,7 @@ import { useToolCount } from './alerts/useToolCount';
 import { getThinkingMessage, getTextAndImageContent } from '../types/message';
 import ParameterInputModal from './ParameterInputModal';
 import { substituteParameters } from '../utils/providerUtils';
+import { useModelAndProvider } from './ModelAndProviderContext';
 import CreateRecipeFromSessionModal from './recipes/CreateRecipeFromSessionModal';
 import { toastSuccess } from '../toasts';
 import { Recipe } from '../recipe';
@@ -176,6 +177,13 @@ export default function BaseChat({
   });
 
   const recipe = session?.recipe;
+  const { setProviderAndModel } = useModelAndProvider();
+
+  useEffect(() => {
+    if (session?.provider_name && session?.model_config?.model_name) {
+      setProviderAndModel(session.provider_name, session.model_config.model_name);
+    }
+  }, [session?.provider_name, session?.model_config?.model_name, setProviderAndModel]);
 
   useEffect(() => {
     if (!recipe) return;

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1549,7 +1549,6 @@ export default function ChatInput({
                 dropdownRef={dropdownRef}
                 setView={setView}
                 alerts={alerts}
-                recipe={recipe}
               />
             </div>
           </Tooltip>

--- a/ui/desktop/src/components/ModelAndProviderContext.tsx
+++ b/ui/desktop/src/components/ModelAndProviderContext.tsx
@@ -26,6 +26,7 @@ interface ModelAndProviderContextType {
   getCurrentModelDisplayName: () => Promise<string>;
   getCurrentProviderDisplayName: () => Promise<string>; // Gets provider display name from subtext
   refreshCurrentModelAndProvider: () => Promise<void>;
+  setProviderAndModel: (provider: string, model: string) => void;
 }
 
 interface ModelAndProviderProviderProps {
@@ -173,6 +174,11 @@ export const ModelAndProviderProvider: React.FC<ModelAndProviderProviderProps> =
     }
   }, [getCurrentModelAndProvider]);
 
+  const setProviderAndModel = useCallback((provider: string, model: string) => {
+    setCurrentProvider(provider);
+    setCurrentModel(model);
+  }, []);
+
   // Load initial model and provider on mount
   useEffect(() => {
     refreshCurrentModelAndProvider();
@@ -189,6 +195,7 @@ export const ModelAndProviderProvider: React.FC<ModelAndProviderProviderProps> =
       getCurrentModelDisplayName,
       getCurrentProviderDisplayName,
       refreshCurrentModelAndProvider,
+      setProviderAndModel,
     }),
     [
       currentModel,
@@ -200,6 +207,7 @@ export const ModelAndProviderProvider: React.FC<ModelAndProviderProviderProps> =
       getCurrentModelDisplayName,
       getCurrentProviderDisplayName,
       refreshCurrentModelAndProvider,
+      setProviderAndModel,
     ]
   );
 


### PR DESCRIPTION
closes: https://github.com/block/goose/issues/6562

## PR description 

The Recipe details view is likely pulling the provider/model from the global settings state instead of reading it from the recipe's YAML configuration.


### Type of Change
<!-- Select all that apply -->
- [x] Feature

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing

Tested in the desktop UI with recipes and different cases 


### Screenshots/Demos (for UX changes)
Before:  

After:   

