### PR TITLE
fix: use command.process_group(0) for CLI providers, not just MCP

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -41,7 +41,7 @@ use crate::config::search_path::SearchPaths;
 use crate::config::{get_all_extensions, Config};
 use crate::oauth::oauth_flow;
 use crate::prompt_template;
-use crate::subprocess::configure_command_no_window;
+use crate::subprocess::configure_subprocess;
 use rmcp::model::{
     CallToolRequestParams, Content, ErrorCode, ErrorData, GetPromptResult, Prompt, Resource,
     ResourceContents, ServerInfo, Tool,
@@ -206,7 +206,7 @@ async fn child_process_client(
     working_dir: Option<&PathBuf>,
     docker_container: Option<String>,
 ) -> ExtensionResult<McpClient> {
-    configure_command_no_window(&mut command);
+    configure_subprocess(&mut command);
 
     if let Ok(path) = SearchPaths::builder().path() {
         command.env("PATH", path);

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -16,7 +16,7 @@ use crate::config::search_path::SearchPaths;
 use crate::config::{Config, GooseMode};
 use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
-use crate::subprocess::configure_command_no_window;
+use crate::subprocess::configure_subprocess;
 use rmcp::model::Tool;
 
 const CLAUDE_CODE_PROVIDER_NAME: &str = "claude-code";
@@ -278,7 +278,7 @@ impl ClaudeCodeProvider {
             .get_or_try_init(|| async {
                 let mut cmd = Command::new(&self.command);
                 // NO -p flag — persistent mode
-                configure_command_no_window(&mut cmd);
+                configure_subprocess(&mut cmd);
                 cmd.arg("--input-format")
                     .arg("stream-json")
                     .arg("--output-format")

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -19,7 +19,7 @@ use crate::config::search_path::SearchPaths;
 use crate::config::{Config, GooseMode};
 use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
-use crate::subprocess::configure_command_no_window;
+use crate::subprocess::configure_subprocess;
 use rmcp::model::Role;
 use rmcp::model::Tool;
 
@@ -155,7 +155,7 @@ impl CodexProvider {
         }
 
         let mut cmd = Command::new(&self.command);
-        configure_command_no_window(&mut cmd);
+        configure_subprocess(&mut cmd);
 
         // Propagate extended PATH so the codex subprocess can find Node.js
         // and other dependencies (especially when launched from the desktop app

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -14,7 +14,7 @@ use crate::config::base::CursorAgentCommand;
 use crate::config::search_path::SearchPaths;
 use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
-use crate::subprocess::configure_command_no_window;
+use crate::subprocess::configure_subprocess;
 use futures::future::BoxFuture;
 use rmcp::model::Tool;
 
@@ -197,7 +197,7 @@ impl CursorAgentProvider {
         }
 
         let mut cmd = Command::new(&self.command);
-        configure_command_no_window(&mut cmd);
+        configure_subprocess(&mut cmd);
 
         if let Ok(path) = SearchPaths::builder().with_npm().path() {
             cmd.env("PATH", path);

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -15,7 +15,7 @@ use crate::config::Config;
 use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
 use crate::providers::base::ConfigKey;
-use crate::subprocess::configure_command_no_window;
+use crate::subprocess::configure_subprocess;
 use futures::future::BoxFuture;
 use rmcp::model::Role;
 use rmcp::model::Tool;
@@ -92,7 +92,7 @@ impl GeminiCliProvider {
         }
 
         let mut cmd = Command::new(&self.command);
-        configure_command_no_window(&mut cmd);
+        configure_subprocess(&mut cmd);
 
         if let Ok(path) = SearchPaths::builder().with_npm().path() {
             cmd.env("PATH", path);

--- a/crates/goose/src/subprocess.rs
+++ b/crates/goose/src/subprocess.rs
@@ -4,7 +4,7 @@ use tokio::process::Command;
 const CREATE_NO_WINDOW_FLAG: u32 = 0x08000000;
 
 #[allow(unused_variables)]
-pub fn configure_command_no_window(command: &mut Command) {
+pub fn configure_subprocess(command: &mut Command) {
     // Isolate subprocess into its own process group so it does not receive
     // SIGINT when the user presses Ctrl+C in the terminal.
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

Ctrl+C cannot cancel CLI provider responses — the user must wait for the full response. The subprocess shares the parent's process group and receives SIGINT directly, racing with goose's `cancel_token` and preventing the cancel branch from firing.

MCP servers already had `process_group(0)` in `extension_manager.rs`. This PR centralizes it into `configure_command_no_window()` in `subprocess.rs`, isolating all subprocesses. With the fix, the subprocess never receives SIGINT and the cancel token wins cleanly.

I could not reproduce the "Broken pipe" from #7070 — the `claude` CLI (2.1.37) survives SIGINT. Other CLI providers may not. The fix eliminates this variable.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

Before (`goose` v1.23.2, no `process_group(0)` on CLI providers): Ctrl+C has no effect. The response completes in full and cannot be interrupted.
```bash
$ goose --version                                                                                                                                                                 
 1.23.2
$ claude --version
2.1.37 (Claude Code)
$ goose
starting session | provider: claude-code model: claude-sonnet-4-20250514
    session id: 20260209_22
    working directory: /Users/codefromthecrypt/oss/goose

goose is running! Enter your instructions, or try asking what goose can do.

Context: ○○○○○○○○○○ 0% (0/200000 tokens)
( O)> write a poem
Here's a poem for you:

---

**The Goose That Codes**

A goose once wandered through the wire,
Through circuits humming, climbing higher,
Not feathered wings but Rust and steel,
With tools and agents at its heel.

It parsed the prompts, it read the files,
It traversed directories for miles,
Through crates and modules, line by line,
It made the tangled code align.

"Honk!" it said, or so we'd dream,
As tokens flowed in endless stream,
No pond, no bread, no grassy lawn—
Just terminals from dusk to dawn.

So raise a cup to goose, our friend,
Who'll debug with you until the end,
An agent born of open source,
A most magnificent digital goose. 🪿

---

⏱️  Elapsed time: 9.87s
Context: ○○○○○○○○○○ 0% (4/200000 tokens)
( O)> write a poem again
Here's another one for you:
--snip--
```

After (dev build with `process_group(0)` in `subprocess.rs`): Ctrl+C cancels immediately. Retry works.
```bash
$ cargo build -p goose-cli
--snip--
$ target/debug/goose
starting session | provider: claude-code model: claude-sonnet-4-20250514
    session id: 20260209_19
    working directory: /Users/codefromthecrypt/oss/goose

goose is running! Enter your instructions, or try asking what goose can do.

Context: ○○○○○○○○○○ 0% (0/200000 tokens)
( O)> write a poem
◒  Unifying understanding units...                                                                                                                                                                               ^CInterrupted before the model replied and removed the last message.

⏱️  Elapsed time: 0.59s
Context: ○○○○○○○○○○ 0% (0/200000 tokens)
( O)> write a poem again
◓  Exploring solution space...                                                                                                                                                                                   ◓  Exploring solution space...                                                                                                                                                                                   ◒  Exploring solution space...                                                                                                                                                                                   Interrupted before the model replied and removed the last message.

⏱️  Elapsed time: 1.48s
Context: ○○○○○○○○○○ 0% (0/200000 tokens)
```

### Related Issues

Relates to #7070 once this change is in, the original "ctrl-c" test should be retried with the latest version of `claude-code`.

Related claude-code issues: [#16135](https://github.com/anthropics/claude-code/issues/16135), [#17466](https://github.com/anthropics/claude-code/issues/17466)

**Follow-up:** The surviving subprocess may continue writing stale output after Ctrl+C. A follow-up PR will drain or cancel this before the next turn.