### PR TITLE
docs: GCP Vertex AI org policy filtering & update OnboardingProviderSetup component

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -255,13 +255,15 @@ goose works with [supported LLM providers][providers] that give goose the AI int
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-    On the welcome screen, choose how to configure a provider:
+    On the welcome screen the first time you open goose, choose how to configure a provider:
     <OnboardingProviderSetup />
   </TabItem>
   <TabItem value="cli" label="goose CLI">
     The CLI automatically enters configuration mode where you can choose how to configure a provider:
 
-    <OnboardingProviderSetup />
+    - **OpenRouter Login** - Sign in with OpenRouter to automatically configure models
+    - **Tetrate Agent Router Service Login** - Sign in with Tetrate Agent Router Service to automatically configure models
+    - **Manual Configuration** - Choose a provider and enter credentials manually
 
     Example configuration flow:
 
@@ -310,6 +312,10 @@ goose works with [supported LLM providers][providers] that give goose the AI int
 
 :::tip
 <ModelSelectionTip />
+:::
+
+:::info Free Credits Offer
+You'll receive $10 in free credits the first time you automatically authenticate with Tetrate through goose. This offer is available to both new and existing Tetrate users.
 :::
 
 ## Update Provider

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -7,6 +7,7 @@ import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { PanelLeft } from 'lucide-react';
 import { ModelSelectionTip } from '@site/src/components/ModelSelectionTip';
+import { OnboardingProviderSetup } from '@site/src/components/OnboardingProviderSetup';
 
 # Supported LLM Providers
 
@@ -29,7 +30,7 @@ goose is compatible with a wide range of LLM providers, allowing you to choose a
 | [Databricks](https://www.databricks.com/)                                   | Unified data analytics and AI platform for building and deploying models.                                                                                                                                                 | `DATABRICKS_HOST`, `DATABRICKS_TOKEN` |
 | [Docker Model Runner](https://docs.docker.com/ai/model-runner/)                             | Local models running in Docker Desktop or Docker CE with OpenAI-compatible API endpoints. **Because this provider runs locally, you must first [download a model](#local-llms).**                     | `OPENAI_HOST`, `OPENAI_BASE_PATH`   |
 | [Gemini](https://ai.google.dev/gemini-api/docs)                             | Advanced LLMs by Google with multimodal capabilities (text, images).                                                                                                                                                      | `GOOGLE_API_KEY`                                                                                                                                                                    |
-| [GCP Vertex AI](https://cloud.google.com/vertex-ai)                         | Google Cloud's Vertex AI platform, supporting Gemini and Claude models. **Credentials must be [configured in advance](https://cloud.google.com/vertex-ai/docs/authentication).**                 | `GCP_PROJECT_ID`, `GCP_LOCATION` and optionally `GCP_MAX_RATE_LIMIT_RETRIES` (5), `GCP_MAX_OVERLOADED_RETRIES` (5), `GCP_INITIAL_RETRY_INTERVAL_MS` (5000), `GCP_BACKOFF_MULTIPLIER` (2.0), `GCP_MAX_RETRY_INTERVAL_MS` (320_000). |
+| [GCP Vertex AI](https://cloud.google.com/vertex-ai)                         | Google Cloud's Vertex AI platform, supporting Gemini and Claude models. **Credentials must be [configured in advance](https://cloud.google.com/vertex-ai/docs/authentication).** Filters for allowed models by organization policy (if configured). | `GCP_PROJECT_ID`, `GCP_LOCATION` and optionally `GCP_MAX_RATE_LIMIT_RETRIES` (5), `GCP_MAX_OVERLOADED_RETRIES` (5), `GCP_INITIAL_RETRY_INTERVAL_MS` (5000), `GCP_BACKOFF_MULTIPLIER` (2.0), `GCP_MAX_RETRY_INTERVAL_MS` (320_000). |
 | [GitHub Copilot](https://docs.github.com/en/copilot/using-github-copilot/ai-models) | Access to AI models from OpenAI, Anthropic, Google, and other providers through GitHub's Copilot infrastructure. **GitHub account with Copilot access required.** | No manual key. Uses [device flow authentication](#github-copilot-authentication) for both CLI and Desktop. |
 | [Groq](https://groq.com/)                                                   | High-performance inference hardware and tools for LLMs.                                                                                                                                                                   | `GROQ_API_KEY`                                                                                                                                                                      |
 | [LiteLLM](https://docs.litellm.ai/docs/) | LiteLLM proxy supporting multiple models with automatic prompt caching and unified API access. | `LITELLM_HOST`, `LITELLM_BASE_PATH` (optional), `LITELLM_API_KEY` (optional), `LITELLM_CUSTOM_HEADERS` (optional), `LITELLM_TIMEOUT` (optional) |
@@ -72,11 +73,9 @@ To configure your chosen provider, see available options, or select a model, vis
   **First-time users:**
   
   On the welcome screen the first time you open goose, you have these options:
-  - **Quick Setup with API Key** - goose will automatically configure your provider based on your API key
-  - **[ChatGPT Subscription](https://chatgpt.com/codex)** - Sign in with your ChatGPT Plus/Pro credentials to access GPT-5 Codex models
-  - **[Agent Router by Tetrate](https://tetrate.io/products/tetrate-agent-router-service)** - Access multiple AI models with automatic setup
-  - **[OpenRouter](https://openrouter.ai/)** - Access 200+ models with one API using pay-per-use pricing
-  - **Other Providers** - Manually configure additional providers through settings
+  
+  <OnboardingProviderSetup />
+  
   <Tabs groupId="setup">
     <TabItem value="apikey" label="Quick Setup" default>
     1. Choose `Quick Setup with API Key`.

--- a/documentation/docs/quickstart.md
+++ b/documentation/docs/quickstart.md
@@ -8,6 +8,7 @@ import Link from "@docusaurus/Link";
 import { IconDownload } from "@site/src/components/icons/download";
 import { RateLimits } from '@site/src/components/RateLimits';
 import { ModelSelectionTip } from '@site/src/components/ModelSelectionTip';
+import { OnboardingProviderSetup } from '@site/src/components/OnboardingProviderSetup';
 import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 import MacDesktopInstallButtons from '@site/src/components/MacDesktopInstallButtons';
 import WindowsDesktopInstallButtons from '@site/src/components/WindowsDesktopInstallButtons';
@@ -115,11 +116,8 @@ goose works with [supported LLM providers](/docs/getting-started/providers) that
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   On the welcome screen, you have these options:
-  - **Quick Setup with API Key** - goose will automatically configure your provider based on your API key
-  - **[ChatGPT Subscription](https://chatgpt.com/codex)** - Sign in with your ChatGPT Plus/Pro credentials to access GPT-5 Codex models
-  - **[Agent Router by Tetrate](https://tetrate.io/products/tetrate-agent-router-service)** - Access multiple AI models with automatic setup
-  - **[OpenRouter](https://openrouter.ai/)** - Access 200+ models with one API using pay-per-use pricing
-  - **Other Providers** - Manually configure additional providers through settings
+  
+  <OnboardingProviderSetup />
 
   For this quickstart, choose **Agent Router by Tetrate**. Tetrate provides access to multiple AI models with built-in rate limiting and automatic failover. For more information about other providers, see [Configure LLM Provider](/docs/getting-started/providers).
   

--- a/documentation/docs/tutorials/rpi.md
+++ b/documentation/docs/tutorials/rpi.md
@@ -62,7 +62,7 @@ In goose, we use a structured RPI workflow using recipes to systematically tackl
 │                           RPI WORKFLOW                                       │
 ├─────────────────────────────────────────────────────────────────────────────-┤
 │                                                                              │
-│  /research_codebase "topic"                                                           │
+│  /research_codebase "topic"                                                  │
 │       │                                                                      │
 │       ├──► Spawns parallel sub-agents:                                       │
 │       │    • find_files (rpi-codebase-locator)                               │
@@ -71,7 +71,7 @@ In goose, we use a structured RPI workflow using recipes to systematically tackl
 │       │                                                                      │
 │       └──► Output: thoughts/research/YYYY-MM-DD-HHmm-topic.md                │
 │                                                                              │
-│  /create_plan "feature/task"                                                        │
+│  /create_plan "feature/task"                                                 │
 │       │                                                                      │
 │       ├──► Reads research docs                                               │
 │       ├──► Asks clarifying questions                                         │
@@ -79,7 +79,7 @@ In goose, we use a structured RPI workflow using recipes to systematically tackl
 │       │                                                                      │
 │       └──► Output: thoughts/plans/YYYY-MM-DD-HHmm-description.md             │
 │                                                                              │
-│  /implement_plan "plan path"                                                      │
+│  /implement_plan "plan path"                                                 │
 │       │                                                                      │
 │       ├──► Executes phase by phase                                           │
 │       ├──► Runs verification after each phase                                │
@@ -87,7 +87,7 @@ In goose, we use a structured RPI workflow using recipes to systematically tackl
 │       │                                                                      │
 │       └──► Working code                                                      │
 │                                                                              │
-│  /iterate_plan "plan path" + feedback                                             │
+│  /iterate_plan "plan path" + feedback                                        │
 │       │                                                                      │
 │       ├──► Researches only what changed                                      │
 │       ├──► Updates the plan surgically                                       │

--- a/documentation/src/components/OnboardingProviderSetup.js
+++ b/documentation/src/components/OnboardingProviderSetup.js
@@ -4,26 +4,11 @@ export const OnboardingProviderSetup = () => {
   return (
     <>
       <ul>
-        <li>
-          <strong>Tetrate Agent Router</strong> - One-click OAuth authentication provides instant access to multiple AI models, starting credits, and built-in rate limiting. See the <a href="/goose/docs/quickstart#configure-provider"> goose quickstart guide</a> for a walkthrough of this setup.
-          <div className="admonition admonition-info alert alert--info" style={{marginTop: '0.5rem', marginBottom: '0.5rem'}}>
-            <div className="admonition-heading">
-              <h5>
-                <span className="admonition-icon" style={{marginRight: '0.5rem'}}>
-                  <svg viewBox="0 0 14 16" width="21" height="23" style={{transform: 'translateY(1px)'}}>
-                    <path fillRule="evenodd" d="M7 2.3c3.14 0 5.7 2.56 5.7 5.7s-2.56 5.7-5.7 5.7A5.71 5.71 0 0 1 1.3 8c0-3.14 2.56-5.7 5.7-5.7zM7 1C3.14 1 0 4.14 0 8s3.14 7 7 7 7-3.14 7-7-3.14-7-7-7zm1 3H6v5h2V4zm0 6H6v2h2v-2z"></path>
-                  </svg>
-                </span>
-                INFO
-              </h5>
-            </div>
-            <div className="admonition-content" style={{paddingBottom: '1rem'}}>
-              <p style={{marginBottom: '0'}}>You'll receive $10 in free credits the first time you automatically authenticate with Tetrate through goose. This offer is available to both new and existing Tetrate users.</p>
-            </div>
-          </div>
-        </li>
-        <li><strong>OpenRouter</strong> - One-click OAuth authentication provides instant access to multiple AI models with built-in rate limiting.</li>
-        <li><strong>Other Providers</strong> - Choose from a selection of <a href="/goose/docs/getting-started/providers">~20 supported providers</a> including OpenAI, Anthropic, Google Gemini, and others through manual configuration. If you don't see your provider in the list, you can add a custom provider. Be ready to provide your API key, API Host address, or other optional parameters depending on provider.</li>
+        <li><strong>Quick Setup with API Key</strong> - goose will automatically configure your provider based on your API key</li>
+        <li><strong><a href="https://chatgpt.com/codex">ChatGPT Subscription</a></strong> - Sign in with your ChatGPT Plus/Pro credentials to access GPT-5 Codex models</li>
+        <li><strong><a href="https://tetrate.io/products/tetrate-agent-router-service">Agent Router by Tetrate</a></strong> - Access multiple AI models with automatic setup</li>
+        <li><strong><a href="https://openrouter.ai/">OpenRouter</a></strong> - Access 200+ models with one API using pay-per-use pricing</li>
+        <li><strong>Other Providers</strong> - Manually configure additional providers through settings</li>
       </ul>
     </>
   );


### PR DESCRIPTION
## Summary
This PR documents GCP Vertex AI org policy filtering and updates/applies the OnboardingProviderSetup component for Desktop onboarding options in the three topics that contain onboarding info.

- GCP Vertex AI org policy filtering:
  - `documentation/docs/getting-started/providers.md`: 
    - Add GCP Vertex AI org policy filtering mention to "Available Providers" table

- OnboardingProviderSetup component:
  - `documentation/docs/getting-started/installation.md`:
    - Desktop: Use shared component for welcome screen options
    - CLI: Replace component with accurate 3-option list matching actual CLI
    - Add Free Credits Offer info box (was removed from component)
  - `documentation/docs/getting-started/providers.md` and `documentation/docs/quickstart.md`: 
    - Use shared component for Desktop welcome screen options (no change to content)
  - `documentation/src/components/OnboardingProviderSetup.js`: 
    - Update to include all 5 Desktop welcome screen options
  
- Misc:
  - `documentation/docs/tutorials/rpi.md`:
    - Fix spacing in codeblock diagram

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
None

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1212975385802764
  - https://app.asana.com/0/0/1213216911502919