### PR TITLE
feat: add Neighborhood as bundled extension

### DIFF
--- a/ui/desktop/src/components/settings/extensions/bundled-extensions.json
+++ b/ui/desktop/src/components/settings/extensions/bundled-extensions.json
@@ -52,5 +52,17 @@
     "type": "builtin",
     "env_keys": [],
     "bundled": true
+  },
+  {
+    "id": "neighborhood",
+    "name": "neighborhood",
+    "display_name": "Neighborhoods",
+    "description": "Discover nearby restaurants, browse menus, and place takeout orders through natural conversation. Sellers are US-based.",
+    "enabled": false,
+    "type": "streamable_http",
+    "uri": "https://connect.squareup.com/v2/mcp/neighborhood",
+    "env_keys": [],
+    "timeout": 300,
+    "bundled": true
   }
 ]

--- a/ui/desktop/src/components/settings/extensions/bundled-extensions.ts
+++ b/ui/desktop/src/components/settings/extensions/bundled-extensions.ts
@@ -10,12 +10,13 @@ type BundledExtension = {
   display_name?: string;
   description?: string;
   enabled: boolean;
-  type: 'builtin' | 'stdio' | 'sse';
+  type: 'builtin' | 'stdio' | 'sse' | 'streamable_http';
   cmd?: string;
   args?: string[];
   uri?: string;
   envs?: { [key: string]: string };
   env_keys?: Array<string>;
+  headers?: { [key: string]: string };
   timeout?: number;
   allow_configure?: boolean;
 };
@@ -79,6 +80,19 @@ export async function syncBundledExtensions(
             uri: bundledExt.uri || '',
             bundled: true,
           };
+          break;
+        case 'streamable_http':
+          extConfig = {
+            name: bundledExt.name,
+            description: bundledExt.description,
+            type: bundledExt.type,
+            timeout: bundledExt.timeout,
+            uri: bundledExt.uri || '',
+            env_keys: bundledExt.env_keys || [],
+            headers: bundledExt.headers || {},
+            bundled: true,
+          };
+          break;
       }
 
       // Add or update the extension, preserving enabled state if it exists


### PR DESCRIPTION
## Summary

- Add the **Neighborhoods** agentic commerce extension as a bundled-but-disabled extension, allowing any developer to opt in from Settings > Extensions
- Add `streamable_http` transport support to the bundled extension sync logic in the desktop UI — this is the first bundled extension that isn't `builtin` and connects to a remote MCP endpoint
- No Rust backend changes needed; the existing `ExtensionConfig` already supports `streamable_http`

## Details

Neighborhoods lets users discover nearby restaurants, browse menus, and place takeout orders through natural conversation. It connects to a remote MCP endpoint at `https://connect.squareup.com/v2/mcp/neighborhood` via `streamable_http` transport — no local binary or stdio process needed. Sellers on the platform are US-based.

### Files changed

| File | Change |
|------|--------|
| `ui/desktop/src/components/settings/extensions/bundled-extensions.json` | Add `neighborhood` entry (disabled by default) |
| `ui/desktop/src/components/settings/extensions/bundled-extensions.ts` | Add `streamable_http` to type union, add `headers` field, add switch case |

## Test plan

- [x] `tsc --noEmit` passes (typecheck)
- [x] Pre-commit hooks pass (eslint, prettier, typecheck)
- [ ] CI checks: `rust-format`, `rust-build-and-test`, `desktop-lint`, `bundle-desktop-unsigned`
- [ ] Manual: launch desktop app, verify "Neighborhoods" appears in Settings > Extensions as disabled
- [ ] Manual: toggle on, verify `streamable_http` config is added to config store

🤖 Generated with [Claude Code](https://claude.com/claude-code)