### PR TITLE
refactor: remove allows_unlisted_models flag, always allow custom model entry

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -465,13 +465,11 @@ fn select_model_from_list(
                 ),
             );
 
-            if provider_meta.allows_unlisted_models {
-                model_items.push((
-                    UNLISTED_MODEL_KEY.to_string(),
-                    "Enter a model not listed...".to_string(),
-                    "",
-                ));
-            }
+            model_items.push((
+                UNLISTED_MODEL_KEY.to_string(),
+                "Enter a model not listed...".to_string(),
+                "",
+            ));
 
             let selection = cliclack::select("Select a model:")
                 .items(&model_items)
@@ -491,13 +489,11 @@ fn select_model_from_list(
         let mut model_items: Vec<(String, String, &str)> =
             models.iter().map(|m| (m.clone(), m.clone(), "")).collect();
 
-        if provider_meta.allows_unlisted_models {
-            model_items.push((
-                UNLISTED_MODEL_KEY.to_string(),
-                "Enter a model not listed...".to_string(),
-                "",
-            ));
-        }
+        model_items.push((
+            UNLISTED_MODEL_KEY.to_string(),
+            "Enter a model not listed...".to_string(),
+            "",
+        ));
 
         let selection = cliclack::select("Select a model:")
             .items(&model_items)

--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -111,9 +111,6 @@ pub struct ProviderMetadata {
     pub model_doc_link: String,
     /// Required configuration keys
     pub config_keys: Vec<ConfigKey>,
-    /// Whether this provider allows entering model names not in the fetched list
-    #[serde(default)]
-    pub allows_unlisted_models: bool,
 }
 
 impl ProviderMetadata {
@@ -144,7 +141,6 @@ impl ProviderMetadata {
                 .collect(),
             model_doc_link: model_doc_link.to_string(),
             config_keys,
-            allows_unlisted_models: false,
         }
     }
 
@@ -165,7 +161,6 @@ impl ProviderMetadata {
             known_models: models,
             model_doc_link: model_doc_link.to_string(),
             config_keys,
-            allows_unlisted_models: false,
         }
     }
 
@@ -178,14 +173,7 @@ impl ProviderMetadata {
             known_models: vec![],
             model_doc_link: "".to_string(),
             config_keys: vec![],
-            allows_unlisted_models: false,
         }
-    }
-
-    /// Set allows_unlisted_models flag (builder pattern)
-    pub fn with_unlisted_models(mut self) -> Self {
-        self.allows_unlisted_models = true;
-        self
     }
 }
 

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -865,7 +865,6 @@ impl ProviderDef for ChatGptCodexProvider {
                 None,
             )],
         )
-        .with_unlisted_models()
     }
 
     fn from_env(

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -647,10 +647,6 @@ impl ProviderDef for ClaudeCodeProvider {
             CLAUDE_CODE_DOC_URL,
             vec![ConfigKey::from_value_type::<ClaudeCodeCommand>(true, false)],
         )
-        // The model list only returns aliases the `claude` CLI uses, such as "default"
-        // and "haiku". There is no listing that includes full names like
-        // "claude-sonnet-4-5-20250929". However, they are permitted.
-        .with_unlisted_models()
     }
 
     fn from_env(

--- a/crates/goose/src/providers/codex.rs
+++ b/crates/goose/src/providers/codex.rs
@@ -603,7 +603,6 @@ impl ProviderDef for CodexProvider {
                 ConfigKey::from_value_type::<CodexSkipGitCheck>(false, false),
             ],
         )
-        .with_unlisted_models()
     }
 
     fn from_env(

--- a/crates/goose/src/providers/cursor_agent.rs
+++ b/crates/goose/src/providers/cursor_agent.rs
@@ -292,7 +292,6 @@ impl ProviderDef for CursorAgentProvider {
                 true, false,
             )],
         )
-        .with_unlisted_models()
     }
 
     fn from_env(

--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -590,7 +590,6 @@ impl ProviderDef for GcpVertexAIProvider {
                 ),
             ],
         )
-        .with_unlisted_models()
     }
 
     fn from_env(
@@ -824,6 +823,5 @@ mod tests {
         assert!(!metadata.known_models.is_empty());
         assert_eq!(metadata.default_model, "gemini-2.5-flash");
         assert_eq!(metadata.config_keys.len(), 6);
-        assert!(metadata.allows_unlisted_models);
     }
 }

--- a/crates/goose/src/providers/gemini_cli.rs
+++ b/crates/goose/src/providers/gemini_cli.rs
@@ -276,7 +276,6 @@ impl ProviderDef for GeminiCliProvider {
             GEMINI_CLI_DOC_URL,
             vec![ConfigKey::from_value_type::<GeminiCliCommand>(true, false)],
         )
-        .with_unlisted_models()
     }
 
     fn from_env(

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -252,7 +252,6 @@ impl ProviderDef for OpenRouterProvider {
                 ),
             ],
         )
-        .with_unlisted_models()
     }
 
     fn from_env(

--- a/crates/goose/src/providers/provider_registry.rs
+++ b/crates/goose/src/providers/provider_registry.rs
@@ -120,7 +120,6 @@ impl ProviderRegistry {
             known_models,
             model_doc_link: base_metadata.model_doc_link,
             config_keys,
-            allows_unlisted_models: false,
         };
 
         self.entries.insert(

--- a/crates/goose/tests/agent.rs
+++ b/crates/goose/tests/agent.rs
@@ -368,7 +368,6 @@ mod tests {
                     known_models: vec![],
                     model_doc_link: "".to_string(),
                     config_keys: vec![],
-                    allows_unlisted_models: false,
                 }
             }
 

--- a/crates/goose/tests/compaction.rs
+++ b/crates/goose/tests/compaction.rs
@@ -187,7 +187,6 @@ impl ProviderDef for MockCompactionProvider {
             known_models: vec![],
             model_doc_link: "".to_string(),
             config_keys: vec![],
-            allows_unlisted_models: false,
         }
     }
 

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -5553,10 +5553,6 @@
           "config_keys"
         ],
         "properties": {
-          "allows_unlisted_models": {
-            "type": "boolean",
-            "description": "Whether this provider allows entering model names not in the fetched list"
-          },
           "config_keys": {
             "type": "array",
             "items": {

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -749,10 +749,6 @@ export type ProviderEngine = 'openai' | 'ollama' | 'anthropic';
  */
 export type ProviderMetadata = {
     /**
-     * Whether this provider allows entering model names not in the fetched list
-     */
-    allows_unlisted_models?: boolean;
-    /**
      * Required configuration keys
      */
     config_keys: Array<ConfigKey>;

--- a/ui/desktop/src/components/recipes/shared/RecipeModelSelector.tsx
+++ b/ui/desktop/src/components/recipes/shared/RecipeModelSelector.tsx
@@ -60,13 +60,11 @@ export const RecipeModelSelector = ({
             provider: p.name,
           }));
 
-          if (p.metadata.allows_unlisted_models) {
-            options.push({
-              value: `__custom__:${p.name}`,
-              label: 'Enter a model not listed...',
-              provider: p.name,
-            });
-          }
+          options.push({
+            value: `__custom__:${p.name}`,
+            label: 'Enter a model not listed...',
+            provider: p.name,
+          });
 
           if (options.length > 0) {
             groupedOptions.push({ options });

--- a/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
+++ b/ui/desktop/src/components/settings/models/subcomponents/SwitchModelModal.tsx
@@ -248,7 +248,7 @@ export const SwitchModelModal = ({
             providerType: p.provider_type,
           }));
 
-          if (p.metadata.allows_unlisted_models && p.provider_type !== 'Custom') {
+          if (p.provider_type !== 'Custom') {
             options.push({
               value: 'custom',
               label: 'Enter a model not listed...',


### PR DESCRIPTION
## Summary
- Removes the `allows_unlisted_models` field from `ProviderMetadata` and its `with_unlisted_models()` builder method
- All providers now always allow users to enter custom model names not in the fetched list
- Simplifies CLI `configure.rs` to unconditionally show "Enter a model not listed..." option
- Updates `RecipeModelSelector.tsx` and `SwitchModelModal.tsx` to always show custom model entry
- Regenerates OpenAPI schema and TypeScript types (field fully removed from API)
- 16 files changed, 56 deletions, 16 insertions

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — passes (2 pre-existing integration failures: claude_code, xai)
- [x] `npx tsc --noEmit` — clean
- [x] `just generate-openapi` — regenerated, no `allows_unlisted_models` references remain

Fixes #7103

🤖 Generated with [Claude Code](https://claude.com/claude-code)