### PR TITLE
fix(ui): preserve server config values on partial provider config save

### DIFF
--- a/ui/desktop/src/components/settings/providers/modal/ProviderConfiguationModal.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/ProviderConfiguationModal.tsx
@@ -105,8 +105,15 @@ export default function ProviderConfigurationModal({
 
     const toSubmit = Object.fromEntries(
       Object.entries(configValues)
-        .filter(([_k, entry]) => !!entry.value)
-        .map(([k, entry]) => [k, entry.value || ''])
+        .filter(
+          ([_k, entry]) =>
+            !!entry.value ||
+            (entry.serverValue != null && typeof entry.serverValue === 'string')
+        )
+        .map(([k, entry]) => [
+          k,
+          entry.value ?? (typeof entry.serverValue === 'string' ? entry.serverValue : ''),
+        ])
     );
 
     try {


### PR DESCRIPTION
## Summary
- Fixes #7245 — OpenAI API Host (and other non-secret config fields) silently revert to default when saving a partial provider configuration
- The submit filter in `ProviderConfiguationModal.tsx` now includes fields with existing non-masked server values (`serverValue` as plain string), not just fields where the user typed a new value
- Masked/secret values are correctly excluded from the fallback (they remain on the server unchanged)

## Test plan
- [ ] Configure a provider with both API Host and API Key set
- [ ] Edit only the API Key (leave Host untouched) and save
- [ ] Verify the Host value persists (previously it silently reverted to default)
- [ ] Verify secret fields (masked values) still work correctly when unchanged
- [ ] TypeScript type check passes: `npx tsc --noEmit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)