### PR TITLE
Allow GOOSE_NODE_DIR override in batch file

### DIFF
--- a/ui/desktop/src/platform/windows/bin/npx.cmd
+++ b/ui/desktop/src/platform/windows/bin/npx.cmd
@@ -1,8 +1,10 @@
 @ECHO OFF
 SETLOCAL EnableDelayedExpansion
 
+if not defined GOOSE_NODE_DIR (
+    SET "GOOSE_NODE_DIR=%LOCALAPPDATA%\Goose\node"
+)
 SET "NODE_VERSION=22.14.0"
-SET "GOOSE_NODE_DIR=%LOCALAPPDATA%\Goose\node"
 
 REM === Check for previously downloaded portable Node.js (matching version) ===
 if exist "%GOOSE_NODE_DIR%\node-v%NODE_VERSION%.installed" (


### PR DESCRIPTION
## Summary

Modifies the batch file which initializes Goose's node directory to not set `GOOSE_NODE_DIR` if it already exists, effectively allowing the user to override it by setting it themselves in the environment the script is ran from.


### Type of Change

- [X] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance

- [ ] This PR was created or reviewed with AI assistance

### Testing

Very simple change, `if not defined` is documented here: https://ss64.com/nt/if.html