### PR TITLE
feat: add Cerebras provider support

### DIFF
--- a/crates/goose/src/providers/declarative/cerebras.json
+++ b/crates/goose/src/providers/declarative/cerebras.json
@@ -1,0 +1,27 @@
+{
+  "name": "cerebras",
+  "engine": "openai",
+  "display_name": "Cerebras",
+  "description": "Fast inference on Cerebras wafer-scale engines",
+  "api_key_env": "CEREBRAS_API_KEY",
+  "base_url": "https://api.cerebras.ai/v1/chat/completions",
+  "models": [
+    {
+      "name": "llama3.1-8b",
+      "context_limit": 131072
+    },
+    {
+      "name": "gpt-oss-120b",
+      "context_limit": 131072
+    },
+    {
+      "name": "qwen-3-235b-a22b-instruct-2507",
+      "context_limit": 131072
+    },
+    {
+      "name": "zai-glm-4.7",
+      "context_limit": 131072
+    }
+  ],
+  "supports_streaming": true
+}


### PR DESCRIPTION
## Summary
- Add Cerebras as a provider using OpenAI-compatible API
- Supports production models (llama3.1-8b, gpt-oss-120b) and preview models (qwen-3-235b-a22b-instruct-2507, zai-glm-4.7)
- Configuration: CEREBRAS_API_KEY (required), CEREBRAS_HOST (optional)

## Testing
- Verified with curl and goose CLI
- All models work correctly