### PR TITLE
fix: allow unlisted models for CLI providers

### DIFF
--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -865,6 +865,7 @@ impl ProviderDef for ChatGptCodexProvider {
                 None,
             )],
         )
+        .with_unlisted_models()
     }
 
     fn from_env(model: ModelConfig) -> BoxFuture<'static, Result<Self::Provider>> {

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -475,6 +475,7 @@ impl ProviderDef for ClaudeCodeProvider {
             CLAUDE_CODE_DOC_URL,
             vec![ConfigKey::from_value_type::<ClaudeCodeCommand>(true, false)],
         )
+        .with_unlisted_models()
     }
 
     fn from_env(model: ModelConfig) -> BoxFuture<'static, Result<Self::Provider>> {

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -596,6 +596,7 @@ impl ProviderDef for CodexProvider {
                 ConfigKey::from_value_type::<CodexSkipGitCheck>(false, false),
             ],
         )
+        .with_unlisted_models()
     }
 
     fn from_env(model: ModelConfig) -> BoxFuture<'static, Result<Self::Provider>> {

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -337,6 +337,7 @@ impl ProviderDef for CursorAgentProvider {
                 true, false,
             )],
         )
+        .with_unlisted_models()
     }
 
     fn from_env(model: ModelConfig) -> BoxFuture<'static, Result<Self::Provider>> {

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -249,6 +249,7 @@ impl ProviderDef for GeminiCliProvider {
             GEMINI_CLI_DOC_URL,
             vec![ConfigKey::from_value_type::<GeminiCliCommand>(true, false)],
         )
+        .with_unlisted_models()
     }
 
     fn from_env(model: ModelConfig) -> BoxFuture<'static, Result<Self::Provider>> {


### PR DESCRIPTION
## Summary
CLI providers use hard-coded model lists that can't keep up with new releases. Enabling allows_unlisted_models lets users enter custom model names during configuration instead of being restricted to the known list.


### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)