### PR TITLE
fix: use correct colors for download progress bar

### DIFF
--- a/ui/desktop/src/components/settings/localInference/LocalInferenceSettings.tsx
+++ b/ui/desktop/src/components/settings/localInference/LocalInferenceSettings.tsx
@@ -209,9 +209,9 @@ export const LocalInferenceSettings = () => {
                   </div>
                   {progress.status === 'downloading' && (
                     <div className="space-y-1">
-                      <div className="w-full bg-background-subtle rounded-full h-2">
+                      <div className="w-full bg-gray-700 rounded-full h-2">
                         <div
-                          className="bg-accent-primary h-2 rounded-full transition-all duration-300"
+                          className="bg-blue-500 h-2 rounded-full transition-all duration-300"
                           style={{ width: `${progress.progress_percent}%` }}
                         />
                       </div>


### PR DESCRIPTION
The local models download progress bar was invisible because `bg-background-subtle` and `bg-accent-primary` are not defined in the theme. Replaced with standard Tailwind colors `bg-gray-700` (track) and `bg-blue-500` (fill).