### PR TITLE
docs: gooseignore negation patterns

### DIFF
--- a/documentation/docs/guides/using-gooseignore.md
+++ b/documentation/docs/guides/using-gooseignore.md
@@ -62,8 +62,8 @@ Within each `.gooseignore` file, patterns are processed in order from top to bot
 # But allow error logs
 !error.log
 
-# Ignore the entire config directory
-config/
+# Ignore all JSON files in the config directory
+config/*.json
 
 # But allow the template
 !config/template.json


### PR DESCRIPTION
## Summary
This PR documents negation pattern support in `.gooseignore` files.

Documentation updates:
- `documentation/docs/guides/using-gooseignore.md`: 
  - Add "Negation Patterns" section explaining `!` prefix syntax and cross-file negation capability
  - Update "Ignore File Types and Priority" section to clarify pattern processing order (global → local)
  - Add concrete example showing how local `.gooseignore` can override global patterns (e.g., `!.env.example` overriding `**/.env*`)
  - Clarify that default patterns only apply when no `.gooseignore` files exist
  - Update tip box to explain that local patterns can override global ones using negation

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
Manual testing:
- ✅ Verified cross-file negation works (local `!.env.example` overrides global `**/.env*`)
- ✅ Verified default patterns only apply when no ignore files exist

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212975386605022