### PR TITLE
docs: rename TLDR to Quick Install in MCP tutorials

### DIFF
--- a/documentation/docs/mcp/_template_.mdx
+++ b/documentation/docs/mcp/_template_.mdx
@@ -18,7 +18,7 @@ import GooseBuiltinInstaller from '@site/src/components/GooseBuiltinInstaller';
 
 This tutorial covers how to add the [{Extension Name} MCP Server](/) as a goose extension to enable ________________.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer]({goose_url})

--- a/documentation/docs/mcp/agentql-mcp.md
+++ b/documentation/docs/mcp/agentql-mcp.md
@@ -12,7 +12,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [AgentQL MCP Server](https://github.com/tinyfish-io/agentql-mcp) as a goose extension to extract and transform unstructured web content into structured data.
 
-:::tip TLDR
+:::tip Quick Install
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>

--- a/documentation/docs/mcp/alby-mcp.md
+++ b/documentation/docs/mcp/alby-mcp.md
@@ -19,7 +19,7 @@ This tutorial covers how to add the [Alby Bitcoin Payments MCP Server](https://g
 You'll need a lightning wallet that supports [NWC](https://nwc.dev). If you don't have one yet, consider trying [Alby Hub](https://albyhub.com).
 :::
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40getalby%2Fmcp&id=alby&name=Alby&description=Connect%20goose%20to%20your%20Bitcoin%20Lightning%20Wallet&env=NWC_CONNECTION_STRING%3DNWC%20Connection%20Secret)

--- a/documentation/docs/mcp/apify-mcp.md
+++ b/documentation/docs/mcp/apify-mcp.md
@@ -16,7 +16,7 @@ This tutorial covers how to add the [Apify MCP server](https://mcp.apify.com) as
 <!-- REMOTE SETUP -->
 <TabItem value="remote" label="Apify Remote MCP" default>
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
    [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.apify.com&id=apify&name=Apify&description=Extract%20data%20from%20any%20website%20with%20thousands%20of%20scrapers%2C%20crawlers%2C%20and%20automations%20on%20Apify%20Store&header=Authorization%3DBearer%20YOUR_APIFY_TOKEN)
@@ -77,7 +77,7 @@ This tutorial covers how to add the [Apify MCP server](https://mcp.apify.com) as
 <!-- LOCAL SETUP -->
 <TabItem value="local" label="Apify Local MCP">
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=@apify/actors-mcp-server&arg=start&id=mcp_apify_local&name=Apify%20Local%20MCP%20Server&description=Run%20Apify%20MCP%20server%20locally%20using%20your%20token&env=APIFY_TOKEN%3DYour%20Apify%20Token)

--- a/documentation/docs/mcp/asana-mcp.md
+++ b/documentation/docs/mcp/asana-mcp.md
@@ -14,7 +14,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [Asana MCP Server](https://github.com/roychri/mcp-server-asana) as a goose extension to enable task automation, project tracking, and team collaboration.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40roychri%2Fmcp-server-asana&id=asana&name=Asana&description=enable%20task%20automation%2C%20project%20tracking%2C%20and%20team%20collaboration&env=ASANA_ACCESS_TOKEN%3DAsana%20Access%20Token)

--- a/documentation/docs/mcp/beads-mcp.md
+++ b/documentation/docs/mcp/beads-mcp.md
@@ -12,7 +12,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Beads MCP Server](https://github.com/steveyegge/beads) as a goose extension. Beads is a distributed, git-backed issue tracker designed for AI agents. It enables persistent task tracking with dependency management, so multiple goose sessions can coordinate work on complex projects.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=beads-mcp&id=beads&name=Beads&description=Git-backed%20issue%20tracker%20for%20AI%20agent%20task%20management)

--- a/documentation/docs/mcp/blender-mcp.md
+++ b/documentation/docs/mcp/blender-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [Blender MCP Server](https://github.com/ahujasid/blender-mcp) as a goose extension to create 3D scenes, control Blender with natural language, generate models, apply materials, and more.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=blender-mcp&id=blender&name=Blender&description=Blender%203D%20scene%20creation%20integration)

--- a/documentation/docs/mcp/brave-mcp.md
+++ b/documentation/docs/mcp/brave-mcp.md
@@ -15,7 +15,7 @@ Server moved
 
 This tutorial will get you started with the [Brave Search MCP Server](https://www.pulsemcp.com/servers/brave-search) as a goose extension to enable interactive searches for both web and local searches.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-brave-search&id=brave-search&name=Brave%20Search&description=Brave%20Search%20API&env=BRAVE_API_KEY%3DYour%20API%20Key)

--- a/documentation/docs/mcp/browserbase-mcp.md
+++ b/documentation/docs/mcp/browserbase-mcp.md
@@ -10,7 +10,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the Browserbase MCP Server as a goose extension for browser automation, enabling programmatic control over navigation, page interactions, and content capture.
 
-:::tip TLDR
+:::tip Quick Install
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>

--- a/documentation/docs/mcp/chrome-devtools-mcp.md
+++ b/documentation/docs/mcp/chrome-devtools-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the Chrome DevTools MCP Server as a goose extension to enable browser automation, web performance testing, and interactive web application debugging in a Chrome browser.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=chrome-devtools-mcp%40latest&id=chrome-devtools&name=Chrome%20DevTools&description=Browser%20automation%20and%20web%20performance%20testing%20capabilities)

--- a/documentation/docs/mcp/cloudflare-mcp.md
+++ b/documentation/docs/mcp/cloudflare-mcp.md
@@ -11,7 +11,7 @@ This tutorial covers how to add [Cloudflare's MCP Servers](https://github.com/cl
 
 Cloudflare provides multiple specialized MCP servers for different aspects of their platform, allowing you to interact with Workers, DNS, security features, analytics, and development tools.
 
-:::tip TLDR
+:::tip Quick Install
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>

--- a/documentation/docs/mcp/cloudinary-asset-management-mcp.md
+++ b/documentation/docs/mcp/cloudinary-asset-management-mcp.md
@@ -13,7 +13,7 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
 This tutorial covers how to add the [Cloudinary Asset Management MCP Server](https://github.com/cloudinary/asset-management-js) as a goose extension to automate complex image processing workflows that would typically require specialized design software or manual editing.
 
-:::tip TLDR
+:::tip Quick Install
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>

--- a/documentation/docs/mcp/cognee-mcp.md
+++ b/documentation/docs/mcp/cognee-mcp.md
@@ -9,7 +9,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [Cognee MCP Server](https://github.com/topoteretes/cognee/tree/main/cognee-mcp) as a goose extension to enable knowledge graph memory capabilities, connecting to over 30 data sources for enhanced context and retrieval.
 
-:::tip TLDR
+:::tip Quick Install
 **Command**
 ```sh
 uv --directory /path/to/cognee-mcp run python src/server.py

--- a/documentation/docs/mcp/container-use-mcp.md
+++ b/documentation/docs/mcp/container-use-mcp.md
@@ -13,7 +13,7 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
 This tutorial covers how to add the [Container Use MCP Server](https://container-use.com) as a goose extension enabling goose to work in an isolated environment.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=container-use&arg=stdio&id=container-use&name=container%20use&description=use%20containers%20with%20dagger%20and%20git%20for%20isolated%20environments)

--- a/documentation/docs/mcp/context7-mcp.mdx
+++ b/documentation/docs/mcp/context7-mcp.mdx
@@ -15,7 +15,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Context7 MCP Server](https://github.com/upstash/context7) as a goose extension to pull up-to-date, version-specific code and docs so goose can vibe code with real context, not hallucinated or outdated answers.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40upstash%2Fcontext7-mcp&id=context7&name=Context7&description=Context7%20MCP%20server%20for%20up-to-date%20code%20and%20docs)

--- a/documentation/docs/mcp/council-of-mine-mcp.md
+++ b/documentation/docs/mcp/council-of-mine-mcp.md
@@ -15,7 +15,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Council of Mine MCP Server](https://github.com/block/mcp-council-of-mine) as a goose extension featuring 9 LLM council members with distinct personalities who debate topics, vote on each other's opinions, and generate synthesized conclusions through AI-powered deliberation. This is great for helping you make a decision.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=--from&arg=git%2Bhttps%3A%2F%2Fgithub.com%2Fblock%2Fmcp-council-of-mine&arg=mcp_council_of_mine&id=council-of-mine&name=Council%20of%20Mine&description=LLM%20Debate)

--- a/documentation/docs/mcp/datahub-mcp.mdx
+++ b/documentation/docs/mcp/datahub-mcp.mdx
@@ -13,7 +13,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [DataHub MCP Server](https://github.com/acryldata/mcp-server-datahub) as a goose extension to enable AI-powered data discovery, lineage exploration, and metadata querying across your data ecosystem.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=mcp-server-datahub%40latest&id=datahub-mcp&name=DataHub&description=Data%20discovery%20and%20metadata%20platform%20integration&env=DATAHUB_GMS_URL%3DDataHub%20GMS%20URL%20(e.g.%2C%20https%3A%2F%2Fyour-instance.acryl.io%20or%20http%3A%2F%2Flocalhost%3A8080)&env=DATAHUB_GMS_TOKEN%3DDataHub%20Personal%20Access%20Token)

--- a/documentation/docs/mcp/dev.to-mcp.md
+++ b/documentation/docs/mcp/dev.to-mcp.md
@@ -14,7 +14,7 @@ import { PanelLeft } from 'lucide-react';
 
 This tutorial covers how to add the [Dev.to MCP Server](https://github.com/nickytonline/dev-to-mcp) as a goose extension to enable access to the Dev.to public API. With this extension, goose can fetch articles, tags, user info, comments, and more—without requiring authentication.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?type=streamable_http&url=http%3A%2F%2Flocalhost%3A3000%2Fmcp&id=dev-to&name=Dev.to&description=Access%20Dev.to%20articles%20and%20content)

--- a/documentation/docs/mcp/elevenlabs-mcp.md
+++ b/documentation/docs/mcp/elevenlabs-mcp.md
@@ -14,7 +14,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [ElevenLabs MCP Server](https://github.com/elevenlabs/elevenlabs-mcp) as a goose extension to enable AI-powered voice generation, voice cloning, audio editing, and speech-to-text transcription.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=elevenlabs-mcp&id=elevenlabs&name=ElevenLabs&description=ElevenLabs%20voice%20synthesis%20server&env=ELEVENLABS_API_KEY)

--- a/documentation/docs/mcp/excalidraw-mcp.md
+++ b/documentation/docs/mcp/excalidraw-mcp.md
@@ -13,7 +13,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Excalidraw MCP App](https://github.com/excalidraw/excalidraw-mcp) as a goose extension that enables goose to draw hand sketched Excalidraw diagrams in real time.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
    [Launch the installer](goose://extension?cmd=http&id=excalidraw&name=Excalidraw&url=https%3A%2F%2Fexcalidraw-mcp-app.vercel.app%2Fmcp&description=Excalidraw%20MCP%20App%20for%20AI-powered%20diagramming)

--- a/documentation/docs/mcp/fetch-mcp.md
+++ b/documentation/docs/mcp/fetch-mcp.md
@@ -17,7 +17,7 @@ The Fetch extension [does not work](https://github.com/block/goose/issues/1184) 
 
 This tutorial covers how to add the [Fetch MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/fetch) as a goose extension to retrieve and process content from the web.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=mcp-server-fetch&id=fetch&name=Fetch&description=Web%20content%20fetching%20and%20processing%20capabilities)

--- a/documentation/docs/mcp/figma-mcp.md
+++ b/documentation/docs/mcp/figma-mcp.md
@@ -16,7 +16,7 @@ This tutorial covers how to add the [Figma Dev Mode MCP Server](https://help.fig
 The MCP Server requires a Dev or Full seat on Professional, Organization, or Enterprise Figma plans.
 :::
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?type=streamable_http&url=http%3A%2F%2F127.0.0.1%3A3845%2Fmcp&id=figma&name=Figma&description=Convert%20Figma%20designs%20into%20code%20and%20extract%20design%20context)

--- a/documentation/docs/mcp/filesystem-mcp.md
+++ b/documentation/docs/mcp/filesystem-mcp.md
@@ -14,7 +14,7 @@ import { PanelLeft, Settings } from 'lucide-react';
 
 This tutorial covers how to add the [Filesystem MCP server](https://github.com/modelcontextprotocol/servers/tree/HEAD/src/filesystem) as a goose extension, enabling powerful code analysis and file management. With this extension, goose can analyze project structures, edit and organize files, detect unused dependencies, and generate documentation to improve software maintainability.
 
-:::tip TLDR
+:::tip Quick Install
   **Command**
   ```sh
   npx -y @modelcontextprotocol/server-filesystem </path/to/allowed/directory>

--- a/documentation/docs/mcp/firecrawl-mcp.md
+++ b/documentation/docs/mcp/firecrawl-mcp.md
@@ -14,7 +14,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial will get you started with the [Firecrawl MCP Server](https://github.com/firecrawl/firecrawl-mcp-server) as a goose extension to enable powerful web scraping, crawling, and search capabilities for AI agents.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=firecrawl-mcp&id=firecrawl&name=Firecrawl&description=Web%20scraping%20and%20crawling%20capabilities&env=FIRECRAWL_API_KEY%3DYour%20API%20Key)

--- a/documentation/docs/mcp/github-mcp.md
+++ b/documentation/docs/mcp/github-mcp.md
@@ -13,7 +13,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [GitHub MCP Server](https://github.com/github/github-mcp-server) as a goose extension to enable file operations, repository management, search functionality, and more.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
    [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fapi.githubcopilot.com%2Fmcp%2F&id=github&name=GitHub&description=GitHub%20repository%20management%20and%20operations&header=Authorization%3DBearer%20YOUR_GITHUB_PERSONAL_ACCESS_TOKEN)

--- a/documentation/docs/mcp/gitmcp-mcp.md
+++ b/documentation/docs/mcp/gitmcp-mcp.md
@@ -14,7 +14,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Git MCP Server](https://github.com/idosal/git-mcp) as a goose extension to give LLMs live access to GitHub repos, enabling smart documentation search, code exploration, and accurate project insights.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=mcp-remote&arg=https%3A%2F%2Fgitmcp.io%2Fdocs&id=gitmcp&name=GitMCP&description=Remote%20MCP%20server%20from%20gitmcp.io)

--- a/documentation/docs/mcp/google-drive-mcp.md
+++ b/documentation/docs/mcp/google-drive-mcp.md
@@ -15,7 +15,7 @@ Server archived
 
 This tutorial covers how to add the [Google Drive MCP Server](https://www.pulsemcp.com/servers/modelcontextprotocol-gdrive) as a goose extension, allowing you to list, read, and search files in Google Drive.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-gdrive&id=google-drive&name=Google%20Drive&description=Google%20Drive%20integration&env=GDRIVE_CREDENTIALS_PATH%3DPath%20to%20Google%20Drive%20credentials&env=GDRIVE_OAUTH_PATH%3DPath%20to%20OAuth%20token)

--- a/documentation/docs/mcp/google-maps-mcp.md
+++ b/documentation/docs/mcp/google-maps-mcp.md
@@ -13,7 +13,7 @@ Server archived
 
 This tutorial covers how to add the [Google Maps MCP Server](https://www.pulsemcp.com/servers/google-maps-docs) as a goose extension to enable geocoding, place searching, distance calculations, elevation data retrieval, and directions.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-google-maps&id=google-maps&name=Google%20Maps&description=Google%20Maps%20API%20integration&env=GOOGLE_MAPS_API_KEY%3DGoogle%20Maps%20API%20key)

--- a/documentation/docs/mcp/goose-docs-mcp.md
+++ b/documentation/docs/mcp/goose-docs-mcp.md
@@ -12,7 +12,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [goose Docs MCP Server](https://github.com/idosal/git-mcp) as a goose extension to enable goose to answer questions about itself.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=mcp-remote&arg=https%3A%2F%2Fblock.gitmcp.io%2Fgoose%2F&id=goose-docs&name=goose%20Docs&description=gitmcp%20for%20goose%20documentation)

--- a/documentation/docs/mcp/gotohuman-mcp.md
+++ b/documentation/docs/mcp/gotohuman-mcp.md
@@ -15,7 +15,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 This tutorial covers how to add the [gotoHuman MCP Server](https://github.com/gotohuman/gotohuman-mcp-server) as a goose extension to bring **human-in-the-loop approvals** into your AI workflows. With gotoHuman, goose can pause and request a review before continuing, perfect for blog drafts, code reviews,compliance checks, etc.  
 
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40gotohuman%2Fmcp-server&id=gotoHuman&name=gotoHuman&description=gotoHuman%20MCP%20server%20for%20human-in-the-loop%20approvals&env=GOTOHUMAN_API_KEY%3DgotoHuman%20API%20Key)

--- a/documentation/docs/mcp/i-ching-mcp.md
+++ b/documentation/docs/mcp/i-ching-mcp.md
@@ -5,7 +5,7 @@ description: Add I Ching MCP Server as a goose Extension
 
 This tutorial covers how to add the [I Ching MCP Server](https://github.com/threemachines/i-ching) as a goose extension to enable traditional I Ching divination readings.
 
-:::tip TLDR
+:::tip Quick Install
 1. Install: `cargo install i-ching`
 2. Configure: [Add I Ching Extension](goose://extension?cmd=i-ching-mcp-server&id=i-ching&name=I%20Ching&description=I%20Ching%20divination%20readings)
 :::

--- a/documentation/docs/mcp/jetbrains-mcp.md
+++ b/documentation/docs/mcp/jetbrains-mcp.md
@@ -24,7 +24,7 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
     Versions 2025.2 and later have built-in MCP server support and generate a dynamic configuration specific to your IDE instance. See your IDE's documentation for more details (e.g. [MCP Server](https://www.jetbrains.com/help/idea/mcp-server.html) for IntelliJ IDEA).
 
     <!-- hide until parsing bugs for paths with spaces are fixed in Desktop and CLI
-    :::tip TLDR
+    :::tip Quick Install
     <Tabs groupId="interface">
       <TabItem value="ui" label="goose Desktop" default>
       Use `Add custom extension` in Settings → Extensions with the command from `Copy Stdio Config` in your IDE.
@@ -117,7 +117,7 @@ This tutorial covers how to add the JetBrains extension to integrate with any Je
 
     Versions 2025.1 and earlier require installing the MCP Server plugin and using the [JetBrains MCP Proxy Server](https://github.com/JetBrains/mcp-jetbrains).
 
-    :::tip TLDR
+    :::tip Quick Install
     <Tabs groupId="interface">
       <TabItem value="ui" label="goose Desktop" default>
       [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40jetbrains%2Fmcp-proxy&id=jetbrains&name=JetBrains&description=Integrate%20goose%20with%20any%20JetBrains%20IDE)

--- a/documentation/docs/mcp/kiwi-flight-search.md
+++ b/documentation/docs/mcp/kiwi-flight-search.md
@@ -18,7 +18,7 @@ Server moved: https://apify.com/agentify/kiwi-mcp-server
 
 This tutorial covers how to add the [Kiwi Flight Search MCP Server](https://mcp.kiwi.com) as a goose extension to enable flight search and price comparison.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   Use `Add custom extension` in Settings → Extensions to add a `Streamable HTTP` extension type with:

--- a/documentation/docs/mcp/knowledge-graph-mcp.md
+++ b/documentation/docs/mcp/knowledge-graph-mcp.md
@@ -14,7 +14,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [Knowledge Graph Memory MCP Server](https://github.com/modelcontextprotocol/servers/tree/main/src/memory) as a goose extension. This enables goose to analyze relationships, detect patterns, and gain a deeper understanding of your data. The knowledge graph builds on the [memory extension](/docs/mcp/memory-mcp) by mapping complex relationships between concepts and providing persistent memory across goose sessions.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-memory&id=knowledge_graph_memory&name=Knowledge%20Graph%20Memory&description=Graph-based%20memory%20system%20for%20persistent%20knowledge%20storage)

--- a/documentation/docs/mcp/mbot-mcp.md
+++ b/documentation/docs/mcp/mbot-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial will get you started with [deemkeen's MQTT MCP server](https://github.com/deemkeen/mbotmcp) for the [MakeBlock mbot2 rover](https://www.makeblock.com/products/buy-mbot2), and outline some code changes we made along the way.
 
-:::tip TLDR
+:::tip Quick Install
   **Command**
   ```sh
   /path/to/java -jar /path/to/mbotmcp-0.0.1-SNAPSHOT.jar

--- a/documentation/docs/mcp/mongodb-mcp.md
+++ b/documentation/docs/mcp/mongodb-mcp.md
@@ -10,7 +10,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 The [MongoDB MCP Server](https://github.com/mongodb-js/mongodb-mcp-server) extension allows goose to interact directly with your MongoDB databases, enabling comprehensive database operations including querying, document manipulation, collection management, and database administration. This makes it easy to work with your MongoDB databases through natural language interactions.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=mongodb-mcp-server&arg=--connection-string&arg=mongodb://localhost:27017&id=mongodb&name=MongoDB&description=MongoDB%20database%20integration)

--- a/documentation/docs/mcp/nano-banana-mcp.md
+++ b/documentation/docs/mcp/nano-banana-mcp.md
@@ -15,7 +15,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Nano Banana MCP Server](https://github.com/ConechoAI/Nano-Banana-MCP) as a goose extension that provides AI image generation and editing capabilities using Google's Gemini Image API.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=nano-banana-mcp&id=nano-banana&name=Nano%20Banana&description=Image%20generation%20with%20Gemini)

--- a/documentation/docs/mcp/neon-mcp.md
+++ b/documentation/docs/mcp/neon-mcp.md
@@ -24,7 +24,7 @@ The Neon MCP Server grants powerful database management capabilities and is inte
 
 <Tabs groupId="remote-or-local">
   <TabItem value="remote" label="Neon Remote MCP" default>
-  :::tip TLDR
+  :::tip Quick Install
   <Tabs groupId="interface">
     <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.neon.tech%2Fmcp&id=neon&name=Neon&description=Manage%20Neon%20Postgres%20databases%2C%20projects%2C%20and%20branches)
@@ -68,7 +68,7 @@ The Neon MCP Server grants powerful database management capabilities and is inte
   </TabItem>
 
   <TabItem value="local" label="Neon Local MCP">
-  :::tip TLDR
+  :::tip Quick Install
   <Tabs groupId="interface">
     <TabItem value="ui" label="goose Desktop" default>
       [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40neondatabase%2Fmcp-server-neon&arg=start&arg=%3CYOUR_NEON_API_KEY%3E&id=neon&name=Neon&description=Manage%20your%20Neon%20Postgres%20databases%2C%20projects%2C%20and%20branches)

--- a/documentation/docs/mcp/netlify-mcp.md
+++ b/documentation/docs/mcp/netlify-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [Netlify MCP Server](https://github.com/netlify/netlify-mcp) as a goose extension to build, deploy, and manage Netlify sites.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40netlify%2Fmcp&id=netlify&name=Netlify&description=Build%2C%20deploy%2C%20and%20manage%20sites%20with%20Netlify%27s%20official%20MCP%20server.)

--- a/documentation/docs/mcp/nostrbook-mcp.md
+++ b/documentation/docs/mcp/nostrbook-mcp.md
@@ -12,7 +12,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 This tutorial covers how to add the [Nostrbook MCP Server](https://gitlab.com/soapbox-pub/nostrbook) as a goose extension to provide access to a comprehensive registry of Nostr documentation that helps users understand the decentralized social protocol, its implementation possibilities, and technical specifications.
 
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40nostrbook%2Fmcp&id=nostrbook&name=Nostrbook&description=A%20comprehensive%20registry%20of%20Nostr%20documentation%20with%20structured%20knowledge)

--- a/documentation/docs/mcp/openmetadata-mcp.md
+++ b/documentation/docs/mcp/openmetadata-mcp.md
@@ -10,7 +10,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 The [OpenMetadata MCP Server](https://open-metadata.org/mcp) extension allows goose to interact directly with your OpenMetadata, enabling operations for OpenMetadata assets, glossaries, and lineage. This makes it easy to work with your metadata stored in OpenMetadata through natural language interactions.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=mcp-remote&arg=http%3A%2F%2Flocalhost%3A8585%2Fmcp&arg=--auth-server-url%3Dhttp%3A%2F%2Flocalhost%3A8585%2Fmcp&arg=--client-id%3Dopenmetadata&arg=--verbose&arg=--clean&arg=--header&arg=Authorization%3A%24%7BAUTH_HEADER%7D&id=openmetadata&name=OpenMetadata&description=Intelligent%20data%20management%20and%20automated%20data%20operations&env=AUTH_HEADER%3DBearer%20YOUR_OPENMETADATA_PAT)

--- a/documentation/docs/mcp/pdf-mcp.md
+++ b/documentation/docs/mcp/pdf-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [PDF Reader MCP Server](https://github.com/michaelneale/mcp-read-pdf) as a goose extension, enabling goose to read and extract text from protected and unprotected PDFs.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=mcp-read-pdf&id=pdf_read&name=PDF%20Reader&description=Read%20large%20and%20complex%20PDF%20documents)

--- a/documentation/docs/mcp/playwright-mcp.md
+++ b/documentation/docs/mcp/playwright-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the Playwright MCP Server as a goose extension, to enable cross-browser testing and web automation across Chromium and Webkit.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@playwright/mcp@latest&id=playwright&name=Playwright&description=Modern%20web%20testing%20and%20automation)

--- a/documentation/docs/mcp/postgres-mcp.md
+++ b/documentation/docs/mcp/postgres-mcp.md
@@ -15,7 +15,7 @@ Server archived
 
 The PostgreSQL MCP Server extension allows goose to interact directly with your PostgreSQL databases, enabling database operations, querying, and schema management capabilities. This makes it easy to work with your databases through natural language interactions.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@modelcontextprotocol/server-postgres&arg=Your%20PostgreSQL%20connection%20URL&id=postgres&name=PostgreSQL&description=PostgreSQL%20database%20integration)

--- a/documentation/docs/mcp/prompts-chat-mcp.md
+++ b/documentation/docs/mcp/prompts-chat-mcp.md
@@ -10,7 +10,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [prompts.chat MCP Server](https://prompts.chat) as a goose extension to enable access to thousands of AI prompts directly in your AI assistant.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@fkadev/prompts.chat-mcp@latest&id=prompts-chat-mcp&name=prompts.chat&description=Access%20thousands%20of%20AI%20prompts%20directly%20in%20your%20AI%20assistant&env=PROMPTS_API_KEY%3DAPI%20Key%20to%20save%20and%20list%20private%20prompts)

--- a/documentation/docs/mcp/puppeteer-mcp.md
+++ b/documentation/docs/mcp/puppeteer-mcp.md
@@ -15,7 +15,7 @@ Server archived
 
 This tutorial covers how to add the [Puppeteer MCP Server](https://www.pulsemcp.com/servers/merajmehrabi-puppeteer) as a goose extension, enabling goose to interact with websites - navigating pages, filling forms, clicking buttons, taking screenshots, and executing JavaScript in a real browser environment.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40modelcontextprotocol%2Fserver-puppeteer&id=puppeteer&name=Puppeteer&description=Headless%20browser%20automation)

--- a/documentation/docs/mcp/reddit-mcp.md
+++ b/documentation/docs/mcp/reddit-mcp.md
@@ -15,7 +15,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Reddit MCP Server](https://github.com/adhikasp/mcp-reddit) as a goose extension to fetch trending threads, analyze Reddit post content, and explore subreddit discussions.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=--from&arg=git%2Bhttps%3A%2F%2Fgithub.com%2Fadhikasp%2Fmcp-reddit.git&arg=mcp-reddit&id=reddit&name=Reddit&description=Fetch%20and%20analyze%20Reddit%20content)

--- a/documentation/docs/mcp/repomix-mcp.md
+++ b/documentation/docs/mcp/repomix-mcp.md
@@ -14,7 +14,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [Repomix MCP Server](https://github.com/yamadashy/repomix) as a goose extension to enable automated repository packing, codebase analysis, architecture summaries, test generation, and code exploration, all while compressing the codebase to minimize token usage and stay within your LLM's context limits.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=repomix&arg=--mcp&id=repomix&name=Repomix&description=Pack%20repositories%20into%20AI-friendly%20formats%20for%20goose)

--- a/documentation/docs/mcp/rube-mcp.md
+++ b/documentation/docs/mcp/rube-mcp.md
@@ -11,7 +11,7 @@ import { PanelLeft } from 'lucide-react';
 
 This tutorial covers how to add [Rube](https://rube.app) as a goose extension to enable seamless integration with 500+ apps including Slack, Gmail, Notion, Google Workspace, Microsoft Office, GitHub, and many more.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Frube.app%2Fmcp&id=rube&name=Rube&description=Seamlessly%20connect%20across%20500%2B%20applications%20including%20Slack%2C%20Gmail%2C%20Notion%2C%20Google%20Workspace%2C%20Microsoft%20Office%2C%20GitHub%2C%20and%20many%20more)

--- a/documentation/docs/mcp/selenium-mcp.md
+++ b/documentation/docs/mcp/selenium-mcp.md
@@ -14,7 +14,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [Selenium MCP Server](https://github.com/angiejones/mcp-selenium) as a goose extension to automate browser interactions such as navigating web pages and completing forms.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40angiejones%2Fmcp-selenium&id=selenium-mcp&name=Selenium%20MCP&description=automates%20browser%20interactions)

--- a/documentation/docs/mcp/speech-mcp.md
+++ b/documentation/docs/mcp/speech-mcp.md
@@ -20,7 +20,7 @@ This tutorial covers how to add the [Speech MCP Server](https://github.com/Kvadr
 [PortAudio](https://github.com/GoogleCloudPlatform/python-docs-samples/blob/main/scripts/readme-gen/templates/install_portaudio.tmpl.rst#install-portaudio) is required for PyAudio to capture audio from your microphone
 :::
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=-p&arg=3.10.14&arg=speech-mcp@latest&id=speech_mcp&name=Speech%20Interface&description=Voice%20interaction%20with%20audio%20visualization%20for%20goose)

--- a/documentation/docs/mcp/square-mcp.md
+++ b/documentation/docs/mcp/square-mcp.md
@@ -37,7 +37,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 <Tabs groupId="remote-or-local">
   <TabItem value="remote" label="Square Remote MCP" default>
-  :::tip TLDR
+  :::tip Quick Install
   <Tabs groupId="interface">
     <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](https://mcp.squareup.com/goose)
@@ -75,7 +75,7 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 </TabItem>
 
   <TabItem value="local" label="Square Local MCP">
-  :::tip TLDR
+  :::tip Quick Install
   <Tabs groupId="interface">
     <TabItem value="ui" label="goose Desktop" default>
     [Launch the installer](goose://extension?cmd=npx&arg=square-mcp-server&arg=start&id=mcp_square_api&name=Square%20MCP%20Server&description=Square%20API%20MCP%20Server&env=ACCESS_TOKEN%3DYour%20Access%20Token&env=SANDBOX%3Dtrue)

--- a/documentation/docs/mcp/sugar-mcp.mdx
+++ b/documentation/docs/mcp/sugar-mcp.mdx
@@ -10,7 +10,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Sugar MCP Server](https://github.com/cdnsteve/sugar) as a goose extension to delegate development tasks to an autonomous AI system that runs in the background.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=sugarai-mcp&id=sugar&name=Sugar&description=Autonomous%20AI%20development%20system%20-%20delegate%20tasks%20and%20run%2024%2F7&env=SUGAR_PROJECT_ROOT%3DProject%20directory%20(optional%2C%20defaults%20to%20current))

--- a/documentation/docs/mcp/supabase-mcp.md
+++ b/documentation/docs/mcp/supabase-mcp.md
@@ -10,7 +10,7 @@ import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 
 This tutorial covers how to add the [Supabase MCP Server](https://github.com/supabase-community/supabase-mcp) as a goose extension to interact with your Supabase projects, manage tables, query data, deploy Edge Functions, and interact with your Supabase backend directly.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.supabase.com%2Fmcp&id=supabase&name=Supabase&description=Connect%20your%20Supabase%20projects%20to%20AI%20assistants.%20Manage%20tables%2C%20query%20data%2C%20deploy%20Edge%20Functions%2C%20and%20interact%20with%20your%20Supabase%20backend%20directly%20from%20your%20MCP%20client.)

--- a/documentation/docs/mcp/tavily-mcp.md
+++ b/documentation/docs/mcp/tavily-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [Tavily Web Search MCP Server](https://github.com/tavily-ai/tavily-mcp) as a goose extension to enable AI-powered web search functionality.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=tavily-mcp&id=tavily&name=Tavily%20Web%20Search&description=Search%20the%20web%20with%20Tavily%20MCP&env=TAVILY_API_KEY%3DTavily%20API%20Key)

--- a/documentation/docs/mcp/vercel-mcp.md
+++ b/documentation/docs/mcp/vercel-mcp.md
@@ -17,7 +17,7 @@ This tutorial covers how to add the [Vercel MCP Server](https://vercel.com/docs/
 Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run installation commands, which use `npx`.
 :::
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?url=https%3A%2F%2Fmcp.vercel.com&type=streamable_http&id=vercel&name=Vercel&description=Access%20deployments%2C%20manage%20projects%2C%20and%20more%20with%20Vercel%E2%80%99s%20official%20MCP%20server)

--- a/documentation/docs/mcp/vs-code-mcp.md
+++ b/documentation/docs/mcp/vs-code-mcp.md
@@ -12,7 +12,7 @@ import YouTubeShortEmbed from '@site/src/components/YouTubeShortEmbed';
 
 This tutorial covers how to add the [VS Code MCP Server](https://github.com/block/vscode-mcp) as a goose extension to enable VS Code integration, file operations, and development workflow management.
 
-:::tip TLDR
+:::tip Quick Install
 
 **Command**
 ```sh

--- a/documentation/docs/mcp/youtube-transcript-mcp.md
+++ b/documentation/docs/mcp/youtube-transcript-mcp.md
@@ -13,7 +13,7 @@ import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructi
 
 This tutorial covers how to add the [YouTube Transcript MCP Server](https://github.com/jkawamoto/mcp-youtube-transcript) as a goose extension to enable fetching and working with YouTube video transcripts.
 
-:::tip TLDR
+:::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
   [Launch the installer](goose://extension?cmd=uvx&arg=--from&arg=git%2Bhttps%3A%2F%2Fgithub.com%2Fjkawamoto%2Fmcp-youtube-transcript&arg=mcp-youtube-transcript&id=youtube-transcript&name=YouTube%20Transcript&description=Access%20YouTube%20video%20transcripts)


### PR DESCRIPTION
## Summary
Updates all MCP tutorial documentation to use 'Quick Install' instead of 'TLDR' for the tip sections.

## Changes
- Renamed `:::tip TLDR` to `:::tip Quick Install` across 58 MCP documentation files
- Updated the template file for consistency with future docs

## Why
'Quick Install' is more descriptive and user-friendly than 'TLDR' for these installation instruction sections.