### PR TITLE
Redirect llama.cpp logs through tracing to avoid polluting CLI stdout/stderr

### DIFF
--- a/crates/goose/src/providers/local_inference.rs
+++ b/crates/goose/src/providers/local_inference.rs
@@ -29,7 +29,7 @@ use futures::future::BoxFuture;
 use llama_cpp_2::llama_backend::LlamaBackend;
 use llama_cpp_2::model::params::LlamaModelParams;
 use llama_cpp_2::model::{LlamaChatMessage, LlamaChatTemplate, LlamaModel};
-use llama_cpp_2::{list_llama_ggml_backend_devices, LlamaBackendDeviceType};
+use llama_cpp_2::{list_llama_ggml_backend_devices, LlamaBackendDeviceType, LogOptions};
 use rmcp::model::{Role, Tool};
 use serde_json::{json, Value};
 use std::collections::HashMap;
@@ -80,6 +80,7 @@ impl InferenceRuntime {
             }
             Err(e) => panic!("Failed to init llama backend: {}", e),
         };
+        llama_cpp_2::send_logs_to_tracing(LogOptions::default());
         let runtime = Arc::new(Self {
             models: StdMutex::new(HashMap::new()),
             backend,


### PR DESCRIPTION
## Problem

When using the `goose` CLI with the local inference provider, llama.cpp output goes directly to stderr, cluttering the text interface and making it harder to use.

## Root Cause

The `llama-cpp-2` Rust bindings provide `send_logs_to_tracing()` to redirect llama.cpp's C library log output through the `tracing` framework, but it was never called. This meant llama.cpp used its default behavior of writing to stderr.

## Fix

Call `llama_cpp_2::send_logs_to_tracing(LogOptions::default())` during `InferenceRuntime` initialization. This redirects all llama.cpp/ggml logs through tracing, which the CLI already routes exclusively to log files (no console layer). When running `goosed` directly or via the GUI, the tracing subscriber typically includes a console layer, so logs remain visible there.

## Changes

- `crates/goose/src/providers/local_inference.rs`: Added `send_logs_to_tracing()` call in `InferenceRuntime::get_or_init()`