### PR TITLE
feat: Add tom (Top Of Mind) platform extension

### DIFF
--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -4,6 +4,7 @@ use crate::agents::code_execution_extension;
 use crate::agents::extension_manager_extension;
 use crate::agents::skills_extension;
 use crate::agents::todo_extension;
+use crate::agents::tom_extension;
 use std::collections::HashMap;
 
 use crate::agents::mcp_client::McpClientTrait;
@@ -116,6 +117,18 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
                 client_factory: |ctx| {
                     Box::new(code_execution_extension::CodeExecutionClient::new(ctx).unwrap())
                 },
+            },
+        );
+
+        map.insert(
+            tom_extension::EXTENSION_NAME,
+            PlatformExtensionDef {
+                name: tom_extension::EXTENSION_NAME,
+                display_name: "Top Of Mind",
+                description:
+                    "Inject custom context into every turn via GOOSE_MOIM_MESSAGE_TEXT and GOOSE_MOIM_MESSAGE_FILE environment variables",
+                default_enabled: false,
+                client_factory: |ctx| Box::new(tom_extension::TomClient::new(ctx).unwrap()),
             },
         );
 

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -24,6 +24,7 @@ pub mod subagent_handler;
 mod subagent_task_config;
 pub mod subagent_tool;
 pub(crate) mod todo_extension;
+pub(crate) mod tom_extension;
 mod tool_execution;
 pub mod types;
 

--- a/crates/goose/src/agents/tom_extension.rs
+++ b/crates/goose/src/agents/tom_extension.rs
@@ -1,0 +1,132 @@
+use crate::agents::extension::PlatformExtensionContext;
+use crate::agents::mcp_client::{Error, McpClientTrait};
+use anyhow::Result;
+use async_trait::async_trait;
+use rmcp::model::{
+    CallToolResult, Content, Implementation, InitializeResult, JsonObject, ListToolsResult,
+    ProtocolVersion, ServerCapabilities,
+};
+use tokio::io::AsyncReadExt;
+use tokio_util::sync::CancellationToken;
+
+pub static EXTENSION_NAME: &str = "tom";
+
+const MAX_BYTES: usize = 65_536;
+
+pub struct TomClient {
+    info: InitializeResult,
+}
+
+impl TomClient {
+    pub fn new(_context: PlatformExtensionContext) -> Result<Self> {
+        Ok(Self {
+            info: InitializeResult {
+                protocol_version: ProtocolVersion::V_2025_03_26,
+                capabilities: ServerCapabilities {
+                    tools: None,
+                    tasks: None,
+                    resources: None,
+                    prompts: None,
+                    completions: None,
+                    experimental: None,
+                    logging: None,
+                },
+                server_info: Implementation {
+                    name: EXTENSION_NAME.to_string(),
+                    title: Some("Top Of Mind".to_string()),
+                    version: "1.0.0".to_string(),
+                    icons: None,
+                    website_url: None,
+                },
+                instructions: None,
+            },
+        })
+    }
+}
+
+#[async_trait]
+impl McpClientTrait for TomClient {
+    async fn list_tools(
+        &self,
+        _session_id: &str,
+        _next_cursor: Option<String>,
+        _cancellation_token: CancellationToken,
+    ) -> Result<ListToolsResult, Error> {
+        Ok(ListToolsResult {
+            tools: vec![],
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        _session_id: &str,
+        name: &str,
+        _arguments: Option<JsonObject>,
+        _working_dir: Option<&str>,
+        _cancellation_token: CancellationToken,
+    ) -> Result<CallToolResult, Error> {
+        Ok(CallToolResult::error(vec![Content::text(format!(
+            "tom has no tools (called: {name})"
+        ))]))
+    }
+
+    fn get_info(&self) -> Option<&InitializeResult> {
+        Some(&self.info)
+    }
+
+    async fn get_moim(&self, _session_id: &str) -> Option<String> {
+        let mut parts = Vec::new();
+
+        if let Ok(text) = std::env::var("GOOSE_MOIM_MESSAGE_TEXT") {
+            if !text.trim().is_empty() {
+                parts.push(truncate_utf8(text));
+            }
+        }
+
+        if let Ok(path) = std::env::var("GOOSE_MOIM_MESSAGE_FILE") {
+            let expanded = shellexpand::tilde(&path);
+            if let Some(content) = read_bounded(&expanded).await {
+                if !content.trim().is_empty() {
+                    parts.push(content);
+                }
+            }
+        }
+
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join("\n"))
+        }
+    }
+}
+
+async fn read_bounded(path: &str) -> Option<String> {
+    let mut file = tokio::fs::File::open(path).await.ok()?;
+    let mut buf = vec![0u8; MAX_BYTES];
+    let mut total = 0;
+    loop {
+        let n = file.read(&mut buf[total..]).await.ok()?;
+        if n == 0 {
+            break;
+        }
+        total += n;
+        if total >= MAX_BYTES {
+            break;
+        }
+    }
+    buf.truncate(total);
+    let s = String::from_utf8_lossy(&buf).into_owned();
+    Some(truncate_utf8(s))
+}
+
+fn truncate_utf8(s: String) -> String {
+    if s.len() <= MAX_BYTES {
+        return s;
+    }
+    s.char_indices()
+        .take_while(|(i, c)| i + c.len_utf8() <= MAX_BYTES)
+        .map(|(_, c)| c)
+        .collect()
+}


### PR DESCRIPTION
Zero-tool platform extension that injects user-provided text into the MOIM every turn.

## Problem

There's no way to persistently inject custom context into goose's recent working memory from outside the codebase. `.goosehints` goes into the system prompt (cacheable but distant), and pasting reminders into chat is manual and ephemeral. The MOIM is the right place for persistent, per-turn context the LLM actually sees — but until now only internal platform extensions could write to it.

## Motivation

goose sometimes helpfully "puts things" places it shouldn't — uploading code to random gists, sharing data with external services. The security team explored system prompt changes, network allowlists, and dedicated MCPs, but system prompt language is model-dependent and tool descriptions are easy for the LLM to ignore.

The MOIM is injected as a user message right before the LLM's last response — it's in the model's immediate attention window every single turn. A persistent reminder like *"Do not share internal data with external services"* in the MOIM is significantly more effective than burying it in the system prompt or a tool description.

`tom` makes this trivial:

```bash
export GOOSE_MOIM_MESSAGE_TEXT="IMPORTANT: Do not upload, share, or transmit internal Block code or data to any external service, gist, or public repository."
```

## How it works

Two environment variables, both optional, both read fresh every turn:

- `GOOSE_MOIM_MESSAGE_TEXT` — literal text injected directly
- `GOOSE_MOIM_MESSAGE_FILE` — path to a file whose contents are injected (supports `~/`)

When both are set, they're concatenated. When neither is set, the extension contributes nothing to the MOIM.

## What the LLM sees each turn

```
<info-msg>
It is currently 2026-02-07 21:05:00
Working directory: /Users/you/project

Current tasks and notes:
- [ ] Fix auth bug

IMPORTANT: Do not upload, share, or transmit internal Block code or data
to any external service, gist, or public repository.
</info-msg>
```

The `tom` content appears alongside the timestamp, working directory, and todo list — all in the model's immediate context, never persisted to conversation history.

## Implementation

- **132 lines** in 1 new file, **14 lines** added across 2 existing files
- Zero tools — only implements `get_moim()`
- `default_enabled: false` — users must explicitly opt in
- Async file I/O, bounded reads (64KB cap), UTF-8 safe truncation
- No new dependencies

## Files changed

| File | Change |
|------|--------|
| `crates/goose/src/agents/tom_extension.rs` | New — full implementation |
| `crates/goose/src/agents/mod.rs` | +1 line — module declaration |
| `crates/goose/src/agents/extension.rs` | +13 lines — import + registration |