### PR TITLE
fix: filter models without tool support from recommended list

### DIFF
--- a/crates/goose-acp/tests/common_tests/mod.rs
+++ b/crates/goose-acp/tests/common_tests/mod.rs
@@ -142,7 +142,6 @@ pub async fn run_model_list<C: Connection>() {
             "gpt-5-codex",
             "gpt-5",
             "gpt-5-2025-08-07",
-            "gpt-5-chat-latest",
             "gpt-5-mini",
             "gpt-5-mini-2025-08-07",
             TEST_MODEL,
@@ -172,16 +171,10 @@ pub async fn run_model_list<C: Connection>() {
             "gpt-4o-2024-05-13",
             "gpt-4o-2024-08-06",
             "gpt-4o-2024-11-20",
-            "text-embedding-3-large",
-            "text-embedding-3-small",
             "gpt-4",
             "gpt-4-0613",
             "gpt-4-turbo",
             "gpt-4-turbo-2024-04-09",
-            "gpt-3.5-turbo",
-            "gpt-3.5-turbo-0125",
-            "gpt-3.5-turbo-1106",
-            "text-embedding-ada-002",
         ]
         .iter()
         .map(|id| ModelInfo::new(ModelId::new(*id), *id))

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -481,6 +481,10 @@ pub trait Provider: Send + Sync {
                     return None;
                 }
 
+                if !canonical_model.tool_call && !self.get_model_config().toolshim {
+                    return None;
+                }
+
                 let release_date = canonical_model.release_date.clone();
 
                 Some((model.clone(), release_date))

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -311,7 +311,6 @@ impl Provider for OpenRouterProvider {
         Ok((message, ProviderUsage::new(response_model, usage)))
     }
 
-    /// Fetch supported models from OpenRouter API (only models with tool support)
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
         let response = self
             .api_client
@@ -350,32 +349,8 @@ impl Provider for OpenRouterProvider {
         let mut models: Vec<String> = data
             .iter()
             .filter_map(|model| {
-                // Get the model ID
                 let id = model.get("id").and_then(|v| v.as_str())?;
-
-                // Check if the model supports tools
-                let supported_params =
-                    match model.get("supported_parameters").and_then(|v| v.as_array()) {
-                        Some(params) => params,
-                        None => {
-                            // If supported_parameters is missing, skip this model (assume no tool support)
-                            tracing::debug!(
-                                "Model '{}' missing supported_parameters field, skipping",
-                                id
-                            );
-                            return None;
-                        }
-                    };
-
-                let has_tool_support = supported_params
-                    .iter()
-                    .any(|param| param.as_str() == Some("tools"));
-
-                if has_tool_support {
-                    Some(id.to_string())
-                } else {
-                    None
-                }
+                Some(id.to_string())
             })
             .collect();
 


### PR DESCRIPTION
## Summary
Models without tool call support are filtered from the recommended model list using the canonical registry, preventing selection during configuration. The filter is bypassed when toolshim is enabled.

OpenRouter's provider-level tool filtering is removed since its models are covered by the canonical registry.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)