### PR TITLE
fix: fixed the broken release

### DIFF
--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -181,15 +181,5 @@ jobs:
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
         with:
           name: Goose-linux-x64-flatpak
-          path: ui/desktop/out/make/flatpak/**/*.flatpak
-          if-no-files-found: error
-
-      - name: Upload combined Linux packages
-        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
-        with:
-          name: Goose-linux-x64
-          path: |
-            ui/desktop/out/make/deb/x64/*.deb
-            ui/desktop/out/make/rpm/x64/*.rpm
-            ui/desktop/out/make/flatpak/**/*.flatpak
+          path: ui/desktop/out/make/flatpak/x86_64/*.flatpak
           if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
             Goose*.zip
             *.deb
             *.rpm
-            **/*.flatpak
+            *.flatpak
             download_cli.sh
           allowUpdates: true
           omitBody: true
@@ -128,7 +128,7 @@ jobs:
             Goose*.zip
             *.deb
             *.rpm
-            **/*.flatpak
+            *.flatpak
             download_cli.sh
           allowUpdates: true
           omitBody: true


### PR DESCRIPTION
## Summary
**Why**
User reports the stable download url returns "not found" error

**Root cause**
- Since V1.22.0 release, we published the flatpak artifacts from downloading `**/*.flatpak`
- In the `bundle-desktop-linux` workflows, it has two steps `Goose-linux-x64-flatpak` and `Goose-linux-x64`, both of them include the same flatpack artifact, but with different paths. 
- Then in the `release.yml` workflow, when it downloads `**/*.flatpak`, it download 2 files with same name. This caused the warning message "Warning: Failed to upload artifact io.atom.electron.goose-app_stable_x86_64.flatpak. Validation Failed: {"resource":"ReleaseAsset","code":"already_exists","field":"name"} - https://docs.github.com/rest." in 
   - v1.22.0, `release version` and `release stable`, and 
   -  v1.21.1, `release version`
   
   They works ok even with the warning message
- However, the [V1.22.1 `release stable`](https://github.com/block/goose/actions/runs/21529244002) failed with "Error: Error 404: Not Found - https://docs.github.com/rest/releases/assets#delete-a-release-asset" because it had problem to delete the duplicate assets in the same tag.  

**What**
1. removed `Goose-linux-x64` step to avoid release step downloading the same artifact.  It seems this step is not referred by anywhere
2. make upload and download regex path more specific


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)



