### PR TITLE
docs: removing LLM Usage admonitions

### DIFF
--- a/documentation/docs/mcp/agentql-mcp.md
+++ b/documentation/docs/mcp/agentql-mcp.md
@@ -74,9 +74,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 Let's use the AgentQL extension to gather and structure tech conference data to help plan speaking engagements. 
 
-:::info LLM
-Anthropic's Claude 4 Sonnet was used for this task.
-:::
 
 ### goose Prompt
 

--- a/documentation/docs/mcp/alby-mcp.md
+++ b/documentation/docs/mcp/alby-mcp.md
@@ -117,10 +117,6 @@ You'll need [Node.js](https://nodejs.org/) installed on your system to run this 
 
 ## Example Usage
 
-:::info LLM
-Claude Sonnet 3.7 was used for this task. A similarly capable model is recommended to ensure the tool is used correctly.
-:::
-
 :::tip Memory Extension
 Use the built-in memory extension to save your contacts. e.g. "My friend Rene's lightning address is reneaaron@getalby.com. Please save it to your memory."
 :::

--- a/documentation/docs/mcp/asana-mcp.md
+++ b/documentation/docs/mcp/asana-mcp.md
@@ -76,10 +76,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 ## Example Usage
 
-:::info LLM
-OpenAI's GPT-4o was used for this task. There's an [open bug](https://github.com/block/goose/issues/1804) for Amazon Bedrock models.
-:::
-
 ### goose Prompt
 
 > _goose, I have one hour. Look through uncompleted tasks assigned to me in Asana and show me ones that you estimate will take an hour or less. Order them by deadline._

--- a/documentation/docs/mcp/beads-mcp.md
+++ b/documentation/docs/mcp/beads-mcp.md
@@ -66,10 +66,6 @@ uv tool install beads-mcp --with packaging
 
 In this example, we'll use Beads to coordinate building an expense tracker web app across **multiple parallel sessions**. This demonstrates how Beads enables multiple goose instances to work on the same project without conflicts.
 
-:::info LLM
-Anthropic's Claude Opus 4.5 was used for this task.
-:::
-
 ### Overview
 
 We'll run **4 goose sessions**:

--- a/documentation/docs/mcp/browserbase-mcp.md
+++ b/documentation/docs/mcp/browserbase-mcp.md
@@ -74,10 +74,6 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 Let's use the Browserbase extension to gather information about trending MCP-related repositories on GitHub.
 
-:::info LLM
-Claude 4 Sonnet was used for this task.
-:::
-
 ### goose Prompt
 
 ```

--- a/documentation/docs/mcp/cloudflare-mcp.md
+++ b/documentation/docs/mcp/cloudflare-mcp.md
@@ -131,10 +131,6 @@ Choose one or more servers based on your needs. Here are the most popular config
 
 Let's use the Observability server to debug performance issues with a Workers application:
 
-:::info LLM
-Anthropic's Claude 4 Sonnet was used for this task.
-:::
-
 #### goose Prompt
 ```
 I'm seeing high error rates on my Workers application "my-api-worker". Can you help me:

--- a/documentation/docs/mcp/cloudinary-asset-management-mcp.md
+++ b/documentation/docs/mcp/cloudinary-asset-management-mcp.md
@@ -76,10 +76,6 @@ Let's use the Cloudinary extension to find and transform product images with adv
 2. Apply complex transformations including background removal
 3. Add text overlays with precise positioning
 
-:::info LLM
-Anthropic's Claude 4 Sonnet was used for this task.
-:::
-
 ### goose Prompt
 ```
 1. find shoe images in my Cloudinary samples that have 'shoe' in the filename or public ID.

--- a/documentation/docs/mcp/cognee-mcp.md
+++ b/documentation/docs/mcp/cognee-mcp.md
@@ -72,10 +72,6 @@ See the [Cognee MCP documentation](https://docs.cognee.ai/how-to-guides/deployme
 
 Cognee provides knowledge graph memory capabilities for goose, allowing it to remember and connect information across conversations and documents.
 
-:::info LLM
-OpenAI's GPT-4o was used for this task.
-:::
-
 ### goose Prompt
 
 > _goose, please cognify this information: "I prefer Python for data analysis and use pandas extensively. My current project involves analyzing customer behavior data." Then search for information about my programming preferences._

--- a/documentation/docs/mcp/computer-controller-mcp.md
+++ b/documentation/docs/mcp/computer-controller-mcp.md
@@ -55,10 +55,6 @@ Let goose complete its tasks without interruption - avoid using your mouse or ke
 
 In this example, I'll show you how goose can multitask, handling everything from system controls and music playback to web research and data organization.
 
-:::info LLM
-Anthropic's Claude 4 Sonnet was used for this task.
-:::
-
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
    1. Open a new session in goose Desktop

--- a/documentation/docs/mcp/developer-mcp.md
+++ b/documentation/docs/mcp/developer-mcp.md
@@ -56,10 +56,6 @@ The Developer extension is already enabled by default when goose is installed.
 
 In this example, I'm going to have goose automate setting up my JavaScript developer environment with Express, Mongoose, Nodemon, Dotenv and initialize Git.
 
-:::info LLM
-Anthropic's Claude 4 Sonnet was used for this task.
-:::
-
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>

--- a/documentation/docs/mcp/jetbrains-mcp.md
+++ b/documentation/docs/mcp/jetbrains-mcp.md
@@ -174,11 +174,6 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
 
 In this example, I'm going to upgrade a Java project to the latest LTS version.
 
-:::info LLM
-Anthropic's Claude 4 Sonnet was used for this task.
-:::
-
-
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
    1. Open [IntelliJ](https://www.jetbrains.com/idea/download) (JetBrains' Java and Kotlin IDE)

--- a/documentation/docs/mcp/playwright-mcp.md
+++ b/documentation/docs/mcp/playwright-mcp.md
@@ -60,10 +60,6 @@ Let's use goose with the Playwright extension to create a cross-browser testing 
 2. Generate maintainable test code
 3. Capture screenshots for visual comparison
 
-:::info LLM
-Anthropic's Claude 4 Sonnet was used for this task.
-:::
-
 ### goose Prompt
 ```
 Test the random redesign generator app (https://blackgirlbytes.github.io/random-redesign-picker/) 


### PR DESCRIPTION
## Summary
a lot of the MCP guides indicated the model that was used... these models are now old, some even deprecated. just removing it altogether.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [X] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

