### PR TITLE
docs: add CLAUDE_THINKING_BUDGET and CLAUDE_THINKING_ENABLED environm…

### DIFF
--- a/documentation/docs/guides/environment-variables.md
+++ b/documentation/docs/guides/environment-variables.md
@@ -164,6 +164,30 @@ export GOOSE_LEAD_FAILURE_THRESHOLD=3
 export GOOSE_LEAD_FALLBACK_TURNS=2
 ```
 
+### Claude Extended Thinking
+
+These variables control Claude's [extended thinking](https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking) feature, which allows the model to reason through complex problems before generating a response. Supported on Anthropic and Databricks providers.
+
+| Variable | Purpose | Values | Default |
+|----------|---------|---------|---------|
+| `CLAUDE_THINKING_ENABLED` | Enables extended thinking for Claude models | Set to any value to enable | Disabled |
+| `CLAUDE_THINKING_BUDGET` | Maximum tokens allocated for Claude's internal reasoning process | Positive integer (minimum 1024) | 16000 |
+
+**Examples**
+
+```bash
+# Enable extended thinking with default budget (16000 tokens)
+export CLAUDE_THINKING_ENABLED=1
+
+# Enable with a larger budget for complex tasks
+export CLAUDE_THINKING_ENABLED=1
+export CLAUDE_THINKING_BUDGET=32000
+
+# Enable with a smaller budget for faster responses
+export CLAUDE_THINKING_ENABLED=1
+export CLAUDE_THINKING_BUDGET=8000
+```
+
 ### Planning Mode Configuration
 
 These variables control goose's [planning functionality](/docs/guides/creating-plans).


### PR DESCRIPTION
## Summary

Adds documentation for the `CLAUDE_THINKING_ENABLED` and `CLAUDE_THINKING_BUDGET` environment variables to the Environment Variables guide.

## What changed

Added a new "Claude Extended Thinking" section under Model Configuration that documents:

- `CLAUDE_THINKING_ENABLED` - Enables extended thinking for Claude models
- `CLAUDE_THINKING_BUDGET` - Controls the token budget for Claude's internal reasoning process (default: 16000)

The documentation includes:
- How the feature works
- When to use it
- Example configurations
- Supported providers (Anthropic direct API, Databricks)

## Why

These environment variables were implemented but not documented. Users need to know how to enable and configure Claude's extended thinking feature.

