### PR TITLE
feat: add Moonshot and Kimi Code declarative providers

### DIFF
--- a/crates/goose/src/providers/declarative/kimi.json
+++ b/crates/goose/src/providers/declarative/kimi.json
@@ -1,0 +1,19 @@
+{
+    "name": "Kimi",
+    "metadata": {
+        "homepage": "https://kimi.ai",
+        "docs": "https://platform.moonshot.cn/docs/intro",
+        "description": "Kimi Code AI models optimized for coding tasks"
+    },
+    "engine": {
+        "type": "openai",
+        "base_url": "https://api.moonshot.cn/v1",
+        "api_key_env_var": "MOONSHOT_API_KEY"
+    },
+    "models": [
+        {"name": "kimi-for-coding", "context_limit": 262144},
+        {"name": "kimi-code", "context_limit": 262144}
+    ],
+    "streaming_default": true,
+    "pricing_info_url": "https://platform.moonshot.cn/pricing"
+}

--- a/crates/goose/src/providers/declarative/moonshot.json
+++ b/crates/goose/src/providers/declarative/moonshot.json
@@ -1,0 +1,23 @@
+{
+    "name": "Moonshot",
+    "metadata": {
+        "homepage": "https://kimi.moonshot.cn/",
+        "docs": "https://platform.moonshot.cn/docs/intro",
+        "description": "Moonshot AI (Kimi) models"
+    },
+    "engine": {
+        "type": "openai",
+        "base_url": "https://api.moonshot.cn/v1",
+        "api_key_env_var": "MOONSHOT_API_KEY"
+    },
+    "models": [
+        {"name": "kimi-latest", "context_limit": 131072},
+        {"name": "kimi-thinking-preview", "context_limit": 131072},
+        {"name": "kimi-k2-0711", "context_limit": 131072},
+        {"name": "kimi-k2", "context_limit": 262144},
+        {"name": "moonshot-v1-8k", "context_limit": 8192},
+        {"name": "moonshot-v1-32k", "context_limit": 32768}
+    ],
+    "streaming_default": true,
+    "pricing_info_url": "https://platform.moonshot.cn/pricing"
+}


### PR DESCRIPTION
## Summary

Add declarative provider configurations for Moonshot AI (Kimi) models, combining the work from PRs #6962 and #7222.

## Changes

### New Provider Files
- **moonshot.json**: General Moonshot/Kimi models
  - kimi-latest (131K context)
  - kimi-thinking-preview (131K context)
  - kimi-k2-0711 (131K context)
  - kimi-k2 (262K context)
  - moonshot-v1-8k (8K context)
  - moonshot-v1-32k (32K context)

- **kimi.json**: Coding-optimized Kimi models
  - kimi-for-coding (262K context)
  - kimi-code (262K context)

Both providers use the Moonshot API (`api.moonshot.cn`) with `MOONSHOT_API_KEY`.

## Related PRs
- Closes #6962 (feat: support for Moonshot LLMs)
- Closes #7222 (feat: add Kimi Code provider)
- #7294 (already merged - reasoning field alias support)

## Notes
The reasoning_content handling changes from #6962 and #7222 are already in main (likely from #7294 or earlier work), so this PR only adds the missing declarative provider configurations.

## Testing
- `cargo build -p goose` ✅
