### PR TITLE
Fix settings tabs getting cut off in narrow windows

### DIFF
--- a/ui/desktop/src/components/settings/SettingsView.tsx
+++ b/ui/desktop/src/components/settings/SettingsView.tsx
@@ -105,7 +105,7 @@ export default function SettingsView({
               className="h-full flex flex-col"
             >
               <div className="px-1">
-                <TabsList className="w-full mb-2 justify-start">
+                <TabsList className="w-full mb-2 justify-start overflow-x-auto flex-nowrap">
                   <TabsTrigger
                     value="models"
                     className="flex gap-2"


### PR DESCRIPTION
Add horizontal scrolling to the settings tab bar (Models, Local Inference, Chat, Session, Prompts, Keyboard, App) so all tabs remain accessible when the window is too narrow to display them all.

Adds `overflow-x-auto flex-nowrap` to the `TabsList` in `SettingsView.tsx`.