### PR TITLE
fix(apps): forward _meta in tool results to MCP Apps

### DIFF
--- a/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
+++ b/ui/desktop/src/components/McpApps/McpAppRenderer.tsx
@@ -637,6 +637,7 @@ export default function McpAppRenderer({
     return {
       content: toolResult.content as unknown as CallToolResult['content'],
       structuredContent: toolResult.structuredContent as { [key: string]: unknown } | undefined,
+      _meta: toolResult._meta,
     };
   }, [toolResult]);
 

--- a/ui/desktop/src/components/McpApps/types.ts
+++ b/ui/desktop/src/components/McpApps/types.ts
@@ -40,6 +40,7 @@ export type McpAppToolCancelled = McpUiToolCancelledNotification['params'];
 export type McpAppToolResult = {
   content: Content[];
   structuredContent?: unknown;
+  _meta?: { [key: string]: unknown };
 };
 
 export type SamplingMessage = {


### PR DESCRIPTION
## Summary

Fixes #7435

The `_meta` property from tool results was being silently dropped when forwarding to MCP Apps via the `@mcp-ui/client` SDK's `AppRenderer` component. This is a regression introduced in #7013.

## Root Cause

When #7013 refactored `McpAppRenderer` to use the SDK's `AppRenderer`, the custom `McpAppToolResult` type was created without `_meta`, and the conversion logic in the `appToolResult` memo only mapped `content` and `structuredContent`.

The upstream data (from rmcp's `CallToolResult`) **does** include `_meta` on the wire — it was just being discarded at the TypeScript boundary.

## Changes

- **`types.ts`**: Add `_meta?: { [key: string]: unknown }` to `McpAppToolResult`
- **`McpAppRenderer.tsx`**: Forward `_meta` in the `appToolResult` memo

## Testing

- TypeScript compiles clean
- ESLint passes
- All 340 UI tests pass
- Manually verified with an MCP App that reads `toolResult._meta`