### PR TITLE
feat(otel): make otel logging level configurable

### DIFF
--- a/crates/goose/src/otel/otlp.rs
+++ b/crates/goose/src/otel/otlp.rs
@@ -546,14 +546,14 @@ mod tests {
         assert_eq!(create_resource(), expected);
     }
 
-    #[test_case(&[], Level::INFO; "default is info")]
+    #[test_case(&[("RUST_LOG", "")], Level::INFO; "default is info")]
     #[test_case(&[("RUST_LOG", "debug")], Level::DEBUG; "RUST_LOG takes precedence")]
-    #[test_case(&[("OTEL_LOG_LEVEL", "error")], Level::ERROR; "OTEL_LOG_LEVEL fallback")]
+    #[test_case(&[("RUST_LOG", ""), ("OTEL_LOG_LEVEL", "error")], Level::ERROR; "OTEL_LOG_LEVEL fallback")]
     #[test_case(&[("RUST_LOG", "warn"), ("OTEL_LOG_LEVEL", "error")], Level::WARN; "RUST_LOG wins over OTEL_LOG_LEVEL")]
     #[test_case(&[("RUST_LOG", "goose=debug"), ("OTEL_LOG_LEVEL", "trace")], Level::TRACE; "directive RUST_LOG falls through to OTEL_LOG_LEVEL")]
     #[test_case(&[("RUST_LOG", "goose=debug")], Level::INFO; "directive RUST_LOG falls through to default")]
-    #[test_case(&[("OTEL_LOG_LEVEL", "INFO")], Level::INFO; "case insensitive")]
-    #[test_case(&[("OTEL_LOG_LEVEL", "bogus")], Level::INFO; "unknown defaults to info")]
+    #[test_case(&[("RUST_LOG", ""), ("OTEL_LOG_LEVEL", "INFO")], Level::INFO; "case insensitive")]
+    #[test_case(&[("RUST_LOG", ""), ("OTEL_LOG_LEVEL", "bogus")], Level::INFO; "unknown defaults to info")]
     fn otel_logs_level_from_env(env: &[(&'static str, &'static str)], expected: Level) {
         let _guard = clear_otel_env(env);
         assert_eq!(otel_logs_level(), expected);


### PR DESCRIPTION
## Summary

Make the OTLP log filter level configurable instead of hardcoded to `WARN`. Follows the Rust community pattern: `RUST_LOG` → `OTEL_LOG_LEVEL` → default `info`.

### Type of Change
- [x] Feature

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

No exporter — no OTel output in console:
```bash
$ ./target/release/goose run -t "hello"
● new session · openai gpt-5-nano
    20260217_5 · /Users/codefromthecrypt/oss/goose-goosed
Hello! Happy to help with Goose.
```

Default (info) — shows INFO log records:
```bash
$ OTEL_LOGS_EXPORTER=console ./target/release/goose run -t "hello"
Logs
Resource
	 ->  service.name=String(Static("goose"))
	 ->  service.namespace=String(Static("goose"))
	 ->  telemetry.sdk.language=String(Static("rust"))
	 ->  service.version=String(Static("1.24.0"))
	 ->  telemetry.sdk.version=String(Static("0.31.0"))
	 ->  telemetry.sdk.name=String(Static("opentelemetry"))
Log #0
	 Instrumentation Scope: InstrumentationScope { name: "", version: None, schema_url: None, attributes: [] }
	 EventName: "event crates/goose-cli/src/cli.rs:1439"
	 Target (Scope): "goose_cli::cli"
	 Observed Timestamp: 2026-02-17 15:03:21.868813
	 SeverityText: "INFO"
	 SeverityNumber: Info
	 Body: String(Owned("CLI command executed"))
	 Attributes:
		 ->  counter.goose.cli_commands: Int(1)
		 ->  command: String(Owned("run"))
```

WARN only — no INFO log records in output:
```bash
$ OTEL_LOG_LEVEL=warn OTEL_LOGS_EXPORTER=console ./target/release/goose run -t "hello"
● new session · openai gpt-5-nano
    20260217_4 · /Users/codefromthecrypt/oss/goose-goosed
Hello! Nice to meet you. I'm ready to help with the goose-goosed repo.
```

### Related Issues

Continues ENV support from #7144