### PR TITLE
Fix/configure add provider custom headers

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1910,7 +1910,6 @@ fn add_provider() -> anyhow::Result<()> {
         .initial_value(true)
         .interact()?;
 
-    // Ask about custom headers for OpenAI compatible providers
     let headers = collect_custom_headers()?;
 
     create_custom_provider(CreateCustomProviderParams {


### PR DESCRIPTION
Previously custom headers were only prompted for openai_compatible providers; now they are offered for every provider type.

## Summary
The CLI's custom provider configuration only asked for custom headers when adding an OpenAI compatible provider. The backend already supports custom headers for all three provider types (OpenAI, Anthropic, and Ollama compatible). This change updates the configure flow so custom headers are prompted for every provider type.

### Type of Change
- [x] Bug fix
- [ ] Feature
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Manual testing: ran `goose configure` → Custom Providers → Add A Custom Provider, chose Anthropic Compatible and Ollama Compatible, and confirmed the custom headers prompt appears for both (same as for OpenAI Compatible).

### Related Issues
Relates to #7014

### Screenshots/Demos (for UX changes)
Before: 
<img width="578" height="485" alt="image" src="https://github.com/user-attachments/assets/f39d50f2-d1c7-4d96-8cb5-04b3a59421a2" />

After: 
<img width="589" height="640" alt="image" src="https://github.com/user-attachments/assets/25b4b174-b740-4a10-ab38-165fc1b132e9" />
