### PR TITLE
Switch tetrate tool filtering back to supports_computer_use

### DIFF
--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -291,10 +291,6 @@ impl Provider for TetrateProvider {
             }
         };
 
-        // The Tetrate API returns boolean capability flags on each model:
-        // supports_computer_use, supports_vision, supports_caching, supports_reasoning.
-        // Filter to models with supports_computer_use=true as a proxy for tool/function support,
-        // which excludes embedding models, OCR models, and other non-chat models.
         let mut models: Vec<String> = data
             .iter()
             .filter_map(|model| {


### PR DESCRIPTION
We swapped this in: https://github.com/block/goose/pull/6808 but I'm not seeing the new field at all, leading to all models being filtered. supports_computer_use still seems like the best proxy from what is provided. 

