### PR TITLE
Option to add changeable defaults in goose-releases

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -1046,7 +1046,6 @@ fn find_workspace_or_exe_root() -> Option<PathBuf> {
         path = parent.to_path_buf();
     }
 
-    // No workspace found, return directory containing the executable
     Some(exe_dir)
 }
 
@@ -1791,7 +1790,6 @@ mod tests {
             defaults_file.path(),
         )
         .unwrap();
-        // Return defaults_file to keep it alive (NamedTempFile deletes on drop)
         (config, defaults_file)
     }
 


### PR DESCRIPTION
## Summary
Add option to add changeable defaults in goose-releases. Currently, there's an option to add defaults in `init-config` and `bundles.py` - the former will only add defaults when there is no config file, and the latter will override everything (even the user's config). This PR adds defaults that will be added if the user hasn't set certain variables in their local config file, but will never override the user's config. 

A PR will be made in goose-releases to add the defaults.yaml file and add some initial variables. 

### Type of Change
<!-- Select all that apply -->
- [x] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [x] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->
Local/manual testing using `just run-ui`

