### PR TITLE
Document duplicate session button and fork command

### DIFF
--- a/documentation/docs/guides/goose-cli-commands.md
+++ b/documentation/docs/guides/goose-cli-commands.md
@@ -187,6 +187,7 @@ Start or resume interactive chat sessions.
 - **`-n, --name <name>`**: Give the session a name
 - **`--path <path>`**: Legacy parameter for specifying session by file path
 - **`-r, --resume`**: Resume a previous session
+- **`--fork`**: Create a new duplicate session with copied history. Must be used with `--resume`. Provide `--name` or `--session-id` to fork a specific session. Otherwise forks the most recent session.
 - **`--history`**: Show previous messages when resuming a session
 - **`--debug`**: Enable debug mode to output complete tool responses, detailed parameter values, and full file paths
 - **`--max-tool-repetitions <NUMBER>`**: Set the maximum number of times the same tool can be called consecutively with identical parameters. Helps prevent infinite loops.
@@ -207,6 +208,12 @@ goose session --resume -n my-project
 goose session --resume --session-id 20251108_2
 goose session --resume --path ./session.json    # exported session
 goose session --resume --path ./session.jsonl   # legacy session storage
+
+# Fork a specific session by name
+goose session --resume --fork --name my-project
+
+# Fork the most recent session and show message history
+goose session --resume --fork --history
 
 # Start with extensions
 goose session --with-extension "npx -y @modelcontextprotocol/server-memory"

--- a/documentation/docs/guides/sessions/in-session-actions.md
+++ b/documentation/docs/guides/sessions/in-session-actions.md
@@ -73,16 +73,20 @@ Forking sessions is useful to:
 
 <Tabs groupId="interface">
     <TabItem value="ui" label="goose Desktop" default>
-
         1. Hover over any of your previous messages
         2. Click the <Edit2 className="inline" size={16} /> `Edit` button that appears
         3. Make your changes in the inline editor
         4. Click `Fork Session` to save your changes and start a new session (or use `Cmd+Enter` (macOS) or `Ctrl+Enter` (Windows/Linux))
 
-        goose copies the conversation history from the original session to the new session. The new session is named "(edited)" and the original session is unchanged.
-    </TabItem>
+        goose creates a new session with conversation history up to and including your edited message. The new session is named "(edited)" and the original session remains unchanged.
+
+        :::tip Fork vs Duplicate
+        - **Fork Session** (Edit button on a message): Creates a new session with history up to a specific edited message. Use this to explore different approaches from a particular point in the conversation.
+        - **[Duplicate Session](/docs/guides/sessions/session-management#duplicate-sessions)** (Copy button in session list): Creates a complete copy of the entire session. Use this to preserve a working session or reuse its configuration.
+        :::
+</TabItem>
     <TabItem value="cli" label="goose CLI">
-        Message editing options are not available in the goose CLI.
+    Message editing is not available in the goose CLI, but you can [duplicate entire sessions](/docs/guides/sessions/session-management#duplicate-sessions) using the `--fork` flag.
     </TabItem>
 </Tabs>
 

--- a/documentation/docs/guides/sessions/session-management.md
+++ b/documentation/docs/guides/sessions/session-management.md
@@ -328,6 +328,63 @@ While you can resume sessions, we recommend creating new sessions for new tasks 
     </TabItem>
 </Tabs>
 
+## Duplicate Sessions
+
+Create a complete copy of any session to reuse configurations, experiment with variations, or preserve important work.
+
+<Tabs groupId="interface">
+    <TabItem value="ui" label="goose Desktop" default>
+        
+        Duplicate a session from the session list:
+
+        1. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
+        2. Click `View All` at the bottom of the `Chat` section
+        3. Find the session you want to duplicate
+        4. Hover over the session card to reveal the action buttons
+        5. Click the <Copy className="inline" size={16} /> button that appears in the top-right corner
+
+        The duplicated session includes:
+        - Complete conversation history
+        - All session metadata and settings
+        - Provider and model configuration
+        - Extension data and configurations
+        - Recipe information (if applicable)
+
+        The new session is named the same as the original and appears at the top of your session list.
+
+        :::tip Duplicate vs Fork Session
+        - **Duplicate** (Copy button in session list): Creates a complete copy of the entire session. Use this to preserve a working session or reuse its configuration.
+        - **[Fork Session](/docs/guides/sessions/in-session-actions#fork-session)** (Edit button on a message): Creates a new session with conversation history up to a specific edited message. Use this when editing a message to explore different approaches from that point.
+        :::
+
+    </TabItem>
+    <TabItem value="cli" label="goose CLI">
+        
+        Create a new session by copying all messages from a previous session using the `--fork` flag along with `--resume`.
+
+        ```bash
+        # Fork the most recent session
+        goose session --resume --fork
+
+        # Fork a specific session by name
+        goose session --resume --fork --name my-project
+
+        # Fork a specific session by ID
+        goose session --resume --fork --session-id 20251108_3
+
+        # Fork and show message history
+        goose session --resume --fork --history
+        ```
+
+        The forked session includes:
+        - Complete conversation history from the original session
+        - All session metadata and settings
+        - Provider and model configuration
+        - Extension data and configurations
+        - Recipe information (if applicable)
+    </TabItem>
+</Tabs>
+
 ## Delete Sessions
 
 <Tabs groupId="interface">


### PR DESCRIPTION
## Summary
Document the `--fork` CLI command and "duplicate session" button in the Desktop UI. Original PR: https://github.com/block/goose/pull/5882


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance
