### PR TITLE
fix(claude-code): defensive coding improvements for model switching

### DIFF
--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -275,8 +275,6 @@ impl ProviderTester {
     }
 
     async fn test_model_switch(&self, session_id: &str) -> Result<()> {
-        // The process is already running with the default model from test_basic_response.
-        // Switch to model_switch_name and call complete_with_model to exercise send_set_model.
         let default = &self.provider.get_model_config().model_name;
         let alt = self
             .model_switch_name
@@ -297,7 +295,7 @@ impl ProviderTester {
             .await?;
 
         assert!(
-            matches!(response.content[0], MessageContent::Text(_)),
+            matches!(response.content.first(), Some(MessageContent::Text(_))),
             "Expected text response after model switch"
         );
         println!(


### PR DESCRIPTION
## Summary

A series of polishing mentioned in #7120 for Claude Code model list support.

### Type of Change
- [x] Bug fix
- [x] Refactor / Code quality

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

re-ran the integration test

```bash
$ RUST_LOG=debug GOOSE_CLAUDE_CODE_DEBUG=1 cargo test -p goose --test providers -- test_claude_code_provider --nocapture
    Blocking waiting for file lock on build directory
   Compiling goose v1.23.0 (/Users/codefromthecrypt/oss/goose-goosed/crates/goose)
    Finished `test` profile [unoptimized + debuginfo] target(s) in 1m 15s
     Running tests/providers.rs (target/debug/deps/providers-83a00f385f05bffd)

running 1 test
=== claude-code::model_listing ===
[crates/goose/tests/providers.rs:315:9] &models = [
    "default",
    "sonnet",
    "haiku",
]
===================
=== CLAUDE CODE PROVIDER DEBUG ===
Command: "/opt/homebrew/bin/claude"
Original system prompt length: 28 chars
Filtered system prompt length: 28 chars
Filtered system prompt: You are a helpful assistant.
================================
set_model: default resolved to claude-opus-4-6
=== claude-code::basic_response === Hello! 👋 How can I help you today?
=== CLAUDE CODE PROVIDER DEBUG ===
Command: "/opt/homebrew/bin/claude"
Original system prompt length: 28 chars
Filtered system prompt length: 28 chars
Filtered system prompt: You are a helpful assistant.
================================
set_model: sonnet resolved to claude-sonnet-4-5-20250929
=== claude-code::model_switch (default -> sonnet) === Hello! 👋 How can I help you today?
test test_claude_code_provider ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 15 filtered out; finished in 6.19s


============== Providers ==============
✅ claude-code
=======================================


```

### Related Issues
Relates to #7120

