### PR TITLE
added build notify

### DIFF
--- a/.github/workflows/build-notify.yml
+++ b/.github/workflows/build-notify.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_GOOSE_STATUS }}
         run: |
-          curl -H "Content-Type: application/json" \
+          curl -sS --fail-with-body -H "Content-Type: application/json" \
             -d '{
               "embeds": [{
                 "title": "❌ Build Failed",


### PR DESCRIPTION
## Summary
**Why**
We have multiple important workflows (CI on main branch, release etc.), but some of them failed sometimes and we did not notice (I guess we don't check our email that much).  This has led to delayed feedback and may make it harder to fix the issue with larger changeset.  In some cases, issues are only discovered after customers report them. For example, a recent release workflow failure caused a broken download link.

**What**
Add notifications to discord `goose-status` channel for failures in key workflows, including merge queue (we added this recently), main CI runs and release.  

**TODO**
will also add the canary build cli and desktop later. Currently they failed on main. will fix this issue first and will then add these workflows for failure notification to avoid the late feedback when generating release artifacts while releasing. 


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [X] Build / Release
- [ ] Other (specify below)
