### PR TITLE
fix tool confirmations not showing up mid chat

### DIFF
--- a/ui/desktop/src/components/sessions/SessionHistoryView.tsx
+++ b/ui/desktop/src/components/sessions/SessionHistoryView.tsx
@@ -38,7 +38,9 @@ const isUserMessage = (message: Message): boolean => {
   if (message.role === 'assistant') {
     return false;
   }
-  return !message.content.every((c) => c.type === 'toolConfirmationRequest');
+  return !message.content.every(
+    (c) => c.type === 'actionRequired' && c.data.actionType === 'toolConfirmation'
+  );
 };
 
 const filterMessagesForDisplay = (messages: Message[]): Message[] => {

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -257,7 +257,8 @@ async function streamFromResponse(
           currentMessages = pushMessage(currentMessages, msg);
 
           const hasToolConfirmation = msg.content.some(
-            (content) => content.type === 'toolConfirmationRequest'
+            (content) =>
+              content.type === 'actionRequired' && content.data.actionType === 'toolConfirmation'
           );
 
           const hasElicitation = msg.content.some(


### PR DESCRIPTION
## Summary
The frontend was checking for the wrong message type when detecting tool confirmation requests.

BEFORE (incorrect):
  content.type === 'toolConfirmationRequest'

AFTER (correct):
  content.type === 'actionRequired' && content.data.actionType === 'toolConfirmation'

The backend sends tool confirmations as `actionRequired` messages with `actionType: 'toolConfirmation'`,
not as a separate `toolConfirmationRequest` type. This mismatch meant the frontend never recognized
confirmation requests, so the chat state never transitioned to `WaitingForUserInput` and the dialog
never appeared.

Also noticed we can't set tool permissions without a session so added some fallback text (will follow up with setting without a session in defaults like extensions)

fixes https://github.com/block/goose/issues/6925


