### PR TITLE
[UI] Harden Session Deletion Guards And ID Reuse

### DIFF
--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -35,7 +35,6 @@ import { useToolCount } from './alerts/useToolCount';
 import { getThinkingMessage, getTextAndImageContent } from '../types/message';
 import ParameterInputModal from './ParameterInputModal';
 import { substituteParameters } from '../utils/providerUtils';
-import { useModelAndProvider } from './ModelAndProviderContext';
 import CreateRecipeFromSessionModal from './recipes/CreateRecipeFromSessionModal';
 import { toastSuccess } from '../toasts';
 import { Recipe } from '../recipe';
@@ -177,13 +176,6 @@ export default function BaseChat({
   });
 
   const recipe = session?.recipe;
-  const { setProviderAndModel } = useModelAndProvider();
-
-  useEffect(() => {
-    if (session?.provider_name && session?.model_config?.model_name) {
-      setProviderAndModel(session.provider_name, session.model_config.model_name);
-    }
-  }, [session?.provider_name, session?.model_config?.model_name, setProviderAndModel]);
 
   useEffect(() => {
     if (!recipe) return;
@@ -275,8 +267,10 @@ export default function BaseChat({
         shouldStartAgent?: boolean;
         editedMessage?: string;
       }>;
-      window.dispatchEvent(new CustomEvent(AppEvents.SESSION_CREATED));
       const { newSessionId, shouldStartAgent, editedMessage } = customEvent.detail;
+      window.dispatchEvent(
+        new CustomEvent(AppEvents.SESSION_CREATED, { detail: { sessionId: newSessionId } })
+      );
 
       const params = new URLSearchParams();
       params.set('resumeSessionId', newSessionId);

--- a/ui/desktop/src/components/ChatSessionsContainer.tsx
+++ b/ui/desktop/src/components/ChatSessionsContainer.tsx
@@ -1,7 +1,10 @@
-import { useSearchParams } from 'react-router-dom';
+import { useEffect, useRef } from 'react';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
 import BaseChat from './BaseChat';
 import { ChatType } from '../types/chat';
 import { UserInput } from '../types/message';
+import { AppEvents } from '../constants/events';
+import { clearDeletedSessionFromCreatedDetail, markSessionDeleted } from '../utils/activeSessions';
 
 interface ChatSessionsContainerProps {
   setChat: (chat: ChatType) => void;
@@ -20,8 +23,73 @@ export default function ChatSessionsContainer({
   setChat,
   activeSessions,
 }: ChatSessionsContainerProps) {
+  const location = useLocation();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const currentSessionId = searchParams.get('resumeSessionId') ?? undefined;
+  const isOnPairRoute = location.pathname === '/pair';
+
+  // Track deleted session IDs to prevent resurrection from stale URL params
+  const deletedSessionIds = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const handleSessionDeleted = (event: Event) => {
+      const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
+      markSessionDeleted(deletedSessionIds.current, sessionId);
+    };
+    const handleSessionCreated = (event: Event) => {
+      const detail = (event as CustomEvent<{ session?: { id?: string }; sessionId?: string }>)
+        .detail;
+      clearDeletedSessionFromCreatedDetail(deletedSessionIds.current, detail);
+    };
+    window.addEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+    window.addEventListener(AppEvents.SESSION_CREATED, handleSessionCreated);
+    return () => {
+      window.removeEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
+      window.removeEventListener(AppEvents.SESSION_CREATED, handleSessionCreated);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!isOnPairRoute) {
+      return;
+    }
+
+    const navigateToSession = (sessionId: string) => {
+      const params = new URLSearchParams();
+      params.set('resumeSessionId', sessionId);
+      navigate(`/pair?${params.toString()}`, { replace: true });
+    };
+
+    const nonDeletedActiveSessions = activeSessions.filter(
+      (session) => !deletedSessionIds.current.has(session.sessionId)
+    );
+
+    // If /pair has no explicit active session, recover to the most-recent active session.
+    if (!currentSessionId) {
+      const fallback = nonDeletedActiveSessions[nonDeletedActiveSessions.length - 1];
+      if (fallback?.sessionId) {
+        navigateToSession(fallback.sessionId);
+      } else {
+        navigate('/', { replace: true });
+      }
+      return;
+    }
+
+    // If URL points at a deleted session, recover instead of showing a blank panel.
+    if (
+      deletedSessionIds.current.has(currentSessionId) &&
+      !nonDeletedActiveSessions.some((session) => session.sessionId === currentSessionId)
+    ) {
+      const fallback = [...nonDeletedActiveSessions].reverse()[0];
+
+      if (fallback?.sessionId) {
+        navigateToSession(fallback.sessionId);
+      } else {
+        navigate('/', { replace: true });
+      }
+    }
+  }, [isOnPairRoute, currentSessionId, activeSessions, navigate]);
 
   // Always render active sessions to keep SSE connections alive, even when not on /pair route
   if (!currentSessionId && activeSessions.length === 0) {
@@ -29,17 +97,26 @@ export default function ChatSessionsContainer({
   }
 
   // Build the list of sessions to render
-  let sessionsToRender = activeSessions;
+  let sessionsToRender = activeSessions.filter(
+    (session) => !deletedSessionIds.current.has(session.sessionId)
+  );
 
   // If we have a currentSessionId that's not in activeSessions, add it (handles page refresh)
-  if (currentSessionId && !activeSessions.some((s) => s.sessionId === currentSessionId)) {
-    sessionsToRender = [...activeSessions, { sessionId: currentSessionId }];
+  // But never restore a session that was explicitly deleted
+  if (
+    currentSessionId &&
+    !sessionsToRender.some((s) => s.sessionId === currentSessionId) &&
+    !deletedSessionIds.current.has(currentSessionId)
+  ) {
+    sessionsToRender = [...sessionsToRender, { sessionId: currentSessionId }];
   }
+
+  const visibleSessionId = currentSessionId ?? activeSessions[activeSessions.length - 1]?.sessionId;
 
   return (
     <div className="relative w-full h-full">
       {sessionsToRender.map((session) => {
-        const isVisible = session.sessionId === currentSessionId;
+        const isVisible = session.sessionId === visibleSessionId;
 
         return (
           <div

--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -53,7 +53,7 @@ export default function Hub({
           allExtensions: extensionConfigs.length > 0 ? undefined : extensionsList,
         });
 
-        window.dispatchEvent(new CustomEvent(AppEvents.SESSION_CREATED));
+        window.dispatchEvent(new CustomEvent(AppEvents.SESSION_CREATED, { detail: { session } }));
         window.dispatchEvent(
           new CustomEvent(AppEvents.ADD_ACTIVE_SESSION, {
             detail: { sessionId: session.id, initialMessage: { msg: userMessage, images } },

--- a/ui/desktop/src/components/__tests__/ChatSessionsContainer.test.tsx
+++ b/ui/desktop/src/components/__tests__/ChatSessionsContainer.test.tsx
@@ -1,0 +1,186 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  MemoryRouter,
+  type NavigateFunction,
+  Route,
+  Routes,
+  useLocation,
+  useNavigate,
+} from 'react-router-dom';
+import ChatSessionsContainer from '../ChatSessionsContainer';
+import { AppEvents } from '../../constants/events';
+
+vi.mock('../BaseChat', () => ({
+  default: ({ sessionId, isActiveSession }: { sessionId: string; isActiveSession: boolean }) => (
+    <div data-testid={`base-chat-${sessionId}`} data-active={isActiveSession ? 'true' : 'false'}>
+      {sessionId}
+    </div>
+  ),
+}));
+
+let navigateRef: NavigateFunction | undefined;
+
+function RouterProbe() {
+  const location = useLocation();
+  navigateRef = useNavigate();
+  return <div data-testid="router-location">{`${location.pathname}${location.search}`}</div>;
+}
+
+function TestHarness({
+  activeSessions,
+  initialEntry,
+}: {
+  activeSessions: Array<{ sessionId: string }>;
+  initialEntry: string;
+}) {
+  return (
+    <MemoryRouter initialEntries={[initialEntry]}>
+      <Routes>
+        <Route
+          path="*"
+          element={
+            <>
+              <RouterProbe />
+              <ChatSessionsContainer setChat={vi.fn()} activeSessions={activeSessions} />
+            </>
+          }
+        />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ChatSessionsContainer deleted-session guard', () => {
+  beforeEach(() => {
+    navigateRef = undefined;
+  });
+
+  it.each([
+    [{ session: { id: 'reused-session' } }, 'session.id payload'],
+    [{ sessionId: 'reused-session' }, 'sessionId payload'],
+  ])(
+    'allows session-id reuse after a delete when session-created clears tombstone state (%s)',
+    async (createdDetail, _label) => {
+      const initialEntry = '/pair?resumeSessionId=reused-session';
+      const { rerender } = render(
+        <TestHarness activeSessions={[{ sessionId: 'stable' }]} initialEntry={initialEntry} />
+      );
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(AppEvents.SESSION_DELETED, {
+            detail: { sessionId: 'reused-session' },
+          })
+        );
+      });
+
+      rerender(
+        <TestHarness activeSessions={[{ sessionId: 'stable' }]} initialEntry={initialEntry} />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('router-location')).toHaveTextContent(
+          '/pair?resumeSessionId=stable'
+        );
+      });
+
+      act(() => {
+        window.dispatchEvent(
+          new CustomEvent(AppEvents.SESSION_CREATED, {
+            detail: createdDetail,
+          })
+        );
+      });
+
+      act(() => {
+        navigateRef?.('/pair?resumeSessionId=reused-session');
+      });
+
+      rerender(
+        <TestHarness
+          activeSessions={[{ sessionId: 'stable' }, { sessionId: 'reused-session' }]}
+          initialEntry={initialEntry}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('router-location')).toHaveTextContent(
+          '/pair?resumeSessionId=reused-session'
+        );
+      });
+      expect(screen.getByTestId('base-chat-reused-session')).toHaveAttribute('data-active', 'true');
+    }
+  );
+
+  it('does not render deleted sessions when activeSessions still contains stale deleted id', async () => {
+    const initialEntry = '/pair?resumeSessionId=reused-session';
+    const { rerender } = render(
+      <TestHarness activeSessions={[{ sessionId: 'stable' }]} initialEntry={initialEntry} />
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AppEvents.SESSION_DELETED, {
+          detail: { sessionId: 'reused-session' },
+        })
+      );
+    });
+
+    rerender(
+      <TestHarness activeSessions={[{ sessionId: 'stable' }]} initialEntry={initialEntry} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('router-location')).toHaveTextContent(
+        '/pair?resumeSessionId=stable'
+      );
+    });
+
+    rerender(
+      <TestHarness
+        activeSessions={[{ sessionId: 'stable' }, { sessionId: 'reused-session' }]}
+        initialEntry={initialEntry}
+      />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('router-location')).toHaveTextContent(
+        '/pair?resumeSessionId=stable'
+      );
+    });
+    expect(screen.queryByTestId('base-chat-reused-session')).not.toBeInTheDocument();
+  });
+
+  it('does not navigate away when deleting a non-active session', async () => {
+    const initialEntry = '/pair?resumeSessionId=active';
+    const { rerender } = render(
+      <TestHarness
+        activeSessions={[{ sessionId: 'active' }, { sessionId: 'other' }]}
+        initialEntry={initialEntry}
+      />
+    );
+
+    act(() => {
+      window.dispatchEvent(
+        new CustomEvent(AppEvents.SESSION_DELETED, {
+          detail: { sessionId: 'other' },
+        })
+      );
+    });
+
+    rerender(
+      <TestHarness activeSessions={[{ sessionId: 'active' }]} initialEntry={initialEntry} />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('router-location')).toHaveTextContent(
+        '/pair?resumeSessionId=active'
+      );
+    });
+    expect(screen.getByTestId('base-chat-active')).toHaveAttribute('data-active', 'true');
+  });
+});

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -29,6 +29,12 @@ import { maybeHandlePlatformEvent } from '../utils/platform_events';
 
 const resultsCache = new Map<string, { messages: Message[]; session: Session }>();
 
+// Clear cache entry when a session is deleted to prevent resurrection from stale cached data
+window.addEventListener(AppEvents.SESSION_DELETED, (event: Event) => {
+  const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
+  resultsCache.delete(sessionId);
+});
+
 interface UseChatStreamProps {
   sessionId: string;
   onStreamFinish: () => void;
@@ -520,7 +526,7 @@ export function useChatStream({
 
       // Emit session-created event for first message in a new session
       if (!hasExistingMessages && hasNewMessage) {
-        window.dispatchEvent(new CustomEvent(AppEvents.SESSION_CREATED));
+        window.dispatchEvent(new CustomEvent(AppEvents.SESSION_CREATED, { detail: { sessionId } }));
 
         // Start polling for session name update during streaming
         // The backend generates the name in parallel with the response

--- a/ui/desktop/src/utils/__tests__/activeSessions.test.ts
+++ b/ui/desktop/src/utils/__tests__/activeSessions.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest';
+import {
+  addActiveSession,
+  clearDeletedSessionFromCreatedDetail,
+  clearInitialMessage,
+  getCreatedSessionId,
+  markSessionDeleted,
+  removeActiveSession,
+} from '../activeSessions';
+
+describe('activeSessions', () => {
+  it('blocks add-active-session for deleted ids and allows id reuse after session-created clear', () => {
+    const deletedSessionIds = new Set<string>();
+    const base = [{ sessionId: 'existing' }];
+
+    markSessionDeleted(deletedSessionIds, 'reused');
+    const blocked = addActiveSession(base, { sessionId: 'reused' }, deletedSessionIds, 10);
+    expect(blocked).toEqual(base);
+
+    const clearedFromSessionObject = clearDeletedSessionFromCreatedDetail(deletedSessionIds, {
+      session: { id: 'reused' },
+    });
+    expect(clearedFromSessionObject).toBe('reused');
+    const allowed = addActiveSession(base, { sessionId: 'reused' }, deletedSessionIds, 10);
+    expect(allowed).toEqual([{ sessionId: 'existing' }, { sessionId: 'reused' }]);
+  });
+
+  it('clears tombstone from flat sessionId payload shape and unblocks add', () => {
+    const deletedSessionIds = new Set<string>();
+    markSessionDeleted(deletedSessionIds, 'flat-shape-id');
+
+    const clearedFromFlatField = clearDeletedSessionFromCreatedDetail(deletedSessionIds, {
+      sessionId: 'flat-shape-id',
+    });
+    expect(clearedFromFlatField).toBe('flat-shape-id');
+
+    const allowed = addActiveSession([], { sessionId: 'flat-shape-id' }, deletedSessionIds, 10);
+    expect(allowed).toEqual([{ sessionId: 'flat-shape-id', initialMessage: undefined }]);
+  });
+
+  it('moves existing sessions to the end and preserves initial message rules', () => {
+    const message = { msg: 'hello', images: [] };
+    const deletedSessionIds = new Set<string>();
+    const base = [
+      { sessionId: 'a' },
+      { sessionId: 'b', initialMessage: message },
+      { sessionId: 'c' },
+    ];
+
+    const moved = addActiveSession(base, { sessionId: 'b' }, deletedSessionIds, 10);
+    expect(moved).toEqual([
+      { sessionId: 'a' },
+      { sessionId: 'c' },
+      { sessionId: 'b', initialMessage: message },
+    ]);
+
+    const enriched = addActiveSession(
+      [{ sessionId: 'x' }],
+      { sessionId: 'x', initialMessage: message },
+      deletedSessionIds,
+      10
+    );
+    expect(enriched).toEqual([{ sessionId: 'x', initialMessage: message }]);
+  });
+
+  it('enforces max active sessions by evicting least-recently used entries', () => {
+    const deletedSessionIds = new Set<string>();
+    const base = [{ sessionId: 'a' }, { sessionId: 'b' }];
+
+    const updated = addActiveSession(base, { sessionId: 'c' }, deletedSessionIds, 2);
+    expect(updated).toEqual([{ sessionId: 'b' }, { sessionId: 'c' }]);
+  });
+
+  it('clears initial message for one session only', () => {
+    const message = { msg: 'hello', images: [] };
+    const base = [
+      { sessionId: 'a', initialMessage: message },
+      { sessionId: 'b', initialMessage: message },
+    ];
+
+    const updated = clearInitialMessage(base, 'a');
+    expect(updated).toEqual([
+      { sessionId: 'a', initialMessage: undefined },
+      { sessionId: 'b', initialMessage: message },
+    ]);
+  });
+
+  it('removes the deleted session from the active list', () => {
+    const base = [{ sessionId: 'a' }, { sessionId: 'b' }];
+    expect(removeActiveSession(base, 'a')).toEqual([{ sessionId: 'b' }]);
+  });
+
+  it('extracts created session id from both payload shapes', () => {
+    expect(getCreatedSessionId({ session: { id: 'session-from-object' } })).toBe(
+      'session-from-object'
+    );
+    expect(getCreatedSessionId({ sessionId: 'session-from-flat-field' })).toBe(
+      'session-from-flat-field'
+    );
+    expect(getCreatedSessionId({})).toBeUndefined();
+  });
+});

--- a/ui/desktop/src/utils/activeSessions.ts
+++ b/ui/desktop/src/utils/activeSessions.ts
@@ -1,0 +1,85 @@
+import { UserInput } from '../types/message';
+
+export interface ActiveSessionEntry {
+  sessionId: string;
+  initialMessage?: UserInput;
+}
+
+export interface AddActiveSessionPayload {
+  sessionId: string;
+  initialMessage?: UserInput;
+}
+
+export interface SessionCreatedDetail {
+  session?: {
+    id?: string;
+  };
+  sessionId?: string;
+}
+
+export function markSessionDeleted(deletedSessionIds: Set<string>, sessionId: string): void {
+  deletedSessionIds.add(sessionId);
+}
+
+export function clearDeletedSessionFromCreatedDetail(
+  deletedSessionIds: Set<string>,
+  detail?: SessionCreatedDetail
+): string | undefined {
+  const sessionId = getCreatedSessionId(detail);
+  if (sessionId) {
+    deletedSessionIds.delete(sessionId);
+  }
+  return sessionId;
+}
+
+export function addActiveSession(
+  prev: ActiveSessionEntry[],
+  payload: AddActiveSessionPayload,
+  deletedSessionIds: Set<string>,
+  maxActiveSessions: number
+): ActiveSessionEntry[] {
+  const { sessionId, initialMessage } = payload;
+
+  if (deletedSessionIds.has(sessionId)) {
+    return prev;
+  }
+
+  const existingIndex = prev.findIndex((s) => s.sessionId === sessionId);
+
+  if (existingIndex !== -1) {
+    const existing = prev[existingIndex];
+    const updatedExisting =
+      !existing.initialMessage && initialMessage ? { ...existing, initialMessage } : existing;
+    return [...prev.slice(0, existingIndex), ...prev.slice(existingIndex + 1), updatedExisting];
+  }
+
+  const newSession = { sessionId, initialMessage };
+  const updated = [...prev, newSession];
+  if (updated.length > maxActiveSessions) {
+    return updated.slice(updated.length - maxActiveSessions);
+  }
+  return updated;
+}
+
+export function clearInitialMessage(
+  prev: ActiveSessionEntry[],
+  sessionId: string
+): ActiveSessionEntry[] {
+  return prev.map((session) => {
+    if (session.sessionId === sessionId) {
+      return { ...session, initialMessage: undefined };
+    }
+    return session;
+  });
+}
+
+export function removeActiveSession(
+  prev: ActiveSessionEntry[],
+  sessionId: string
+): ActiveSessionEntry[] {
+  return prev.filter((session) => session.sessionId !== sessionId);
+}
+
+export function getCreatedSessionId(detail?: SessionCreatedDetail): string | undefined {
+  return detail?.session?.id ?? detail?.sessionId;
+}

--- a/ui/desktop/src/vite-env.d.ts
+++ b/ui/desktop/src/vite-env.d.ts
@@ -59,7 +59,7 @@ declare global {
       sessionId: string;
     }>;
     responseStyleChanged: CustomEvent;
-    'session-created': CustomEvent<{ session?: import('./api').Session }>;
+    'session-created': CustomEvent<{ session?: import('./api').Session; sessionId?: string }>;
     'session-deleted': CustomEvent<{ sessionId: string }>;
     'session-renamed': CustomEvent<{ sessionId: string; newName: string }>;
   }


### PR DESCRIPTION
## What
Improve session lifecycle guard behavior so deleted sessions cannot cause stale resurrection and ID reuse remains routable.

## Changes
- Normalize session-created event payload handling across chat creation paths
- Add shared active-session guard helpers for delete/create tombstone lifecycle
- Add regression tests for ID reuse and non-active deletion behavior

## References
- Review order: PR 1 -> PR 2 -> PR 3
- PR 1: https://github.com/block/goose/pull/7169
- PR 2 (this PR): https://github.com/block/goose/pull/7170
- PR 3: https://github.com/block/goose/pull/7171