### PR TITLE
fix extension selector not displaying the correct enabled extensions

### DIFF
--- a/ui/desktop/src/components/bottom_menu/BottomMenuExtensionSelection.tsx
+++ b/ui/desktop/src/components/bottom_menu/BottomMenuExtensionSelection.tsx
@@ -34,6 +34,11 @@ export const BottomMenuExtensionSelection = ({ sessionId }: BottomMenuExtensionS
   const isHubView = !sessionId;
 
   useEffect(() => {
+    setIsSessionExtensionsLoaded(false);
+    setSessionExtensions([]);
+  }, [sessionId]);
+
+  useEffect(() => {
     const handleExtensionsLoaded = () => {
       setRefreshTrigger((prev) => prev + 1);
     };
@@ -53,8 +58,11 @@ export const BottomMenuExtensionSelection = ({ sessionId }: BottomMenuExtensionS
     };
   }, []);
 
-  // Fetch session-specific extensions or use global defaults
   useEffect(() => {
+    if (refreshTrigger === 0 && !isOpen) {
+      return;
+    }
+
     const fetchExtensions = async () => {
       if (!sessionId) {
         return;
@@ -75,7 +83,6 @@ export const BottomMenuExtensionSelection = ({ sessionId }: BottomMenuExtensionS
       }
     };
 
-    setIsSessionExtensionsLoaded(false);
     fetchExtensions();
   }, [sessionId, isOpen, refreshTrigger]);
 

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -433,6 +433,7 @@ export function useChatStream({
           },
         },
       });
+      window.dispatchEvent(new CustomEvent(AppEvents.SESSION_EXTENSIONS_LOADED));
       onSessionLoaded?.();
       return;
     }


### PR DESCRIPTION
## Summary
The extension selector count in the bottom menu was showing wrong numbers
when starting a new chat — for example showing 3 instead of 4 — even though
all extensions loaded successfully in the agent.

Two problems were causing this:

On the backend, when a new session starts, all extensions load concurrently.
Each one was individually persisting the extension state to the session
database after it finished loading, snapshotting whatever extensions happened
to exist in the manager at that moment. Since they finish at different times,
the last persist to complete could miss extensions that other concurrent
futures hadn't yet registered, corrupting the session's extension list. The
fix extracts the shared logic into add_extension_inner, has add_extension
(used by user-initiated actions) call it then persist, and has
load_extensions_from_session call it directly for each concurrent extension
then do a single persist after all of them complete.

On the frontend, the extension selector was eagerly fetching the session's
extension list from the API the moment the session ID changed, before the
backend had finished loading extensions. This returned stale data and caused
a brief wrong count before the correct data arrived. The fix separates the
session ID reset into its own effect and gates the fetch effect so it only
runs after the SESSION_EXTENSIONS_LOADED event fires or the dropdown opens —
never on a bare session ID change. That event is now also dispatched for
cached sessions so the selector gets the signal when resuming an existing
chat too.
