### PR TITLE
fix: remove Option from model listing return types, propagate errors

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -691,15 +691,15 @@ pub async fn configure_provider_dialog() -> anyhow::Result<bool> {
     };
     spin.stop(style("Model fetch complete").green());
 
-    // Select a model: on fetch error show styled error and abort; if Some(models), show list; if None, free-text input
+    // Select a model: on fetch error show styled error and abort; if models available, show list; otherwise free-text input
     let model: String = match models_res {
         Err(e) => {
             // Provider hook error
             cliclack::outro(style(e.to_string()).on_red().white())?;
             return Ok(false);
         }
-        Ok(Some(models)) => select_model_from_list(&models, provider_meta)?,
-        Ok(None) => {
+        Ok(models) if !models.is_empty() => select_model_from_list(&models, provider_meta)?,
+        Ok(_) => {
             let default_model =
                 std::env::var("GOOSE_MODEL").unwrap_or(provider_meta.default_model.clone());
             cliclack::input("Enter a model from that provider:")

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -372,19 +372,6 @@ pub async fn providers() -> Result<Json<Vec<ProviderDetails>>, ErrorResponse> {
 pub async fn get_provider_models(
     Path(name): Path<String>,
 ) -> Result<Json<Vec<String>>, ErrorResponse> {
-    let loaded_provider = goose::config::declarative_providers::load_provider(name.as_str()).ok();
-    // TODO(Douwe): support a get models url for custom providers
-    if let Some(loaded_provider) = loaded_provider {
-        return Ok(Json(
-            loaded_provider
-                .config
-                .models
-                .into_iter()
-                .map(|m| m.name)
-                .collect::<Vec<_>>(),
-        ));
-    }
-
     let all = get_providers().await.into_iter().collect::<Vec<_>>();
     let Some((metadata, provider_type)) = all.into_iter().find(|(m, _)| m.name == name) else {
         return Err(ErrorResponse::bad_request(format!(
@@ -405,8 +392,7 @@ pub async fn get_provider_models(
     let models_result = provider.fetch_recommended_models().await;
 
     match models_result {
-        Ok(Some(models)) => Ok(Json(models)),
-        Ok(None) => Ok(Json(Vec::new())),
+        Ok(models) => Ok(Json(models)),
         Err(provider_error) => Err(provider_error.into()),
     }
 }

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -31,9 +31,12 @@ async fn enhance_model_error(error: ProviderError, provider: &Arc<dyn Provider>)
         return error;
     }
 
-    let Ok(Some(models)) = provider.fetch_recommended_models().await else {
+    let Ok(models) = provider.fetch_recommended_models().await else {
         return error;
     };
+    if models.is_empty() {
+        return error;
+    }
 
     ProviderError::RequestFailed(format!(
         "{}. Available models for this provider: {}",

--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -256,7 +256,7 @@ impl Provider for AnthropicProvider {
         Ok((message, provider_usage))
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self.api_client.request(None, "v1/models").api_get().await?;
 
         if response.status != StatusCode::OK {
@@ -267,17 +267,18 @@ impl Provider for AnthropicProvider {
         }
 
         let json = response.payload.unwrap_or_default();
-        let arr = match json.get("data").and_then(|v| v.as_array()) {
-            Some(arr) => arr,
-            None => return Ok(None),
-        };
+        let arr = json.get("data").and_then(|v| v.as_array()).ok_or_else(|| {
+            ProviderError::RequestFailed(
+                "Missing 'data' array in Anthropic models response".to_string(),
+            )
+        })?;
 
         let mut models: Vec<String> = arr
             .iter()
             .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(str::to_string))
             .collect();
         models.sort();
-        Ok(Some(models))
+        Ok(models)
     }
 
     async fn stream(

--- a/crates/goose/src/providers/auto_detect.rs
+++ b/crates/goose/src/providers/auto_detect.rs
@@ -31,7 +31,9 @@ pub async fn detect_provider_from_api_key(api_key: &str) -> Option<(String, Vec<
                         })
                         .await
                         {
-                            Ok(Some(models)) => Some((provider_name.to_string(), models)),
+                            Ok(models) if !models.is_empty() => {
+                                Some((provider_name.to_string(), models))
+                            }
                             _ => None,
                         }
                     }

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -447,16 +447,13 @@ pub trait Provider: Send + Sync {
         RetryConfig::default()
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
-        Ok(None)
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        Ok(vec![])
     }
 
     /// Fetch models filtered by canonical registry and usability
-    async fn fetch_recommended_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
-        let all_models = match self.fetch_supported_models().await? {
-            Some(models) => models,
-            None => return Ok(None),
-        };
+    async fn fetch_recommended_models(&self) -> Result<Vec<String>, ProviderError> {
+        let all_models = self.fetch_supported_models().await?;
 
         let registry = CanonicalModelRegistry::bundled().map_err(|e| {
             ProviderError::ExecutionError(format!("Failed to load canonical registry: {}", e))
@@ -501,9 +498,9 @@ pub trait Provider: Send + Sync {
             .collect();
 
         if recommended_models.is_empty() {
-            Ok(Some(all_models))
+            Ok(all_models)
         } else {
-            Ok(Some(recommended_models))
+            Ok(recommended_models)
         }
     }
 

--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -301,6 +301,10 @@ impl Provider for BedrockProvider {
         self.model.clone()
     }
 
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        Ok(BEDROCK_KNOWN_MODELS.iter().map(|s| s.to_string()).collect())
+    }
+
     #[tracing::instrument(
         skip(self, model_config, system, messages, tools),
         fields(model_config, input, output, input_tokens, output_tokens, total_tokens)

--- a/crates/goose/src/providers/canonical/build_canonical_models.rs
+++ b/crates/goose/src/providers/canonical/build_canonical_models.rs
@@ -493,13 +493,9 @@ async fn check_provider(
     };
 
     let fetched_models = match provider.fetch_supported_models().await {
-        Ok(Some(models)) => {
+        Ok(models) => {
             println!("  ✓ Fetched {} models", models.len());
             models
-        }
-        Ok(None) => {
-            println!("  ⚠ Provider does not support model listing");
-            Vec::new()
         }
         Err(e) => {
             println!("  ⚠ Failed to fetch models: {}", e);
@@ -509,11 +505,10 @@ async fn check_provider(
     };
 
     let recommended_models = match provider.fetch_recommended_models().await {
-        Ok(Some(models)) => {
+        Ok(models) => {
             println!("  ✓ Found {} recommended models", models.len());
             models
         }
-        Ok(None) => Vec::new(),
         Err(e) => {
             println!("  ⚠ Failed to fetch recommended models: {}", e);
             Vec::new()

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -985,13 +985,11 @@ impl Provider for ChatGptCodexProvider {
         Ok(())
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
-        Ok(Some(
-            CHATGPT_CODEX_KNOWN_MODELS
-                .iter()
-                .map(|s| s.to_string())
-                .collect(),
-        ))
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        Ok(CHATGPT_CODEX_KNOWN_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect())
     }
 }
 

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -493,6 +493,13 @@ impl Provider for ClaudeCodeProvider {
         self.model.clone()
     }
 
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        Ok(CLAUDE_CODE_KNOWN_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect())
+    }
+
     #[tracing::instrument(
         skip(self, model_config, system, messages, tools),
         fields(model_config, input, output, input_tokens, output_tokens, total_tokens)

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -662,10 +662,8 @@ impl Provider for CodexProvider {
         ))
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
-        Ok(Some(
-            CODEX_KNOWN_MODELS.iter().map(|s| s.to_string()).collect(),
-        ))
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        Ok(CODEX_KNOWN_MODELS.iter().map(|s| s.to_string()).collect())
     }
 }
 

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -355,6 +355,13 @@ impl Provider for CursorAgentProvider {
         self.model.clone()
     }
 
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        Ok(CURSOR_AGENT_KNOWN_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect())
+    }
+
     #[tracing::instrument(
         skip(self, model_config, system, messages, tools),
         fields(model_config, input, output, input_tokens, output_tokens, total_tokens)

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -695,10 +695,10 @@ impl Provider for GcpVertexAIProvider {
         }))
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let models: Vec<String> = KNOWN_MODELS.iter().map(|s| s.to_string()).collect();
         let filtered = self.filter_by_org_policy(models).await;
-        Ok(Some(filtered))
+        Ok(filtered)
     }
 }
 

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -267,6 +267,13 @@ impl Provider for GeminiCliProvider {
         self.model.clone()
     }
 
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        Ok(GEMINI_CLI_KNOWN_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect())
+    }
+
     #[tracing::instrument(
         skip(self, _model_config, system, messages, tools),
         fields(model_config, input, output, input_tokens, output_tokens, total_tokens)

--- a/crates/goose/src/providers/lead_worker.rs
+++ b/crates/goose/src/providers/lead_worker.rs
@@ -445,22 +445,14 @@ impl Provider for LeadWorkerProvider {
         final_result
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         // Combine models from both providers
-        let lead_models = self.lead_provider.fetch_supported_models().await?;
+        let mut all_models = self.lead_provider.fetch_supported_models().await?;
         let worker_models = self.worker_provider.fetch_supported_models().await?;
-
-        match (lead_models, worker_models) {
-            (Some(lead), Some(worker)) => {
-                let mut all_models = lead;
-                all_models.extend(worker);
-                all_models.sort();
-                all_models.dedup();
-                Ok(Some(all_models))
-            }
-            (Some(models), None) | (None, Some(models)) => Ok(Some(models)),
-            (None, None) => Ok(None),
-        }
+        all_models.extend(worker_models);
+        all_models.sort();
+        all_models.dedup();
+        Ok(all_models)
     }
 
     fn supports_embeddings(&self) -> bool {

--- a/crates/goose/src/providers/litellm.rs
+++ b/crates/goose/src/providers/litellm.rs
@@ -223,17 +223,11 @@ impl Provider for LiteLLMProvider {
         self.model.model_name.to_lowercase().contains("claude")
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
-        match self.fetch_models().await {
-            Ok(models) => {
-                let model_names: Vec<String> = models.into_iter().map(|m| m.name).collect();
-                Ok(Some(model_names))
-            }
-            Err(e) => {
-                tracing::warn!("Failed to fetch models from LiteLLM: {}", e);
-                Ok(None)
-            }
-        }
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        let models = self.fetch_models().await.map_err(|e| {
+            ProviderError::RequestFailed(format!("Failed to fetch models from LiteLLM: {}", e))
+        })?;
+        Ok(models.into_iter().map(|m| m.name).collect())
     }
 }
 

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -307,7 +307,7 @@ impl Provider for OllamaProvider {
         stream_ollama(response, log)
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client
             .request(None, "api/tags")
@@ -340,7 +340,7 @@ impl Provider for OllamaProvider {
 
         model_names.sort();
 
-        Ok(Some(model_names))
+        Ok(model_names)
     }
 }
 

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -353,7 +353,7 @@ impl Provider for OpenAiProvider {
         }
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let models_path = self.base_path.replace("v1/chat/completions", "v1/models");
         let response = self
             .api_client
@@ -377,7 +377,7 @@ impl Provider for OpenAiProvider {
             .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(str::to_string))
             .collect();
         models.sort();
-        Ok(Some(models))
+        Ok(models)
     }
 
     fn supports_embeddings(&self) -> bool {

--- a/crates/goose/src/providers/openai_compatible.rs
+++ b/crates/goose/src/providers/openai_compatible.rs
@@ -112,7 +112,7 @@ impl Provider for OpenAiCompatibleProvider {
         Ok((message, ProviderUsage::new(response_model, usage)))
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client
             .response_get(None, "models")
@@ -128,18 +128,15 @@ impl Provider for OpenAiCompatibleProvider {
             return Err(ProviderError::Authentication(msg.to_string()));
         }
 
-        let data = json.get("data").and_then(|v| v.as_array());
-        match data {
-            Some(arr) => {
-                let mut models: Vec<String> = arr
-                    .iter()
-                    .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(str::to_string))
-                    .collect();
-                models.sort();
-                Ok(Some(models))
-            }
-            None => Ok(None),
-        }
+        let arr = json.get("data").and_then(|v| v.as_array()).ok_or_else(|| {
+            ProviderError::RequestFailed("Missing 'data' array in models response".to_string())
+        })?;
+        let mut models: Vec<String> = arr
+            .iter()
+            .filter_map(|m| m.get("id").and_then(|v| v.as_str()).map(str::to_string))
+            .collect();
+        models.sort();
+        Ok(models)
     }
 
     fn supports_streaming(&self) -> bool {

--- a/crates/goose/src/providers/snowflake.rs
+++ b/crates/goose/src/providers/snowflake.rs
@@ -328,6 +328,13 @@ impl Provider for SnowflakeProvider {
         self.model.clone()
     }
 
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
+        Ok(SNOWFLAKE_KNOWN_MODELS
+            .iter()
+            .map(|s| s.to_string())
+            .collect())
+    }
+
     #[tracing::instrument(
         skip(self, model_config, system, messages, tools),
         fields(model_config, input, output, input_tokens, output_tokens, total_tokens)

--- a/crates/goose/src/providers/venice.rs
+++ b/crates/goose/src/providers/venice.rs
@@ -239,7 +239,7 @@ impl Provider for VeniceProvider {
         self.model.clone()
     }
 
-    async fn fetch_supported_models(&self) -> Result<Option<Vec<String>>, ProviderError> {
+    async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client
             .request(None, &self.models_path)
@@ -264,7 +264,7 @@ impl Provider for VeniceProvider {
             })
             .collect::<Vec<String>>();
         models.sort();
-        Ok(Some(models))
+        Ok(models)
     }
 
     #[tracing::instrument(

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -374,19 +374,17 @@ impl ProviderTester {
         dbg!(&models);
         println!("===================");
 
-        if let Some(models) = models {
-            assert!(!models.is_empty(), "Expected non-empty model list");
-            let model_name = &self.provider.get_model_config().model_name;
-            // Some providers (e.g. Ollama) return names with tags like "qwen3:latest"
-            // while the configured model name may be just "qwen3".
-            assert!(
-                models
-                    .iter()
-                    .any(|m| m == model_name || m.starts_with(&format!("{}:", model_name))),
-                "Expected model '{}' in supported models",
-                model_name
-            );
-        }
+        assert!(!models.is_empty(), "Expected non-empty model list");
+        let model_name = &self.provider.get_model_config().model_name;
+        // Some providers (e.g. Ollama) return names with tags like "qwen3:latest"
+        // while the configured model name may be just "qwen3".
+        assert!(
+            models
+                .iter()
+                .any(|m| m == model_name || m.starts_with(&format!("{}:", model_name))),
+            "Expected model '{}' in supported models",
+            model_name
+        );
         Ok(())
     }
 


### PR DESCRIPTION
## Summary

Remove `Option` from `fetch_supported_models` and `fetch_recommended_models` return types. An empty vec already means "no models" — the `Option` wrapper just forced every caller to handle `None` differently.

Additionally, dynamic providers now propagate errors instead of swallowing them into `Ok(None)`. This ensures misconfigured providers (e.g. bad credentials, unreachable host) surface errors to the desktop and CLI rather than silently returning no models.

### Type of Change
- [x] Refactor / Code quality

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

providers test with ollama:
<details>

```bash
$ OLLAMA_HOST=http://localhost:11434 cargo test -p goose --test providers -- test_ollama_provider --nocapture                                                
Compiling tonic v0.12.3
Compiling goose-mcp v1.23.0 (/Users/codefromthecrypt/oss/goose-goosed/crates/goose-mcp)
Compiling opentelemetry-proto v0.27.0
Compiling opentelemetry-otlp v0.27.0
Compiling goose v1.23.0 (/Users/codefromthecrypt/oss/goose-goosed/crates/goose)
Finished `test` profile [unoptimized + debuginfo] target(s) in 37.60s
Running tests/providers.rs (target/debug/deps/providers-28809165ae79d804)

running 1 test
=== Ollama::model_listing ===
[crates/goose/tests/providers.rs:374:9] &models = [
"all-minilm:33m",
"all-minilm:l6-v2",
"devstral:latest",
"gemma3:latest",
"llama3.2:latest",
"nomic-embed-text:latest",
"qwen2.5-coder:32b",
"qwen2.5:0.5b",
"qwen2.5:latest",
"qwen3-vl:2b",
"qwen3-vl:latest",
"qwen3:0.6b",
"qwen3:1.7b",
"qwen3:4b",
"qwen3:latest",
]
===================
=== Ollama::reponse1 ===
[crates/goose/tests/providers.rs:154:9] &response1 = Message {
id: None,
role: Assistant,
created: 1770519075,
content: [
Text(
Annotated {
raw: RawTextContent {
text: "",
meta: None,
},
annotations: None,
},
),
ToolRequest(
ToolRequest {
id: "call_p694a081",
tool_call: Ok(
CallToolRequestParams {
meta: None,
name: "get_weather",
arguments: Some(
{
"location": String("San Francisco, CA"),
},
),
task: None,
},
),
metadata: None,
tool_meta: None,
},
),
],
metadata: MessageMetadata {
user_visible: true,
agent_visible: true,
},
}
===================
=== Ollama::reponse2 ===
[crates/goose/tests/providers.rs:203:9] &response2 = Message {
id: None,
role: Assistant,
created: 1770519079,
content: [
Text(
Annotated {
raw: RawTextContent {
text: "The weather in San Francisco is currently **Clear** with a temperature of **50°F (10°C)**. Conditions show **0% precipitation**, **84% humidity**, and **2 mph wind**. This forecast is valid for Saturday at 9:00 PM. ☀\u{fe0f}",
meta: None,
},
annotations: None,
},
),
],
metadata: MessageMetadata {
user_visible: true,
agent_visible: true,
},
}
===================
=== Ollama::context_length_exceeded_error ===
[crates/goose/tests/providers.rs:247:9] &result = Ok(
(
Message {
id: None,
role: Assistant,
created: 1770519089,
content: [
Text(
Annotated {
raw: RawTextContent {
text: "no",
meta: None,
},
annotations: None,
},
),
],
metadata: MessageMetadata {
user_visible: true,
agent_visible: true,
},
},
ProviderUsage {
model: "qwen3",
usage: Usage {
input_tokens: Some(
79,
),
output_tokens: Some(
691,
),
total_tokens: Some(
770,
),
},
},
),
)
===================
Test image not found at crates/goose/examples/test_assets/test_image.png, skipping image test
test test_ollama_provider ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 13 filtered out; finished in 19.35s


============== Providers ==============
✅ Ollama
=======================================
```
</details>

### Related Issues

Obviates #7065