### PR TITLE
fix(claude-code): allow goose to run inside a Claude Code session

### DIFF
--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -198,6 +198,8 @@ impl ClaudeCodeProvider {
     fn build_stream_json_command(&self) -> Command {
         let mut cmd = Command::new(&self.command);
         configure_subprocess(&mut cmd);
+        // Allow goose to run inside a Claude Code session.
+        cmd.env_remove("CLAUDECODE");
         cmd.arg("--input-format")
             .arg("stream-json")
             .arg("--output-format")


### PR DESCRIPTION
## Summary

This makes the Claude Code provider to work when goose is run inside a Claude Code session.

Claude Code 2.1.42+ sets `CLAUDECODE=1` and refuses to start when it detects that variable. Removing it from the child process environment lets goose spawn claude normally.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

Before (from inside a Claude Code session):
```bash
GOOSE_PROVIDER=claude-code GOOSE_MODEL=sonnet target/release/goose run --text "say just hello"
# starting session | provider: claude-code model: sonnet
#     session id: 20260214_23
#     working directory: /Users/codefromthecrypt/oss/goose-goosed
# Ran into this error: Request failed: CLI process terminated while waiting for set_model response.
```

After:
```bash
GOOSE_PROVIDER=claude-code GOOSE_MODEL=sonnet target/release/goose run --text "say just hello"
# starting session | provider: claude-code model: sonnet
#     session id: 20260214_24
#     working directory: /Users/codefromthecrypt/oss/goose-goosed
# Hello! 👋
```