### PR TITLE
docs: generate manpages

### DIFF
--- a/documentation/docs/getting-started/installation.md
+++ b/documentation/docs/getting-started/installation.md
@@ -407,6 +407,18 @@ In CI/CD (and other automated, non-interactive environments), pin a specific ver
 
 See [CI/CD Environments](/docs/tutorials/cicd) for a complete example and usage details.
 
+## Generate manpages for Linux distributions
+
+If you're packaging goose for a Linux distribution or creating a custom build, you can generate Unix manpages from the CLI command definitions:
+
+```bash
+just generate-manpages
+```
+
+This creates ROFF-formatted manpages in `target/man/` (e.g., `goose.1`, `goose-session.1`) that can be installed to `/usr/share/man/man1/` to provide offline documentation via the `man` command.
+
+Manpage generation requires the goose source repository and is intended for distribution packagers preparing packages for Fedora, Debian, and other Linux distributions. See the [generate_manpages.rs source](https://github.com/block/goose/blob/main/crates/goose-cli/src/bin/generate_manpages.rs) for implementation details.
+
 ## Additional Resources
 
 You can also configure Extensions to extend goose's functionality, including adding new ones or toggling them on and off. For detailed instructions, visit the [Using Extensions Guide][using-extensions].


### PR DESCRIPTION
## Summary
Documents the manpage generation feature, targets Linux distribution packagers (Fedora, Debian, etc.) who need to generate manpages when packaging goose for their repositories.

Documentation updates:
- `documentation/docs/getting-started/installation.md`:
  - Add "Generate manpages for Linux distributions" section

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance

### Testing
None

### Related PRs
#6980 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213344831306273