### PR TITLE
feat(ui): add inline rename for chat sessions in sidebar

### DIFF
--- a/ui/desktop/src/components/common/InlineEditText.tsx
+++ b/ui/desktop/src/components/common/InlineEditText.tsx
@@ -1,0 +1,186 @@
+import React, { useState, useRef, useEffect, useCallback } from 'react';
+import { toast } from 'react-toastify';
+import { errorMessage } from '../../utils/conversionUtils';
+
+interface InlineEditTextProps {
+  value: string;
+  onSave: (newValue: string) => Promise<void>;
+  maxLength?: number;
+  placeholder?: string;
+  disabled?: boolean;
+  className?: string;
+  editClassName?: string;
+  onEditStart?: () => void;
+  onEditEnd?: () => void;
+  allowEmpty?: boolean;
+  singleClickEdit?: boolean;
+}
+
+export const InlineEditText: React.FC<InlineEditTextProps> = ({
+  value,
+  onSave,
+  maxLength = 200,
+  placeholder = 'Enter text',
+  disabled = false,
+  className = '',
+  editClassName = '',
+  onEditStart,
+  onEditEnd,
+  allowEmpty = false,
+  singleClickEdit = true,
+}) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value);
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const originalValue = useRef(value);
+
+  useEffect(() => {
+    if (!isEditing) {
+      setEditValue(value);
+      originalValue.current = value;
+    }
+  }, [value, isEditing]);
+
+  useEffect(() => {
+    if (isEditing && inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  }, [isEditing]);
+
+  const handleStartEdit = useCallback(() => {
+    if (disabled || isSaving) return;
+    setIsEditing(true);
+    setEditValue(value);
+    onEditStart?.();
+  }, [disabled, isSaving, value, onEditStart]);
+
+  const handleCancel = useCallback(() => {
+    setIsEditing(false);
+    setEditValue(originalValue.current);
+    onEditEnd?.();
+  }, [onEditEnd]);
+
+  const handleSave = useCallback(async () => {
+    if (isSaving) return;
+
+    const trimmedValue = editValue.trim();
+
+    // Check if value unchanged
+    if (trimmedValue === originalValue.current) {
+      handleCancel();
+      return;
+    }
+
+    // Check if empty when not allowed
+    if (!allowEmpty && !trimmedValue) {
+      handleCancel();
+      return;
+    }
+
+    setIsSaving(true);
+    try {
+      await onSave(trimmedValue);
+      originalValue.current = trimmedValue;
+      setIsEditing(false);
+      onEditEnd?.();
+    } catch (error) {
+      const errMsg = errorMessage(error, 'Failed to save');
+      console.error('InlineEditText save error:', errMsg);
+      toast.error(errMsg);
+      setEditValue(originalValue.current);
+      handleCancel();
+    } finally {
+      setIsSaving(false);
+    }
+  }, [editValue, isSaving, allowEmpty, onSave, handleCancel, onEditEnd]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLInputElement>) => {
+      if (e.key === 'Enter' && !isSaving) {
+        e.preventDefault();
+        handleSave();
+      } else if (e.key === 'Escape' && !isSaving) {
+        e.preventDefault();
+        handleCancel();
+      }
+    },
+    [handleSave, handleCancel, isSaving]
+  );
+
+  const handleBlur = useCallback(() => {
+    if (!isSaving) {
+      handleSave();
+    }
+  }, [handleSave, isSaving]);
+
+  const handleChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      setEditValue(e.target.value);
+    },
+    []
+  );
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (singleClickEdit) {
+        e.stopPropagation();
+        handleStartEdit();
+      }
+    },
+    [singleClickEdit, handleStartEdit]
+  );
+
+  const handleDoubleClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (!singleClickEdit) {
+        e.stopPropagation();
+        handleStartEdit();
+      }
+    },
+    [singleClickEdit, handleStartEdit]
+  );
+
+  if (isEditing) {
+    return (
+      <input
+        ref={inputRef}
+        type="text"
+        value={editValue}
+        onChange={handleChange}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        maxLength={maxLength}
+        placeholder={placeholder}
+        disabled={isSaving}
+        className={`
+          w-full px-2 py-1 border rounded
+          bg-background-default text-text-standard
+          border-blue-500 ring-2 ring-blue-500/20
+          focus:outline-none focus:ring-2 focus:ring-blue-500/40
+          disabled:opacity-50 disabled:cursor-not-allowed
+          ${editClassName}
+        `}
+        onClick={(e) => e.stopPropagation()}
+      />
+    );
+  }
+
+  return (
+    <div
+      className={`
+        cursor-pointer px-2 py-1 rounded
+        hover:bg-background-hover
+        transition-colors
+        ${disabled ? 'opacity-50 cursor-not-allowed' : ''}
+        ${className}
+      `}
+      onClick={handleClick}
+      onDoubleClick={handleDoubleClick}
+      title={disabled ? '' : singleClickEdit ? 'Click to edit' : 'Double-click to edit'}
+    >
+      {value || <span className="text-text-subtle italic">{placeholder}</span>}
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Add double-click inline editing for chat session names in the sidebar
- Improves UX by allowing quick renames without opening a modal
- Maintains compatibility with existing modal-based rename

## Implementation
- Created reusable `InlineEditText` component with validation and keyboard shortcuts
- Integrated into sidebar session list with double-click activation
- Pointer cursor indicates clickability, text cursor when editing
- Recipe sessions protected from renaming (read-only)
- Updates synced across components via SESSION_RENAMED event

## User Experience
- **Double-click** session name in sidebar to edit
- **Enter** to save, **Escape** to cancel
- **Click away** (blur) also saves
- Error handling with toast notifications
- Max 200 characters, auto-trims whitespace

## Testing
- Manual testing completed
- Works alongside existing session history modal
- Recipe sessions remain read-only
- Error cases handled gracefully

### Type of Change
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)

https://github.com/user-attachments/assets/fbc4a716-f6b9-43cc-80f2-48440117dce4



