### PR TITLE
refactor: move disable_session_naming into AgentConfig

### DIFF
--- a/clippy-baselines/too_many_lines.txt
+++ b/clippy-baselines/too_many_lines.txt
@@ -10,13 +10,12 @@ crates/goose-mcp/src/computercontroller/pdf_tool.rs::pdf_tool
 crates/goose-mcp/src/memory/mod.rs::new
 crates/goose-server/src/openapi.rs::convert_typed_schema
 crates/goose-server/src/openapi.rs::convert_typed_schema
-crates/goose-server/src/routes/audio.rs::transcribe_elevenlabs_handler
-crates/goose-server/src/routes/audio.rs::transcribe_elevenlabs_handler
 crates/goose/src/agents/agent.rs::create_recipe
 crates/goose/src/agents/agent.rs::dispatch_tool_call
 crates/goose/src/agents/agent.rs::reply
 crates/goose/src/agents/agent.rs::reply_internal
-crates/goose/src/providers/canonical/build_canonical_models.rs::build_canonical_models
+crates/goose/src/providers/claude_code.rs::execute_command
+crates/goose/src/providers/codex.rs::execute_command
 crates/goose/src/providers/formats/anthropic.rs::format_messages
 crates/goose/src/providers/formats/anthropic.rs::response_to_streaming_message
 crates/goose/src/providers/formats/databricks.rs::format_messages

--- a/crates/goose-acp/src/server.rs
+++ b/crates/goose-acp/src/server.rs
@@ -55,6 +55,7 @@ pub struct AcpServerConfig {
     pub data_dir: std::path::PathBuf,
     pub config_dir: std::path::PathBuf,
     pub goose_mode: goose::config::GooseMode,
+    pub disable_session_naming: bool,
 }
 
 fn mcp_server_to_extension_config(mcp_server: McpServer) -> Result<ExtensionConfig, String> {
@@ -309,6 +310,7 @@ impl GooseAcpAgent {
             data_dir: Paths::data_dir(),
             config_dir: Paths::config_dir(),
             goose_mode,
+            disable_session_naming: config.get_goose_disable_session_naming().unwrap_or(false),
         })
         .await
     }
@@ -323,6 +325,7 @@ impl GooseAcpAgent {
             permission_manager,
             None,
             config.goose_mode,
+            config.disable_session_naming,
         ));
 
         let agent_ptr = Arc::new(agent);

--- a/crates/goose-acp/src/server_factory.rs
+++ b/crates/goose-acp/src/server_factory.rs
@@ -66,6 +66,9 @@ impl AcpServer {
             data_dir: self.config.data_dir.clone(),
             config_dir: self.config.config_dir.clone(),
             goose_mode,
+            disable_session_naming: global_config
+                .get_goose_disable_session_naming()
+                .unwrap_or(false),
         };
 
         let agent = GooseAcpAgent::with_config(acp_config).await?;

--- a/crates/goose-acp/tests/test_data/openai_session_description.json
+++ b/crates/goose-acp/tests/test_data/openai_session_description.json
@@ -1,1 +1,0 @@
-{"id":"chatcmpl-test","object":"chat.completion","created":1766229622,"model":"gpt-5-nano","choices":[{"index":0,"message":{"role":"assistant","content":"Test session"},"finish_reason":"stop"}],"usage":{"prompt_tokens":79,"completion_tokens":10,"total_tokens":89}}

--- a/crates/goose-cli/src/scenario_tests/recordings/openai/image_analysis.json
+++ b/crates/goose-cli/src/scenario_tests/recordings/openai/image_analysis.json
@@ -1,12 +1,12 @@
 {
   "c848f22f273e158c32435d3e72cc999c046dc1a9afdc3efda68ff451f833a185": {
     "input": {
-      "system": "You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.\ngoose is being developed as an open-source software project.\n\nThe current date is 2025-10-15 21:57:42.\n\ngoose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o,\nclaude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).\nThese models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10\nmonths prior to the current date.\n\n# Extensions\n\nExtensions allow other applications to provide context to goose. Extensions connect goose to different data sources and\ntools.\nYou are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level\nproblems using the tools in these extensions, and can interact with multiple at once.\nUse the search_available_extensions tool to find additional extensions to enable to help with your task. To enable\nextensions, use the enable_extension tool and provide the extension_name. You should only enable extensions found from\nthe search_available_extensions tool.\n\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n\n\n## weather_extension\n\n\n\n\n\n\n\n\n\n# Suggestion\n\n\"\"\n\n\n\n\n# sub agents\n\nExecute self contained tasks where step-by-step visibility is not important through subagents.\n\n- Delegate via `dynamic_task__create_task` for: result-only operations, parallelizable work, multi-part requests,\n  verification, exploration\n- Parallel subagents for multiple operations, single subagents for independent work\n- Explore solutions in parallel — launch parallel subagents with different approaches (if non-interfering)\n- Provide all needed context — subagents cannot see your context\n- Use extension filters to limit resource access\n- Use return_last_only when only a summary or simple answer is required — inform subagent of this choice.\n\n# Response Guidelines\n\n- Use Markdown formatting for all responses.\n- Follow best practices for Markdown, including:\n    - Using headers for organization.\n    - Bullet points for lists.\n    - Links formatted correctly, either as linked text (e.g., [this is linked text](https://example.com)) or automatic\n      links using angle brackets (e.g., <http://example.com/>).\n- For code examples, use fenced code blocks by placing triple backticks (` ``` `) before and after the code. Include the\n  language identifier after the opening backticks (e.g., ` ```python `) to enable syntax highlighting.\n- Ensure clarity, conciseness, and proper formatting to enhance readability and usability.\n\n# Additional Instructions:\n\nRight now you are *NOT* in the chat only mode and have access to tool use and system.",
+      "system": "You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.\ngoose is being developed as an open-source software project.\n\ngoose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o,\nclaude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).\nThese models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10\nmonths prior to the current date.\n\n# Extensions\n\nExtensions allow other applications to provide context to goose. Extensions connect goose to different data sources and\ntools.\nYou are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level\nproblems using the tools in these extensions, and can interact with multiple at once.\n\nIf the Extension Manager extension is enabled, you can use the search_available_extensions tool to discover additional\nextensions that can help with your task. To enable or disable extensions, use the manage_extensions tool with the\nextension_name. You should only enable extensions found from the search_available_extensions tool.\nIf Extension Manager is not available, you can only work with currently enabled extensions and cannot dynamically load\nnew ones.\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n\n## weather_extension\n\n\n\n\n# Response Guidelines\n\n- Use Markdown formatting for all responses.\n- Follow best practices for Markdown, including:\n    - Using headers for organization.\n    - Bullet points for lists.\n    - Links formatted correctly, either as linked text (e.g., [this is linked text](https://example.com)) or automatic\n      links using angle brackets (e.g., <http://example.com/>).\n- For code examples, use fenced code blocks by placing triple backticks (` ``` `) before and after the code. Include the\n  language identifier after the opening backticks (e.g., ` ```python `) to enable syntax highlighting.\n- Ensure clarity, conciseness, and proper formatting to enhance readability and usability.\n\n# Additional Instructions:\n\n\n### Global Hints\nThese are my global goose hints.\nThese are my global goose hints.",
       "messages": [
         {
-          "id": null,
+          "id": "msg_20260207_1_1a01be5d-1611-436d-a85b-0d56aee554e3",
           "role": "user",
-          "created": 1760565462,
+          "created": 1770423951,
           "content": [
             {
               "type": "text",
@@ -26,254 +26,75 @@
       ],
       "tools": [
         {
+          "name": "subagent",
+          "description": "Delegate a task to a subagent that runs independently with its own context.\n\nModes:\n1. Ad-hoc: Provide `instructions` for a custom task\n2. Predefined: Provide `subrecipe` name to run a predefined task\n3. Augmented: Provide both `subrecipe` and `instructions` to add context\n\nThe subagent has access to the same tools as you by default. Use `extensions` to limit which extensions the subagent can use.\n\nFor parallel execution, make multiple `subagent` tool calls in the same message.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "instructions": {
+                "type": "string",
+                "description": "Instructions for the subagent. Required for ad-hoc tasks. For predefined tasks, adds additional context."
+              },
+              "subrecipe": {
+                "type": "string",
+                "description": "Name of a predefined subrecipe to run."
+              },
+              "parameters": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Parameters for the subrecipe. Only valid when 'subrecipe' is specified."
+              },
+              "extensions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Extensions to enable. Omit to inherit all, empty array for none."
+              },
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "description": "Override LLM provider"
+                  },
+                  "model": {
+                    "type": "string",
+                    "description": "Override model"
+                  },
+                  "temperature": {
+                    "type": "number",
+                    "description": "Override temperature"
+                  },
+                  "max_turns": {
+                    "type": "number",
+                    "description": "Override max turns"
+                  }
+                },
+                "description": "Override model/provider/settings."
+              },
+              "summary": {
+                "type": "boolean",
+                "default": true,
+                "description": "If true (default), return only the subagent's final summary."
+              }
+            }
+          }
+        },
+        {
           "name": "weather_extension__get_weather",
           "description": "Get the weather for a location",
           "inputSchema": {
-            "properties": {
-              "location": {
-                "description": "The city and state, e.g. San Francisco, CA",
-                "type": "string"
-              }
-            },
+            "type": "object",
             "required": [
               "location"
             ],
-            "type": "object"
-          }
-        },
-        {
-          "name": "platform__search_available_extensions",
-          "description": "Searches for additional extensions available to help complete tasks.\n        Use this tool when you're unable to find a specific feature or functionality you need to complete your task, or when standard approaches aren't working.\n        These extensions might provide the exact tools needed to solve your problem.\n        If you find a relevant one, consider using your tools to enable it.",
-          "inputSchema": {
-            "properties": {},
-            "required": [],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Discover extensions",
-            "readOnlyHint": true,
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": false
-          }
-        },
-        {
-          "name": "platform__manage_extensions",
-          "description": "Tool to manage extensions and tools in goose context.\n            Enable or disable extensions to help complete tasks.\n            Enable or disable an extension by providing the extension name.\n            ",
-          "inputSchema": {
             "properties": {
-              "action": {
-                "description": "The action to perform",
-                "enum": [
-                  "enable",
-                  "disable"
-                ],
-                "type": "string"
-              },
-              "extension_name": {
-                "description": "The name of the extension to enable",
-                "type": "string"
+              "location": {
+                "type": "string",
+                "description": "The city and state, e.g. San Francisco, CA"
               }
-            },
-            "required": [
-              "action",
-              "extension_name"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Enable or disable an extension",
-            "readOnlyHint": false,
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": false
-          }
-        },
-        {
-          "name": "platform__manage_schedule",
-          "description": "Manage scheduled recipe execution for this goose instance.\n\nActions:\n- \"list\": List all scheduled jobs\n- \"create\": Create a new scheduled job from a recipe file\n- \"run_now\": Execute a scheduled job immediately  \n- \"pause\": Pause a scheduled job\n- \"unpause\": Resume a paused job\n- \"delete\": Remove a scheduled job\n- \"kill\": Terminate a currently running job\n- \"inspect\": Get details about a running job\n- \"sessions\": List execution history for a job\n- \"session_content\": Get the full content (messages) of a specific session\n",
-          "inputSchema": {
-            "properties": {
-              "action": {
-                "enum": [
-                  "list",
-                  "create",
-                  "run_now",
-                  "pause",
-                  "unpause",
-                  "delete",
-                  "kill",
-                  "inspect",
-                  "sessions",
-                  "session_content"
-                ],
-                "type": "string"
-              },
-              "cron_expression": {
-                "description": "A cron expression for create action. Supports both 5-field (minute hour day month weekday) and 6-field (second minute hour day month weekday) formats. 5-field expressions are automatically converted to 6-field by prepending '0' for seconds.",
-                "type": "string"
-              },
-              "execution_mode": {
-                "default": "background",
-                "description": "Execution mode for create action: 'foreground' or 'background'",
-                "enum": [
-                  "foreground",
-                  "background"
-                ],
-                "type": "string"
-              },
-              "job_id": {
-                "description": "Job identifier for operations on existing jobs",
-                "type": "string"
-              },
-              "limit": {
-                "default": 50,
-                "description": "Limit for sessions list",
-                "type": "integer"
-              },
-              "recipe_path": {
-                "description": "Path to recipe file for create action",
-                "type": "string"
-              },
-              "session_id": {
-                "description": "Session identifier for session_content action",
-                "type": "string"
-              }
-            },
-            "required": [
-              "action"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Manage scheduled recipes",
-            "readOnlyHint": false,
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": false
-          }
-        },
-        {
-          "name": "dynamic_task__create_task",
-          "description": "Create tasks with instructions or prompt. For simple tasks, only include the instructions field. Extensions control: omit field = use all current extensions; empty array [] = no extensions; array with names = only those extensions. Specify extensions as shortnames (the prefixes for your tools). Specify return_last_only as true and have your subagent summarize its work in its last message to conserve your own context. Optional: title, description, extensions, settings, retry, response schema, context, activities. Arrays for multiple tasks.",
-          "inputSchema": {
-            "properties": {
-              "execution_mode": {
-                "description": "How to execute multiple tasks (default: parallel for multiple tasks, sequential for single task)",
-                "enum": [
-                  "sequential",
-                  "parallel"
-                ],
-                "type": "string"
-              },
-              "task_parameters": {
-                "description": "Array of tasks. Each task must have either 'instructions' OR 'prompt' field (at least one is required).",
-                "items": {
-                  "properties": {
-                    "activities": {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "context": {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "extensions": {
-                      "items": {
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "instructions": {
-                      "description": "Task instructions (required if prompt is not provided)",
-                      "type": "string"
-                    },
-                    "parameters": {
-                      "items": {
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "prompt": {
-                      "description": "Initial prompt (required if instructions is not provided)",
-                      "type": "string"
-                    },
-                    "response": {
-                      "type": "object"
-                    },
-                    "retry": {
-                      "type": "object"
-                    },
-                    "return_last_only": {
-                      "description": "If true, return only the last message from the subagent (default: false, returns full conversation)",
-                      "type": "boolean"
-                    },
-                    "settings": {
-                      "type": "object"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "minItems": 1,
-                "type": "array"
-              }
-            },
-            "required": [
-              "task_parameters"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Create Dynamic Tasks",
-            "readOnlyHint": false,
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true
-          }
-        },
-        {
-          "name": "subagent__execute_task",
-          "description": "Only use the subagent__execute_task tool when you execute sub recipe task or dynamic task.\n        EXECUTION STRATEGY DECISION:\n        1. If the tasks are created with execution_mode, use the execution_mode.\n        2. Execute tasks sequentially unless user explicitly requests parallel execution. PARALLEL: User uses keywords like 'parallel', 'simultaneously', 'at the same time', 'concurrently'\n\n        IMPLEMENTATION:\n        - Sequential execution: Call this tool multiple times, passing exactly ONE task per call\n        - Parallel execution: Call this tool once, passing an ARRAY of all tasks\n\n        EXAMPLES:\n        User Intent Based:\n        - User: 'get weather and tell me a joke' → Sequential (2 separate tool calls, 1 task each)\n        - User: 'get weather and joke in parallel' → Parallel (1 tool call with array of 2 tasks)\n        - User: 'run these simultaneously' → Parallel (1 tool call with task array)\n        - User: 'do task A then task B' → Sequential (2 separate tool calls)",
-          "inputSchema": {
-            "properties": {
-              "execution_mode": {
-                "default": "sequential",
-                "description": "Execution strategy for multiple tasks. Use 'sequential' (default) unless user explicitly requests parallel execution with words like 'parallel', 'simultaneously', 'at the same time', or 'concurrently'.",
-                "enum": [
-                  "sequential",
-                  "parallel"
-                ],
-                "type": "string"
-              },
-              "task_ids": {
-                "items": {
-                  "description": "Unique identifier for the task",
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "task_ids"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Run tasks in parallel",
-            "readOnlyHint": false,
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": true
+            }
           }
         }
       ]
@@ -282,11 +103,11 @@
       "message": {
         "id": null,
         "role": "assistant",
-        "created": 1760565465,
+        "created": 1770423954,
         "content": [
           {
             "type": "text",
-            "text": "This image shows a goose standing near a body of water. The goose has grey and brown feathers with a distinctive orange beak. It’s standing on grassy ground by the water's edge."
+            "text": "This is a photo of a goose standing near water. If you have any questions or need more information, feel free to ask!"
           }
         ],
         "metadata": {
@@ -297,9 +118,9 @@
       "usage": {
         "model": "gpt-4o-2024-08-06",
         "usage": {
-          "input_tokens": 1953,
-          "output_tokens": 39,
-          "total_tokens": 1992
+          "input_tokens": 1069,
+          "output_tokens": 27,
+          "total_tokens": 1096
         }
       }
     }

--- a/crates/goose-cli/src/scenario_tests/recordings/openai/weather_tool.json
+++ b/crates/goose-cli/src/scenario_tests/recordings/openai/weather_tool.json
@@ -1,301 +1,12 @@
 {
-  "1bc400a528c54b25f4f1f609481e98e44222b3deaf7eee2c9e640e6345c73861": {
+  "24095cf8d18f13d750138a81eb3dc7d598d461b643a3b51d7aa8feb5ab598c46": {
     "input": {
-      "system": "You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.\ngoose is being developed as an open-source software project.\n\ngoose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o,\nclaude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).\nThese models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10\nmonths prior to the current date.\n\n# Extensions\n\nExtensions allow other applications to provide context to goose. Extensions connect goose to different data sources and\ntools.\nYou are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level\nproblems using the tools in these extensions, and can interact with multiple at once.\n\nIf the Extension Manager extension is enabled, you can use the search_available_extensions tool to discover additional\nextensions that can help with your task. To enable or disable extensions, use the manage_extensions tool with the\nextension_name. You should only enable extensions found from the search_available_extensions tool.\nIf Extension Manager is not available, you can only work with currently enabled extensions and cannot dynamically load\nnew ones.\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n\n## weather_extension\n\n\n\n\n\n\n# Response Guidelines\n\n- Use Markdown formatting for all responses.\n- Follow best practices for Markdown, including:\n    - Using headers for organization.\n    - Bullet points for lists.\n    - Links formatted correctly, either as linked text (e.g., [this is linked text](https://example.com)) or automatic\n      links using angle brackets (e.g., <http://example.com/>).\n- For code examples, use fenced code blocks by placing triple backticks (` ``` `) before and after the code. Include the\n  language identifier after the opening backticks (e.g., ` ```python `) to enable syntax highlighting.\n- Ensure clarity, conciseness, and proper formatting to enhance readability and usability.",
+      "system": "You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.\ngoose is being developed as an open-source software project.\n\ngoose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o,\nclaude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).\nThese models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10\nmonths prior to the current date.\n\n# Extensions\n\nExtensions allow other applications to provide context to goose. Extensions connect goose to different data sources and\ntools.\nYou are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level\nproblems using the tools in these extensions, and can interact with multiple at once.\n\nIf the Extension Manager extension is enabled, you can use the search_available_extensions tool to discover additional\nextensions that can help with your task. To enable or disable extensions, use the manage_extensions tool with the\nextension_name. You should only enable extensions found from the search_available_extensions tool.\nIf Extension Manager is not available, you can only work with currently enabled extensions and cannot dynamically load\nnew ones.\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n\n## weather_extension\n\n\n\n\n# Response Guidelines\n\n- Use Markdown formatting for all responses.\n- Follow best practices for Markdown, including:\n    - Using headers for organization.\n    - Bullet points for lists.\n    - Links formatted correctly, either as linked text (e.g., [this is linked text](https://example.com)) or automatic\n      links using angle brackets (e.g., <http://example.com/>).\n- For code examples, use fenced code blocks by placing triple backticks (` ``` `) before and after the code. Include the\n  language identifier after the opening backticks (e.g., ` ```python `) to enable syntax highlighting.\n- Ensure clarity, conciseness, and proper formatting to enhance readability and usability.\n\n# Additional Instructions:\n\n\n### Global Hints\nThese are my global goose hints.\nThese are my global goose hints.",
       "messages": [
         {
-          "id": "msg_20251211_26_0",
+          "id": "msg_20260207_1_2bc5e542-e0c9-471c-a682-1a9476dd2856",
           "role": "user",
-          "created": 1765495261,
-          "content": [
-            {
-              "type": "text",
-              "text": "tell me what the weather is in Berlin, Germany"
-            }
-          ],
-          "metadata": {
-            "userVisible": true,
-            "agentVisible": true
-          }
-        }
-      ],
-      "tools": [
-        {
-          "name": "dynamic_task__create_task",
-          "description": "Create tasks with instructions or prompt. For simple tasks, only include the instructions field. Extensions control: omit field = use all current extensions; empty array [] = no extensions; array with names = only those extensions. Specify extensions as shortnames (the prefixes for your tools). Specify return_last_only as true and have your subagent summarize its work in its last message to conserve your own context. Optional: title, description, extensions, settings, retry, response schema, activities. Arrays for multiple tasks.",
-          "inputSchema": {
-            "$defs": {
-              "TaskParameter": {
-                "description": "Parameters for a single task",
-                "properties": {
-                  "activities": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "extensions": {
-                    "items": {
-                      "additionalProperties": true,
-                      "type": "object"
-                    },
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "instructions": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "parameters": {
-                    "items": {
-                      "additionalProperties": true,
-                      "type": "object"
-                    },
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "prompt": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "response": {
-                    "additionalProperties": true,
-                    "type": [
-                      "object",
-                      "null"
-                    ]
-                  },
-                  "retry": {
-                    "additionalProperties": true,
-                    "type": [
-                      "object",
-                      "null"
-                    ]
-                  },
-                  "return_last_only": {
-                    "description": "If true, return only the last message from the subagent (default: false, returns full conversation)",
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "settings": {
-                    "additionalProperties": true,
-                    "type": [
-                      "object",
-                      "null"
-                    ]
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "type": "object"
-              }
-            },
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
-            "properties": {
-              "execution_mode": {
-                "description": "How to execute multiple tasks (default: parallel for multiple tasks, sequential for single task)",
-                "type": [
-                  "string",
-                  "null"
-                ]
-              },
-              "task_parameters": {
-                "description": "Array of tasks. Each task must have either 'instructions' OR 'prompt' field (at least one is required).",
-                "items": {
-                  "$ref": "#/$defs/TaskParameter"
-                },
-                "minItems": 1,
-                "type": "array"
-              }
-            },
-            "required": [
-              "task_parameters"
-            ],
-            "title": "CreateDynamicTaskParams",
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Create Dynamic Tasks",
-            "readOnlyHint": false,
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true
-          }
-        },
-        {
-          "name": "platform__manage_schedule",
-          "description": "Manage scheduled recipe execution for this goose instance.\n\nActions:\n- \"list\": List all scheduled jobs\n- \"create\": Create a new scheduled job from a recipe file\n- \"run_now\": Execute a scheduled job immediately  \n- \"pause\": Pause a scheduled job\n- \"unpause\": Resume a paused job\n- \"delete\": Remove a scheduled job\n- \"kill\": Terminate a currently running job\n- \"inspect\": Get details about a running job\n- \"sessions\": List execution history for a job\n- \"session_content\": Get the full content (messages) of a specific session\n",
-          "inputSchema": {
-            "properties": {
-              "action": {
-                "enum": [
-                  "list",
-                  "create",
-                  "run_now",
-                  "pause",
-                  "unpause",
-                  "delete",
-                  "kill",
-                  "inspect",
-                  "sessions",
-                  "session_content"
-                ],
-                "type": "string"
-              },
-              "cron_expression": {
-                "description": "A cron expression for create action. Supports both 5-field (minute hour day month weekday) and 6-field (second minute hour day month weekday) formats. 5-field expressions are automatically converted to 6-field by prepending '0' for seconds.",
-                "type": "string"
-              },
-              "job_id": {
-                "description": "Job identifier for operations on existing jobs",
-                "type": "string"
-              },
-              "limit": {
-                "default": 50,
-                "description": "Limit for sessions list",
-                "type": "integer"
-              },
-              "recipe_path": {
-                "description": "Path to recipe file for create action",
-                "type": "string"
-              },
-              "session_id": {
-                "description": "Session identifier for session_content action",
-                "type": "string"
-              }
-            },
-            "required": [
-              "action"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Manage scheduled recipes",
-            "readOnlyHint": false,
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": false
-          }
-        },
-        {
-          "name": "subagent__execute_task",
-          "description": "Only use the subagent__execute_task tool when you execute sub recipe task or dynamic task.\n        EXECUTION STRATEGY DECISION:\n        1. If the tasks are created with execution_mode, use the execution_mode.\n        2. Execute tasks sequentially unless user explicitly requests parallel execution. PARALLEL: User uses keywords like 'parallel', 'simultaneously', 'at the same time', 'concurrently'\n\n        IMPLEMENTATION:\n        - Sequential execution: Call this tool multiple times, passing exactly ONE task per call\n        - Parallel execution: Call this tool once, passing an ARRAY of all tasks\n\n        EXAMPLES:\n        User Intent Based:\n        - User: 'get weather and tell me a joke' → Sequential (2 separate tool calls, 1 task each)\n        - User: 'get weather and joke in parallel' → Parallel (1 tool call with array of 2 tasks)\n        - User: 'run these simultaneously' → Parallel (1 tool call with task array)\n        - User: 'do task A then task B' → Sequential (2 separate tool calls)",
-          "inputSchema": {
-            "properties": {
-              "execution_mode": {
-                "default": "sequential",
-                "description": "Execution strategy for multiple tasks. Use 'sequential' (default) unless user explicitly requests parallel execution with words like 'parallel', 'simultaneously', 'at the same time', or 'concurrently'.",
-                "enum": [
-                  "sequential",
-                  "parallel"
-                ],
-                "type": "string"
-              },
-              "task_ids": {
-                "items": {
-                  "description": "Unique identifier for the task",
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "task_ids"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Run tasks in parallel",
-            "readOnlyHint": false,
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": true
-          }
-        },
-        {
-          "name": "weather_extension__get_weather",
-          "description": "Get the weather for a location",
-          "inputSchema": {
-            "properties": {
-              "location": {
-                "description": "The city and state, e.g. San Francisco, CA",
-                "type": "string"
-              }
-            },
-            "required": [
-              "location"
-            ],
-            "type": "object"
-          }
-        }
-      ]
-    },
-    "output": {
-      "message": {
-        "id": null,
-        "role": "assistant",
-        "created": 1765495262,
-        "content": [
-          {
-            "type": "toolRequest",
-            "id": "call_sVLij6GavUkUc5Ri4VeDdgmN",
-            "toolCall": {
-              "status": "success",
-              "value": {
-                "name": "weather_extension__get_weather",
-                "arguments": {
-                  "location": "Berlin, Germany"
-                }
-              }
-            }
-          }
-        ],
-        "metadata": {
-          "userVisible": true,
-          "agentVisible": true
-        }
-      },
-      "usage": {
-        "model": "gpt-4o-2024-08-06",
-        "usage": {
-          "input_tokens": 1492,
-          "output_tokens": 19,
-          "total_tokens": 1511
-        }
-      }
-    }
-  },
-  "950a6b5ec929abdd9e7cd337d2ea80c07631c23c6d64edac31988e18c6207e92": {
-    "input": {
-      "system": "You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.\ngoose is being developed as an open-source software project.\n\ngoose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o,\nclaude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).\nThese models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10\nmonths prior to the current date.\n\n# Extensions\n\nExtensions allow other applications to provide context to goose. Extensions connect goose to different data sources and\ntools.\nYou are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level\nproblems using the tools in these extensions, and can interact with multiple at once.\n\nIf the Extension Manager extension is enabled, you can use the search_available_extensions tool to discover additional\nextensions that can help with your task. To enable or disable extensions, use the manage_extensions tool with the\nextension_name. You should only enable extensions found from the search_available_extensions tool.\nIf Extension Manager is not available, you can only work with currently enabled extensions and cannot dynamically load\nnew ones.\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n\n## weather_extension\n\n\n\n\n\n\n# Response Guidelines\n\n- Use Markdown formatting for all responses.\n- Follow best practices for Markdown, including:\n    - Using headers for organization.\n    - Bullet points for lists.\n    - Links formatted correctly, either as linked text (e.g., [this is linked text](https://example.com)) or automatic\n      links using angle brackets (e.g., <http://example.com/>).\n- For code examples, use fenced code blocks by placing triple backticks (` ``` `) before and after the code. Include the\n  language identifier after the opening backticks (e.g., ` ```python `) to enable syntax highlighting.\n- Ensure clarity, conciseness, and proper formatting to enhance readability and usability.",
-      "messages": [
-        {
-          "id": "msg_20251211_26_0",
-          "role": "user",
-          "created": 1765495261,
+          "created": 1770423951,
           "content": [
             {
               "type": "text",
@@ -308,13 +19,13 @@
           }
         },
         {
-          "id": "msg_899ef38b-1440-47f7-a942-1b2e58c8835c",
+          "id": "msg_097c7c4b-cd02-46b4-99e8-a6932032e66d",
           "role": "assistant",
-          "created": 1765495262,
+          "created": 1770423953,
           "content": [
             {
               "type": "toolRequest",
-              "id": "call_sVLij6GavUkUc5Ri4VeDdgmN",
+              "id": "call_NwyWutYuGQ8wujr6Ae3dO6tL",
               "toolCall": {
                 "status": "success",
                 "value": {
@@ -332,13 +43,13 @@
           }
         },
         {
-          "id": "msg_2f8ddf2e-dedb-4b99-9549-826796292622",
+          "id": "msg_5e059d80-a4e1-4d8c-ab35-f18d5f597437",
           "role": "user",
-          "created": 1765495262,
+          "created": 1770423953,
           "content": [
             {
               "type": "toolResponse",
-              "id": "call_sVLij6GavUkUc5Ri4VeDdgmN",
+              "id": "call_NwyWutYuGQ8wujr6Ae3dO6tL",
               "toolResult": {
                 "status": "success",
                 "value": {
@@ -360,234 +71,75 @@
       ],
       "tools": [
         {
-          "name": "dynamic_task__create_task",
-          "description": "Create tasks with instructions or prompt. For simple tasks, only include the instructions field. Extensions control: omit field = use all current extensions; empty array [] = no extensions; array with names = only those extensions. Specify extensions as shortnames (the prefixes for your tools). Specify return_last_only as true and have your subagent summarize its work in its last message to conserve your own context. Optional: title, description, extensions, settings, retry, response schema, activities. Arrays for multiple tasks.",
+          "name": "subagent",
+          "description": "Delegate a task to a subagent that runs independently with its own context.\n\nModes:\n1. Ad-hoc: Provide `instructions` for a custom task\n2. Predefined: Provide `subrecipe` name to run a predefined task\n3. Augmented: Provide both `subrecipe` and `instructions` to add context\n\nThe subagent has access to the same tools as you by default. Use `extensions` to limit which extensions the subagent can use.\n\nFor parallel execution, make multiple `subagent` tool calls in the same message.",
           "inputSchema": {
-            "$defs": {
-              "TaskParameter": {
-                "description": "Parameters for a single task",
-                "properties": {
-                  "activities": {
-                    "items": {
-                      "type": "string"
-                    },
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "description": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "extensions": {
-                    "items": {
-                      "additionalProperties": true,
-                      "type": "object"
-                    },
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "instructions": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "parameters": {
-                    "items": {
-                      "additionalProperties": true,
-                      "type": "object"
-                    },
-                    "type": [
-                      "array",
-                      "null"
-                    ]
-                  },
-                  "prompt": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  },
-                  "response": {
-                    "additionalProperties": true,
-                    "type": [
-                      "object",
-                      "null"
-                    ]
-                  },
-                  "retry": {
-                    "additionalProperties": true,
-                    "type": [
-                      "object",
-                      "null"
-                    ]
-                  },
-                  "return_last_only": {
-                    "description": "If true, return only the last message from the subagent (default: false, returns full conversation)",
-                    "type": [
-                      "boolean",
-                      "null"
-                    ]
-                  },
-                  "settings": {
-                    "additionalProperties": true,
-                    "type": [
-                      "object",
-                      "null"
-                    ]
-                  },
-                  "title": {
-                    "type": [
-                      "string",
-                      "null"
-                    ]
-                  }
-                },
-                "type": "object"
-              }
-            },
-            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
             "properties": {
-              "execution_mode": {
-                "description": "How to execute multiple tasks (default: parallel for multiple tasks, sequential for single task)",
-                "type": [
-                  "string",
-                  "null"
-                ]
+              "instructions": {
+                "type": "string",
+                "description": "Instructions for the subagent. Required for ad-hoc tasks. For predefined tasks, adds additional context."
               },
-              "task_parameters": {
-                "description": "Array of tasks. Each task must have either 'instructions' OR 'prompt' field (at least one is required).",
+              "subrecipe": {
+                "type": "string",
+                "description": "Name of a predefined subrecipe to run."
+              },
+              "parameters": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Parameters for the subrecipe. Only valid when 'subrecipe' is specified."
+              },
+              "extensions": {
+                "type": "array",
                 "items": {
-                  "$ref": "#/$defs/TaskParameter"
-                },
-                "minItems": 1,
-                "type": "array"
-              }
-            },
-            "required": [
-              "task_parameters"
-            ],
-            "title": "CreateDynamicTaskParams",
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Create Dynamic Tasks",
-            "readOnlyHint": false,
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true
-          }
-        },
-        {
-          "name": "platform__manage_schedule",
-          "description": "Manage scheduled recipe execution for this goose instance.\n\nActions:\n- \"list\": List all scheduled jobs\n- \"create\": Create a new scheduled job from a recipe file\n- \"run_now\": Execute a scheduled job immediately  \n- \"pause\": Pause a scheduled job\n- \"unpause\": Resume a paused job\n- \"delete\": Remove a scheduled job\n- \"kill\": Terminate a currently running job\n- \"inspect\": Get details about a running job\n- \"sessions\": List execution history for a job\n- \"session_content\": Get the full content (messages) of a specific session\n",
-          "inputSchema": {
-            "properties": {
-              "action": {
-                "enum": [
-                  "list",
-                  "create",
-                  "run_now",
-                  "pause",
-                  "unpause",
-                  "delete",
-                  "kill",
-                  "inspect",
-                  "sessions",
-                  "session_content"
-                ],
-                "type": "string"
-              },
-              "cron_expression": {
-                "description": "A cron expression for create action. Supports both 5-field (minute hour day month weekday) and 6-field (second minute hour day month weekday) formats. 5-field expressions are automatically converted to 6-field by prepending '0' for seconds.",
-                "type": "string"
-              },
-              "job_id": {
-                "description": "Job identifier for operations on existing jobs",
-                "type": "string"
-              },
-              "limit": {
-                "default": 50,
-                "description": "Limit for sessions list",
-                "type": "integer"
-              },
-              "recipe_path": {
-                "description": "Path to recipe file for create action",
-                "type": "string"
-              },
-              "session_id": {
-                "description": "Session identifier for session_content action",
-                "type": "string"
-              }
-            },
-            "required": [
-              "action"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Manage scheduled recipes",
-            "readOnlyHint": false,
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": false
-          }
-        },
-        {
-          "name": "subagent__execute_task",
-          "description": "Only use the subagent__execute_task tool when you execute sub recipe task or dynamic task.\n        EXECUTION STRATEGY DECISION:\n        1. If the tasks are created with execution_mode, use the execution_mode.\n        2. Execute tasks sequentially unless user explicitly requests parallel execution. PARALLEL: User uses keywords like 'parallel', 'simultaneously', 'at the same time', 'concurrently'\n\n        IMPLEMENTATION:\n        - Sequential execution: Call this tool multiple times, passing exactly ONE task per call\n        - Parallel execution: Call this tool once, passing an ARRAY of all tasks\n\n        EXAMPLES:\n        User Intent Based:\n        - User: 'get weather and tell me a joke' → Sequential (2 separate tool calls, 1 task each)\n        - User: 'get weather and joke in parallel' → Parallel (1 tool call with array of 2 tasks)\n        - User: 'run these simultaneously' → Parallel (1 tool call with task array)\n        - User: 'do task A then task B' → Sequential (2 separate tool calls)",
-          "inputSchema": {
-            "properties": {
-              "execution_mode": {
-                "default": "sequential",
-                "description": "Execution strategy for multiple tasks. Use 'sequential' (default) unless user explicitly requests parallel execution with words like 'parallel', 'simultaneously', 'at the same time', or 'concurrently'.",
-                "enum": [
-                  "sequential",
-                  "parallel"
-                ],
-                "type": "string"
-              },
-              "task_ids": {
-                "items": {
-                  "description": "Unique identifier for the task",
                   "type": "string"
                 },
-                "type": "array"
+                "description": "Extensions to enable. Omit to inherit all, empty array for none."
+              },
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "description": "Override LLM provider"
+                  },
+                  "model": {
+                    "type": "string",
+                    "description": "Override model"
+                  },
+                  "temperature": {
+                    "type": "number",
+                    "description": "Override temperature"
+                  },
+                  "max_turns": {
+                    "type": "number",
+                    "description": "Override max turns"
+                  }
+                },
+                "description": "Override model/provider/settings."
+              },
+              "summary": {
+                "type": "boolean",
+                "default": true,
+                "description": "If true (default), return only the subagent's final summary."
               }
-            },
-            "required": [
-              "task_ids"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Run tasks in parallel",
-            "readOnlyHint": false,
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": true
+            }
           }
         },
         {
           "name": "weather_extension__get_weather",
           "description": "Get the weather for a location",
           "inputSchema": {
-            "properties": {
-              "location": {
-                "description": "The city and state, e.g. San Francisco, CA",
-                "type": "string"
-              }
-            },
+            "type": "object",
             "required": [
               "location"
             ],
-            "type": "object"
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The city and state, e.g. San Francisco, CA"
+              }
+            }
           }
         }
       ]
@@ -596,7 +148,7 @@
       "message": {
         "id": null,
         "role": "assistant",
-        "created": 1765495263,
+        "created": 1770423954,
         "content": [
           {
             "type": "text",
@@ -611,25 +163,25 @@
       "usage": {
         "model": "gpt-4o-2024-08-06",
         "usage": {
-          "input_tokens": 1534,
+          "input_tokens": 866,
           "output_tokens": 18,
-          "total_tokens": 1552
+          "total_tokens": 884
         }
       }
     }
   },
-  "8b1b8633232ca390cb3ff37a48daf74168b58f13e2943efcb17957129ee34d1a": {
+  "1bc400a528c54b25f4f1f609481e98e44222b3deaf7eee2c9e640e6345c73861": {
     "input": {
-      "system": "Reply with only a description in four words or less",
+      "system": "You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.\ngoose is being developed as an open-source software project.\n\ngoose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o,\nclaude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).\nThese models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10\nmonths prior to the current date.\n\n# Extensions\n\nExtensions allow other applications to provide context to goose. Extensions connect goose to different data sources and\ntools.\nYou are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level\nproblems using the tools in these extensions, and can interact with multiple at once.\n\nIf the Extension Manager extension is enabled, you can use the search_available_extensions tool to discover additional\nextensions that can help with your task. To enable or disable extensions, use the manage_extensions tool with the\nextension_name. You should only enable extensions found from the search_available_extensions tool.\nIf Extension Manager is not available, you can only work with currently enabled extensions and cannot dynamically load\nnew ones.\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n\n## weather_extension\n\n\n\n\n# Response Guidelines\n\n- Use Markdown formatting for all responses.\n- Follow best practices for Markdown, including:\n    - Using headers for organization.\n    - Bullet points for lists.\n    - Links formatted correctly, either as linked text (e.g., [this is linked text](https://example.com)) or automatic\n      links using angle brackets (e.g., <http://example.com/>).\n- For code examples, use fenced code blocks by placing triple backticks (` ``` `) before and after the code. Include the\n  language identifier after the opening backticks (e.g., ` ```python `) to enable syntax highlighting.\n- Ensure clarity, conciseness, and proper formatting to enhance readability and usability.\n\n# Additional Instructions:\n\n\n### Global Hints\nThese are my global goose hints.\nThese are my global goose hints.",
       "messages": [
         {
-          "id": null,
+          "id": "msg_20260207_1_2bc5e542-e0c9-471c-a682-1a9476dd2856",
           "role": "user",
-          "created": 1765495261,
+          "created": 1770423951,
           "content": [
             {
               "type": "text",
-              "text": "Here are the first few user messages:\ntell me what the weather is in Berlin, Germany\n\nBased on the conversation so far, provide a concise description of this session in 4 words or less. This will be used for finding the session later in a UI with limited space - reply *ONLY* with the description"
+              "text": "tell me what the weather is in Berlin, Germany"
             }
           ],
           "metadata": {
@@ -638,17 +190,99 @@
           }
         }
       ],
-      "tools": []
+      "tools": [
+        {
+          "name": "subagent",
+          "description": "Delegate a task to a subagent that runs independently with its own context.\n\nModes:\n1. Ad-hoc: Provide `instructions` for a custom task\n2. Predefined: Provide `subrecipe` name to run a predefined task\n3. Augmented: Provide both `subrecipe` and `instructions` to add context\n\nThe subagent has access to the same tools as you by default. Use `extensions` to limit which extensions the subagent can use.\n\nFor parallel execution, make multiple `subagent` tool calls in the same message.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "instructions": {
+                "type": "string",
+                "description": "Instructions for the subagent. Required for ad-hoc tasks. For predefined tasks, adds additional context."
+              },
+              "subrecipe": {
+                "type": "string",
+                "description": "Name of a predefined subrecipe to run."
+              },
+              "parameters": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Parameters for the subrecipe. Only valid when 'subrecipe' is specified."
+              },
+              "extensions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Extensions to enable. Omit to inherit all, empty array for none."
+              },
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "description": "Override LLM provider"
+                  },
+                  "model": {
+                    "type": "string",
+                    "description": "Override model"
+                  },
+                  "temperature": {
+                    "type": "number",
+                    "description": "Override temperature"
+                  },
+                  "max_turns": {
+                    "type": "number",
+                    "description": "Override max turns"
+                  }
+                },
+                "description": "Override model/provider/settings."
+              },
+              "summary": {
+                "type": "boolean",
+                "default": true,
+                "description": "If true (default), return only the subagent's final summary."
+              }
+            }
+          }
+        },
+        {
+          "name": "weather_extension__get_weather",
+          "description": "Get the weather for a location",
+          "inputSchema": {
+            "type": "object",
+            "required": [
+              "location"
+            ],
+            "properties": {
+              "location": {
+                "type": "string",
+                "description": "The city and state, e.g. San Francisco, CA"
+              }
+            }
+          }
+        }
+      ]
     },
     "output": {
       "message": {
         "id": null,
         "role": "assistant",
-        "created": 1765495262,
+        "created": 1770423953,
         "content": [
           {
-            "type": "text",
-            "text": "Berlin weather inquiry"
+            "type": "toolRequest",
+            "id": "call_NwyWutYuGQ8wujr6Ae3dO6tL",
+            "toolCall": {
+              "status": "success",
+              "value": {
+                "name": "weather_extension__get_weather",
+                "arguments": {
+                  "location": "Berlin, Germany"
+                }
+              }
+            }
           }
         ],
         "metadata": {
@@ -659,9 +293,9 @@
       "usage": {
         "model": "gpt-4o-2024-08-06",
         "usage": {
-          "input_tokens": 84,
-          "output_tokens": 3,
-          "total_tokens": 87
+          "input_tokens": 824,
+          "output_tokens": 19,
+          "total_tokens": 843
         }
       }
     }

--- a/crates/goose-cli/src/scenario_tests/recordings/openai/what_is_your_name.json
+++ b/crates/goose-cli/src/scenario_tests/recordings/openai/what_is_your_name.json
@@ -1,12 +1,12 @@
 {
   "1b998117eba523901ae6a4dbf8caa81a95ea88ef7a84d0434c9b41a26164a2b9": {
     "input": {
-      "system": "You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.\ngoose is being developed as an open-source software project.\n\nThe current date is 2025-10-15 21:57:42.\n\ngoose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o,\nclaude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).\nThese models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10\nmonths prior to the current date.\n\n# Extensions\n\nExtensions allow other applications to provide context to goose. Extensions connect goose to different data sources and\ntools.\nYou are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level\nproblems using the tools in these extensions, and can interact with multiple at once.\nUse the search_available_extensions tool to find additional extensions to enable to help with your task. To enable\nextensions, use the enable_extension tool and provide the extension_name. You should only enable extensions found from\nthe search_available_extensions tool.\n\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n\n\n## weather_extension\n\n\n\n\n\n\n\n\n\n# Suggestion\n\n\"\"\n\n\n\n\n# sub agents\n\nExecute self contained tasks where step-by-step visibility is not important through subagents.\n\n- Delegate via `dynamic_task__create_task` for: result-only operations, parallelizable work, multi-part requests,\n  verification, exploration\n- Parallel subagents for multiple operations, single subagents for independent work\n- Explore solutions in parallel — launch parallel subagents with different approaches (if non-interfering)\n- Provide all needed context — subagents cannot see your context\n- Use extension filters to limit resource access\n- Use return_last_only when only a summary or simple answer is required — inform subagent of this choice.\n\n# Response Guidelines\n\n- Use Markdown formatting for all responses.\n- Follow best practices for Markdown, including:\n    - Using headers for organization.\n    - Bullet points for lists.\n    - Links formatted correctly, either as linked text (e.g., [this is linked text](https://example.com)) or automatic\n      links using angle brackets (e.g., <http://example.com/>).\n- For code examples, use fenced code blocks by placing triple backticks (` ``` `) before and after the code. Include the\n  language identifier after the opening backticks (e.g., ` ```python `) to enable syntax highlighting.\n- Ensure clarity, conciseness, and proper formatting to enhance readability and usability.\n\n# Additional Instructions:\n\nRight now you are *NOT* in the chat only mode and have access to tool use and system.",
+      "system": "You are a general-purpose AI agent called goose, created by Block, the parent company of Square, CashApp, and Tidal.\ngoose is being developed as an open-source software project.\n\ngoose uses LLM providers with tool calling capability. You can be used with different language models (gpt-4o,\nclaude-sonnet-4, o1, llama-3.2, deepseek-r1, etc).\nThese models have varying knowledge cut-off dates depending on when they were trained, but typically it's between 5-10\nmonths prior to the current date.\n\n# Extensions\n\nExtensions allow other applications to provide context to goose. Extensions connect goose to different data sources and\ntools.\nYou are capable of dynamically plugging into new extensions and learning how to use them. You solve higher level\nproblems using the tools in these extensions, and can interact with multiple at once.\n\nIf the Extension Manager extension is enabled, you can use the search_available_extensions tool to discover additional\nextensions that can help with your task. To enable or disable extensions, use the manage_extensions tool with the\nextension_name. You should only enable extensions found from the search_available_extensions tool.\nIf Extension Manager is not available, you can only work with currently enabled extensions and cannot dynamically load\nnew ones.\n\nBecause you dynamically load extensions, your conversation history may refer\nto interactions with extensions that are not currently active. The currently\nactive extensions are below. Each of these extensions provides tools that are\nin your tool specification.\n\n\n## weather_extension\n\n\n\n\n# Response Guidelines\n\n- Use Markdown formatting for all responses.\n- Follow best practices for Markdown, including:\n    - Using headers for organization.\n    - Bullet points for lists.\n    - Links formatted correctly, either as linked text (e.g., [this is linked text](https://example.com)) or automatic\n      links using angle brackets (e.g., <http://example.com/>).\n- For code examples, use fenced code blocks by placing triple backticks (` ``` `) before and after the code. Include the\n  language identifier after the opening backticks (e.g., ` ```python `) to enable syntax highlighting.\n- Ensure clarity, conciseness, and proper formatting to enhance readability and usability.\n\n# Additional Instructions:\n\n\n### Global Hints\nThese are my global goose hints.\nThese are my global goose hints.",
       "messages": [
         {
-          "id": null,
+          "id": "msg_20260207_1_084e0e53-1342-4e74-abad-41bac54e11b4",
           "role": "user",
-          "created": 1760565462,
+          "created": 1770423951,
           "content": [
             {
               "type": "text",
@@ -21,254 +21,75 @@
       ],
       "tools": [
         {
+          "name": "subagent",
+          "description": "Delegate a task to a subagent that runs independently with its own context.\n\nModes:\n1. Ad-hoc: Provide `instructions` for a custom task\n2. Predefined: Provide `subrecipe` name to run a predefined task\n3. Augmented: Provide both `subrecipe` and `instructions` to add context\n\nThe subagent has access to the same tools as you by default. Use `extensions` to limit which extensions the subagent can use.\n\nFor parallel execution, make multiple `subagent` tool calls in the same message.",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "instructions": {
+                "type": "string",
+                "description": "Instructions for the subagent. Required for ad-hoc tasks. For predefined tasks, adds additional context."
+              },
+              "subrecipe": {
+                "type": "string",
+                "description": "Name of a predefined subrecipe to run."
+              },
+              "parameters": {
+                "type": "object",
+                "additionalProperties": true,
+                "description": "Parameters for the subrecipe. Only valid when 'subrecipe' is specified."
+              },
+              "extensions": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Extensions to enable. Omit to inherit all, empty array for none."
+              },
+              "settings": {
+                "type": "object",
+                "properties": {
+                  "provider": {
+                    "type": "string",
+                    "description": "Override LLM provider"
+                  },
+                  "model": {
+                    "type": "string",
+                    "description": "Override model"
+                  },
+                  "temperature": {
+                    "type": "number",
+                    "description": "Override temperature"
+                  },
+                  "max_turns": {
+                    "type": "number",
+                    "description": "Override max turns"
+                  }
+                },
+                "description": "Override model/provider/settings."
+              },
+              "summary": {
+                "type": "boolean",
+                "default": true,
+                "description": "If true (default), return only the subagent's final summary."
+              }
+            }
+          }
+        },
+        {
           "name": "weather_extension__get_weather",
           "description": "Get the weather for a location",
           "inputSchema": {
-            "properties": {
-              "location": {
-                "description": "The city and state, e.g. San Francisco, CA",
-                "type": "string"
-              }
-            },
+            "type": "object",
             "required": [
               "location"
             ],
-            "type": "object"
-          }
-        },
-        {
-          "name": "platform__search_available_extensions",
-          "description": "Searches for additional extensions available to help complete tasks.\n        Use this tool when you're unable to find a specific feature or functionality you need to complete your task, or when standard approaches aren't working.\n        These extensions might provide the exact tools needed to solve your problem.\n        If you find a relevant one, consider using your tools to enable it.",
-          "inputSchema": {
-            "properties": {},
-            "required": [],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Discover extensions",
-            "readOnlyHint": true,
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": false
-          }
-        },
-        {
-          "name": "platform__manage_extensions",
-          "description": "Tool to manage extensions and tools in goose context.\n            Enable or disable extensions to help complete tasks.\n            Enable or disable an extension by providing the extension name.\n            ",
-          "inputSchema": {
             "properties": {
-              "action": {
-                "description": "The action to perform",
-                "enum": [
-                  "enable",
-                  "disable"
-                ],
-                "type": "string"
-              },
-              "extension_name": {
-                "description": "The name of the extension to enable",
-                "type": "string"
+              "location": {
+                "type": "string",
+                "description": "The city and state, e.g. San Francisco, CA"
               }
-            },
-            "required": [
-              "action",
-              "extension_name"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Enable or disable an extension",
-            "readOnlyHint": false,
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": false
-          }
-        },
-        {
-          "name": "platform__manage_schedule",
-          "description": "Manage scheduled recipe execution for this goose instance.\n\nActions:\n- \"list\": List all scheduled jobs\n- \"create\": Create a new scheduled job from a recipe file\n- \"run_now\": Execute a scheduled job immediately  \n- \"pause\": Pause a scheduled job\n- \"unpause\": Resume a paused job\n- \"delete\": Remove a scheduled job\n- \"kill\": Terminate a currently running job\n- \"inspect\": Get details about a running job\n- \"sessions\": List execution history for a job\n- \"session_content\": Get the full content (messages) of a specific session\n",
-          "inputSchema": {
-            "properties": {
-              "action": {
-                "enum": [
-                  "list",
-                  "create",
-                  "run_now",
-                  "pause",
-                  "unpause",
-                  "delete",
-                  "kill",
-                  "inspect",
-                  "sessions",
-                  "session_content"
-                ],
-                "type": "string"
-              },
-              "cron_expression": {
-                "description": "A cron expression for create action. Supports both 5-field (minute hour day month weekday) and 6-field (second minute hour day month weekday) formats. 5-field expressions are automatically converted to 6-field by prepending '0' for seconds.",
-                "type": "string"
-              },
-              "execution_mode": {
-                "default": "background",
-                "description": "Execution mode for create action: 'foreground' or 'background'",
-                "enum": [
-                  "foreground",
-                  "background"
-                ],
-                "type": "string"
-              },
-              "job_id": {
-                "description": "Job identifier for operations on existing jobs",
-                "type": "string"
-              },
-              "limit": {
-                "default": 50,
-                "description": "Limit for sessions list",
-                "type": "integer"
-              },
-              "recipe_path": {
-                "description": "Path to recipe file for create action",
-                "type": "string"
-              },
-              "session_id": {
-                "description": "Session identifier for session_content action",
-                "type": "string"
-              }
-            },
-            "required": [
-              "action"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Manage scheduled recipes",
-            "readOnlyHint": false,
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": false
-          }
-        },
-        {
-          "name": "dynamic_task__create_task",
-          "description": "Create tasks with instructions or prompt. For simple tasks, only include the instructions field. Extensions control: omit field = use all current extensions; empty array [] = no extensions; array with names = only those extensions. Specify extensions as shortnames (the prefixes for your tools). Specify return_last_only as true and have your subagent summarize its work in its last message to conserve your own context. Optional: title, description, extensions, settings, retry, response schema, context, activities. Arrays for multiple tasks.",
-          "inputSchema": {
-            "properties": {
-              "execution_mode": {
-                "description": "How to execute multiple tasks (default: parallel for multiple tasks, sequential for single task)",
-                "enum": [
-                  "sequential",
-                  "parallel"
-                ],
-                "type": "string"
-              },
-              "task_parameters": {
-                "description": "Array of tasks. Each task must have either 'instructions' OR 'prompt' field (at least one is required).",
-                "items": {
-                  "properties": {
-                    "activities": {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "context": {
-                      "items": {
-                        "type": "string"
-                      },
-                      "type": "array"
-                    },
-                    "description": {
-                      "type": "string"
-                    },
-                    "extensions": {
-                      "items": {
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "instructions": {
-                      "description": "Task instructions (required if prompt is not provided)",
-                      "type": "string"
-                    },
-                    "parameters": {
-                      "items": {
-                        "type": "object"
-                      },
-                      "type": "array"
-                    },
-                    "prompt": {
-                      "description": "Initial prompt (required if instructions is not provided)",
-                      "type": "string"
-                    },
-                    "response": {
-                      "type": "object"
-                    },
-                    "retry": {
-                      "type": "object"
-                    },
-                    "return_last_only": {
-                      "description": "If true, return only the last message from the subagent (default: false, returns full conversation)",
-                      "type": "boolean"
-                    },
-                    "settings": {
-                      "type": "object"
-                    },
-                    "title": {
-                      "type": "string"
-                    }
-                  },
-                  "type": "object"
-                },
-                "minItems": 1,
-                "type": "array"
-              }
-            },
-            "required": [
-              "task_parameters"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Create Dynamic Tasks",
-            "readOnlyHint": false,
-            "destructiveHint": false,
-            "idempotentHint": false,
-            "openWorldHint": true
-          }
-        },
-        {
-          "name": "subagent__execute_task",
-          "description": "Only use the subagent__execute_task tool when you execute sub recipe task or dynamic task.\n        EXECUTION STRATEGY DECISION:\n        1. If the tasks are created with execution_mode, use the execution_mode.\n        2. Execute tasks sequentially unless user explicitly requests parallel execution. PARALLEL: User uses keywords like 'parallel', 'simultaneously', 'at the same time', 'concurrently'\n\n        IMPLEMENTATION:\n        - Sequential execution: Call this tool multiple times, passing exactly ONE task per call\n        - Parallel execution: Call this tool once, passing an ARRAY of all tasks\n\n        EXAMPLES:\n        User Intent Based:\n        - User: 'get weather and tell me a joke' → Sequential (2 separate tool calls, 1 task each)\n        - User: 'get weather and joke in parallel' → Parallel (1 tool call with array of 2 tasks)\n        - User: 'run these simultaneously' → Parallel (1 tool call with task array)\n        - User: 'do task A then task B' → Sequential (2 separate tool calls)",
-          "inputSchema": {
-            "properties": {
-              "execution_mode": {
-                "default": "sequential",
-                "description": "Execution strategy for multiple tasks. Use 'sequential' (default) unless user explicitly requests parallel execution with words like 'parallel', 'simultaneously', 'at the same time', or 'concurrently'.",
-                "enum": [
-                  "sequential",
-                  "parallel"
-                ],
-                "type": "string"
-              },
-              "task_ids": {
-                "items": {
-                  "description": "Unique identifier for the task",
-                  "type": "string"
-                },
-                "type": "array"
-              }
-            },
-            "required": [
-              "task_ids"
-            ],
-            "type": "object"
-          },
-          "annotations": {
-            "title": "Run tasks in parallel",
-            "readOnlyHint": false,
-            "destructiveHint": true,
-            "idempotentHint": false,
-            "openWorldHint": true
+            }
           }
         }
       ]
@@ -277,11 +98,11 @@
       "message": {
         "id": null,
         "role": "assistant",
-        "created": 1760565463,
+        "created": 1770423954,
         "content": [
           {
             "type": "text",
-            "text": "My name is goose. I'm an AI agent developed by Block, the parent company of Square, CashApp, and Tidal. How can I assist you today?"
+            "text": "My name is goose, and I'm an AI agent created by Block. How can I assist you today?"
           }
         ],
         "metadata": {
@@ -292,9 +113,9 @@
       "usage": {
         "model": "gpt-4o-2024-08-06",
         "usage": {
-          "input_tokens": 1702,
-          "output_tokens": 34,
-          "total_tokens": 1736
+          "input_tokens": 818,
+          "output_tokens": 22,
+          "total_tokens": 840
         }
       }
     }

--- a/crates/goose-cli/src/scenario_tests/scenario_runner.rs
+++ b/crates/goose-cli/src/scenario_tests/scenario_runner.rs
@@ -204,7 +204,13 @@ where
     let temp_dir = TempDir::new()?;
     let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
     let permission_manager = Arc::new(PermissionManager::new(temp_dir.path().to_path_buf()));
-    let agent_config = AgentConfig::new(session_manager, permission_manager, None, GooseMode::Auto);
+    let agent_config = AgentConfig::new(
+        session_manager,
+        permission_manager,
+        None,
+        GooseMode::Auto,
+        true,
+    );
     let agent = Agent::with_config(agent_config);
     agent
         .extension_manager

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -94,6 +94,7 @@ pub struct AgentConfig {
     pub permission_manager: Arc<PermissionManager>,
     pub scheduler_service: Option<Arc<dyn SchedulerTrait>>,
     pub goose_mode: GooseMode,
+    pub disable_session_naming: bool,
 }
 
 impl AgentConfig {
@@ -102,12 +103,14 @@ impl AgentConfig {
         permission_manager: Arc<PermissionManager>,
         scheduler_service: Option<Arc<dyn SchedulerTrait>>,
         goose_mode: GooseMode,
+        disable_session_naming: bool,
     ) -> Self {
         Self {
             session_manager,
             permission_manager,
             scheduler_service,
             goose_mode,
+            disable_session_naming,
         }
     }
 }
@@ -189,6 +192,9 @@ impl Agent {
             PermissionManager::instance(),
             None,
             Config::global().get_goose_mode().unwrap_or(GooseMode::Auto),
+            Config::global()
+                .get_goose_disable_session_naming()
+                .unwrap_or(false),
         ))
     }
 
@@ -1112,10 +1118,7 @@ impl Agent {
         let provider = self.provider().await?;
         let session_manager = self.config.session_manager.clone();
         let session_id = session_config.id.clone();
-        let naming_disabled = Config::global()
-            .get_goose_disable_session_naming()
-            .unwrap_or(false);
-        if !naming_disabled {
+        if !self.config.disable_session_naming {
             let manager_for_spawn = session_manager.clone();
             tokio::spawn(async move {
                 if let Err(e) = manager_for_spawn

--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -89,6 +89,9 @@ impl AgentManager {
             permission_manager,
             Some(Arc::clone(&self.scheduler)),
             mode,
+            Config::global()
+                .get_goose_disable_session_naming()
+                .unwrap_or(false),
         );
         let agent = Arc::new(Agent::with_config(config));
         if let Some(provider) = &*self.default_provider.read().await {

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -128,6 +128,7 @@ mod tests {
                 permission_manager,
                 Some(mock_scheduler),
                 GooseMode::Auto,
+                false,
             );
             let agent = Agent::with_config(config);
 
@@ -168,6 +169,7 @@ mod tests {
                 permission_manager,
                 Some(mock_scheduler),
                 GooseMode::Auto,
+                false,
             );
             let agent = Agent::with_config(config);
 
@@ -221,6 +223,7 @@ mod tests {
                 permission_manager,
                 Some(mock_scheduler),
                 GooseMode::Auto,
+                false,
             );
             let agent = Agent::with_config(config);
 
@@ -541,6 +544,7 @@ mod tests {
                 PermissionManager::instance(),
                 None,
                 GooseMode::Auto,
+                false,
             );
 
             let agent = Agent::with_config(config);


### PR DESCRIPTION
## Summary

Move `disable_session_naming` from a global config read into an injectable `AgentConfig` parameter, following the `goose_mode` pattern.

- Promote `disable_session_naming` to `AgentConfig` and `AcpServerConfig`
- ACP tests set `true`, removing the `openai_session_description.json` fixture and session rename intercept
- Scenario tests set `true`, re-recorded OpenAI scenarios without the session naming interaction

### Type of Change
- [x] Refactor / Code quality
- [x] Tests

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

All existing tests pass with `cargo test` and `scripts/clippy-lint.sh`.

To re-record OpenAI scenarios:
```
rm crates/goose-cli/src/scenario_tests/recordings/openai/*.json
OPENAI_API_KEY=sk-... cargo test -p goose-cli scenario
```

### Related Issues
Builds on #7052
