### PR TITLE
Add local model settings access from bottom bar model menu

### DIFF
--- a/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
+++ b/ui/desktop/src/components/settings/models/bottom_bar/ModelsBottomBar.tsx
@@ -1,4 +1,4 @@
-import { Sliders, Bot } from 'lucide-react';
+import { Sliders, Bot, Settings } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { useModelAndProvider } from '../../../ModelAndProviderContext';
 import { SwitchModelModal } from '../subcomponents/SwitchModelModal';
@@ -16,6 +16,8 @@ import { getProviderMetadata } from '../modelInterface';
 import { getModelDisplayName } from '../predefinedModelsUtils';
 import { Alert } from '../../../alerts';
 import BottomMenuAlertPopover from '../../../bottom_menu/BottomMenuAlertPopover';
+import { ModelSettingsPanel } from '../../localInference/ModelSettingsPanel';
+import { ScrollArea } from '../../../ui/scroll-area';
 
 interface ModelsBottomBarProps {
   sessionId: string | null;
@@ -37,6 +39,7 @@ export default function ModelsBottomBar({
   const [displayModelName, setDisplayModelName] = useState<string>('Select Model');
   const [isAddModelModalOpen, setIsAddModelModalOpen] = useState(false);
   const [isLeadWorkerModalOpen, setIsLeadWorkerModalOpen] = useState(false);
+  const [isLocalModelSettingsOpen, setIsLocalModelSettingsOpen] = useState(false);
   const [isLeadWorkerActive, setIsLeadWorkerActive] = useState(false);
   const [providerDefaultModel, setProviderDefaultModel] = useState<string | null>(null);
 
@@ -165,6 +168,12 @@ export default function ModelsBottomBar({
             <span>Lead/Worker Settings</span>
             <Sliders className="ml-auto h-4 w-4" />
           </DropdownMenuItem>
+          {currentProvider === 'local' && currentModel && (
+            <DropdownMenuItem onClick={() => setIsLocalModelSettingsOpen(true)}>
+              <span>Local Model Settings</span>
+              <Settings className="ml-auto h-4 w-4" />
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
 
@@ -179,6 +188,27 @@ export default function ModelsBottomBar({
       {isLeadWorkerModalOpen ? (
         <LeadWorkerSettings isOpen={isLeadWorkerModalOpen} onClose={handleLeadWorkerModalClose} />
       ) : null}
+
+      {isLocalModelSettingsOpen && currentModel && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+          <div className="bg-background-default rounded-lg shadow-lg w-[480px] max-h-[80vh] flex flex-col">
+            <div className="flex items-center justify-between px-4 py-3 border-b border-border-subtle">
+              <h3 className="text-sm font-medium text-text-default">
+                Local Model Settings — {getModelDisplayName(currentModel)}
+              </h3>
+              <button
+                onClick={() => setIsLocalModelSettingsOpen(false)}
+                className="text-text-muted hover:text-text-default text-lg leading-none"
+              >
+                ×
+              </button>
+            </div>
+            <ScrollArea className="flex-1 px-4 py-3 overflow-y-auto max-h-[calc(80vh-52px)]">
+              <ModelSettingsPanel modelId={currentModel} />
+            </ScrollArea>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
When using a local model, the model dropdown in the bottom bar now shows a **Local Model Settings** option that opens a modal with the full model settings panel (temperature, sampling strategy, tool calling, performance tuning, etc).

This makes it easy to tweak local inference settings without navigating to the full settings page.

## Changes

- Added a 'Local Model Settings' menu item to the bottom bar model dropdown (only visible when provider is `local`)
- Opens a modal with the existing `ModelSettingsPanel` component for quick access to all model parameters