### PR TITLE
docs: update Claude Code approve behavior and model list in cli-providers guide

### DIFF
--- a/documentation/docs/guides/cli-providers.md
+++ b/documentation/docs/guides/cli-providers.md
@@ -284,16 +284,17 @@ goose session
 
 The following models are recognized and passed to the Claude CLI via the `--model` flag. If `GOOSE_MODEL` is set to a value not in this list, no model flag is passed and Claude Code uses its default:
 
+- `default` (opus)
 - `sonnet`
-- `opus`
+- `haiku`
 
 **Permission Modes (`GOOSE_MODE`):**
 
 | Mode | Claude Code Flag | Behavior |
 |------|------------------|----------|
 | `auto` | `--dangerously-skip-permissions` | Bypasses all permission prompts |
-| `smart-approve` | `--permission-mode acceptEdits` | Auto-accepts edits, prompts for other actions |
-| `approve` | `--permission-prompt-tool stdio` | Routes permission checks through the control protocol |
+| `smart-approve` | `--permission-prompt-tool stdio` | Routes permission checks through the control protocol (prompts as needed) |
+| `approve` | `--permission-prompt-tool stdio` | Routes permission checks through the control protocol (prompts as needed) |
 | `chat` | (none) | Default Claude Code behavior |
 
 ### Cursor Agent Configuration


### PR DESCRIPTION
## Summary
Updates cli-providers documentation to reflect that Claude Code now supports approve/smart-approve mode via `--permission-prompt-tool stdio`. It also corrects model name drift

### Type of Change
- [x] Documentation

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Related Issues

Docs from #7420