### PR TITLE
fix: handle keyring fallback as success

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -802,11 +802,15 @@ impl Config {
         match &self.secrets {
             SecretStorage::Keyring { service } => {
                 let json_value = serde_json::to_string(&values)?;
-                self.handle_keyring_operation(
+                match self.handle_keyring_operation(
                     |entry| entry.set_password(&json_value),
                     service,
                     Some(&values),
-                )?;
+                ) {
+                    Ok(_) => {}
+                    Err(ConfigError::FallbackToFileStorage) => {}
+                    Err(e) => return Err(e),
+                }
             }
             SecretStorage::File { path } => {
                 let yaml_value = serde_yaml::to_string(&values)?;
@@ -839,11 +843,15 @@ impl Config {
         match &self.secrets {
             SecretStorage::Keyring { service } => {
                 let json_value = serde_json::to_string(&values)?;
-                self.handle_keyring_operation(
+                match self.handle_keyring_operation(
                     |entry| entry.set_password(&json_value),
                     service,
                     Some(&values),
-                )?;
+                ) {
+                    Ok(_) => {}
+                    Err(ConfigError::FallbackToFileStorage) => {}
+                    Err(e) => return Err(e),
+                }
             }
             SecretStorage::File { path } => {
                 let yaml_value = serde_yaml::to_string(&values)?;


### PR DESCRIPTION
## Summary

Relates to #6607 

set_secret/delete_secret returned error when keyring unavailable despite file write succeeding. Treat FallbackToFileStorage as success since operation completed.

GitHub Copilot OAuth failed in WSL/environments without keyring:
- Token saved to file successfully
- But error was returned anyway
- CLI handled this, provider didn't

`set_secret` and `delete_secret` now treat `FallbackToFileStorage` as success (file already written).

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Test
I don't have GitHub Copilot access to verify the fix.

github_copilot should complete without "Failed to save token" error
change is straightforward: file write succeeds → return success.