### PR TITLE
ci: enable agentic provider live tests (claude-code, codex, gemini-cli)

### DIFF
--- a/.github/workflows/pr-smoke-test.yml
+++ b/.github/workflows/pr-smoke-test.yml
@@ -95,11 +95,21 @@ jobs:
       - name: Make Binary Executable
         run: chmod +x target/debug/goose
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install agentic providers
+        run: npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli
+
       - name: Run Smoke Tests with Provider Script
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
@@ -171,11 +181,21 @@ jobs:
       - name: Make Binary Executable
         run: chmod +x target/debug/goose
 
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install agentic providers
+        run: npm install -g @anthropic-ai/claude-code @openai/codex @google/gemini-cli
+
       - name: Run Provider Tests (Code Execution Mode)
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          CODEX_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+          GEMINI_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           DATABRICKS_HOST: ${{ secrets.DATABRICKS_HOST }}
           DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}


### PR DESCRIPTION
## Summary

Enable agentic provider live tests in CI. These providers were conditionally included in `test_providers.sh` but always skipped because the CLI tools weren't installed.

This sets up claude-code, codex, gemini-cli because we have credentials for them already. This doesn't do cursor-agent as it needs authentication we don't already have. Someone could follow-up.

Here are the main changes
- Install `@anthropic-ai/claude-code`, `@openai/codex`, `@google/gemini-cli` via npm in both smoke test jobs
- Map exiting creds to `CODEX_API_KEY` and `GEMINI_API_KEY`  env vars
- Agentic providers use a file-read prompt with known content marker (`test-content-abc123`) instead of the shell/ls prompt, since they handle tools internally and can't produce `shell | developer` log patterns
- Skip agentic providers in `--code-exec` mode, as we currently don't export our extensions to agents as MCP.

### Type of Change
- [x] Tests
- [x] Build / Release

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Verified all three agentic providers pass in CI: https://github.com/block/goose/actions/runs/21844636599

```bash
2026-02-09T23:20:41.0261178Z ✓ claude-code: claude-sonnet-4-20250514                                                                                                              
2026-02-09T23:20:41.0261740Z ✓ codex: gpt-5.2-codex                                                                                                                               
2026-02-09T23:20:41.0262283Z ✓ gemini-cli: gemini-2.5-pro   
```