### PR TITLE
fix(openai): support "reasoning" field alias in streaming deltas

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -53,6 +53,7 @@ struct Delta {
     role: Option<String>,
     tool_calls: Option<Vec<DeltaToolCall>>,
     reasoning_details: Option<Vec<Value>>,
+    #[serde(alias = "reasoning")]
     reasoning_content: Option<String>,
 }
 
@@ -338,8 +339,11 @@ pub fn response_to_message(response: &Value) -> anyhow::Result<Message> {
 
     let mut content = Vec::new();
 
-    // Capture reasoning_content if present (for DeepSeek reasoning models)
-    if let Some(reasoning_content) = original.get("reasoning_content") {
+    // Capture reasoning content if present (DeepSeek uses "reasoning_content", vLLM uses "reasoning")
+    let reasoning_value = original
+        .get("reasoning_content")
+        .or_else(|| original.get("reasoning"));
+    if let Some(reasoning_content) = reasoning_value {
         if let Some(reasoning_str) = reasoning_content.as_str() {
             if !reasoning_str.is_empty() {
                 content.push(MessageContent::reasoning(reasoning_str));


### PR DESCRIPTION
## Summary

Add serde alias so both "reasoning" (vLLM, see vllm-project/vllm#27752) and "reasoning_content" (DeepSeek, SGLang etc) are recognized in streaming deltas. Once "reasoning" becomes the standard, it could become the primary field name.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested locally with vllm.