### PR TITLE
fix: flake.nix build failure and deprecation warning

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -37,7 +37,7 @@
           ++ pkgs.lib.optionals pkgs.stdenv.isDarwin darwinInputs;
       in
       {
-        defaultPackage = pkgs.rustPlatform.buildRustPackage {
+        packages.default = pkgs.rustPlatform.buildRustPackage {
           pname = cargoToml.package.name;
           version = workspaceToml.workspace.package.version;
           src = self;


### PR DESCRIPTION
## Summary

- **Remove stale `outputHashes` for `crunchy-0.2.3`** — `Cargo.lock` now has `crunchy 0.2.4` from crates.io (not a git dependency), so the old `outputHashes` entry causes `nix build` to fail with: `"A hash was specified for crunchy-0.2.3, but there is no corresponding git dependency"`
- **Replace deprecated `defaultPackage` with `packages.default`** — `defaultPackage` has been deprecated since Nix 2.7

## Test plan

- [ ] `nix build` completes without the crunchy hash error
- [ ] No deprecation warning about `defaultPackage`