### PR TITLE
[UI] Sidebar Context Menu Actions And Test Hooks

### DIFF
--- a/ui/desktop/src/components/common/InlineEditText.tsx
+++ b/ui/desktop/src/components/common/InlineEditText.tsx
@@ -14,6 +14,9 @@ interface InlineEditTextProps {
   onEditEnd?: () => void;
   allowEmpty?: boolean;
   singleClickEdit?: boolean;
+  /** Increment this value to programmatically trigger edit mode */
+  editTrigger?: number;
+  testId?: string;
 }
 
 export const InlineEditText: React.FC<InlineEditTextProps> = ({
@@ -28,6 +31,8 @@ export const InlineEditText: React.FC<InlineEditTextProps> = ({
   onEditEnd,
   allowEmpty = false,
   singleClickEdit = true,
+  editTrigger = 0,
+  testId,
 }) => {
   const [isEditing, setIsEditing] = useState(false);
   const [editValue, setEditValue] = useState(value);
@@ -48,6 +53,17 @@ export const InlineEditText: React.FC<InlineEditTextProps> = ({
       inputRef.current.select();
     }
   }, [isEditing]);
+
+  // Allow external triggers to enter edit mode (e.g., from a context menu)
+  useEffect(() => {
+    if (editTrigger > 0 && !isEditing && !disabled && !isSaving) {
+      setIsEditing(true);
+      setEditValue(value);
+      onEditStart?.();
+    }
+    // Only react to editTrigger changes, not other deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [editTrigger]);
 
   const handleStartEdit = useCallback(() => {
     if (disabled || isSaving) return;
@@ -115,12 +131,9 @@ export const InlineEditText: React.FC<InlineEditTextProps> = ({
     }
   }, [handleSave, isSaving]);
 
-  const handleChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      setEditValue(e.target.value);
-    },
-    []
-  );
+  const handleChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    setEditValue(e.target.value);
+  }, []);
 
   const handleClick = useCallback(
     (e: React.MouseEvent) => {
@@ -146,6 +159,7 @@ export const InlineEditText: React.FC<InlineEditTextProps> = ({
     return (
       <input
         ref={inputRef}
+        data-testid={testId ? `${testId}-input` : undefined}
         type="text"
         value={editValue}
         onChange={handleChange}
@@ -169,6 +183,7 @@ export const InlineEditText: React.FC<InlineEditTextProps> = ({
 
   return (
     <div
+      data-testid={testId}
       className={`
         cursor-pointer px-2 py-1 rounded
         hover:bg-background-hover

--- a/ui/desktop/src/components/ui/ConfirmationModal.tsx
+++ b/ui/desktop/src/components/ui/ConfirmationModal.tsx
@@ -18,6 +18,9 @@ export function ConfirmationModal({
   cancelLabel = 'No',
   isSubmitting = false,
   confirmVariant = 'default',
+  messageTestId,
+  confirmButtonTestId,
+  cancelButtonTestId,
 }: {
   isOpen: boolean;
   title: string;
@@ -28,20 +31,33 @@ export function ConfirmationModal({
   cancelLabel?: string;
   isSubmitting?: boolean; // To handle debounce state
   confirmVariant?: 'default' | 'destructive' | 'outline' | 'secondary' | 'ghost' | 'link';
+  messageTestId?: string;
+  confirmButtonTestId?: string;
+  cancelButtonTestId?: string;
 }) {
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
       <DialogContent className="sm:max-w-[425px]">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
-          <DialogDescription>{message}</DialogDescription>
+          <DialogDescription data-testid={messageTestId}>{message}</DialogDescription>
         </DialogHeader>
 
         <DialogFooter className="pt-2">
-          <Button variant="outline" onClick={onCancel} disabled={isSubmitting}>
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            data-testid={cancelButtonTestId}
+          >
             {cancelLabel}
           </Button>
-          <Button variant={confirmVariant} onClick={onConfirm} disabled={isSubmitting}>
+          <Button
+            variant={confirmVariant}
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            data-testid={confirmButtonTestId}
+          >
             {isSubmitting ? 'Processing...' : confirmLabel}
           </Button>
         </DialogFooter>

--- a/ui/desktop/src/components/ui/context-menu.tsx
+++ b/ui/desktop/src/components/ui/context-menu.tsx
@@ -1,0 +1,179 @@
+import React, { useEffect, useRef, useCallback, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { cn } from '../../utils';
+
+interface ContextMenuPosition {
+  x: number;
+  y: number;
+}
+
+interface ContextMenuProps {
+  children: React.ReactNode;
+  content: React.ReactNode;
+}
+
+/**
+ * A lightweight context menu (right-click menu) component.
+ * Styled to match the existing DropdownMenu from Radix UI.
+ *
+ * Usage:
+ *   <ContextMenu content={<><ContextMenuItem onSelect={...}>Rename</ContextMenuItem></>}>
+ *     <button>Right-click me</button>
+ *   </ContextMenu>
+ */
+export function ContextMenu({ children, content }: ContextMenuProps) {
+  const [position, setPosition] = useState<ContextMenuPosition | null>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
+
+  const handleContextMenu = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    setPosition({ x: e.clientX, y: e.clientY });
+  }, []);
+
+  const close = useCallback(() => {
+    setPosition(null);
+  }, []);
+
+  // Close on click outside or Escape
+  useEffect(() => {
+    if (!position) return;
+
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        close();
+      }
+    };
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        close();
+      }
+    };
+
+    // Use a microtask to avoid immediately closing from the same click
+    requestAnimationFrame(() => {
+      document.addEventListener('mousedown', handleClickOutside);
+      document.addEventListener('keydown', handleKeyDown);
+    });
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('keydown', handleKeyDown);
+    };
+  }, [position, close]);
+
+  // Adjust position to keep menu within viewport
+  useEffect(() => {
+    if (!position || !menuRef.current) return;
+    const menu = menuRef.current;
+    const rect = menu.getBoundingClientRect();
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+
+    let adjustedX = position.x;
+    let adjustedY = position.y;
+
+    if (position.x + rect.width > viewportWidth) {
+      adjustedX = viewportWidth - rect.width - 8;
+    }
+    if (position.y + rect.height > viewportHeight) {
+      adjustedY = viewportHeight - rect.height - 8;
+    }
+
+    if (adjustedX !== position.x || adjustedY !== position.y) {
+      setPosition({ x: adjustedX, y: adjustedY });
+    }
+  }, [position]);
+
+  return (
+    <>
+      <div onContextMenu={handleContextMenu}>{children}</div>
+      {position &&
+        createPortal(
+          <div
+            ref={menuRef}
+            className={cn(
+              'fixed z-50 min-w-[8rem] overflow-hidden rounded-xl border p-1 shadow-lg',
+              'bg-background-default text-text-default',
+              'animate-in fade-in-0 zoom-in-95'
+            )}
+            style={{ top: position.y, left: position.x }}
+          >
+            <ContextMenuCloseContext.Provider value={close}>
+              {content}
+            </ContextMenuCloseContext.Provider>
+          </div>,
+          document.body
+        )}
+    </>
+  );
+}
+
+// Internal context for closing the menu from menu items
+const ContextMenuCloseContext = React.createContext<() => void>(() => {});
+
+export function ContextMenuItem({
+  children,
+  onSelect,
+  variant = 'default',
+  disabled = false,
+  className,
+  dataTestId,
+}: {
+  children: React.ReactNode;
+  onSelect: () => void;
+  variant?: 'default' | 'destructive';
+  disabled?: boolean;
+  className?: string;
+  dataTestId?: string;
+}) {
+  const close = React.useContext(ContextMenuCloseContext);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      if (disabled) return;
+      close();
+      onSelect();
+    },
+    [close, onSelect, disabled]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        e.stopPropagation();
+        if (disabled) return;
+        close();
+        onSelect();
+      }
+    },
+    [close, onSelect, disabled]
+  );
+
+  return (
+    <div
+      role="menuitem"
+      tabIndex={disabled ? -1 : 0}
+      data-testid={dataTestId}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none',
+        variant === 'destructive'
+          ? 'text-text-danger hover:bg-background-danger/10 focus:bg-background-danger/10'
+          : 'hover:bg-background-muted focus:bg-background-muted',
+        disabled && 'pointer-events-none opacity-50',
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function ContextMenuSeparator({ className }: { className?: string }) {
+  return <div className={cn('bg-border-default -mx-1 my-1 h-px', className)} />;
+}


### PR DESCRIPTION
## What
Add sidebar context menu interaction improvements and deterministic UI test hooks for rename/delete flows.

## Changes
- Add context menu action wiring for session rename/delete flows
- Add targeted test-id hooks in sidebar row, inline edit, and confirmation modal controls
- Keep delete-confirm navigation behavior aligned with recent guard fixes

## References
- Review order: PR 1 -> PR 2 -> PR 3
- PR 1: https://github.com/block/goose/pull/7169
- PR 2: https://github.com/block/goose/pull/7170
- PR 3 (this PR): https://github.com/block/goose/pull/7171