### PR TITLE
fix: flake.nix

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -42,17 +42,42 @@
           version = workspaceToml.workspace.package.version;
           src = self;
 
-          cargoLock = {
-            lockFile = ./Cargo.lock;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          LIBCLANG_PATH = "${pkgs.libclang.lib}/lib";
+
+          # Pre-fetch rusty_v8 binary to avoid network access during build
+          # Map Nix system to rusty_v8 target triple
+          RUSTY_V8_ARCHIVE = let
+            cargoLock = builtins.fromTOML (builtins.readFile ./Cargo.lock);
+            rustyV8Version = (builtins.head (builtins.filter (p: p.name == "v8") cargoLock.package)).version;
+            rustyV8Target = {
+              "x86_64-linux" = "x86_64-unknown-linux-gnu";
+              "aarch64-linux" = "aarch64-unknown-linux-gnu";
+              "x86_64-darwin" = "x86_64-apple-darwin";
+              "aarch64-darwin" = "aarch64-apple-darwin";
+            }.${system} or (throw "Unsupported system: ${system}");
+            rustyV8Sha256 = {
+              "x86_64-linux" = "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=";
+              "aarch64-linux" = "sha256-4IivYskhUSsMLZY97+g23UtUYh4p5jk7CzhMbMyqXyY=";
+              "x86_64-darwin" = "sha256-1jUuC+z7saQfPYILNyRJanD4+zOOhXU2ac/LFoytwho=";
+              "aarch64-darwin" = "sha256-yHa1eydVCrfYGgrZANbzgmmf25p7ui1VMas2A7BhG6k=";
+            }.${system};
+          in pkgs.fetchurl {
+            url = "https://github.com/denoland/rusty_v8/releases/download/v${rustyV8Version}/librusty_v8_release_${rustyV8Target}.a.gz";
+            sha256 = rustyV8Sha256;
           };
 
           nativeBuildInputs = with pkgs; [
             pkg-config
+            clang
+            cmake
           ];
 
           buildInputs = with pkgs; [
             openssl
-            xorg.libxcb  # Required for xcap screenshot functionality
+            cacert       # CA certificates for tests
+            libxcb       # Required for xcap screenshot functionality
             dbus         # Required for system integration features
           ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
 
@@ -82,7 +107,7 @@
           };
         };
 
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           packages = buildInputs ++ (with pkgs; [
             cargo-watch
             cargo-edit
@@ -93,7 +118,7 @@
             nodejs_24 # 'just' run-ui
             ripgrep
             rustfmt
-            xorg.libxcb
+            libxcb
             dbus
             yarn # 'just' install-deps
           ]);


### PR DESCRIPTION
## Summary
The flake was broken. ~The rust deps were too old. I updated the flake.lock dependencies.~ (Edit: someone else did this and I rebased on their change.) I also added a new V8 download (cargo build tries to download a blob but nix can't access the net during build using normal methods -- you have to use fetchurl) and removed the crunchy hash override (no longer needed now -- apparently you all previously had a `git = "..."` in Cargo.toml).

I also updated the flake to the new schema (packages.default vs defaultPackage).

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [X] This PR was created or reviewed with AI assistance

### Testing
I'm using the flake.