### PR TITLE
feat: add GOOSE_SUBAGENT_MODEL and GOOSE_SUBAGENT_PROVIDER config options

### DIFF
--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -1414,6 +1414,11 @@ impl SummonClient {
                     .as_ref()
                     .and_then(|s| s.goose_provider.clone())
             })
+            .or_else(|| {
+                Config::global()
+                    .get_param::<String>("GOOSE_SUBAGENT_PROVIDER")
+                    .ok()
+            })
             .or_else(|| session.provider_name.clone())
             .ok_or_else(|| anyhow::anyhow!("No provider configured"))?;
 
@@ -1430,6 +1435,8 @@ impl SummonClient {
             .and_then(|s| s.goose_model.as_ref())
         {
             model_config.model_name = model.clone();
+        } else if let Ok(model) = Config::global().get_param::<String>("GOOSE_SUBAGENT_MODEL") {
+            model_config.model_name = model;
         }
 
         if let Some(temp) = params.temperature {


### PR DESCRIPTION
Adds `GOOSE_SUBAGENT_MODEL` and `GOOSE_SUBAGENT_PROVIDER` to the subagent provider resolution chain in `resolve_provider()`. Uses `Config::global().get_param()` (env var with config.yaml fallback), matching the `GOOSE_LEAD_*`/`GOOSE_PLANNER_*` pattern.

Priority: delegate params > recipe/agent settings > these config options > parent session inheritance.

One or both can be set. When neither is set, behavior is unchanged.