### PR TITLE
Dockerfile: add missing build/runtime dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,11 @@ FROM rust:1.82-bookworm AS builder
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential \
+    cmake \
     pkg-config \
     libssl-dev \
     libdbus-1-dev \
+    libclang-dev \
     protobuf-compiler \
     libprotobuf-dev \
     ca-certificates \
@@ -40,6 +42,7 @@ RUN apt-get update && \
     ca-certificates \
     libssl3 \
     libdbus-1-3 \
+    libgomp1 \
     libxcb1 \
     curl \
     git \


### PR DESCRIPTION
## Summary
Add cmake and libclang-dev to the builder stage and libgomp1 to the runtime stage to fix Docker build failures.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ x] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x ] This PR was created or reviewed with AI assistance

### Testing
manually tested and working. Was unable to build with Dockerfile before these fixes.
