### PR TITLE
Added lmstudio declarative provider

### DIFF
--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -260,7 +260,10 @@ pub fn load_provider(id: &str) -> Result<LoadedProvider> {
             .contents_utf8()
             .ok_or_else(|| anyhow::anyhow!("Failed to read file as UTF-8: {:?}", file.path()))?;
 
-        let config: DeclarativeProviderConfig = serde_json::from_str(content)?;
+        let config: DeclarativeProviderConfig = match serde_json::from_str(content) {
+            Ok(config) => config,
+            Err(_) => continue,
+        };
         if config.name == id {
             return Ok(LoadedProvider {
                 config,
@@ -300,8 +303,16 @@ fn load_fixed_providers() -> Result<Vec<DeclarativeProviderConfig>> {
             .contents_utf8()
             .ok_or_else(|| anyhow::anyhow!("Failed to read file as UTF-8: {:?}", file.path()))?;
 
-        let config: DeclarativeProviderConfig = serde_json::from_str(content)?;
-        res.push(config)
+        match serde_json::from_str(content) {
+            Ok(config) => res.push(config),
+            Err(e) => {
+                tracing::warn!(
+                    "Skipping invalid declarative provider {:?}: {}",
+                    file.path(),
+                    e
+                );
+            }
+        }
     }
 
     Ok(res)

--- a/crates/goose/src/providers/declarative/kimi.json
+++ b/crates/goose/src/providers/declarative/kimi.json
@@ -1,19 +1,13 @@
 {
-    "name": "Kimi",
-    "metadata": {
-        "homepage": "https://kimi.ai",
-        "docs": "https://platform.moonshot.cn/docs/intro",
-        "description": "Kimi Code AI models optimized for coding tasks"
-    },
-    "engine": {
-        "type": "openai",
-        "base_url": "https://api.moonshot.cn/v1",
-        "api_key_env_var": "MOONSHOT_API_KEY"
-    },
-    "models": [
-        {"name": "kimi-for-coding", "context_limit": 262144},
-        {"name": "kimi-code", "context_limit": 262144}
-    ],
-    "streaming_default": true,
-    "pricing_info_url": "https://platform.moonshot.cn/pricing"
+  "name": "kimi",
+  "engine": "openai",
+  "display_name": "Kimi",
+  "description": "Kimi Code AI models optimized for coding tasks",
+  "api_key_env": "MOONSHOT_API_KEY",
+  "base_url": "https://api.moonshot.cn/v1/chat/completions",
+  "models": [
+    {"name": "kimi-for-coding", "context_limit": 262144},
+    {"name": "kimi-code", "context_limit": 262144}
+  ],
+  "supports_streaming": true
 }

--- a/crates/goose/src/providers/declarative/lmstudio.json
+++ b/crates/goose/src/providers/declarative/lmstudio.json
@@ -1,0 +1,11 @@
+{
+  "name": "lmstudio",
+  "engine": "openai",
+  "display_name": "LM Studio",
+  "description": "Run local models with LM Studio",
+  "api_key_env": "",
+  "base_url": "http://localhost:1234/v1/chat/completions",
+  "models": [],
+  "supports_streaming": true,
+  "requires_auth": false
+}

--- a/crates/goose/src/providers/declarative/moonshot.json
+++ b/crates/goose/src/providers/declarative/moonshot.json
@@ -1,23 +1,17 @@
 {
-    "name": "Moonshot",
-    "metadata": {
-        "homepage": "https://kimi.moonshot.cn/",
-        "docs": "https://platform.moonshot.cn/docs/intro",
-        "description": "Moonshot AI (Kimi) models"
-    },
-    "engine": {
-        "type": "openai",
-        "base_url": "https://api.moonshot.cn/v1",
-        "api_key_env_var": "MOONSHOT_API_KEY"
-    },
-    "models": [
-        {"name": "kimi-latest", "context_limit": 131072},
-        {"name": "kimi-thinking-preview", "context_limit": 131072},
-        {"name": "kimi-k2-0711", "context_limit": 131072},
-        {"name": "kimi-k2", "context_limit": 262144},
-        {"name": "moonshot-v1-8k", "context_limit": 8192},
-        {"name": "moonshot-v1-32k", "context_limit": 32768}
-    ],
-    "streaming_default": true,
-    "pricing_info_url": "https://platform.moonshot.cn/pricing"
+  "name": "moonshot",
+  "engine": "openai",
+  "display_name": "Moonshot",
+  "description": "Moonshot AI (Kimi) models",
+  "api_key_env": "MOONSHOT_API_KEY",
+  "base_url": "https://api.moonshot.cn/v1/chat/completions",
+  "models": [
+    {"name": "kimi-latest", "context_limit": 131072},
+    {"name": "kimi-thinking-preview", "context_limit": 131072},
+    {"name": "kimi-k2-0711", "context_limit": 131072},
+    {"name": "kimi-k2", "context_limit": 262144},
+    {"name": "moonshot-v1-8k", "context_limit": 8192},
+    {"name": "moonshot-v1-32k", "context_limit": 32768}
+  ],
+  "supports_streaming": true
 }


### PR DESCRIPTION
## Summary
Added LM Studio as a declarative provider for Goose and fixed some issues.

While testing, I discovered that a recent PR (#7304) had added Kimi and Moonshot
provider configs with invalid JSON schema. This silently broke ALL declarative
provider loading — Groq, DeepSeek, Cerebras, Mistral, Inception, and OVHcloud were
all invisible in the UI because the loader aborted on the first malformed file. I
fixed the two broken JSON files and made the loader resilient so one bad file can't
take down the rest.

Also fixed a UX issue in the sidebar where clicking "Start New Chat" would get
stuck reusing a session that had failed to load. Sessions with errors and no messages
were being treated as empty/reusable. Now errored sessions are tracked and skipped
when looking for a session to reuse.

