### PR TITLE
ci: add fork guards to scheduled workflows

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -18,6 +18,7 @@ on:
 jobs:
   deny:
     runs-on: ubuntu-latest
+    if: github.repository == 'block/goose'
     permissions:
       contents: read
     steps:

--- a/.github/workflows/minor-release.yaml
+++ b/.github/workflows/minor-release.yaml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   release:
+    if: github.repository == 'block/goose'
     uses: ./.github/workflows/create-release-pr.yaml
     with:
       bump_type: "minor"

--- a/.github/workflows/rebuild-skills-marketplace.yml
+++ b/.github/workflows/rebuild-skills-marketplace.yml
@@ -23,6 +23,7 @@ concurrency:
 jobs:
   rebuild-docs:
     runs-on: ubuntu-latest
+    if: github.repository == 'block/goose'
     permissions:
       contents: write
 

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     # `publish_results: true` only works when run from the default branch. conditional can be removed if disabled.
-    if: github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request'
+    if: github.repository == 'block/goose' && (github.event.repository.default_branch == github.ref_name || github.event_name == 'pull_request')
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -24,6 +24,7 @@ jobs:
   stale:
     name: 'Mark and Close Stale PRs'
     runs-on: ubuntu-latest
+    if: github.repository == 'block/goose'
     
     steps:
       # Use the official stale action from GitHub

--- a/.github/workflows/update-hacktoberfest-leaderboard.yml
+++ b/.github/workflows/update-hacktoberfest-leaderboard.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   update-leaderboard:
     runs-on: ubuntu-latest
+    if: github.repository == 'block/goose'
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/update-health-dashboard.yml
+++ b/.github/workflows/update-health-dashboard.yml
@@ -23,6 +23,7 @@ jobs:
   update-dashboard:
     name: 'Update Health Dashboard'
     runs-on: ubuntu-latest
+    if: github.repository == 'block/goose'
     
     steps:
       - name: 'Download previous metrics'


### PR DESCRIPTION
## Summary
Prevent scheduled GH workflows from failing on forks of goose


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [x] Build / Release
- [ ] Other (specify below)
