### PR TITLE
docs: add Permission Policy documentation for MCP Apps

### DIFF
--- a/documentation/docs/tutorials/building-mcp-apps.md
+++ b/documentation/docs/tutorials/building-mcp-apps.md
@@ -589,7 +589,7 @@ Only add domains you trust. Each domain you add expands what external content ca
 
 ### Requesting Browser Permissions
 
-MCP Apps can request specific browser permissions using Permission Policy. This is useful for apps that need access to device capabilities like camera, microphone, or location services.
+MCP Apps can request specific browser permissions using Permission Policy. This is useful for apps that need access to device capabilities like camera, microphone, or location services. These are requests only - the host may not grant them, and apps should use feature detection to handle cases where permissions are unavailable.
 
 To declare permissions for your MCP App, include the `permissions` object in the resource's `_meta.ui` section:
 


### PR DESCRIPTION
## Summary

Documents the new Permission Policy support for MCP Apps introduced in PR #6947.

## Changes

### `documentation/docs/tutorials/building-mcp-apps.md`

- **Added "Requesting Browser Permissions" subsection** with:
  - Explanation of Permission Policy support for sandbox iframes
  - Code example showing how to declare permissions in `_meta.ui.permissions`
  - Table documenting all 4 permission options (`camera`, `microphone`, `geolocation`, `clipboardWrite`)
  - Practical example of a video recording app requesting camera/microphone
  - Info callout about user consent still being required

- **Updated CSP Configuration section**:
  - Removed deprecated `frameDomains` and `baseUriDomains` options from documentation and code examples (removed in #6947)

## Related

- Ref: PR #6947