### PR TITLE
docs: rename Code Execution extension to Code Mode extension

### DIFF
--- a/documentation/blog/2025-12-21-code-mode-doesnt-replace-mcp/index.md
+++ b/documentation/blog/2025-12-21-code-mode-doesnt-replace-mcp/index.md
@@ -37,7 +37,7 @@ When the concept of Code Mode landed on socials, many people claimed it was a re
 
 ### How goose Implemented Code Mode
 
-[goose](/) took a unique approach by making [Code Mode](/blog/2025/12/15/code-mode-mcp) itself an extension called the Code Execution extension. When active, it wraps your other extensions and exposes them as JavaScript modules, allowing the LLM to see only three tools instead of eighty.
+[goose](/) took a unique approach by making [Code Mode](/blog/2025/12/15/code-mode-mcp) itself an extension called the Code Mode extension. When active, it wraps your other extensions and exposes them as JavaScript modules, allowing the LLM to see only three tools instead of eighty.
 
 When the agent needs to perform a complex task, it writes a script that looks something like this:
 

--- a/documentation/blog/2026-02-06-8-things-you-didnt-know-about-code-mode/index.md
+++ b/documentation/blog/2026-02-06-8-things-you-didnt-know-about-code-mode/index.md
@@ -32,7 +32,7 @@ Code Mode support landed in goose v1.17.0 in December 2025. It ships as a platfo
 To enable it:
 
 - **Desktop app:** Click the extensions icon and toggle on "Code Execution"
-- **CLI:** Run `goose configure` and enable the Code Execution extension
+- **CLI:** Run `goose configure` and enable the Code Mode extension
 
 Since its initial implementation, we've added so many improvements!
 

--- a/documentation/docs/getting-started/using-extensions.md
+++ b/documentation/docs/getting-started/using-extensions.md
@@ -37,7 +37,7 @@ Platform extensions are built-in extensions that provide global features like co
 
 - [Apps](/docs/mcp/apps-mcp): Create, manage, and launch custom HTML apps in standalone windows
 - [Chat Recall](/docs/mcp/chatrecall-mcp): Search conversation content across all your session history
-- [Code Execution](/docs/mcp/code-execution-mcp): Execute JavaScript code for tool discovery and tool calling
+- [Code Mode](/docs/mcp/code-mode-mcp): Execute JavaScript code for tool discovery and tool calling
 - [Extension Manager](/docs/mcp/extension-manager-mcp): Discover, enable, and disable extensions dynamically during sessions (enabled by default)
 - [Summon](/docs/mcp/summon-mcp): Load skills and recipes, and delegate tasks to subagents (enabled by default)
 - [Todo](/docs/mcp/todo-mcp): Manage task lists and track progress across sessions (enabled by default)

--- a/documentation/docs/guides/managing-tools/code-mode.md
+++ b/documentation/docs/guides/managing-tools/code-mode.md
@@ -11,7 +11,7 @@ import TabItem from '@theme/TabItem';
 Code Mode is a method of interacting with MCP tools programmatically instead of calling them directly. Code Mode is particularly useful when working with many enabled extensions, as it can help manage context window usage more efficiently.
 
 :::info
-This functionality requires the built-in [Code Execution extension](/docs/mcp/code-execution-mcp) to be enabled.
+This functionality requires the built-in [Code Mode extension](/docs/mcp/code-mode-mcp) to be enabled.
 :::
 
 Code Mode controls how tools are discovered and called:
@@ -21,7 +21,7 @@ Code Mode controls how tools are discovered and called:
 
 ## How Code Mode Works
 
-The [Code Execution extension](/docs/mcp/code-execution-mcp) is an MCP server that uses the MCP protocol to expose three foundational meta-tools. When Code Execution is enabled, goose switches to Code Mode. For every request, the LLM writes JavaScript code that goose runs in a sandbox environment to:
+The [Code Mode extension](/docs/mcp/code-mode-mcp) is an MCP server that uses the MCP protocol to expose three foundational meta-tools. When Code Mode is enabled, goose switches to Code Mode. For every request, the LLM writes JavaScript code that goose runs in a sandbox environment to:
 - Discover available tools from your enabled extensions (if needed)
 - Learn how to work with the tools it needs for the current task
 - Call those tools programmatically to complete the task
@@ -32,7 +32,7 @@ Traditional MCP tool calling and Code Mode are two different approaches to the s
 
 | Aspect | Traditional | Code Mode |
 |--------|------------------|-----------|
-| **Tool Discovery** | All tools from enabled extensions, for example:<br/>• `developer.shell`<br/>• `developer.text_editor`<br/>• `github.list_issues`<br/>• `github.get_pull_request`<br/>• `slack.send_message`<br/>• ... *potentially many more* | Code Execution extension's meta-tools:<br/>• `list_functions`<br/>• `get_function_details`<br/>• `execute`<br/><br/>The LLM uses these tools to discover tools from other enabled extensions as needed |
+| **Tool Discovery** | All tools from enabled extensions, for example:<br/>• `developer.shell`<br/>• `developer.text_editor`<br/>• `github.list_issues`<br/>• `github.get_pull_request`<br/>• `slack.send_message`<br/>• ... *potentially many more* | Code Mode extension's meta-tools:<br/>• `list_functions`<br/>• `get_function_details`<br/>• `execute`<br/><br/>The LLM uses these tools to discover tools from other enabled extensions as needed |
 | **Tool Calling** | • Sequential tool calls<br/>• Each result sent to the LLM before the next call | • May require tool discovery calls<br/>• Multiple tool calls batched in one execution<br/>• Intermediate results are chained and processed locally |
 | **Context Window** | Every LLM call includes all tool definitions from enabled extensions | Every LLM call includes the 3 meta-tool definitions, plus any tool definitions previously discovered in the session |
 | **Best For** | • 1-3 enabled extensions<br/>• Simple tasks using 1-2 tools | • 5+ extensions<br/>• Well-defined multi-step workflows |

--- a/documentation/docs/mcp/code-mode-mcp.md
+++ b/documentation/docs/mcp/code-mode-mcp.md
@@ -1,5 +1,5 @@
 ---
-title: Code Execution Extension
+title: Code Mode Extension
 description: Execute JavaScript code to interact with multiple MCP tools
 ---
 
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 import { PlatformExtensionNote } from '@site/src/components/PlatformExtensionNote';
 import GooseBuiltinInstaller from '@site/src/components/GooseBuiltinInstaller';
 
-The Code Execution extension enables [Code Mode](/docs/guides/managing-tools/code-mode), a programmatic approach for interacting with MCP tools.
+The Code Mode extension enables [Code Mode](/docs/guides/managing-tools/code-mode), a programmatic approach for interacting with MCP tools.
 
 In Code Mode, the LLM discovers which tools are available from your enabled extensions and writes JavaScript code that goose runs in one execution instead of calling tools directly and one at a time. This helps manage context window usage more efficiently when multiple extensions are enabled and when performing workflows with multiple tool calls.
 


### PR DESCRIPTION
## Summary

Renames the "Code Execution extension" to "Code Mode extension" throughout the documentation for consistency.

## Changes

### File Rename
- `docs/mcp/code-execution-mcp.md` → `docs/mcp/code-mode-mcp.md`

### Content Updates
- **docs/mcp/code-mode-mcp.md**: Updated title and description
- **docs/guides/managing-tools/code-mode.md**: Updated 3 references (info box, description, and table)
- **docs/getting-started/using-extensions.md**: Updated link and name in built-in extensions list
- **blog/2025-12-21-code-mode-doesnt-replace-mcp/index.md**: Updated 1 reference
- **blog/2026-02-06-8-things-you-didnt-know-about-code-mode/index.md**: Updated 1 reference (CLI instructions)

### Link Updates
All internal links updated from `/docs/mcp/code-execution-mcp` to `/docs/mcp/code-mode-mcp`

## Test Plan

Documentation changes only - verified all source file references have been updated and no remaining references to "Code Execution extension" or `code-execution-mcp` exist.