### PR TITLE
chore: added notification for canary build failure

### DIFF
--- a/.github/workflows/build-notify.yml
+++ b/.github/workflows/build-notify.yml
@@ -5,6 +5,7 @@ on:
     workflows:
       - CI
       - Release
+      - Canary
     types: [completed]
 
 


### PR DESCRIPTION
## Summary
Added notification for canary build failure.  Instead of find problem at the release stage, Tthis will help to have early feedback when something is wrong to create the artifacts.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [X] Build / Release
- [ ] Other (specify below)