### PR TITLE
fix: use dynamic port for Tetrate auth callback server

### DIFF
--- a/crates/goose/examples/tetrate_auth.rs
+++ b/crates/goose/examples/tetrate_auth.rs
@@ -10,13 +10,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create new PKCE auth flow
     let mut auth_flow = TetrateAuth::new()?;
 
-    // Get the auth URL that would be opened
-    let auth_url = auth_flow.get_auth_url();
-    println!("Auth URL: {}", auth_url);
-    println!("\nStarting authentication flow...");
+    println!("Starting authentication flow...");
     println!("This will:");
-    println!("1. Open your browser to the auth page");
-    println!("2. Start a local server on port 3000");
+    println!("1. Start a local server on a dynamic port");
+    println!("2. Open your browser to the auth page");
     println!("3. Wait for the callback\n");
 
     // Complete the full flow

--- a/crates/goose/src/config/signup_tetrate/server.rs
+++ b/crates/goose/src/config/signup_tetrate/server.rs
@@ -9,7 +9,6 @@ use axum::{
 use include_dir::{include_dir, Dir};
 use minijinja::{context, Environment};
 use serde::Deserialize;
-use std::net::SocketAddr;
 use tokio::sync::oneshot;
 
 static TEMPLATES_DIR: Dir = include_dir!("$CARGO_MANIFEST_DIR/src/config/signup_tetrate/templates");
@@ -20,14 +19,13 @@ struct CallbackQuery {
     error: Option<String>,
 }
 
-/// Run the callback server on localhost:3000
+/// Run the callback server using the provided listener.
 pub async fn run_callback_server(
+    listener: tokio::net::TcpListener,
     code_tx: oneshot::Sender<String>,
     shutdown_rx: oneshot::Receiver<()>,
 ) -> Result<()> {
     let app = Router::new().route("/", get(handle_callback));
-    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
-    let listener = tokio::net::TcpListener::bind(addr).await?;
     let state = std::sync::Arc::new(tokio::sync::Mutex::new(Some(code_tx)));
 
     axum::serve(listener, app.with_state(state.clone()).into_make_service())

--- a/crates/goose/src/config/signup_tetrate/tests.rs
+++ b/crates/goose/src/config/signup_tetrate/tests.rs
@@ -34,15 +34,16 @@ fn test_code_challenge_generation() {
 #[test]
 fn test_auth_url_generation() {
     let flow = PkceAuthFlow::new().unwrap();
-    let auth_url = flow.get_auth_url();
+    let auth_url = flow.get_auth_url(12345);
 
     // Verify URL contains required parameters
     assert!(auth_url.contains("callback="));
     assert!(auth_url.contains("code_challenge="));
     assert!(auth_url.starts_with(TETRATE_AUTH_URL));
 
-    // Verify callback URL is properly encoded
-    assert!(auth_url.contains(&*urlencoding::encode(CALLBACK_URL)));
+    // Verify callback URL contains the dynamic port
+    let expected_callback = format!("{}:{}", CALLBACK_BASE, 12345);
+    assert!(auth_url.contains(&*urlencoding::encode(&expected_callback)));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
<!-- Describe your change -->

  - The Tetrate login auth callback server was hardcoded to port 3000, causing failures when that port was already in use
  - Changed to bind to port 0 (OS assigned), read back the actual port, and pass it into the auth URL dynamically
  - The listener is now created by the caller and passed into run_callback_server, keeping port knowledge in one place


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

Fixed port 3000

https://github.com/user-attachments/assets/c864cd49-886c-4e00-b36c-40a4e22837f3

After:   

Dynamic port allocation

https://github.com/user-attachments/assets/d9b833e9-3162-4c70-97b9-07e451bbf4a6


