### PR TITLE
fix: fork session

### DIFF
--- a/ui/desktop/src/components/ProgressiveMessageList.tsx
+++ b/ui/desktop/src/components/ProgressiveMessageList.tsx
@@ -36,7 +36,7 @@ interface ProgressiveMessageListProps {
   // Custom render function for messages
   renderMessage?: (message: Message, index: number) => React.ReactNode | null;
   isStreamingMessage?: boolean; // Whether messages are currently being streamed
-  onMessageUpdate?: (messageId: string, newContent: string) => void;
+  onMessageUpdate?: (messageId: string, newContent: string, editType?: 'fork' | 'edit') => void;
   onRenderingComplete?: () => void; // Callback when all messages are rendered
   submitElicitationResponse?: (
     elicitationId: string,

--- a/ui/desktop/src/components/UserMessage.tsx
+++ b/ui/desktop/src/components/UserMessage.tsx
@@ -80,7 +80,7 @@ export default function UserMessage({ message, onMessageUpdate }: UserMessagePro
 
       setIsEditing(false);
 
-      if (editContent.trim() === textContent.trim()) {
+      if (editType === 'edit' && editContent.trim() === textContent.trim()) {
         return;
       }
 


### PR DESCRIPTION
## Summary
The `Fork Session` feature was not working if the message was not edited. 

In `UserMessage.tsx`, the handleSave function had this flow:

```
const handleSave = (editType: 'fork' | 'edit' = 'fork') => {
  setIsEditing(false);                              // ← always closes the textbox
  if (editContent.trim() === textContent.trim()) {  // ← if content unchanged...
    return;                                          // ← ...bail out early!
  }
  onMessageUpdate(message.id, editContent, editType); // ← fork never reached
};
```

When you click "Fork Session", the most common case is that you haven't changed the message text — you just want to create a new session from that point. But the early return on the content-unchanged check prevented onMessageUpdate from ever being called. The edit textbox closed (setIsEditing(false)) but no fork happened.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [X] This PR was created or reviewed with AI assistance

### Testing
tested locally

