### PR TITLE
docs: remove ALPHA_FEATURES flag from documentation

### DIFF
--- a/documentation/blog/2025-07-21-orchestrating-subagents/index.md
+++ b/documentation/blog/2025-07-21-orchestrating-subagents/index.md
@@ -50,11 +50,9 @@ For this project, I turned my subagents into an on-demand dev squad, and I assig
 Sidenote: It felt like I was assembling the Avengers.
 ![avengers](avengers.gif)
 
-Since the feature is still experimental, I had to enable it via an environment variable:
-
-```bash
-export GOOSE_ALPHA_FEATURES=true  
-```
+:::note
+As of version 1.10.0, subagents are no longer experimental and don't require enabling any feature flags.
+:::
 
 ## Instructing My Team
 

--- a/documentation/blog/2025-08-10-vibe-coding-with-goose-building-apps-with-ai-agents/index.md
+++ b/documentation/blog/2025-08-10-vibe-coding-with-goose-building-apps-with-ai-agents/index.md
@@ -395,8 +395,11 @@ What we demonstrated in this workshop hints at a fascinating future for software
 Want to try this yourself? Here's what you need:
 
 1. **Install and Configure Goose**: Follow the [quickstart guide](https://block.github.io/goose/docs/quickstart)
-2. **Enable Alpha Features**: Add `ALPHA_FEATURES: true` to your config
-3. **Start Small**: Try building a simple app first to get comfortable with the workflow
+2. **Start Small**: Try building a simple app first to get comfortable with the workflow
+
+:::note
+As of version 1.10.0, subagents are no longer experimental and don't require enabling any feature flags.
+:::
 
 The [complete workshop materials](https://gist.github.com/angiejones/60ff19c08c5a3992e42adc8de3e96309) are available, including step-by-step instructions and cheat sheet prompts. 
 

--- a/documentation/docs/guides/config-files.md
+++ b/documentation/docs/guides/config-files.md
@@ -56,14 +56,6 @@ The following settings can be configured at the root level of your config.yaml f
 | `SECURITY_PROMPT_CLASSIFIER_TOKEN` | Authentication token for `SECURITY_PROMPT_CLASSIFIER_ENDPOINT` | String | None | No |
 | `GOOSE_TELEMETRY_ENABLED` | Enable [anonymous usage data](/docs/guides/usage-data) collection | true/false | false | No |
 
-## Experimental Features
-
-These settings enable experimental features that are in active development. These may change or be removed in future releases.
-
-| Setting | Purpose | Values | Default | Required |
-|---------|---------|---------|---------|-----------|
-| `ALPHA_FEATURES` | Enables access to experimental alpha features&mdash;check the feature docs to see if this flag is required | true/false | false | No |
-
 Additional [environment variables](/docs/guides/environment-variables) may also be supported in config.yaml.
 
 ## Example Configuration

--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -543,24 +543,6 @@ export GOOSE_RECIPE_RETRY_TIMEOUT_SECONDS=300
 export GOOSE_RECIPE_ON_FAILURE_TIMEOUT_SECONDS=60
 ```
 
-## Experimental Features
-
-These variables enable experimental features that are in active development. These may change or be removed in future releases. Use with caution in production environments.
-
-| Variable | Purpose | Values | Default |
-|----------|---------|---------|---------|
-| `ALPHA_FEATURES` | Enables experimental alpha features&mdash;check the feature docs to see if this flag is required | "true", "1" (case-insensitive) to enable | false |
-
-**Examples**
-
-```bash
-# Enable alpha features
-export ALPHA_FEATURES=true
-
-# Or enable for a single session
-ALPHA_FEATURES=true goose session
-```
-
 ## Development & Testing
 
 These variables are primarily used for development, testing, and debugging goose itself.


### PR DESCRIPTION
## Summary
Remove the ALPHA_FEATURES flag from documentation since subagents are now generally available.

## Changes
- Remove "Experimental Features" section from `config-files.md`
- Remove "Experimental Features" section from `environment-variables.md`
- Update blog posts with note that subagents are GA as of version 1.10.0:
  - `2025-07-21-orchestrating-subagents/index.md`
  - `2025-08-10-vibe-coding-with-goose-building-apps-with-ai-agents/index.md`

## Why
Subagents were moved out of experimental in version 1.10.0 (commit 937c75bc51a), so the ALPHA_FEATURES flag is no longer needed.