### PR TITLE
Bug Fix: bump pctx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6951,9 +6951,9 @@ dependencies = [
 
 [[package]]
 name = "pctx_code_mode"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5788a3f1aaa7bc0fdcbae6d9ff24a080a6cc0d202d8affa8f1c29097e40a504a"
+checksum = "1006bf745381b3726592032cbee129f27873296810be199e04dfe759820e96f8"
 dependencies = [
  "futures",
  "pctx_code_execution_runtime",
@@ -6971,9 +6971,9 @@ dependencies = [
 
 [[package]]
 name = "pctx_codegen"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aebab01af80ced5df67e44d85c6caa9ccc5d0c6e07e0881e7d573447f1ee0f13"
+checksum = "fe8bc4029f5177e4c7a3fd03f702832fe56ef77c34bb165990875fba25980f95"
 dependencies = [
  "biome_formatter",
  "biome_js_formatter",
@@ -7029,9 +7029,9 @@ dependencies = [
 
 [[package]]
 name = "pctx_executor"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5377dedd1b2f8dd5eed9baed09ae8efe46d131ed4eb1669a579e2588e91386"
+checksum = "1d0d78d239a4840d4452bafa4fde7c5ad1f128af85f14c2e3d4c72360551183f"
 dependencies = [
  "deno_core",
  "deno_resolver",
@@ -7053,9 +7053,9 @@ dependencies = [
 
 [[package]]
 name = "pctx_type_check_runtime"
-version = "0.1.1"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b3e2fa9831b26e71f86d714c08a4b2cb052b594bfae8528efbc6ccd3b0b1ce"
+checksum = "46d99b3ee5c8b345ba4038552ed4f6776a7a702e9739d35b99ffcc4eb7647e9b"
 dependencies = [
  "deno_ast",
  "deno_core",

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -131,7 +131,7 @@ shellexpand = "3.1.1"
 indexmap = "2.12.0"
 ignore = { workspace = true }
 which = { workspace = true }
-pctx_code_mode = "^0.2.2"
+pctx_code_mode = "^0.2.3"
 unbinder = "0.1.7"
 
 [target.'cfg(target_os = "windows")'.dependencies]


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
Fixes mutex bug that was causing a race-condition on deno runtimes.
```
../../../../third_party/libc++/src/include/__vector/vector.h:416: libc++ Hardening assertion __n < size() failed: vector[] index out of bounds
```

See: https://github.com/portofcontext/pctx/pull/55

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Unit tests for the scenario added to `pctx`

### Related Issues
Relates to #ISSUE_ID  
Discussion: [Discord](https://discord.com/channels/1287729918100246654/1408153538537721966/1468416040349466798)


### Screenshots/Demos (for UX changes)
Before:  

After:   

