### PR TITLE
docs: remove hardcoded_stuff links

### DIFF
--- a/documentation/docs/tutorials/goose-in-docker.md
+++ b/documentation/docs/tutorials/goose-in-docker.md
@@ -12,9 +12,9 @@ This guide covers two Docker-related scenarios:
 
 You can build goose from the source file within a Docker container. This approach not only provides security benefits by creating an isolated environment but also enhances consistency and portability. For example, if you need to troubleshoot an error on a platform you don't usually work with (such as Ubuntu), you can easily debug it using Docker.
 
-To begin, you will need to modify the `Dockerfile` and `docker-compose.yml` files to suit your requirements. Some changes you might consider include:
+To begin, you will need to modify the [`Dockerfile` and `docker-compose.yml` files](https://github.com/block/goose/tree/main/documentation/docs/docker) to suit your requirements. Some changes you might consider include:
 
-- **Required:** Setting your API key, provider, and model in the `docker-compose.yml` file as environment variables because the keyring settings do not work on Ubuntu in Docker. This example uses the Google API key and its corresponding settings, but you can [find your own list of supported providers and their API keys](https://github.com/block/goose/blob/main/ui/desktop/src/components/settings/providers/ProviderRegistry.tsx) in the provider registry.
+- **Required:** Setting your API key, provider, and model in the `docker-compose.yml` file as environment variables because the keyring settings do not work on Ubuntu in Docker. This example uses Google Gemini.
 
 - **Optional:** Changing the base image to a different Linux distribution in the `Dockerfile`. This example uses Ubuntu, but you can switch to another distribution such as CentOS, Fedora, or Alpine.
 


### PR DESCRIPTION
## Summary
This PR removes links from the "goose in Docker" topic to files that no longer exist in the repo

Documentation updates:
- `documentation/docs/tutorials/goose-in-docker.md`:
  - Add link to source docker files
  - Remove links to nonexistent files

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance