### PR TITLE
feat: Allow overriding default bat themes using environment variables

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -18,6 +18,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 pub const DEFAULT_MIN_PRIORITY: f32 = 0.0;
+pub const DEFAULT_CLI_LIGHT_THEME: &str = "GitHub";
+pub const DEFAULT_CLI_DARK_THEME: &str = "zenburn";
 
 // Re-export theme for use in main
 #[derive(Clone, Copy)]
@@ -28,11 +30,15 @@ pub enum Theme {
 }
 
 impl Theme {
-    fn as_str(&self) -> &'static str {
+    fn as_str(&self) -> String {
         match self {
-            Theme::Light => "GitHub",
-            Theme::Dark => "zenburn",
-            Theme::Ansi => "base16",
+            Theme::Light => Config::global()
+                .get_param::<String>("GOOSE_CLI_LIGHT_THEME")
+                .unwrap_or(DEFAULT_CLI_LIGHT_THEME.to_string()),
+            Theme::Dark => Config::global()
+                .get_param::<String>("GOOSE_CLI_DARK_THEME")
+                .unwrap_or(DEFAULT_CLI_DARK_THEME.to_string()),
+            Theme::Ansi => "base16".to_string(),
         }
     }
 


### PR DESCRIPTION
## Summary

Replaces the hardcoded theme names for the light and dark themes with the values from GOOSE_CLI_DARK_THEME and GOOSE_CLI_LIGHT_THEME, if unset, fall back to the current hardcoded values.

### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

Manual testing

### Related Issues
Relates to #7037 
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  (GitHub):

<img width="1412" height="148" alt="image" src="https://github.com/user-attachments/assets/d8db2611-7c23-4b42-a63f-59c7cc461ab3" />

After:   (Solarized (light)):

<img width="1412" height="191" alt="image" src="https://github.com/user-attachments/assets/6a7eb0fd-5929-4060-a39d-d866819c12d7" />
