### PR TITLE
fix(openai): handle null reasoning effort in Responses API

### DIFF
--- a/crates/goose/src/providers/formats/openai_responses.rs
+++ b/crates/goose/src/providers/formats/openai_responses.rs
@@ -67,7 +67,7 @@ pub enum ResponseContentBlock {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ResponseReasoningInfo {
-    pub effort: String,
+    pub effort: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<String>,
 }
@@ -870,5 +870,21 @@ mod tests {
             types,
             vec!["assistant", "function_call", "assistant", "function_call"]
         );
+    }
+
+    #[test]
+    fn test_deserialize_reasoning_info_with_null_effort() {
+        let json = r#"{"effort": null}"#;
+        let info: ResponseReasoningInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.effort, None);
+        assert_eq!(info.summary, None);
+    }
+
+    #[test]
+    fn test_deserialize_reasoning_info_with_effort() {
+        let json = r#"{"effort": "high", "summary": "Thought deeply"}"#;
+        let info: ResponseReasoningInfo = serde_json::from_str(json).unwrap();
+        assert_eq!(info.effort.as_deref(), Some("high"));
+        assert_eq!(info.summary.as_deref(), Some("Thought deeply"));
     }
 }


### PR DESCRIPTION
## Summary
Non-reasoning models like gpt-4o return `"effort": null` in the reasoning field of Responses API events. The ResponseReasoningInfo struct expected a String, causing deserialization to fail with:

  `invalid type: null, expected a string`

Make the field Optional to handle both reasoning models (which return a string like "medium") and non-reasoning models (which return null).

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested locally.