### PR TITLE
Remove build-dependencies section from Cargo.toml

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -14,14 +14,6 @@ cuda = ["candle-core/cuda", "candle-nn/cuda"]
 [lints]
 workspace = true
 
-[build-dependencies]
-tokio = { workspace = true }
-reqwest = { workspace = true, features = [
-    "json",
-    "rustls-tls-native-roots",
-    "system-proxy",
-], default-features = false }
-
 [dependencies]
 lru = "0.16"
 rmcp = { workspace = true, features = [


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
Looks like the build.rs script that was using tokio/reqwest was deleted in commit 75454b96d, and this is a leftover.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [x] Other (specify below)

Cleanup technical debt

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

Ran `cargo test` locally

### Related Issues
Relates to https://github.com/block/goose/pull/3115, #5716
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

