### PR TITLE
fix: ensure animated elements are visible when prefers-reduced-motion is enabled

### DIFF
--- a/ui/desktop/src/styles/main.css
+++ b/ui/desktop/src/styles/main.css
@@ -373,6 +373,11 @@
   [class*='animate-[wind'] {
     animation: none !important;
   }
+
+  /* Elements that use opacity-0 with appear animation need to be visible when animations are disabled */
+  .opacity-0[class*='animate-'] {
+    opacity: 1 !important;
+  }
 }
 
 /* Toast close button styling */


### PR DESCRIPTION
## Problem

User chat messages were not displaying for users with **"Reduce motion"** enabled in their OS accessibility settings.

## Root Cause

User messages use `opacity-0` with an `appear` animation to fade in:
```tsx
className="opacity-0 animate-[appear_150ms_ease-in_forwards]"
```

When `prefers-reduced-motion: reduce` is enabled, the CSS disables animations:
```css
animation: none !important;
```

But the opacity remained at `0`, making messages invisible.

## Fix

Added a CSS rule to ensure elements with both `opacity-0` and `animate-*` classes are set to `opacity: 1` when reduced motion is preferred:

```css
@media (prefers-reduced-motion: reduce) {
  .opacity-0[class*='animate-'] {
    opacity: 1 !important;
  }
}
```

## Testing

1. Enable "Reduce motion" in your OS:
   - **macOS**: System Settings → Accessibility → Display → Reduce motion
   - **Windows**: Settings → Ease of Access → Display → Show animations (off)
2. Send a message in Goose Desktop
3. Verify the message appears immediately (without animation)