### PR TITLE
Added cmd to validate bundled extensions json

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1532,20 +1532,15 @@ pub async fn cli() -> anyhow::Result<()> {
         Some(Command::Term { command }) => handle_term_subcommand(command).await,
         Some(Command::ValidateExtensions { file }) => {
             use goose::agents::validate_extensions::validate_bundled_extensions;
-            let result = validate_bundled_extensions(&file)?;
-            if result.is_ok() {
-                println!("✓ All {} extensions validated successfully.", result.total);
-                Ok(())
-            } else {
-                eprintln!(
-                    "✗ Found {} error(s) in {} extensions:\n",
-                    result.errors.len(),
-                    result.total
-                );
-                for err in &result.errors {
-                    eprintln!("  {}", err);
+            match validate_bundled_extensions(&file) {
+                Ok(msg) => {
+                    println!("{msg}");
+                    Ok(())
                 }
-                std::process::exit(1);
+                Err(e) => {
+                    eprintln!("{e}");
+                    std::process::exit(1);
+                }
             }
         }
         None => handle_default_session().await,

--- a/crates/goose-server/src/main.rs
+++ b/crates/goose-server/src/main.rs
@@ -69,19 +69,12 @@ async fn main() -> anyhow::Result<()> {
             }
         }
         Commands::ValidateExtensions { path } => {
-            let result = validate_extensions::validate_bundled_extensions(&path)?;
-            if result.errors.is_empty() {
-                println!("✓ All {} extensions validated successfully.", result.total);
-            } else {
-                eprintln!(
-                    "✗ Found {} error(s) in {} extension(s):\n",
-                    result.errors.len(),
-                    result.errors.len()
-                );
-                for (i, error) in result.errors.iter().enumerate() {
-                    eprintln!("  [{}] {}", i, error);
+            match validate_extensions::validate_bundled_extensions(&path) {
+                Ok(msg) => println!("{msg}"),
+                Err(e) => {
+                    eprintln!("{e}");
+                    std::process::exit(1);
                 }
-                std::process::exit(1);
             }
         }
     }

--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -374,16 +374,6 @@ impl ExtensionConfig {
         }
     }
 
-    pub const VALID_TYPES: &[&str] = &[
-        "sse",
-        "stdio",
-        "builtin",
-        "platform",
-        "streamable_http",
-        "frontend",
-        "inline_python",
-    ];
-
     pub fn key(&self) -> String {
         name_to_key(&self.name())
     }


### PR DESCRIPTION
## Summary
Problem: The goose-releases repo has a bundled-extensions.json that defines extensions
shipped with the internal desktop app. Two extensions (Asana and Neighborhood) were added
with "type": "http", but the app only recognizes "builtin", "stdio", and "streamable_http".
When the sync loop hit Asana, it crashed and silently dropped every extension after it.
There was no way to catch this before shipping. The release built fine and the error only
surfaced at runtime.

Solution: Added a hidden `validate-extensions` command to both the goose CLI and goosed
server binaries. It reads a bundled-extensions.json file, attempts to deserialize each
entry into the same ExtensionConfig enum the runtime uses, and reports all errors with
the extension name and index. It specifically detects common mistakes like unknown type
values (listing the valid ones) and "url" vs "uri" field confusion on streamable_http
entries. It exits with code 1 on any error, making it suitable as a CI gate step in the
release workflow right after the Rust build, before packaging. The list of valid types is
defined as a constant on ExtensionConfig itself so it lives next to the enum definition
and has a test ensuring it stays in sync.
