### PR TITLE
feat: pass --no-session-persistence to Claude Code when goose uses --no-session

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -597,6 +597,10 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
         (None, None)
     };
 
+    if session_config.no_session {
+        std::env::set_var("GOOSE_NO_SESSION", "true");
+    }
+
     let resolved =
         resolve_provider_and_model(&session_config, config, saved_provider, saved_model_config);
 

--- a/crates/goose/src/providers/claude_code.rs
+++ b/crates/goose/src/providers/claude_code.rs
@@ -382,6 +382,10 @@ impl ClaudeCodeProvider {
 
         let control_protocol_enabled = Self::apply_permission_flags(&mut cmd)?;
 
+        if std::env::var("GOOSE_NO_SESSION").unwrap_or_default() == "true" {
+            cmd.arg("--no-session-persistence");
+        }
+
         let mut child = cmd.spawn().map_err(|e| {
             ProviderError::RequestFailed(format!(
                 "Failed to spawn Claude CLI command '{:?}': {}.",


### PR DESCRIPTION
## Summary

- When goose runs with `--no-session`, the Claude Code provider now passes `--no-session-persistence` to the `claude` subprocess, preventing it from creating its own persistent session
- Uses a process-scoped environment variable (`GOOSE_NO_SESSION`) to communicate the flag from the CLI session builder to the provider, avoiding any persistent config changes

## Test plan

- [x] `cargo build -p goose-cli -p goose-server` compiles without errors
- [x] `cargo test -p goose` — existing tests pass
- [x] `cargo fmt -- --check` — clean
- [x] `cargo clippy -p goose -p goose-cli -- -D warnings` — no warnings
- [x] Manual: run `goose run --no-session -i "hello"` with Claude Code provider and confirm `claude` subprocess receives `--no-session-persistence` flag