### PR TITLE
fix: searchbar zindex modal overlay

### DIFF
--- a/ui/desktop/src/components/conversation/SearchBar.tsx
+++ b/ui/desktop/src/components/conversation/SearchBar.tsx
@@ -146,7 +146,7 @@ export const SearchBar: React.FC<SearchBarProps> = ({
 
   return (
     <div
-      className={`sticky top-0 bg-background-inverse text-text-inverse z-[60] mb-4 ${
+      className={`sticky top-0 bg-background-inverse text-text-inverse z-30 mb-4 ${
         isExiting ? 'search-bar-exit' : 'search-bar-enter'
       }`}
     >


### PR DESCRIPTION
## Summary
small cosmetic fix

### Screenshots/Demos (for UX changes)
Before:  

<img width="1886" height="1504" alt="image" src="https://github.com/user-attachments/assets/9f6ebc3b-f280-47a2-b23a-abd113b5dfcc" />


After:   

<img width="2038" height="1520" alt="image" src="https://github.com/user-attachments/assets/a3bce77d-059f-4698-9b68-8ee1ee06ff29" />
