### PR TITLE
fix: handle toolnames without underscores

### DIFF
--- a/ui/desktop/src/utils/toolIconMapping.tsx
+++ b/ui/desktop/src/utils/toolIconMapping.tsx
@@ -109,7 +109,8 @@ export const getExtensionIcon = (extensionName: string): React.ComponentType<Too
  * @returns Extracted tool name (e.g., "text_editor")
  */
 export const extractToolName = (toolCallName: string): string => {
-  return toolCallName.substring(toolCallName.lastIndexOf('__') + 2);
+  const lastIndex = toolCallName.lastIndexOf('__');
+  return lastIndex === -1 ? toolCallName : toolCallName.substring(lastIndex + 2);
 };
 
 /**


### PR DESCRIPTION
## Summary
Improve handling for tool calls without a `__` present in the name (see name truncation issue in the screenshot).

### Type of Change
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [ ] This PR was created or reviewed with AI assistance

### Testing
Manual testing

### Related Issues
Relates to https://github.com/block/goose/pull/6318

### Screenshots/Demos (for UX changes)
<img width="1766" height="436" alt="image" src="https://github.com/user-attachments/assets/c853afc7-94d4-4259-a525-08da2015fb5d" />

