### PR TITLE
feat(mcp-apps): improve communication protocol compliance

### DIFF
--- a/crates/goose-server/src/routes/templates/mcp_app_proxy.html
+++ b/crates/goose-server/src/routes/templates/mcp_app_proxy.html
@@ -138,7 +138,7 @@
           .parent
           .postMessage({
             jsonrpc: '2.0',
-            method: 'ui/notifications/sandbox-ready',
+            method: 'ui/notifications/sandbox-proxy-ready',
             params: {}
           }, '*');
       })();

--- a/ui/desktop/src/components/McpApps/types.ts
+++ b/ui/desktop/src/components/McpApps/types.ts
@@ -56,6 +56,17 @@ export interface JsonRpcResponse {
 
 export type JsonRpcMessage = JsonRpcRequest | JsonRpcNotification | JsonRpcResponse;
 
+/**
+ * Container dimensions can be either fixed or flexible.
+ * Fixed: exact width/height values
+ * Flexible: maxWidth/maxHeight constraints (View can request size within these bounds)
+ */
+export type ContainerDimensions =
+  | { width: number; height: number }
+  | { maxWidth: number; maxHeight: number };
+
+export type DisplayMode = 'inline' | 'fullscreen' | 'pip';
+
 export interface HostContext {
   toolInfo?: {
     id?: string | number;
@@ -66,14 +77,9 @@ export interface HostContext {
     };
   };
   theme: 'light' | 'dark';
-  displayMode: 'inline' | 'fullscreen' | 'standalone';
-  availableDisplayModes: ('inline' | 'fullscreen' | 'standalone')[];
-  viewport: {
-    width: number;
-    height: number;
-    maxHeight: number;
-    maxWidth: number;
-  };
+  displayMode: DisplayMode;
+  availableDisplayModes: DisplayMode[];
+  containerDimensions: ContainerDimensions;
   locale: string;
   timeZone: string;
   userAgent: string;
@@ -100,4 +106,16 @@ export interface ToolInputPartial {
 
 export interface ToolCancelled {
   reason?: string;
+}
+
+/**
+ * Capabilities sent by the View (MCP App) during ui/initialize
+ */
+export interface AppCapabilities {
+  availableDisplayModes?: DisplayMode[];
+  tools?: Array<{
+    name: string;
+    description?: string;
+    inputSchema?: Record<string, unknown>;
+  }>;
 }


### PR DESCRIPTION
## Description

This PR improves compliance with the [MCP Apps specification (2026-01-26 Stable)](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx).

### Changes

| Change | Details |
|--------|---------|
| **Protocol Version** | `2025-06-18` → `2026-01-26` |
| **Host Capabilities** | Restructured to spec format: `{ openLinks: {}, messages: {}, serverTools: {}, serverResources: {}, logging: {} }` |
| **Container Dimensions** | Replaced `viewport` with `containerDimensions` (flexible mode: `maxWidth`/`maxHeight`) |
| **Display Mode Types** | Fixed from `standalone` to `pip` per spec |
| **Sandbox Notification** | Renamed `sandbox-ready` → `sandbox-proxy-ready` |
| **New Handler** | Added `ui/request-display-mode` with validation against host and app capabilities |
| **App Capabilities** | Now parses and stores `appCapabilities` from View's `ui/initialize` |

### Files Changed
- `crates/goose-server/src/routes/templates/mcp_app_proxy.html`
- `ui/desktop/src/components/McpApps/types.ts`
- `ui/desktop/src/components/McpApps/useSandboxBridge.ts`

### Not Included (Future Work)
- `ui/update-model-context` - Requires backend integration
- Actual `fullscreen`/`pip` implementation - Only `inline` currently supported
- `toolInfo` in hostContext - Requires tool metadata plumbing
- `styles.variables` (theming) - Requires CSS variable mapping

### Testing
- ✅ `npm run lint`
- ✅ `npx tsc --noEmit`
- ✅ `cargo build`

### Spec Reference
https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx