### PR TITLE
fix(deps): broken goose/goose-cli build on main

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -27,7 +27,7 @@ anyhow = { workspace = true }
 thiserror = "1.0"
 futures = { workspace = true }
 dirs = "5.0"
-reqwest = { workspace = true, features = ["rustls-tls-native-roots", "json", "cookies", "gzip", "brotli", "deflate", "zstd", "charset", "http2", "stream", "blocking"], default-features = false }
+reqwest = { workspace = true, features = ["rustls-tls-native-roots", "json", "cookies", "gzip", "brotli", "deflate", "zstd", "charset", "http2", "stream", "blocking", "multipart"], default-features = false }
 tokio = { workspace = true }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { workspace = true }


### PR DESCRIPTION
## Summary
The multipart_post function added in commit 2661454 uses reqwest::multipart::Form, which requires the multipart feature. This was masked in CI because goose-server already enables it, and Cargo's feature unification made workspace builds pass. However, building goose or goose-cli in isolation fails.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)