### PR TITLE
fix: Dictation API error message shows incorrect limit

### DIFF
--- a/crates/goose-server/src/routes/dictation.rs
+++ b/crates/goose-server/src/routes/dictation.rs
@@ -127,7 +127,7 @@ fn convert_error(e: anyhow::Error) -> ErrorResponse {
         (status = 400, description = "Invalid request (bad base64 or unsupported format)"),
         (status = 401, description = "Invalid API key"),
         (status = 412, description = "Provider not configured"),
-        (status = 413, description = "Audio file too large (max 25MB)"),
+        (status = 413, description = "Audio file too large (max 50MB)"),
         (status = 429, description = "Rate limit exceeded"),
         (status = 500, description = "Internal server error"),
         (status = 502, description = "Provider API error"),

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -1767,7 +1767,7 @@
             "description": "Provider not configured"
           },
           "413": {
-            "description": "Audio file too large (max 25MB)"
+            "description": "Audio file too large (max 50MB)"
           },
           "429": {
             "description": "Rate limit exceeded"

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -2870,7 +2870,7 @@ export type TranscribeDictationErrors = {
      */
     412: unknown;
     /**
-     * Audio file too large (max 25MB)
+     * Audio file too large (max 50MB)
      */
     413: unknown;
     /**


### PR DESCRIPTION
closes: #7398 

## Summary


### Type of Change

- [x] Bug fix


### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Screenshots/Demos (for UX changes)
Before:  

After:   

