### PR TITLE
fix(claude-code): Permission routing for smart-approve

### DIFF
--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -344,7 +344,7 @@ impl ClaudeCodeProvider {
         cmd
     }
 
-    /// Returns true when the control protocol is enabled (Approve mode).
+    /// Returns true when the control protocol is enabled.
     fn apply_permission_flags(cmd: &mut Command) -> Result<bool, ProviderError> {
         let config = Config::global();
         let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
@@ -354,11 +354,7 @@ impl ClaudeCodeProvider {
                 cmd.arg("--dangerously-skip-permissions");
                 Ok(false)
             }
-            GooseMode::SmartApprove => {
-                cmd.arg("--permission-mode").arg("acceptEdits");
-                Ok(false)
-            }
-            GooseMode::Approve => {
+            GooseMode::SmartApprove | GooseMode::Approve => {
                 cmd.arg("--permission-prompt-tool").arg("stdio");
                 Ok(true)
             }


### PR DESCRIPTION
## Summary
SmartApprove was passing --permission-mode acceptEdits without enabling the control protocol (--permission-prompt-tool stdio), causing non-edit permission requests to silently fail.

Removed --permission-mode acceptEdits to align with goose's own smart-approve semantics rather than Claude Code's (auto-approve edits). Both SmartApprove and Approve now route all permissions through goose via the control protocol.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested locally.