### PR TITLE
feat(ui): show token counts directly for "free" providers

### DIFF
--- a/ui/desktop/src/components/bottom_menu/CostTracker.tsx
+++ b/ui/desktop/src/components/bottom_menu/CostTracker.tsx
@@ -134,22 +134,15 @@ export function CostTracker({ inputTokens = 0, outputTokens = 0, sessionCosts }:
     !costInfo ||
     (costInfo.input_token_cost === undefined && costInfo.output_token_cost === undefined)
   ) {
-    // If it's a known free/local provider, show $0.000000 without "not available" message
     const freeProviders = ['ollama', 'local', 'localhost'];
     if (freeProviders.includes(currentProvider.toLowerCase())) {
       return (
         <>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <div className="flex items-center justify-center h-full text-text-default/70 hover:text-text-default transition-colors cursor-default translate-y-[1px]">
-                <CoinIcon className="mr-1" size={16} />
-                <span className="text-xs font-mono">0.0000</span>
-              </div>
-            </TooltipTrigger>
-            <TooltipContent>
-              {`Local model (${inputTokens.toLocaleString()} input, ${outputTokens.toLocaleString()} output tokens)`}
-            </TooltipContent>
-          </Tooltip>
+          <div className="flex items-center justify-center h-full text-text-default/70 transition-colors cursor-default translate-y-[1px]">
+            <span className="text-xs font-mono">
+              {inputTokens.toLocaleString()}↑ {outputTokens.toLocaleString()}↓
+            </span>
+          </div>
           <div className="w-px h-4 bg-border-default mx-2" />
         </>
       );


### PR DESCRIPTION
When using "free" providers (ollama, local, localhost), the bottom bar now shows token counts directly (e.g. `1,234↑ 567↓`) instead of displaying a $0.0000 cost that requires hovering to reveal token usage.

<img width="802" height="52" alt="image" src="https://github.com/user-attachments/assets/2235f14c-60b0-46a4-ad41-f738caf06937" />