### PR TITLE
fix: display 'Code Mode' instead of 'code_execution' in CLI

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -756,7 +756,14 @@ fn split_tool_name(tool_name: &str) -> (String, String) {
         .split_first()
         .map(|(_, s)| s.iter().rev().copied().collect::<Vec<_>>().join("__"))
         .unwrap_or_default();
-    (tool.to_string(), extension)
+    (tool.to_string(), extension_display_name(&extension))
+}
+
+fn extension_display_name(name: &str) -> String {
+    match name {
+        "code_execution" => "Code Mode".to_string(),
+        _ => name.to_string(),
+    }
 }
 
 pub fn format_subagent_tool_call_message(subagent_id: &str, tool_name: &str) -> String {


### PR DESCRIPTION
## Summary
Map the internal extension name `code_execution` to the user-friendly display name `Code Mode` in the CLI to match the Desktop app.

## Changes
- Added `extension_display_name()` function to map internal extension names to display names
- Updated `split_tool_name()` to use this mapping

## Before
Tool calls showed: `execute_code | code_execution`

## After  
Tool calls show: `execute_code | Code Mode`

This matches the display name defined in `crates/goose/src/agents/platform_extensions/mod.rs`.