### PR TITLE
fix(otel): use monotonic_counter prefix and support temporality env var

### DIFF
--- a/crates/goose-cli/src/cli.rs
+++ b/crates/goose-cli/src/cli.rs
@@ -1059,7 +1059,7 @@ async fn handle_interactive_session(
     };
 
     tracing::info!(
-        counter.goose.session_starts = 1,
+        monotonic_counter.goose.session_starts = 1,
         session_type,
         interactive = true,
         "Session started"
@@ -1136,7 +1136,7 @@ async fn log_session_completion(
         .unwrap_or((0, 0));
 
     tracing::info!(
-        counter.goose.session_completions = 1,
+        monotonic_counter.goose.session_completions = 1,
         session_type,
         exit_type,
         duration_ms = session_duration.as_millis() as u64,
@@ -1146,14 +1146,14 @@ async fn log_session_completion(
     );
 
     tracing::info!(
-        counter.goose.session_duration_ms = session_duration.as_millis() as u64,
+        monotonic_counter.goose.session_duration_ms = session_duration.as_millis() as u64,
         session_type,
         "Session duration"
     );
 
     if total_tokens > 0 {
         tracing::info!(
-            counter.goose.session_tokens = total_tokens,
+            monotonic_counter.goose.session_tokens = total_tokens,
             session_type,
             "Session tokens"
         );
@@ -1236,7 +1236,7 @@ fn parse_run_input(
             }
 
             tracing::info!(
-                counter.goose.recipe_runs = 1,
+                monotonic_counter.goose.recipe_runs = 1,
                 recipe_name = %recipe_display_name,
                 recipe_version = %recipe_version,
                 session_type = "recipe",
@@ -1323,7 +1323,7 @@ async fn handle_run_command(
         let session_type = if recipe.is_some() { "recipe" } else { "run" };
 
         tracing::info!(
-            counter.goose.session_starts = 1,
+            monotonic_counter.goose.session_starts = 1,
             session_type,
             interactive = false,
             "Headless session started"
@@ -1437,7 +1437,7 @@ pub async fn cli() -> anyhow::Result<()> {
 
     let command_name = get_command_name(&cli.command);
     tracing::info!(
-        counter.goose.cli_commands = 1,
+        monotonic_counter.goose.cli_commands = 1,
         command = command_name,
         "CLI command executed"
     );

--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1740,7 +1740,7 @@ fn log_tool_metrics(message: &Message, messages: &Conversation) {
         if let MessageContent::ToolRequest(tool_request) = content {
             if let Ok(tool_call) = &tool_request.tool_call {
                 tracing::info!(
-                    counter.goose.tool_calls = 1,
+                    monotonic_counter.goose.tool_calls = 1,
                     tool_name = %tool_call.name,
                     "Tool call started"
                 );
@@ -1771,7 +1771,7 @@ fn log_tool_metrics(message: &Message, messages: &Conversation) {
                 "error"
             };
             tracing::info!(
-                counter.goose.tool_completions = 1,
+                monotonic_counter.goose.tool_completions = 1,
                 tool_name = %tool_name,
                 result = %result_status,
                 "Tool call completed"

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -66,7 +66,7 @@ fn track_tool_telemetry(content: &MessageContent, all_messages: &[Message]) {
             let result_status = if success { "success" } else { "error" };
 
             tracing::info!(
-                counter.goose.tool_completions = 1,
+                monotonic_counter.goose.tool_completions = 1,
                 tool_name = %tool_name,
                 result = %result_status,
                 "Tool call completed"
@@ -209,7 +209,7 @@ pub async fn reply(
     let session_start = std::time::Instant::now();
 
     tracing::info!(
-        counter.goose.session_starts = 1,
+        monotonic_counter.goose.session_starts = 1,
         session_type = "app",
         interface = "ui",
         "Session started"
@@ -225,7 +225,7 @@ pub async fn reply(
                 .unwrap_or_else(|| "unknown".to_string());
 
             tracing::info!(
-                counter.goose.recipe_runs = 1,
+                monotonic_counter.goose.recipe_runs = 1,
                 recipe_name = %recipe_name,
                 recipe_version = %recipe_version,
                 session_type = "app",
@@ -396,7 +396,7 @@ pub async fn reply(
         if let Ok(session) = state.session_manager().get_session(&session_id, true).await {
             let total_tokens = session.total_tokens.unwrap_or(0);
             tracing::info!(
-                counter.goose.session_completions = 1,
+                monotonic_counter.goose.session_completions = 1,
                 session_type = "app",
                 interface = "ui",
                 exit_type = "normal",
@@ -407,7 +407,7 @@ pub async fn reply(
             );
 
             tracing::info!(
-                counter.goose.session_duration_ms = session_duration.as_millis() as u64,
+                monotonic_counter.goose.session_duration_ms = session_duration.as_millis() as u64,
                 session_type = "app",
                 interface = "ui",
                 "Session duration"
@@ -415,7 +415,7 @@ pub async fn reply(
 
             if total_tokens > 0 {
                 tracing::info!(
-                    counter.goose.session_tokens = total_tokens,
+                    monotonic_counter.goose.session_tokens = total_tokens,
                     session_type = "app",
                     interface = "ui",
                     "Session tokens"
@@ -423,7 +423,7 @@ pub async fn reply(
             }
         } else {
             tracing::info!(
-                counter.goose.session_completions = 1,
+                monotonic_counter.goose.session_completions = 1,
                 session_type = "app",
                 interface = "ui",
                 exit_type = "normal",
@@ -434,7 +434,7 @@ pub async fn reply(
             );
 
             tracing::info!(
-                counter.goose.session_duration_ms = session_duration.as_millis() as u64,
+                monotonic_counter.goose.session_duration_ms = session_duration.as_millis() as u64,
                 session_type = "app",
                 interface = "ui",
                 "Session duration"

--- a/crates/goose-server/src/routes/schedule.rs
+++ b/crates/goose-server/src/routes/schedule.rs
@@ -274,7 +274,7 @@ async fn run_now_handler(
 
     let recipe_version_tag = recipe_version_opt.as_deref().unwrap_or("");
     tracing::info!(
-        counter.goose.recipe_runs = 1,
+        monotonic_counter.goose.recipe_runs = 1,
         recipe_name = %recipe_display_name,
         recipe_version = %recipe_version_tag,
         session_type = "schedule",

--- a/crates/goose/src/agents/tool_execution.rs
+++ b/crates/goose/src/agents/tool_execution.rs
@@ -88,7 +88,7 @@ impl Agent {
                         // Log user decision if this was a security alert
                         if let Some(finding_id) = get_security_finding_id_from_results(&request.id, inspection_results) {
                             tracing::info!(
-                                counter.goose.prompt_injection_user_decisions = 1,
+                                monotonic_counter.goose.prompt_injection_user_decisions = 1,
                                 decision = ?confirmation.permission,
                                 finding_id = %finding_id,
                                 tool_request_id = %request.id,

--- a/crates/goose/src/security/mod.rs
+++ b/crates/goose/src/security/mod.rs
@@ -61,7 +61,7 @@ impl SecurityManager {
     ) -> Result<Vec<SecurityResult>> {
         if !self.is_prompt_injection_detection_enabled() {
             tracing::debug!(
-                counter.goose.prompt_injection_scanner_disabled = 1,
+                monotonic_counter.goose.prompt_injection_scanner_disabled = 1,
                 "Security scanning disabled"
             );
             return Ok(vec![]);
@@ -74,7 +74,7 @@ impl SecurityManager {
                 match PromptInjectionScanner::with_ml_detection() {
                     Ok(s) => {
                         tracing::info!(
-                            counter.goose.prompt_injection_scanner_enabled = 1,
+                            monotonic_counter.goose.prompt_injection_scanner_enabled = 1,
                             "Security scanner initialized with ML-based detection"
                         );
                         s
@@ -90,7 +90,7 @@ impl SecurityManager {
                 }
             } else {
                 tracing::info!(
-                    counter.goose.prompt_injection_scanner_enabled = 1,
+                    monotonic_counter.goose.prompt_injection_scanner_enabled = 1,
                     "Security scanner initialized with pattern-based detection only"
                 );
                 PromptInjectionScanner::new()
@@ -124,7 +124,7 @@ impl SecurityManager {
                         serde_json::to_string(&tool_call).unwrap_or_else(|_| "{}".to_string());
 
                     tracing::warn!(
-                        counter.goose.prompt_injection_finding = 1,
+                        monotonic_counter.goose.prompt_injection_finding = 1,
                         threat_type = "command_injection",
                         above_threshold = above_threshold,
                         tool_name = %tool_call.name,
@@ -164,7 +164,7 @@ impl SecurityManager {
         }
 
         tracing::info!(
-            counter.goose.prompt_injection_analysis_performed = 1,
+            monotonic_counter.goose.prompt_injection_analysis_performed = 1,
             security_issues_found = results.len(),
             "Prompt injection detection: Security analysis complete"
         );


### PR DESCRIPTION
## Summary

This fixes a regression where most (not all) otel metrics were accidentally changed from `monotonic_counter.` to `counter.` and adds ENV support for metrics temporality preference.

The regression is subtle but made the metrics practically unusable for the things you'd actually want (rates, alerts, per-minute breakdowns).
For example, when monotonic a counter becomes a Prometheus counter, suppporting `rate()` and `increase()`, allowing you to build dashbaords like "tool calls per minute" or "sessions per hour".

Similar to our other ENV, this adds support for `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`
The default temporarilty is `cumulative`, which on export sends the total since the process start.
Backends who compute deltas internally, like Prometheus, expect this default.

`delta` only sends the delta since the last export, which is needed for backends like Elastic Stack and otel-tui.
When this isn't configurable, metrics are counted incorrectly, a total mistaken for a delta. This makes the metrics unusable.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

- New `temporality_preference_from_env` parameterized tests

### Related Issues

- #3772 — initial OTel PR (used correct `monotonic_counter.` prefix)
- #3871 — regressed prefix to `counter.` for all but one metric.
- #7144 — use ENV for otel config
- open-telemetry/opentelemetry-rust#3351 — `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` in the SDK