### PR TITLE
fix: removed unnecessary version for goose acp macro dependency

### DIFF
--- a/crates/goose-acp/Cargo.toml
+++ b/crates/goose-acp/Cargo.toml
@@ -45,7 +45,7 @@ bytes = { workspace = true }
 http-body-util = "0.1.3"
 uuid = { workspace = true, features = ["v7"] }
 schemars = { workspace = true, features = ["derive"] }
-goose-acp-macros = { version = "1.24.0", path = "../goose-acp-macros" }
+goose-acp-macros = { path = "../goose-acp-macros" }
 
 [dev-dependencies]
 assert-json-diff = "2.0.2"


### PR DESCRIPTION
## Summary
[Canary build ](https://github.com/block/goose/actions/runs/22284735973/job/64460996408) keep failing since 4 days ago. (having version: 1.24.0-canary... that does not meet the version `1.24.0`. 

Since `goose-acp-macros` is not published, so we don't need to specify the version here, just use dependency in the workspace.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)