### PR TITLE
Revert "fix(1785): enable lto and codegen-units in release build (#65…

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,3 @@ reqwest = { version = "0.12.28", default-features = false, features = ["multipar
 tower = "0.5.2"
 tower-http = "0.6.8"
 url = "2.5.8"
-
-[profile.release]
-codegen-units = 1
-lto = true


### PR DESCRIPTION
…86)"

This reverts commit 79088dbc80d55cc715ef251b03b6158897d87982.

Release builds are failing with SIGTERM since this change. We should look into making it work, but for now we'll revert until it does.