### PR TITLE
Fix: Only send command content to command injection classifier (excluding part of tool call dict)

### DIFF
--- a/crates/goose/src/security/scanner.rs
+++ b/crates/goose/src/security/scanner.rs
@@ -350,12 +350,13 @@ impl PromptInjectionScanner {
     }
 
     fn extract_tool_content(&self, tool_call: &CallToolRequestParams) -> String {
-        if let Some(args) = &tool_call.arguments {
-            if let Some(command_value) = args.get("command") {
-                if let Some(cmd_str) = command_value.as_str() {
-                    return cmd_str.to_string();
-                }
-            }
+        if let Some(cmd_str) = tool_call
+            .arguments
+            .as_ref()
+            .and_then(|args| args.get("command"))
+            .and_then(|v| v.as_str())
+        {
+            return cmd_str.to_string();
         }
 
         let mut s = format!("Tool: {}", tool_call.name);


### PR DESCRIPTION
## Summary
Modified command injection scanning to send only the raw command string (e.g., `grep -n "..."`) to the ML classifier, instead of the JSON-wrapped format (`{"command":"grep -n \"...\""}`) which makes the injection score slightly higher. 

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [x] Performance improvement
- [ ] Documentation
- [ ] Tests
- [x] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Local/manual testing with debug logging using `just run-ui`



