### PR TITLE
feat: expose context window utilization to agent via MOIM

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -1608,8 +1608,15 @@ impl ExtensionManager {
             working_dir.display()
         );
 
-        if let Ok(session) = self.context.session_manager.get_session(session_id, false).await {
-            if let (Some(total), Some(config)) = (session.total_tokens, session.model_config.as_ref()) {
+        if let Ok(session) = self
+            .context
+            .session_manager
+            .get_session(session_id, false)
+            .await
+        {
+            if let (Some(total), Some(config)) =
+                (session.total_tokens, session.model_config.as_ref())
+            {
                 let limit = config.context_limit();
                 if total > 0 && limit > 0 {
                     let pct = (total as f64 / limit as f64 * 100.0).round() as u32;


### PR DESCRIPTION
## Summary

Add token/context usage info to the per-turn `<info-msg>` (MOIM — Minus One Info Message) injection so the agent can see how much of its context window is consumed and make informed decisions (e.g., summarize early, hand off, or keep going).

The agent now sees a line like:
```
Context: ~85k/128k tokens used (66%)
```

## Implementation

~22 lines in `collect_moim()` in `extension_manager.rs`, which already has access to both the provider (`context_limit`) and `session_manager` (`total_tokens`). No new files, no new dependencies, no new abstractions.

### Fail-open guarantees (4 layers)
1. `if let Ok(session)` — session lookup fails → skip silently
2. `if let (Some(total), Some(config))` — missing token data or model config → skip silently
3. `total > 0` — negative or zero tokens (first turn, corrupt state) → skip silently
4. `limit > 0` — zero context limit → skip silently (also prevents division by zero)

## Why this matters

The agent currently has **zero visibility** into its own context usage. It can't tell if it's at 20% or 95% of its context window. This leads to:
- Agents running into compaction unexpectedly
- No ability to proactively summarize or hand off when running low
- Context management decisions happening around the agent instead of with it

Related issues: #1703, #7415, #7413, #6930, #5255, #3485