### PR TITLE
Improve compaction messages to enable better post-compaction agent behavior

### DIFF
--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -17,19 +17,19 @@ use tracing::log::warn;
 pub const DEFAULT_COMPACTION_THRESHOLD: f64 = 0.8;
 
 const CONVERSATION_CONTINUATION_TEXT: &str =
-    "The previous message contains a summary that was prepared because a context limit was reached.
+    "Your context was compacted. The previous message contains a summary of the conversation so far.
 Do not mention that you read a summary or that conversation summarization occurred.
-Just continue the conversation naturally based on the summarized context";
+Just continue the conversation naturally based on the summarized context.";
 
 const TOOL_LOOP_CONTINUATION_TEXT: &str =
-    "The previous message contains a summary that was prepared because a context limit was reached.
+    "Your context was compacted. The previous message contains a summary of the conversation so far.
 Do not mention that you read a summary or that conversation summarization occurred.
 Continue calling tools as necessary to complete the task.";
 
 const MANUAL_COMPACT_CONTINUATION_TEXT: &str =
-    "The previous message contains a summary that was prepared at the user's request.
+    "Your context was compacted at the user's request. The previous message contains a summary of the conversation so far.
 Do not mention that you read a summary or that conversation summarization occurred.
-Just continue the conversation naturally based on the summarized context";
+Just continue the conversation naturally based on the summarized context.";
 
 #[derive(Serialize)]
 struct SummarizeContext {


### PR DESCRIPTION
## Summary

Updates the continuation messages injected after context compaction to explicitly inform the agent that its context was compacted. This gives the agent accurate information about its own state, enabling it to act appropriately after compaction events.

## Problem

The previous wording was passive and indirect:
> "The previous message contains a summary that was prepared because a context limit was reached."

This phrasing obscures what actually happened. The agent doesn't clearly understand that:
1. Its context window was compacted
2. It's now operating from a summary, not full conversation history
3. It may need to re-verify assumptions or reload context

## Solution

Updated all three continuation messages to use explicit, direct language:
> "Your context was compacted. The previous message contains a summary of the conversation so far."

This accurate framing allows agents to:
- Understand their current state
- Make informed decisions about whether to reload context (e.g., re-read files, check TODO)
- Avoid assumptions based on "remembered" details that may have been lost in summarization

## Changes

- `CONVERSATION_CONTINUATION_TEXT` — normal conversation flow
- `TOOL_LOOP_CONTINUATION_TEXT` — compaction during active tool execution  
- `MANUAL_COMPACT_CONTINUATION_TEXT` — user-triggered `/compact`

## Testing

All existing `context_mgmt` tests pass. No behavioral changes to compaction logic—this is purely a wording improvement to the injected messages.