### PR TITLE
fix: detect context length errors in GCP Vertex AI provider

### DIFF
--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -26,6 +26,7 @@ use crate::providers::formats::gcpvertexai::{
     ModelProvider, RequestContext, DEFAULT_MODEL, KNOWN_MODELS,
 };
 use crate::providers::gcpauth::GcpAuth;
+use crate::providers::openai_compatible::map_http_error_to_provider_error;
 use crate::providers::retry::RetryConfig;
 use crate::providers::utils::RequestLog;
 use crate::session_context::SESSION_ID_HEADER;
@@ -351,9 +352,8 @@ impl GcpVertexAIProvider {
                 )));
             } else {
                 let response_text = response.text().await.unwrap_or_default();
-                return Err(ProviderError::RequestFailed(format!(
-                    "Request failed with status {status}: {response_text}"
-                )));
+                let payload = serde_json::from_str::<Value>(&response_text).ok();
+                return Err(map_http_error_to_provider_error(status, payload));
             }
         }
     }


### PR DESCRIPTION
## Summary
Use `map_http_error_to_provider_error` for proper error classification, enabling recovery compaction when context limit is exceeded. 

Otherwise we get the follwing error  and  forced to start a new session.

```
Ran into this error trying to compact: Request failed: Request failed with status 413 Payload Too Large: {"type":"error","error":{"type":"invalid_request_error","message":"Prompt is too long"},"request_id":"req_vrtx_011CXnThejoLK3fcwz1vFZ5C"}.

Please try again or create a new session

```
### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested locally.