### PR TITLE
docs: escape variable syntax in recipes

### DIFF
--- a/documentation/docs/guides/prompt-templates.md
+++ b/documentation/docs/guides/prompt-templates.md
@@ -111,6 +111,15 @@ Templates use [Jinja2](https://jinja.palletsprojects.com/) syntax for dynamic co
 
 Check out the default templates (linked to from the [table](#available-prompt-templates) above) to find common variables, such as `{{ extensions }}` and `{{ hints }}`.
 
+#### Escaping Template Variables
+
+If you need to include literal variable syntax in your templates without substitution, wrap it in single quotes:
+
+```markdown
+This will substitute: {{ variable }}
+This will appear literally: {{'{{variable}}'}}
+```
+
 :::warning
 Be careful when modifying template variables, as incorrect changes can break functionality. Test your changes in a new session to ensure they work as expected.
 :::

--- a/documentation/docs/guides/recipes/recipe-reference.md
+++ b/documentation/docs/guides/recipes/recipe-reference.md
@@ -682,6 +682,7 @@ activities:
 ```
 
 Advanced template features include:
+- [Escaping template variables](#escaping-template-variables) for literal output
 - [Template inheritance](#template-inheritance) using `{% extends "parent.yaml" %}`
 - Blocks that can be defined and overridden:
   ```yaml
@@ -690,6 +691,35 @@ Advanced template features include:
   {% endblock %}
   ```
 - [`indent()` template filter](#indent-filter-for-multi-line-values)
+
+### Escaping Template Variables
+
+To include literal template syntax (like `{{ variable }}`) in your recipe without parameter substitution, wrap it in single quotes:
+
+```yaml
+prompt: |
+  This will be substituted: {{ actual_parameter }}
+  This will appear literally: {{'{{example_variable}}'}}
+```
+
+**Example:** Generate a configuration file template
+
+```yaml
+version: "1.0.0"
+title: "Generate Config Template"
+description: "Generate a template with placeholder values"
+parameters:
+  - key: app_name
+    input_type: string
+    requirement: required
+    description: "Application name"
+
+prompt: |
+  Create a config.yaml file for {{ app_name }} with these placeholder variables:
+  - {{'{{API_KEY}}'}} for the API key
+  - {{'{{DATABASE_URL}}'}} for the database connection
+  - {{'{{PORT}}'}} for the server port
+```
 
 ### Template Inheritance
 


### PR DESCRIPTION
## Summary
Document escaping Jinja variable syntax in recipes: https://github.com/block/goose/pull/6975


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Manual testing
