### PR TITLE
docs: add GOOSE_INPUT_LIMIT environment variable documentation

### DIFF
--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -306,6 +306,7 @@ These variables allow you to override the default context window size (token lim
 | Variable | Purpose | Values | Default |
 |----------|---------|---------|---------|
 | `GOOSE_CONTEXT_LIMIT` | Override context limit for the main model | Integer (number of tokens) | Model-specific default or 128,000 |
+| `GOOSE_INPUT_LIMIT` | Override input prompt limit for ollama requests (maps to `num_ctx`) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 | `GOOSE_LEAD_CONTEXT_LIMIT` | Override context limit for the lead model in [lead/worker mode](/docs/tutorials/lead-worker) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 | `GOOSE_WORKER_CONTEXT_LIMIT` | Override context limit for the worker model in lead/worker mode | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
 | `GOOSE_PLANNER_CONTEXT_LIMIT` | Override context limit for the [planner model](/docs/guides/creating-plans) | Integer (number of tokens) | Falls back to `GOOSE_CONTEXT_LIMIT` or model default |
@@ -315,6 +316,8 @@ These variables allow you to override the default context window size (token lim
 ```bash
 # Set context limit for main model (useful for LiteLLM proxies)
 export GOOSE_CONTEXT_LIMIT=200000
+# Override ollama input prompt limit
+export GOOSE_INPUT_LIMIT=32000
 
 # Set different context limits for lead/worker models
 export GOOSE_LEAD_CONTEXT_LIMIT=500000   # Large context for planning


### PR DESCRIPTION
Split from #7281 - documents the new `GOOSE_INPUT_LIMIT` environment variable for overriding ollama input prompt limits.

Relates to #7264