### PR TITLE
fix: handle missing arguments in MCP tool calls to prevent GUI crash

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -527,7 +527,7 @@ function ToolCallView({
 
   // Function to create a descriptive representation of what the tool is doing
   const getToolDescription = (): string | null => {
-    const args = toolCall.arguments as Record<string, ToolCallArgumentValue>;
+    const args = (toolCall.arguments ?? {}) as Record<string, ToolCallArgumentValue>;
     const toolName = getToolName(toolCall.name);
 
     const getStringValue = (value: ToolCallArgumentValue): string => {


### PR DESCRIPTION
## Summary

When a tool request arrives without an `arguments` field (valid for no-arg tools like MATLAB toolbox detection), the desktop renderer crashes with:

```
Cannot convert undefined or null to object
```

## Root Cause

In `ui/desktop/src/components/ToolCallWithResponse.tsx`, the `getToolDescription()` function casts `toolCall.arguments` directly without a fallback:

```ts
const args = toolCall.arguments as Record<string, ToolCallArgumentValue>;
```

When `arguments` is `undefined` (valid per MCP spec for no-arg tools), the subsequent `Object.entries(args)` call in the default branch throws.

## Fix

Add nullish coalescing default so `args` safely falls back to an empty object:

```ts
const args = (toolCall.arguments ?? {}) as Record<string, ToolCallArgumentValue>;
```

This is consistent with how the same file already handles `arguments` elsewhere (e.g., line 469 uses optional chaining, line 815 uses `&&` guard).

## Testing

- No-arg tool calls (e.g. `matlab__detect_matlab_toolboxes`) now render without crashing
- Tools with arguments continue to work as before (all existing switch cases access `args.*` properties which safely return `undefined` on an empty object)

Fixes #7116