### PR TITLE
fix: relax test_basic_response assertion for providers returning reasoning_content

### DIFF
--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -179,15 +179,17 @@ impl ProviderTester {
             .complete(session_id, "You are a helpful assistant.", &[message], &[])
             .await?;
 
-        assert_eq!(
-            response.content.len(),
-            1,
-            "Expected single content item in response"
+        assert!(
+            !response.content.is_empty(),
+            "Expected at least one content item in response"
         );
 
         assert!(
-            matches!(response.content[0], MessageContent::Text(_)),
-            "Expected text response"
+            response
+                .content
+                .iter()
+                .any(|c| matches!(c, MessageContent::Text(_))),
+            "Expected at least one text content item in response"
         );
 
         println!(


### PR DESCRIPTION
## Summary
- Relaxes `test_basic_response` assertion in `crates/goose/tests/providers.rs` from requiring exactly 1 content item to requiring >= 1
- Verifies at least one content item is `Text` (instead of checking only `content[0]`)
- Fixes xAI provider test failure where models return `reasoning_content` alongside text (2 content items)

## Context
xAI (and other OpenAI-compatible providers like DeepSeek) can return a `reasoning_content` field in their response. The OpenAI format handler (`openai.rs:346-352`) correctly captures this as a `MessageContent::reasoning()` item, but the test assertion assumed all providers return exactly 1 content item.

## Test plan
- [ ] `cargo check --test providers -p goose` compiles clean
- [ ] Assertion logic correctly handles single-item responses (most providers)
- [ ] Assertion logic correctly handles multi-item responses with reasoning_content (xAI, DeepSeek)

🤖 Generated with [Claude Code](https://claude.com/claude-code)