### PR TITLE
fix(acp): Use ACP schema types for session/list

### DIFF
--- a/crates/goose-acp/Cargo.toml
+++ b/crates/goose-acp/Cargo.toml
@@ -23,7 +23,7 @@ goose = { path = "../goose" }
 goose-mcp = { path = "../goose-mcp" }
 rmcp = { workspace = true }
 sacp = "10.1.0"
-agent-client-protocol-schema = { version = "0.10", features = ["unstable_session_model"] }
+agent-client-protocol-schema = { version = "0.10", features = ["unstable_session_model", "unstable_session_list"] }
 anyhow = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true, features = ["compat", "rt"] }

--- a/crates/goose-acp/src/custom_requests.rs
+++ b/crates/goose-acp/src/custom_requests.rs
@@ -82,12 +82,6 @@ pub struct GetSessionResponse {
     pub session: serde_json::Value,
 }
 
-/// List all sessions.
-#[derive(Debug, Serialize, JsonSchema)]
-pub struct ListSessionsResponse {
-    pub sessions: Vec<serde_json::Value>,
-}
-
 /// Delete a session.
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct DeleteSessionRequest {

--- a/crates/goose-acp/src/server.rs
+++ b/crates/goose-acp/src/server.rs
@@ -24,10 +24,11 @@ use sacp::schema::{
     AgentCapabilities, AuthMethod, AuthenticateRequest, AuthenticateResponse, BlobResourceContents,
     CancelNotification, Content, ContentBlock, ContentChunk, EmbeddedResource,
     EmbeddedResourceResource, ImageContent, InitializeRequest, InitializeResponse,
-    LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer, ModelId, ModelInfo,
-    NewSessionRequest, NewSessionResponse, PermissionOption, PermissionOptionKind,
-    PromptCapabilities, PromptRequest, PromptResponse, RequestPermissionOutcome,
-    RequestPermissionRequest, ResourceLink, SessionId, SessionModelState, SessionNotification,
+    ListSessionsResponse, LoadSessionRequest, LoadSessionResponse, McpCapabilities, McpServer,
+    ModelId, ModelInfo, NewSessionRequest, NewSessionResponse, PermissionOption,
+    PermissionOptionKind, PromptCapabilities, PromptRequest, PromptResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, ResourceLink, SessionCapabilities,
+    SessionId, SessionInfo, SessionListCapabilities, SessionModelState, SessionNotification,
     SessionUpdate, SetSessionModelRequest, SetSessionModelResponse, StopReason, TextContent,
     TextResourceContents, ToolCall, ToolCallContent, ToolCallId, ToolCallLocation, ToolCallStatus,
     ToolCallUpdate, ToolCallUpdateFields, ToolKind,
@@ -653,6 +654,7 @@ impl GooseAcpAgent {
 
         let capabilities = AgentCapabilities::new()
             .load_session(true)
+            .session_capabilities(SessionCapabilities::new().list(SessionListCapabilities::new()))
             .prompt_capabilities(
                 PromptCapabilities::new()
                     .image(true)
@@ -1086,14 +1088,15 @@ impl GooseAcpAgent {
             .list_sessions()
             .await
             .map_err(|e| sacp::Error::internal_error().data(e.to_string()))?;
-        let sessions_json = sessions
+        let session_infos: Vec<SessionInfo> = sessions
             .into_iter()
-            .map(|s| serde_json::to_value(&s))
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(|e| sacp::Error::internal_error().data(e.to_string()))?;
-        Ok(ListSessionsResponse {
-            sessions: sessions_json,
-        })
+            .map(|s| {
+                SessionInfo::new(SessionId::new(s.id), s.working_dir)
+                    .title(s.name)
+                    .updated_at(s.updated_at.to_rfc3339())
+            })
+            .collect();
+        Ok(ListSessionsResponse::new(session_infos))
     }
 
     #[custom_method("session/get")]
@@ -1269,6 +1272,14 @@ impl JrMessageHandler for GooseAcpHandler {
                                 let resp = agent
                                     .on_set_model(&params.session_id.0, &params.model_id.0)
                                     .await?;
+                                let json = serde_json::to_value(resp).map_err(|e| {
+                                    sacp::Error::internal_error().data(e.to_string())
+                                })?;
+                                request_cx.respond(json)?;
+                                Ok(())
+                            }
+                            MessageCx::Request(req, request_cx) if req.method == "session/list" => {
+                                let resp = agent.on_list_sessions().await?;
                                 let json = serde_json::to_value(resp).map_err(|e| {
                                     sacp::Error::internal_error().data(e.to_string())
                                 })?;


### PR DESCRIPTION
## Summary

Replace the hand-rolled ListSessionsResponse with ListSessionsResponse and SessionInfo from agent-client-protocol-schema crate, aligning the session/list endpoint with the ACP specification.

Handle ACP session/list via direct standard routing while keeping `_goose/session/list` custom-path compatibility.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Existing unit test and locally tested.
