### PR TITLE
fix(goose-acp): heap allocations

### DIFF
--- a/crates/goose-acp/src/transport/http.rs
+++ b/crates/goose-acp/src/transport/http.rs
@@ -41,13 +41,11 @@ impl HttpState {
 
         let acp_session_id = uuid::Uuid::new_v4().to_string();
 
+        let read_stream = ReceiverToAsyncRead::new(to_agent_rx);
+        let write_stream = SenderToAsyncWrite::new(from_agent_tx);
+        let fut = crate::server::serve(agent, read_stream.compat(), write_stream.compat_write());
         let handle = tokio::spawn(async move {
-            let read_stream = ReceiverToAsyncRead::new(to_agent_rx);
-            let write_stream = SenderToAsyncWrite::new(from_agent_tx);
-
-            if let Err(e) =
-                crate::server::serve(agent, read_stream.compat(), write_stream.compat_write()).await
-            {
+            if let Err(e) = fut.await {
                 error!("ACP session error: {}", e);
             }
         });


### PR DESCRIPTION
`goose-acp` frequently errors out now when clients connect to it via HTTP

```
2026-02-18T14:44:06.016245Z  INFO goose_acp::transport::http: Session created acp_session_id=565b645e-dd6d-4cf9-94d4-0ceff7fd0016

thread 'tokio-runtime-worker' (7050194) has overflowed its stack
fatal runtime error: stack overflow, aborting
zsh: abort      cargo run -p goose-acp
```

this addresses it by `Box`ing things 