### PR TITLE
feat: add goose-powered release notes generator workflow

### DIFF
--- a/.github/workflows/goose-release-notes.yml
+++ b/.github/workflows/goose-release-notes.yml
@@ -101,12 +101,15 @@ jobs:
     steps:
       - name: Get release tag
         id: get-tag
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+          WORKFLOW_RUN_BRANCH: ${{ github.event.workflow_run.head_branch }}
         run: |
-          # For workflow_run, the tag is in head_branch; for workflow_dispatch, use input
-          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "tag=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "tag=$INPUT_TAG" >> $GITHUB_OUTPUT
           else
-            echo "tag=${{ github.event.workflow_run.head_branch }}" >> $GITHUB_OUTPUT
+            echo "tag=$WORKFLOW_RUN_BRANCH" >> $GITHUB_OUTPUT
           fi
 
       - name: Checkout repository


### PR DESCRIPTION
## Summary

Automatically generates categorized release notes using goose AI agent when a new release is published. Updates the GitHub release page with AI-generated notes and posts to Discord.

## What it does

1. **Triggers** when the Release workflow completes successfully (or manually via `workflow_dispatch`)
2. **Runs goose** with the developer extension to analyze git history between tags
3. **Generates categorized release notes** with:
   - ✨ Features
   - 🐛 Bug Fixes
   - 🔧 Improvements
   - 📚 Documentation
4. **Updates the GitHub Release** page with the generated notes
5. **Posts to Discord** with smart content splitting:
   - Main message: Header + as many complete bullet points as fit + @everyone ping
   - Thread: Remaining content split at line boundaries (never mid-item)

## Configuration

**Required Secrets:**
- `RELEASE_BOT_ANTHROPIC_KEY` - API key for Anthropic

**Optional Secrets (for Discord):**
- `DISCORD_RELEASE_BOT_TOKEN` - Discord bot token for posting release announcements
- `DISCORD_RELEASE_BOT_CHANNEL_ID` - Discord channel ID for release announcements

**Default Settings:**
- `GOOSE_PROVIDER`: anthropic
- `GOOSE_MODEL`: claude-opus-4-5

## Testing

Tested on fork: https://github.com/blackgirlbytes/goose/releases/tag/v1.25.0

Example generated release notes show proper categorization and PR linking.

## Key Implementation Details

### Why `workflow_run` instead of `release: published`?

GitHub doesn't trigger workflows for events created by `GITHUB_TOKEN` (to prevent infinite loops). Since `release.yml` publishes releases using `GITHUB_TOKEN`, a `release: published` trigger would **never fire** for automated releases.

The solution is to use `workflow_run` which triggers when another workflow completes - this **does** fire even when the original workflow used `GITHUB_TOKEN`. This follows the same pattern used by `build-notify.yml` in this repo.

### Changes from initial implementation

- Fixed YAML syntax errors (multiline string indentation)
- Switched from OpenRouter to Anthropic (claude-opus-4-5)
- **Fixed trigger**: Changed from `release: published` to `workflow_run` on Release workflow
- Redesigned Discord posting to avoid cutting off content mid-item
- Added @everyone ping in main message footer
- Renamed secrets to be more descriptive (DISCORD_RELEASE_BOT_*)

Results

<img width="1504" height="1772" alt="image" src="https://github.com/user-attachments/assets/7ac8a3d9-be84-489a-bca0-6fdb7a703477" />

<img width="1452" height="1816" alt="image" src="https://github.com/user-attachments/assets/8becc10e-5240-46a6-9f02-7798222051d0" />
