### PR TITLE
fix(ui): prevent MCP app iframe from staying stuck at compressed width

### DIFF
--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -547,8 +547,8 @@ export default function McpAppRenderer({
   const containerStyle = isExpandedView
     ? { width: '100%', height: '100%' }
     : {
-        width: iframeWidth !== null ? `${iframeWidth}px` : '100%',
-        maxWidth: '100%',
+        width: '100%',
+        maxWidth: iframeWidth !== null ? `${iframeWidth}px` : '100%',
         height: `${iframeHeight || DEFAULT_IFRAME_HEIGHT}px`,
       };
 


### PR DESCRIPTION
## Summary
- Fixes #6818 — MCP app iframe gets stuck at compressed width after window resize
- The `size-changed` notification from MCP apps was setting a fixed pixel `width` on the container, which never grew back when the window expanded (the app can't detect size changes beyond its own container bounds)
- Changed to use the app-reported width as `maxWidth` instead of `width`, so the container stays fluid (`width: 100%`) and naturally expands with the window while still respecting the app's preferred maximum

## Root cause
PR #6376 introduced width tracking from `ui/notifications/size-changed`. When an app reported its width (e.g., `400px` when compressed), the container was pinned to that exact width. Since the app is inside the container, it couldn't detect the window growing beyond `400px` to send a larger width notification — a feedback loop that kept it stuck.

## Test plan
- [ ] Open an MCP app in Goose desktop
- [ ] Shrink the window to compress the app
- [ ] Expand the window back — app should now fill available width (previously stayed compressed)
- [ ] Verify apps that report a preferred width still get `maxWidth` capping
- [ ] `npx tsc --noEmit` passes
- [ ] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)