### PR TITLE
fix(providers): Azure OpenAI model listing 404 during configure

### DIFF
--- a/crates/goose/src/providers/azure.rs
+++ b/crates/goose/src/providers/azure.rs
@@ -82,11 +82,7 @@ impl ProviderDef for AzureProvider {
             })?;
 
             let auth_provider = AzureAuthProvider { auth };
-            let host = format!(
-                "{}/openai/deployments/{}",
-                endpoint.trim_end_matches('/'),
-                deployment_name
-            );
+            let host = format!("{}/openai", endpoint.trim_end_matches('/'));
             let api_client = ApiClient::new(host, AuthMethod::Custom(Box::new(auth_provider)))?
                 .with_query(vec![("api-version".to_string(), api_version)]);
 
@@ -94,6 +90,7 @@ impl ProviderDef for AzureProvider {
                 AZURE_PROVIDER_NAME.to_string(),
                 api_client,
                 model,
+                format!("deployments/{}/", deployment_name),
             ))
         })
     }

--- a/crates/goose/src/providers/xai.rs
+++ b/crates/goose/src/providers/xai.rs
@@ -65,6 +65,7 @@ impl ProviderDef for XaiProvider {
                 XAI_PROVIDER_NAME.to_string(),
                 api_client,
                 model,
+                String::new(),
             ))
         })
     }


### PR DESCRIPTION
## Summary

Fix Azure OpenAI model listing 404 during `goose configure`. The deployment path was being prepended to `models`, but should only apply to completions. Matches the [openai-python SDK](https://github.com/openai/openai-python/blob/main/src/openai/lib/azure.py) behavior.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

normal tests

### Related Issues

Fixes #6987
Relates to #6832 which broke this
