### PR TITLE
Add global config switch to disable automatic session naming

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -967,6 +967,7 @@ config_value!(GOOSE_PROVIDER, String);
 config_value!(GOOSE_MODEL, String);
 config_value!(GOOSE_PROMPT_EDITOR, Option<String>);
 config_value!(GOOSE_MAX_ACTIVE_AGENTS, usize);
+config_value!(GOOSE_DISABLE_SESSION_NAMING, bool);
 config_value!(GEMINI3_THINKING_LEVEL, String);
 
 /// Load init-config.yaml from workspace root if it exists.


### PR DESCRIPTION
Adds a `GOOSE_DISABLE_SESSION_NAMING` configuration flag that lets users turn off the LLM-powered automatic session naming feature. This is useful in headless/CI environments or for users who find the background naming calls unnecessary, reducing token usage and latency.