### PR TITLE
chore: update build deps

### DIFF
--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -17,8 +17,6 @@ workspace = true
 [build-dependencies]
 tokio = { workspace = true }
 reqwest = { workspace = true, features = [
-    "json",
-    "rustls-tls-native-roots",
     "system-proxy",
 ], default-features = false }
 


### PR DESCRIPTION
An updated version of https://github.com/block/goose/pull/6946 that removes the `json` and `rustls-tls-native-roots` entries without removing the whole `build-dependencies` section

Reason: a newer change from @DOsinga added `system-proxy`. Douwe, unless you confirm that also isn't needed this seems like the best resolution for https://github.com/block/goose/pull/6946 for now