### PR TITLE
fix: avoid shell-escaping special characters except quotes

### DIFF
--- a/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionList.tsx
+++ b/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionList.tsx
@@ -2,6 +2,7 @@ import ExtensionItem from './ExtensionItem';
 import builtInExtensionsData from '../../../../built-in-extensions.json';
 import { ExtensionConfig } from '../../../../api';
 import { FixedExtensionEntry } from '../../../ConfigContext';
+import { combineCmdAndArgs } from '../utils';
 
 interface ExtensionListProps {
   extensions: FixedExtensionEntry[];
@@ -137,7 +138,7 @@ export function getSubtitle(config: ExtensionConfig) {
     default:
       return {
         description: config.description || null,
-        command: 'cmd' in config ? [config.cmd, ...config.args].join(' ') : null,
+        command: 'cmd' in config ? combineCmdAndArgs(config.cmd, config.args) : null,
       };
   }
 }

--- a/ui/desktop/src/components/settings/extensions/utils.test.ts
+++ b/ui/desktop/src/components/settings/extensions/utils.test.ts
@@ -156,6 +156,85 @@ describe('Extension Utils', () => {
         headers: [],
       });
     });
+
+    it('should not escape @ in command args', () => {
+      const extension: FixedExtensionEntry = {
+        type: 'stdio',
+        name: 'context7',
+        description: 'Context7 MCP',
+        cmd: 'npx',
+        args: ['-y', '@upstash/context7-mcp'],
+        enabled: true,
+      };
+
+      const formData = extensionToFormData(extension);
+      expect(formData.cmd).toBe('npx -y @upstash/context7-mcp');
+    });
+
+    it('should quote args with spaces', () => {
+      const extension: FixedExtensionEntry = {
+        type: 'stdio',
+        name: 'java-app',
+        description: 'Java app',
+        cmd: '/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home/bin/java',
+        args: ['-classpath', '/path/with spaces/lib.jar', 'Main'],
+        enabled: true,
+      };
+
+      const formData = extensionToFormData(extension);
+      expect(formData.cmd).toBe(
+        '"/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home/bin/java" -classpath "/path/with spaces/lib.jar" Main'
+      );
+    });
+
+    it('should roundtrip command with @ through form data', () => {
+      const extension: FixedExtensionEntry = {
+        type: 'stdio',
+        name: 'context7',
+        description: 'Context7 MCP',
+        cmd: 'npx',
+        args: ['-y', '@upstash/context7-mcp'],
+        enabled: true,
+      };
+
+      const formData = extensionToFormData(extension);
+      const { cmd, args } = splitCmdAndArgs(formData.cmd || '');
+      expect(cmd).toBe('npx');
+      expect(args).toEqual(['-y', '@upstash/context7-mcp']);
+    });
+
+    it('should roundtrip command with spaces through form data', () => {
+      const extension: FixedExtensionEntry = {
+        type: 'stdio',
+        name: 'java-app',
+        description: 'Java app',
+        cmd: '/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home/bin/java',
+        args: ['-classpath', '/path/with spaces/lib.jar', 'Main'],
+        enabled: true,
+      };
+
+      const formData = extensionToFormData(extension);
+      const { cmd, args } = splitCmdAndArgs(formData.cmd || '');
+      expect(cmd).toBe('/Applications/IntelliJ IDEA.app/Contents/jbr/Contents/Home/bin/java');
+      expect(args).toEqual(['-classpath', '/path/with spaces/lib.jar', 'Main']);
+    });
+
+    it('should roundtrip args with double quotes and spaces through form data', () => {
+      const extension: FixedExtensionEntry = {
+        type: 'stdio',
+        name: 'test',
+        description: 'test',
+        cmd: 'node',
+        args: ['/My "Project"/bin/run'],
+        enabled: true,
+      };
+
+      const formData = extensionToFormData(extension);
+      expect(formData.cmd).toBe('node \'/My "Project"/bin/run\'');
+      const { cmd, args } = splitCmdAndArgs(formData.cmd || '');
+      expect(cmd).toBe('node');
+      expect(args).toEqual(['/My "Project"/bin/run']);
+    });
   });
 
   describe('createExtensionConfig', () => {


### PR DESCRIPTION
## Summary

Fixed https://github.com/block/goose/issues/6816 with the display issue.

Replace shell-quote's quote() with a simple quoting function for displaying extension commands in the UI.  The shell quote function does more escape which is not necessary for display eg: "@" -> "//@".  Keep shell-quote's parse() for command parsing on user input.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Unit test and manual testing

### Screenshots/Demos (for UX changes)
Before:  
<img width="605" height="690" alt="Screenshot 2026-02-16 at 3 48 49 pm" src="https://github.com/user-attachments/assets/ed62cde2-bc5d-424f-92da-bba66927e993" />

After:   
<img width="604" height="694" alt="Screenshot 2026-02-16 at 3 48 00 pm" src="https://github.com/user-attachments/assets/ffa958e9-c998-426c-969e-0fe2e145b1a9" />


