### PR TITLE
docs: update skills detail page to reference Goose Summon extension

### DIFF
--- a/documentation/src/pages/skills/detail.tsx
+++ b/documentation/src/pages/skills/detail.tsx
@@ -227,7 +227,7 @@ export default function SkillDetailPage(): JSX.Element {
                 </Button>
               </div>
               <p className="text-xs text-zinc-500 dark:text-zinc-500">
-                Requires <a href="https://block.github.io/goose/docs/mcp/summon-mcp" className="text-purple-600 hover:underline">Goose Summon extension</a> enabled
+                Requires <a href="https://block.github.io/goose/docs/mcp/summon-mcp" className="text-purple-600 hover:underline">Summon extension</a> enabled
               </p>
             </div>
 


### PR DESCRIPTION
## Summary

The skills detail page at `/skills/detail` previously referenced the "Goose Skills extension" which has been replaced by the **Summon extension**.

### Changes
- Updated the requirement text from "Requires Goose Skills extension enabled" to "Requires Goose Summon extension enabled"
- Updated the link from `/docs/mcp/skills-mcp` to `/docs/mcp/summon-mcp` to point to the new Summon extension documentation