### PR TITLE
docs: change RPI slash commands

### DIFF
--- a/documentation/docs/tutorials/rpi.md
+++ b/documentation/docs/tutorials/rpi.md
@@ -52,7 +52,7 @@ Now that the recipes are imported, to quickly invoke them in-session [add custom
 
 In goose, we use a structured RPI workflow using recipes to systematically tackle complex codebase changes. The workflow consists of slash commands that guide goose through disciplined phases of work:
 
-1. `research_codebase`– Document what exists today. No opinions.
+1. `research_codebase` – Document what exists today. No opinions.
 2. `create_plan` - Design the change with clear phases and success criteria.
 3. `implement_plan` - Execute the plan step by step with verification.
 4. `iterate_plan` – (optional) Adjust the plan if necessary.


### PR DESCRIPTION
## Summary
Updated RPI slash commands to be more specific

- `/research` → `/research_codebase`
- `/plan` → `/create_plan`
- `/iterate` → `/iterate_plan`
- `/implement` → `/implement_plan`


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [X] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

