### PR TITLE
feat(chatgpt_codex): add gpt-5.3-codex support

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -74,6 +74,7 @@ impl ModelConfig {
     }
 
     fn new_base(model_name: String, context_env_var: Option<&str>) -> Result<Self, ConfigError> {
+        let predefined = find_predefined_model(&model_name);
         let context_limit = if let Some(env_var) = context_env_var {
             if let Ok(val) = std::env::var(env_var) {
                 Some(Self::validate_context_limit(&val, env_var)?)
@@ -83,7 +84,10 @@ impl ModelConfig {
         } else if let Ok(val) = std::env::var("GOOSE_CONTEXT_LIMIT") {
             Some(Self::validate_context_limit(&val, "GOOSE_CONTEXT_LIMIT")?)
         } else {
-            None
+            predefined
+                .as_ref()
+                .and_then(|pm| pm.context_limit)
+                .or_else(|| Self::get_model_specific_limit(&model_name))
         };
 
         let max_tokens = Self::parse_max_tokens()?;
@@ -92,8 +96,7 @@ impl ModelConfig {
         let toolshim_model = Self::parse_toolshim_model()?;
 
         // Pick up request_params from predefined models (always applies)
-        let predefined = find_predefined_model(&model_name);
-        let request_params = predefined.and_then(|pm| pm.request_params);
+        let request_params = predefined.as_ref().and_then(|pm| pm.request_params.clone());
 
         Ok(Self {
             model_name,
@@ -217,6 +220,14 @@ impl ModelConfig {
             )),
             Ok(val) => Ok(Some(val)),
             Err(_) => Ok(None),
+        }
+    }
+
+    fn get_model_specific_limit(model_name: &str) -> Option<usize> {
+        if model_name.contains("gpt-5.3-codex") {
+            Some(400_000)
+        } else {
+            None
         }
     }
 
@@ -356,5 +367,18 @@ mod tests {
         ]);
         let config = ModelConfig::new("test-model").unwrap();
         assert_eq!(config.max_tokens, None);
+    }
+
+    #[test]
+    fn test_model_config_gpt_5_3_codex_context_limit() {
+        let _guard = env_lock::lock_env([
+            ("GOOSE_MAX_TOKENS", None::<&str>),
+            ("GOOSE_TEMPERATURE", None::<&str>),
+            ("GOOSE_CONTEXT_LIMIT", None::<&str>),
+            ("GOOSE_TOOLSHIM", None::<&str>),
+            ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None::<&str>),
+        ]);
+        let config = ModelConfig::new("gpt-5.3-codex").unwrap();
+        assert_eq!(config.context_limit(), 400_000);
     }
 }

--- a/crates/goose/src/providers/chatgpt_codex.rs
+++ b/crates/goose/src/providers/chatgpt_codex.rs
@@ -45,8 +45,9 @@ const OAUTH_TIMEOUT_SECS: u64 = 300;
 const HTML_AUTO_CLOSE_TIMEOUT_MS: u64 = 2000;
 
 const CHATGPT_CODEX_PROVIDER_NAME: &str = "chatgpt_codex";
-pub const CHATGPT_CODEX_DEFAULT_MODEL: &str = "gpt-5.1-codex";
+pub const CHATGPT_CODEX_DEFAULT_MODEL: &str = "gpt-5.3-codex";
 pub const CHATGPT_CODEX_KNOWN_MODELS: &[&str] = &[
+    "gpt-5.3-codex",
     "gpt-5.2-codex",
     "gpt-5.1-codex",
     "gpt-5.1-codex-mini",
@@ -1227,5 +1228,40 @@ mod tests {
         let claims = parse_jwt_claims_with_jwks(&token, &jwks).unwrap();
 
         assert_eq!(claims.chatgpt_account_id.as_deref(), Some("account-1"));
+    }
+
+    #[test]
+    fn test_metadata_default_model_and_known_models() {
+        let metadata = ChatGptCodexProvider::metadata();
+        assert_eq!(metadata.default_model, "gpt-5.3-codex");
+        assert_eq!(
+            metadata
+                .known_models
+                .iter()
+                .map(|m| m.name.as_str())
+                .collect::<Vec<_>>(),
+            CHATGPT_CODEX_KNOWN_MODELS
+        );
+        assert!(metadata
+            .known_models
+            .iter()
+            .any(|m| m.name == "gpt-5.3-codex"));
+    }
+
+    #[tokio::test]
+    async fn test_fetch_supported_models_order() {
+        let provider =
+            ChatGptCodexProvider::from_env(ModelConfig::new_or_fail(CHATGPT_CODEX_DEFAULT_MODEL))
+                .await
+                .unwrap();
+        let models = provider.fetch_supported_models().await.unwrap();
+        assert_eq!(
+            models,
+            CHATGPT_CODEX_KNOWN_MODELS
+                .iter()
+                .map(|m| m.to_string())
+                .collect::<Vec<_>>()
+        );
+        assert_eq!(models.first().map(String::as_str), Some("gpt-5.3-codex"));
     }
 }


### PR DESCRIPTION
## Summary
- add `gpt-5.3-codex` to ChatGPT Codex provider known models
- switch ChatGPT Codex default model to `gpt-5.3-codex`
- add explicit context limit for `gpt-5.3-codex` (`400_000`) in model limits

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
- `source /Users/er/Development/goose/bin/activate-hermit`
- `cargo fmt`
- `cargo test -p goose chatgpt_codex -- --nocapture`
- `cargo test -p goose model -- --nocapture`
- `cargo clippy --all-targets -- -D warnings`

### Related Issues
Relates to: N/A  
Discussion: N/A

### Screenshots/Demos (for UX changes)
Before: N/A  
After: N/A