### PR TITLE
Improve link confirmation modal

### DIFF
--- a/ui/desktop/src/components/ui/ConfirmationModal.tsx
+++ b/ui/desktop/src/components/ui/ConfirmationModal.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import {
   Dialog,
   DialogContent,
@@ -12,6 +13,7 @@ export function ConfirmationModal({
   isOpen,
   title,
   message,
+  detail,
   onConfirm,
   onCancel,
   confirmLabel = 'Yes',
@@ -22,6 +24,7 @@ export function ConfirmationModal({
   isOpen: boolean;
   title: string;
   message: string;
+  detail?: React.ReactNode;
   onConfirm: () => void;
   onCancel: () => void;
   confirmLabel?: string;
@@ -31,17 +34,31 @@ export function ConfirmationModal({
 }) {
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onCancel()}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[425px] max-h-[85vh] flex flex-col">
         <DialogHeader>
           <DialogTitle>{title}</DialogTitle>
           <DialogDescription>{message}</DialogDescription>
         </DialogHeader>
 
-        <DialogFooter className="pt-2">
-          <Button variant="outline" onClick={onCancel} disabled={isSubmitting}>
+        {detail && (
+          <div className="overflow-y-auto min-h-0 text-sm text-text-muted break-all">{detail}</div>
+        )}
+
+        <DialogFooter className="pt-2 shrink-0">
+          <Button
+            variant="outline"
+            onClick={onCancel}
+            disabled={isSubmitting}
+            className="focus-visible:ring-2 focus-visible:ring-background-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background-default"
+          >
             {cancelLabel}
           </Button>
-          <Button variant={confirmVariant} onClick={onConfirm} disabled={isSubmitting}>
+          <Button
+            variant={confirmVariant}
+            onClick={onConfirm}
+            disabled={isSubmitting}
+            className="focus-visible:ring-2 focus-visible:ring-background-accent focus-visible:ring-offset-2 focus-visible:ring-offset-background-default"
+          >
             {isSubmitting ? 'Processing...' : confirmLabel}
           </Button>
         </DialogFooter>


### PR DESCRIPTION
## Summary
Fixed the confirm-open-link modal not scrolling when URLs are very long, 
making the action buttons unreachable.

Replaced the native Electron `showMessageBox` dialog with the existing React 
`ConfirmationModal` component for the external link confirmation flow. The 
`ConfirmationModal` now supports an optional scrollable detail section with 
max viewport height constraints, so long URLs wrap and scroll while the 
Cancel/Open buttons always remain visible and accessible.

Also added error handling for when no application is found to open the 
link protocol, and improved keyboard focus visibility on the modal buttons 
using the theme accent color instead of the barely-visible default ring.

<img width="445" height="378" alt="Screenshot 2026-02-18 at 2 57 53 PM" src="https://github.com/user-attachments/assets/78bb3f63-d35c-467d-8185-bf448413ce5f" />
<img width="459" height="524" alt="Screenshot 2026-02-18 at 2 57 42 PM" src="https://github.com/user-attachments/assets/2f8c64e4-a773-4df7-b010-0576b0a494b3" />
