### PR TITLE
refactor: change open recipe in new window to pass recipe id

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -84,17 +84,23 @@ const PairRouteWrapper = ({
 
   const resumeSessionId = searchParams.get('resumeSessionId') ?? undefined;
   const recipeDeeplinkFromConfig = window.appConfig?.get('recipeDeeplink') as string | undefined;
+  const recipeIdFromConfig = window.appConfig?.get('recipeId') as string | undefined;
   const initialMessage = routeState.initialMessage;
 
-  // Create session if we have an initialMessage or recipeDeeplink but no sessionId
+  // Create session if we have an initialMessage, recipeDeeplink, or recipeId but no sessionId
   useEffect(() => {
-    if ((initialMessage || recipeDeeplinkFromConfig) && !resumeSessionId && !isCreatingSession) {
+    if (
+      (initialMessage || recipeDeeplinkFromConfig || recipeIdFromConfig) &&
+      !resumeSessionId &&
+      !isCreatingSession
+    ) {
       setIsCreatingSession(true);
 
       (async () => {
         try {
           const newSession = await createSession(getInitialWorkingDir(), {
             recipeDeeplink: recipeDeeplinkFromConfig,
+            recipeId: recipeIdFromConfig,
             allExtensions: extensionsList,
           });
 
@@ -126,7 +132,14 @@ const PairRouteWrapper = ({
     // Note: isCreatingSession is intentionally NOT in the dependency array
     // It's only used as a guard to prevent concurrent session creation
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [initialMessage, recipeDeeplinkFromConfig, resumeSessionId, setSearchParams, extensionsList]);
+  }, [
+    initialMessage,
+    recipeDeeplinkFromConfig,
+    recipeIdFromConfig,
+    resumeSessionId,
+    setSearchParams,
+    extensionsList,
+  ]);
 
   // Add resumed session to active sessions if not already there
   useEffect(() => {
@@ -450,7 +463,7 @@ export function AppInner() {
       if ((isMac ? event.metaKey : event.ctrlKey) && event.key === 'n') {
         event.preventDefault();
         try {
-          window.electron.createChatWindow(undefined, getInitialWorkingDir());
+          window.electron.createChatWindow({ dir: getInitialWorkingDir() });
         } catch (error) {
           console.error('Error creating new window:', error);
         }

--- a/ui/desktop/src/components/LauncherView.tsx
+++ b/ui/desktop/src/components/LauncherView.tsx
@@ -10,7 +10,7 @@ export default function LauncherView() {
     if (query.trim()) {
       const initialMessage = query;
       setQuery('');
-      window.electron.createChatWindow(initialMessage, getInitialWorkingDir());
+      window.electron.createChatWindow({ query: initialMessage, dir: getInitialWorkingDir() });
       setTimeout(() => {
         window.electron.closeWindow();
       }, 200);

--- a/ui/desktop/src/components/Layout/AppLayout.tsx
+++ b/ui/desktop/src/components/Layout/AppLayout.tsx
@@ -84,10 +84,9 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
   };
 
   const handleNewWindow = () => {
-    window.electron.createChatWindow(
-      undefined,
-      window.appConfig.get('GOOSE_WORKING_DIR') as string | undefined
-    );
+    window.electron.createChatWindow({
+      dir: window.appConfig.get('GOOSE_WORKING_DIR') as string | undefined,
+    });
   };
 
   return (

--- a/ui/desktop/src/components/ParameterInputModal.tsx
+++ b/ui/desktop/src/components/ParameterInputModal.tsx
@@ -75,7 +75,7 @@ const ParameterInputModal: React.FC<ParameterInputModalProps> = ({
     if (option === 'new-chat') {
       try {
         const workingDir = getInitialWorkingDir();
-        window.electron.createChatWindow(undefined, workingDir);
+        window.electron.createChatWindow({ dir: workingDir });
         window.electron.hideWindow();
       } catch (error) {
         console.error('Error creating new window:', error);

--- a/ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx
+++ b/ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx
@@ -1,12 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useForm } from '@tanstack/react-form';
-import {
-  Recipe,
-  generateDeepLink,
-  Parameter,
-  encodeRecipe,
-  stripEmptyExtensions,
-} from '../../recipe';
+import { Recipe, generateDeepLink, Parameter } from '../../recipe';
 import { Check, ExternalLink, Play, Save, X } from 'lucide-react';
 import { Geese } from '../icons/Geese';
 import Copy from '../icons/Copy';
@@ -333,21 +327,12 @@ export default function CreateEditRecipeModal({
     try {
       const recipe = getCurrentRecipe();
 
-      await saveRecipe(recipe, recipeId);
+      const savedId = await saveRecipe(recipe, recipeId);
 
       // Close modal first
       onClose(true);
 
-      // Encode the recipe as a deeplink before passing to the new window
-      const encodedRecipe = await encodeRecipe(stripEmptyExtensions(recipe));
-      window.electron.createChatWindow(
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        encodedRecipe
-      );
+      window.electron.createChatWindow({ recipeId: savedId });
 
       toastSuccess({
         title: recipe.title,

--- a/ui/desktop/src/components/recipes/CreateRecipeFromSessionModal.tsx
+++ b/ui/desktop/src/components/recipes/CreateRecipeFromSessionModal.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useForm } from '@tanstack/react-form';
-import { Recipe, encodeRecipe, stripEmptyExtensions } from '../../recipe';
+import { Recipe } from '../../recipe';
 import { Geese } from '../icons/Geese';
 import { X, Save, Play, Loader2 } from 'lucide-react';
 import { Button } from '../ui/button';
@@ -182,21 +182,13 @@ export default function CreateRecipeFromSessionModal({
             : undefined,
       };
 
-      await saveRecipe(recipe, null);
+      const recipeId = await saveRecipe(recipe, null);
 
       onRecipeCreated?.(recipe);
       onClose();
 
       if (runAfterSave) {
-        const encodedRecipe = await encodeRecipe(stripEmptyExtensions(recipe));
-        window.electron.createChatWindow(
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          encodedRecipe
-        );
+        window.electron.createChatWindow({ recipeId });
       }
     } catch (error) {
       console.error('Failed to create recipe:', error);

--- a/ui/desktop/src/components/sessions/SessionListView.tsx
+++ b/ui/desktop/src/components/sessions/SessionListView.tsx
@@ -536,13 +536,11 @@ const SessionListView: React.FC<SessionListViewProps> = React.memo(
 
     const handleOpenInNewWindow = useCallback((session: Session, e: React.MouseEvent) => {
       e.stopPropagation();
-      window.electron.createChatWindow(
-        undefined,
-        session.working_dir,
-        undefined,
-        session.id,
-        'pair'
-      );
+      window.electron.createChatWindow({
+        dir: session.working_dir,
+        resumeSessionId: session.id,
+        viewType: 'pair',
+      });
     }, []);
 
     const SessionItem = React.memo(function SessionItem({

--- a/ui/desktop/src/preload.ts
+++ b/ui/desktop/src/preload.ts
@@ -51,6 +51,15 @@ interface UpdaterEvent {
   data?: unknown;
 }
 
+export interface CreateChatWindowOptions {
+  query?: string;
+  dir?: string;
+  version?: string;
+  resumeSessionId?: string;
+  viewType?: string;
+  recipeId?: string;
+}
+
 // Define the API types in a single place
 type ElectronAPI = {
   platform: string;
@@ -58,14 +67,7 @@ type ElectronAPI = {
   getConfig: () => Record<string, unknown>;
   hideWindow: () => void;
   directoryChooser: () => Promise<Electron.OpenDialogReturnValue>;
-  createChatWindow: (
-    query?: string,
-    dir?: string,
-    version?: string,
-    resumeSessionId?: string,
-    viewType?: string,
-    recipeDeeplink?: string
-  ) => void;
+  createChatWindow: (options?: CreateChatWindowOptions) => void;
   logInfo: (txt: string) => void;
   showNotification: (data: NotificationData) => void;
   showMessageBox: (options: MessageBoxOptions) => Promise<MessageBoxResponse>;
@@ -150,23 +152,8 @@ const electronAPI: ElectronAPI = {
   },
   hideWindow: () => ipcRenderer.send('hide-window'),
   directoryChooser: () => ipcRenderer.invoke('directory-chooser'),
-  createChatWindow: (
-    query?: string,
-    dir?: string,
-    version?: string,
-    resumeSessionId?: string,
-    viewType?: string,
-    recipeDeeplink?: string
-  ) =>
-    ipcRenderer.send(
-      'create-chat-window',
-      query,
-      dir,
-      version,
-      resumeSessionId,
-      viewType,
-      recipeDeeplink
-    ),
+  createChatWindow: (options?: CreateChatWindowOptions) =>
+    ipcRenderer.send('create-chat-window', options || {}),
   logInfo: (txt: string) => ipcRenderer.send('logInfo', txt),
   showNotification: (data: NotificationData) => ipcRenderer.send('notify', data),
   showMessageBox: (options: MessageBoxOptions) => ipcRenderer.invoke('show-message-box', options),

--- a/ui/desktop/src/recipe/recipe_management.ts
+++ b/ui/desktop/src/recipe/recipe_management.ts
@@ -1,10 +1,11 @@
 import { Recipe, saveRecipe as saveRecipeApi, listRecipes, RecipeManifest } from '../api';
+import { stripEmptyExtensions } from '.';
 
 export const saveRecipe = async (recipe: Recipe, recipeId?: string | null): Promise<string> => {
   try {
     let response = await saveRecipeApi({
       body: {
-        recipe,
+        recipe: stripEmptyExtensions(recipe),
         id: recipeId,
       },
       throwOnError: true,

--- a/ui/desktop/src/sessions.ts
+++ b/ui/desktop/src/sessions.ts
@@ -38,6 +38,7 @@ export async function createSession(
   workingDir: string,
   options?: {
     recipeDeeplink?: string;
+    recipeId?: string;
     extensionConfigs?: ExtensionConfig[];
     allExtensions?: FixedExtensionEntry[];
   }
@@ -45,12 +46,15 @@ export async function createSession(
   const body: {
     working_dir: string;
     recipe?: Recipe;
+    recipe_id?: string;
     extension_overrides?: ExtensionConfig[];
   } = {
     working_dir: workingDir,
   };
 
-  if (options?.recipeDeeplink) {
+  if (options?.recipeId) {
+    body.recipe_id = options.recipeId;
+  } else if (options?.recipeDeeplink) {
     body.recipe = await decodeRecipe(options.recipeDeeplink);
   }
 
@@ -79,6 +83,7 @@ export async function startNewSession(
   workingDir: string,
   options?: {
     recipeDeeplink?: string;
+    recipeId?: string;
     allExtensions?: FixedExtensionEntry[];
   }
 ): Promise<Session> {


### PR DESCRIPTION
## Summary
Use `recipeId` instead of encoded deeplinks when opening a new window

For internal flows (open recipe in new window, save & run), we now pass just the recipe manifest id string through the IPC chain instead of encoding the full recipe into a deeplink. The server's existing recipe_id + load_recipe_by_id support handles the lookup.

Also refactored `createChatWindow` from 6 positional optional params to an options object while I was in there.

Before:
```
window.electron.createChatWindow(undefined, undefined, undefined, undefined, undefined, savedId);
```

After:
```
window.electron.createChatWindow({ recipeId });
```
Verified locally with recipes in new windows from the ui and from deeplinks.