### PR TITLE
fix: update dictation API error message to reflect 50MB limit

### DIFF
--- a/crates/goose-server/src/routes/dictation.rs
+++ b/crates/goose-server/src/routes/dictation.rs
@@ -127,7 +127,7 @@ fn convert_error(e: anyhow::Error) -> ErrorResponse {
         (status = 400, description = "Invalid request (bad base64 or unsupported format)"),
         (status = 401, description = "Invalid API key"),
         (status = 412, description = "Provider not configured"),
-        (status = 413, description = "Audio file too large (max 25MB)"),
+        (status = 413, description = "Audio file too large (max 50MB)"),
         (status = 429, description = "Rate limit exceeded"),
         (status = 500, description = "Internal server error"),
         (status = 502, description = "Provider API error"),


### PR DESCRIPTION
## Summary
Corrects the error message in the OpenAPI specification for the dictation transcribe endpoint. The message incorrectly stated 'max 25MB' while the actual enforced limit is 50MB.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Code inspection - verified that:
- The actual limit enforcement remains 50MB (MAX_AUDIO_SIZE_BYTES constant)
- The error message now matches the enforced limit
- No functional changes, only documentation string update

### Related Issues
Discovered during documentation review for voice dictation features (PRs #6877, #6950)

**Technical Details:**
- File: [`crates/goose-server/src/routes/dictation.rs`](https://github.com/block/goose/blob/main/crates/goose-server/src/routes/dictation.rs)
- Line 130: Updated error description from "max 25MB" to "max 50MB"
- The actual limit is 50MB (`MAX_AUDIO_SIZE_BYTES = 50 * 1024 * 1024`)
- This only affects the OpenAPI spec documentation, not the enforcement logic