### PR TITLE
fix: handle truncated tool calls that break conversation alternation

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1443,6 +1443,16 @@ impl Agent {
                                                                 .lock().await.clone();
                                         yield AgentEvent::Message(final_response.clone());
                                         messages_to_add.push(final_response);
+                                    } else {
+                                        let error_msg = format!(
+                                            "[system: Tool call could not be parsed: {}. The response may have been truncated. Try breaking the task into smaller steps.]",
+                                            request.tool_call.as_ref().unwrap_err(),
+                                        );
+                                        let error_response = Message::user()
+                                            .with_generated_id()
+                                            .with_text(&error_msg);
+                                        yield AgentEvent::Message(error_response.clone());
+                                        messages_to_add.push(error_response);
                                     }
                                 }
 


### PR DESCRIPTION
## Summary

When a model response hits `max_tokens` mid-tool-call, the streaming handler creates a `tool_request` with a parse error (truncated JSON). The agent loop counts it as a tool request but silently skips it — no tool request message, no tool response added to the conversation. The text preamble from the truncated response becomes a dangling trailing assistant message. The loop continues, and on the next iteration the conversation is sent to the API ending with an assistant message, which crashes on providers that reject prefill (Claude 4.6+, Snowflake, others).

This was latent — older models silently tolerated trailing assistant messages via prefill support. Claude Opus 4.6 (Feb 5) removed prefill as a documented breaking change, exposing it. Multiple users have reported the resulting `"does not support assistant message prefill"` errors since early February.

## The fix

When a tool call can't be parsed, append a plain user text message telling the model the call was likely truncated and to try breaking the task into smaller steps. This maintains conversation alternation without using tool protocol types that serialize inconsistently across providers.

## Type of Change
- [x] Bug fix

## Testing

All existing tests pass. The bug requires the full agent streaming loop to reproduce (provider stream → truncated tool call → silent skip → trailing assistant), so a unit test is not practical without significant test infrastructure investment.

## See also
- #7421 — patches a downstream symptom of the same bug in MOIM injection
- #5997 — same error class reported with Snowflake provider
- #6941 — related Anthropic prompt caching issue