### PR TITLE
fix: correct Tailwind @source paths for tarball builds

### DIFF
--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -2,8 +2,8 @@
 @import 'tw-animate-css';
 @plugin '@tailwindcss/typography';
 
-@source './index.html';
-@source './src/**/*.{js,ts,jsx,tsx}';
+@source '../../index.html';
+@source '../**/*.{js,ts,jsx,tsx}';
 
 @theme {
   --breakpoint-md: 930px;


### PR DESCRIPTION
## Summary
Previous PR #6917 added incorrect relative paths that worked in dev but failed in tarball releases. Paths are resolved relative to the CSS file location (src/styles/main.css), not project root.

Fixed paths:
```diff
- @source './index.html';
- @source './src/**/*.{js,ts,jsx,tsx}';
+ @source '../../index.html';
+ @source '../**/*.{js,ts,jsx,tsx}';
```

