### PR TITLE
Goose Self Tester MCP + Specs

### DIFF
--- a/ui/desktop/goose-electron-tester-mcp/.gitignore
+++ b/ui/desktop/goose-electron-tester-mcp/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/ui/desktop/goose-electron-tester-mcp/README.md
+++ b/ui/desktop/goose-electron-tester-mcp/README.md
@@ -1,0 +1,194 @@
+# goose-electron-tester-mcp
+
+An MCP server for testing and QA of the Goose Desktop app (aka "Goose Tester" 🦢🔍). Provides four sets of tools:
+
+1. **Electron CDP tools** — connect to the Electron app's Chrome DevTools Protocol endpoint for live console log collection, JS evaluation, and target inspection.
+2. **Screenshot & DOM inspection tools** — capture screenshots of the app (full page or specific elements), get DOM snapshots, and extract HTML. Useful for visual QA, bug documentation, and verifying UI changes.
+3. **Navigation & interaction tools** — click elements, type text, press keys, navigate, scroll, and wait for selectors. Enables agents to drive the UI for smoke tests, feature testing, and bug reproduction.
+4. **Server log tools** — read goosed server logs, MCP extension logs, and the Electron main process log from disk.
+
+## Quick Start
+
+### 1. Build
+
+```bash
+cd ui/desktop/goose-electron-tester-mcp
+npm install
+npx tsc
+```
+
+### 2. Start the dev Electron app with remote debugging
+
+```bash
+cd ui/desktop
+ENABLE_PLAYWRIGHT=1 npm start
+```
+
+Or with a custom port:
+
+```bash
+ENABLE_PLAYWRIGHT=1 PLAYWRIGHT_DEBUG_PORT=9333 npm start
+```
+
+Or use the launcher script:
+
+```bash
+# Dev server with Vite hot reload
+./tests/e2e/specs/launch-app.sh dev /path/to/ui/desktop 9224
+
+# Bundled/packaged app
+./tests/e2e/specs/launch-app.sh app "/path/to/Goose.app" 9223
+```
+
+### 3. Add as an extension in Goose
+
+In the production Goose Desktop app, go to **Extensions → Add Custom Extension**:
+
+| Field | Value |
+|-------|-------|
+| Name | Goose Electron Tester |
+| Type | stdio |
+| Command | `node` |
+| Args | `/path/to/goose-main/ui/desktop/goose-electron-tester-mcp/dist/index.js` |
+| Env | `ELECTRON_DEBUG_PORT=9222` |
+
+Or add directly to `~/.config/goose/config.yaml`:
+
+```yaml
+gooseelectrontester:
+  enabled: true
+  name: Goose Electron Tester
+  type: stdio
+  cmd: node
+  args:
+    - /path/to/goose-main/ui/desktop/goose-electron-tester-mcp/dist/index.js
+  env:
+    ELECTRON_DEBUG_PORT: "9222"
+```
+
+## Tools
+
+### Electron CDP Tools
+
+These require the dev Electron app to be running with `ENABLE_PLAYWRIGHT=1`.
+
+| Tool | Description |
+|------|-------------|
+| `electron_connect` | Connect to the Electron app's CDP endpoint and start collecting console logs. Accepts optional `port` and `host` to target different instances. |
+| `electron_list_targets` | List all debuggable targets (renderer windows, workers, etc.) |
+| `electron_get_logs` | View collected console logs with filtering by `level`, `target_id`, `search`, and pagination via `since` cursor |
+| `electron_clear_logs` | Clear the in-memory log buffer |
+| `electron_evaluate` | Evaluate JavaScript in a renderer window |
+| `electron_version` | Get Electron/Chromium version info |
+
+### Screenshot & DOM Inspection Tools
+
+These require a CDP connection (`electron_connect` first). No extra dependencies — uses CDP's built-in `Page.captureScreenshot`, `DOM`, and `DOMSnapshot` domains.
+
+| Tool | Description |
+|------|-------------|
+| `electron_screenshot` | Capture a screenshot of a renderer window. Options: `format` (png/jpeg/webp), `quality`, `full_page` (scroll capture), `save_path` (save to file). Returns base64 image inline or saves to disk. |
+| `electron_screenshot_element` | Screenshot a specific DOM element by CSS selector. Options: `selector` (required), `padding` (extra px around element), `format`, `save_path`. |
+| `electron_dom_snapshot` | Get a structured DOM snapshot with computed styles (display, visibility, colors, sizes, etc). Compact representation for understanding layout without pixels. |
+| `electron_get_html` | Get outerHTML of the document or a specific element by CSS selector. Use targeted selectors to keep output manageable. |
+
+**QA workflow example:**
+```
+1. "Connect to the electron app"              → electron_connect
+2. "Screenshot the current state"             → electron_screenshot
+3. "Screenshot the chat input area"           → electron_screenshot_element { selector: ".chat-input" }
+4. "Save a screenshot for the bug report"     → electron_screenshot { save_path: "/tmp/bug-123.png" }
+5. "What's the DOM structure of the sidebar?"  → electron_get_html { selector: ".sidebar" }
+```
+
+### Navigation & Interaction Tools
+
+These let agents drive the UI — click buttons, type text, navigate, and wait for transitions. Combined with screenshots, this enables full smoke tests and bug reproduction workflows.
+
+| Tool | Description |
+|------|-------------|
+| `electron_click` | Click an element by CSS selector (resolves bounding box, clicks center) or at x,y coordinates. Options: `button` (left/right/middle), `click_count` (2 for double-click). |
+| `electron_type` | Type text into the focused element or a selector. Options: `clear` (select-all + delete first), `press_enter` (submit after typing). |
+| `electron_press_key` | Press a key: Enter, Tab, Escape, Backspace, arrows, F-keys, a-z. Supports modifier bitmask: 1=Alt, 2=Ctrl, 4=Cmd, 8=Shift (e.g., Cmd+A = `key:"a", modifiers:4`). |
+| `electron_navigate` | Navigate the renderer to a URL. For SPA in-app navigation, prefer clicking nav elements. |
+| `electron_wait_for` | Wait for a CSS selector to appear/become visible. Polls at 200ms. Use after clicks/navigation before screenshotting. |
+| `electron_scroll` | Scroll to coordinates or scroll an element into view by selector. |
+
+**Smoke test example:**
+```
+1. electron_connect
+2. electron_screenshot                                    → capture initial state
+3. electron_click { selector: "[data-testid='nav-settings']" } → open settings
+4. electron_wait_for { selector: ".settings-panel", visible: true }
+5. electron_screenshot                                    → capture settings page
+6. electron_click { selector: "[data-testid='dark-mode-button']" } → toggle theme
+7. electron_screenshot                                    → verify theme changed
+8. electron_get_logs { level: "error" }                   → check for console errors
+```
+
+**Bug reproduction example:**
+```
+1. electron_connect
+2. electron_screenshot { save_path: "/tmp/before.png" }   → document initial state
+3. electron_type { selector: "[data-session-active='true'] textarea", text: "test message", press_enter: true }
+4. electron_wait_for { selector: "[data-testid='message-container']" }
+5. electron_screenshot { save_path: "/tmp/after.png" }    → document result
+6. electron_get_logs { level: "error,warn" }              → check for issues
+```
+
+### Server Log Tools
+
+These work anytime — they read log files from disk. No CDP connection required.
+
+| Tool | Description |
+|------|-------------|
+| `server_list_sessions` | List goosed server log sessions with date, start time, and size. Each session = one goosed process. |
+| `server_get_logs` | Read a session's server logs. Filter by `level` (TRACE/DEBUG/INFO/WARN/ERROR), `module` prefix, `search` text. Supports `head`/`tail`. |
+| `server_list_mcp_logs` | List available MCP extension log files |
+| `server_get_mcp_log` | Read an MCP extension's log by name (e.g., "developer") |
+| `electron_get_main_log` | Read the Electron main process log (main.log) |
+
+## Log Locations
+
+| Log | Path |
+|-----|------|
+| Goosed server | `~/.local/state/goose/logs/server/YYYY-MM-DD/YYYYMMDD_HHMMSS-goosed.log` |
+| MCP extensions | `~/.local/state/goose/logs/mcps/mcp_<name>.log` |
+| Electron main | `~/Library/Application Support/Goose/logs/main.log` |
+
+## Multiple Instances
+
+Start each dev instance on a different port:
+
+```bash
+ENABLE_PLAYWRIGHT=1 PLAYWRIGHT_DEBUG_PORT=9222 npm start   # Instance 1
+ENABLE_PLAYWRIGHT=1 PLAYWRIGHT_DEBUG_PORT=9223 npm start   # Instance 2
+```
+
+Then switch between them:
+
+```
+"Connect to the electron app on port 9222"   → attaches to instance 1
+"Connect to the electron app on port 9223"   → disconnects from 1, attaches to 2
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ELECTRON_DEBUG_PORT` | `9222` | Default CDP port |
+| `ELECTRON_DEBUG_HOST` | `127.0.0.1` | Default CDP host |
+
+## Architecture
+
+```
+src/
+├── index.ts        # MCP server — tool definitions and handlers
+├── cdp-client.ts   # Raw CDP WebSocket client for Electron (console, screenshots, DOM)
+├── log-reader.ts   # File-based log reader for goosed/MCP/Electron logs
+└── session-db.ts   # SQLite reader for goose sessions.db
+```
+
+The CDP client connects directly to Electron's remote debugging endpoint using raw WebSocket (no Puppeteer). It discovers targets via `http://<host>:<port>/json/list`, attaches to each via WebSocket, and uses the `Runtime`, `Log`, `Page`, `DOM`, `DOMSnapshot`, and `Input` CDP domains. This provides console log collection, screenshot capture, element inspection, DOM snapshots, click/type/key input, and navigation — all through the same WebSocket connection with zero additional dependencies.
+
+The log reader uses simple file I/O to read goosed server logs (tracing format), MCP extension logs, and the Electron main.log.

--- a/ui/desktop/goose-electron-tester-mcp/package-lock.json
+++ b/ui/desktop/goose-electron-tester-mcp/package-lock.json
@@ -1,0 +1,1209 @@
+{
+  "name": "goose-electron-tester-mcp",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "goose-electron-tester-mcp",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.12.1",
+        "ws": "^8.18.0"
+      },
+      "bin": {
+        "goose-electron-tester-mcp": "dist/index.js"
+      },
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "@types/ws": "^8.5.13",
+        "typescript": "^5.7.0"
+      }
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
+      "integrity": "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.11.9.tgz",
+      "integrity": "sha512-Eaw2YTGM6WOxA6CXbckaEvslr2Ne4NFsKrvc0v97JD5awbmeBLO5w9Ho9L9kmKonrwF9RJlW6BxT1PVv/agBHQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
+      }
+    }
+  }
+}

--- a/ui/desktop/goose-electron-tester-mcp/package.json
+++ b/ui/desktop/goose-electron-tester-mcp/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "goose-electron-tester-mcp",
+  "version": "1.0.0",
+  "description": "MCP server for viewing console logs and debugging the Goose Electron app via Chrome DevTools Protocol",
+  "type": "module",
+  "main": "dist/index.js",
+  "bin": {
+    "goose-electron-tester-mcp": "dist/index.js"
+  },
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js",
+    "dev": "tsc && node dist/index.js"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.1",
+    "ws": "^8.18.0"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "@types/ws": "^8.5.13",
+    "typescript": "^5.7.0"
+  }
+}

--- a/ui/desktop/goose-electron-tester-mcp/src/cdp-client.ts
+++ b/ui/desktop/goose-electron-tester-mcp/src/cdp-client.ts
@@ -1,0 +1,774 @@
+/**
+ * Lightweight Chrome DevTools Protocol client for Electron.
+ *
+ * Connects to Electron's remote-debugging endpoint over raw WebSocket
+ * (no Puppeteer dependency). Subscribes to Runtime and Log domains to
+ * collect console messages, exceptions, and log entries in real time.
+ */
+
+// ── CDP target as returned by /json/list ────────────────────────────
+export interface CDPTarget {
+  id: string;
+  type: string;
+  title: string;
+  url: string;
+  webSocketDebuggerUrl?: string;
+  devtoolsFrontendUrl?: string;
+  description?: string;
+  faviconUrl?: string;
+}
+
+// ── Collected console entry ─────────────────────────────────────────
+export interface ConsoleEntry {
+  id: number;
+  timestamp: number;
+  source: "console-api" | "exception" | "log-entry";
+  level: string;
+  text: string;
+  url?: string;
+  lineNumber?: number;
+  columnNumber?: number;
+  stackTrace?: string;
+  targetId: string;
+  targetTitle: string;
+}
+
+// ── Minimal WebSocket interface (works with both native and 'ws') ───
+interface MinimalWebSocket {
+  addEventListener(type: "open", listener: () => void): void;
+  addEventListener(type: "close", listener: () => void): void;
+  addEventListener(type: "error", listener: (e: unknown) => void): void;
+  addEventListener(type: "message", listener: (e: { data: unknown }) => void): void;
+  send(data: string): void;
+  close(): void;
+}
+
+// ── Per-target CDP session ──────────────────────────────────────────
+interface CDPSession {
+  ws: MinimalWebSocket;
+  nextId: number;
+  pending: Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>;
+  targetId: string;
+  targetTitle: string;
+}
+
+type WsConstructor = new (url: string) => MinimalWebSocket;
+
+const KEY_CODES: Record<string, number> = {
+  Enter: 13, Tab: 9, Escape: 27, Backspace: 8, Delete: 46,
+  ArrowUp: 38, ArrowDown: 40, ArrowLeft: 37, ArrowRight: 39,
+  Home: 36, End: 35, PageUp: 33, PageDown: 34,
+  Space: 32, F1: 112, F2: 113, F3: 114, F4: 115, F5: 116,
+  F6: 117, F7: 118, F8: 119, F9: 120, F10: 121, F11: 122, F12: 123,
+  a: 65, b: 66, c: 67, d: 68, e: 69, f: 70, g: 71, h: 72, i: 73,
+  j: 74, k: 75, l: 76, m: 77, n: 78, o: 79, p: 80, q: 81, r: 82,
+  s: 83, t: 84, u: 85, v: 86, w: 87, x: 88, y: 89, z: 90,
+};
+
+export class CDPClient {
+  private port: number;
+  private host: string;
+  private entries: ConsoleEntry[] = [];
+  private entryId = 0;
+  private maxEntries: number;
+  private sessions = new Map<string, CDPSession>();
+  private WsClass: WsConstructor | null = null;
+
+  constructor(port: number, host = "127.0.0.1", maxEntries = 5000) {
+    this.port = port;
+    this.host = host;
+    this.maxEntries = maxEntries;
+  }
+
+  // ── Public API ──────────────────────────────────────────────────
+
+  async listTargets(): Promise<CDPTarget[]> {
+    const res = await fetch(`http://${this.host}:${this.port}/json/list`);
+    if (!res.ok) {
+      throw new Error(`Failed to list targets: ${res.status} ${res.statusText}`);
+    }
+    return (await res.json()) as CDPTarget[];
+  }
+
+  async getVersion(): Promise<Record<string, string>> {
+    const res = await fetch(`http://${this.host}:${this.port}/json/version`);
+    if (!res.ok) {
+      throw new Error(`Failed to get version: ${res.status} ${res.statusText}`);
+    }
+    return (await res.json()) as Record<string, string>;
+  }
+
+  async attach(target: CDPTarget): Promise<void> {
+    if (this.sessions.has(target.id)) return;
+    if (!target.webSocketDebuggerUrl) {
+      throw new Error(`Target ${target.id} (${target.title}) has no webSocketDebuggerUrl`);
+    }
+
+    const WS = await this.getWsClass();
+    const ws = new WS(target.webSocketDebuggerUrl);
+
+    const session: CDPSession = {
+      ws,
+      nextId: 1,
+      pending: new Map(),
+      targetId: target.id,
+      targetTitle: target.title,
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      ws.addEventListener("open", () => resolve());
+      ws.addEventListener("error", (e) => reject(new Error(`WebSocket error: ${e}`)));
+    });
+
+    ws.addEventListener("message", (event) => {
+      const data = JSON.parse(String(event.data));
+      if (data.id !== undefined) {
+        const p = session.pending.get(data.id);
+        if (p) {
+          session.pending.delete(data.id);
+          if (data.error) {
+            p.reject(new Error(data.error.message));
+          } else {
+            p.resolve(data.result);
+          }
+        }
+        return;
+      }
+      this.handleCDPEvent(session, data.method, data.params);
+    });
+
+    ws.addEventListener("close", () => {
+      this.sessions.delete(target.id);
+    });
+
+    this.sessions.set(target.id, session);
+
+    await this.send(session, "Runtime.enable");
+    await this.send(session, "Log.enable");
+  }
+
+  async attachAll(): Promise<CDPTarget[]> {
+    const targets = await this.listTargets();
+    const attached: CDPTarget[] = [];
+    for (const t of targets) {
+      if (!t.webSocketDebuggerUrl) continue;
+      try {
+        await this.attach(t);
+        attached.push(t);
+      } catch {
+        // Skip targets we can't attach to
+      }
+    }
+    return attached;
+  }
+
+  async disconnect(targetId: string): Promise<void> {
+    const session = this.sessions.get(targetId);
+    if (session) {
+      this.sessions.delete(targetId);
+      // Reject any pending requests
+      for (const [, p] of session.pending) {
+        p.reject(new Error("Session disconnected"));
+      }
+      session.pending.clear();
+
+      await new Promise<void>((resolve) => {
+        const timeout = setTimeout(() => resolve(), 2000);
+        session.ws.addEventListener("close", () => {
+          clearTimeout(timeout);
+          resolve();
+        });
+        session.ws.close();
+      });
+    }
+  }
+
+  async disconnectAll(): Promise<void> {
+    const ids = [...this.sessions.keys()];
+    await Promise.all(ids.map((id) => this.disconnect(id)));
+  }
+
+  getEntries(opts?: {
+    targetId?: string;
+    level?: string;
+    since?: number;
+    limit?: number;
+    search?: string;
+  }): ConsoleEntry[] {
+    let result = this.entries;
+
+    if (opts?.targetId) {
+      result = result.filter((e) => e.targetId === opts.targetId);
+    }
+    if (opts?.level) {
+      const levels = opts.level.split(",").map((l) => l.trim().toLowerCase());
+      result = result.filter((e) => levels.includes(e.level.toLowerCase()));
+    }
+    if (opts?.since !== undefined) {
+      const sinceId = opts.since;
+      result = result.filter((e) => e.id > sinceId);
+    }
+    if (opts?.search) {
+      const term = opts.search.toLowerCase();
+      result = result.filter((e) => e.text.toLowerCase().includes(term));
+    }
+    if (opts?.limit) {
+      result = result.slice(-opts.limit);
+    }
+
+    return result;
+  }
+
+  clearEntries(): void {
+    this.entries = [];
+  }
+
+  getAttachedTargetIds(): string[] {
+    return [...this.sessions.keys()];
+  }
+
+  async evaluate(
+    targetId: string,
+    expression: string,
+    returnByValue = true
+  ): Promise<{ result: unknown; exceptionDetails?: unknown }> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+    return (await this.send(session, "Runtime.evaluate", {
+      expression,
+      returnByValue,
+      awaitPromise: true,
+      generatePreview: true,
+      userGesture: true,
+    })) as { result: unknown; exceptionDetails?: unknown };
+  }
+
+  // ── Screenshot & DOM inspection ────────────────────────────────
+
+  async captureScreenshot(
+    targetId: string,
+    opts?: {
+      format?: "png" | "jpeg" | "webp";
+      quality?: number;
+      clip?: { x: number; y: number; width: number; height: number; scale?: number };
+      fullPage?: boolean;
+    }
+  ): Promise<string> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    // If fullPage, get the full document dimensions and set clip
+    let clip = opts?.clip;
+    if (opts?.fullPage) {
+      const layoutMetrics = (await this.send(session, "Page.getLayoutMetrics")) as {
+        contentSize: { width: number; height: number };
+        cssContentSize?: { width: number; height: number };
+      };
+      const size = layoutMetrics.cssContentSize ?? layoutMetrics.contentSize;
+      clip = { x: 0, y: 0, width: size.width, height: size.height, scale: 1 };
+    }
+
+    const params: Record<string, unknown> = {
+      format: opts?.format ?? "png",
+    };
+    if (opts?.quality !== undefined) params.quality = opts.quality;
+    if (clip) params.clip = { ...clip, scale: clip.scale ?? 1 };
+
+    const result = (await this.send(session, "Page.captureScreenshot", params)) as { data: string };
+    return result.data;
+  }
+
+  async captureElementScreenshot(
+    targetId: string,
+    selector: string,
+    opts?: { format?: "png" | "jpeg" | "webp"; quality?: number; padding?: number }
+  ): Promise<{ data: string; box: { x: number; y: number; width: number; height: number } }> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    // Get document root
+    const doc = (await this.send(session, "DOM.getDocument", { depth: 0 })) as {
+      root: { nodeId: number };
+    };
+
+    // Find the element
+    const queryResult = (await this.send(session, "DOM.querySelector", {
+      nodeId: doc.root.nodeId,
+      selector,
+    })) as { nodeId: number };
+
+    if (!queryResult.nodeId || queryResult.nodeId === 0) {
+      throw new Error(`No element found matching selector: ${selector}`);
+    }
+
+    // Get bounding box
+    const boxModel = (await this.send(session, "DOM.getBoxModel", {
+      nodeId: queryResult.nodeId,
+    })) as {
+      model: {
+        content: number[];
+        padding: number[];
+        border: number[];
+        margin: number[];
+        width: number;
+        height: number;
+      };
+    };
+
+    // border quad: [x1,y1, x2,y2, x3,y3, x4,y4] — use border box for screenshot
+    const quad = boxModel.model.border;
+    const xs = [quad[0], quad[2], quad[4], quad[6]];
+    const ys = [quad[1], quad[3], quad[5], quad[7]];
+    const pad = opts?.padding ?? 0;
+    const x = Math.max(0, Math.min(...xs) - pad);
+    const y = Math.max(0, Math.min(...ys) - pad);
+    const width = Math.max(...xs) - Math.min(...xs) + pad * 2;
+    const height = Math.max(...ys) - Math.min(...ys) + pad * 2;
+
+    const clip = { x, y, width, height, scale: 1 };
+
+    const params: Record<string, unknown> = {
+      format: opts?.format ?? "png",
+      clip,
+    };
+    if (opts?.quality !== undefined) params.quality = opts.quality;
+
+    const result = (await this.send(session, "Page.captureScreenshot", params)) as { data: string };
+
+    // Disable DOM to avoid holding references
+    await this.send(session, "DOM.disable").catch(() => {});
+
+    return { data: result.data, box: { x, y, width, height } };
+  }
+
+  async getDomSnapshot(
+    targetId: string,
+    opts?: { computedStyles?: string[] }
+  ): Promise<unknown> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    return await this.send(session, "DOMSnapshot.captureSnapshot", {
+      computedStyles: opts?.computedStyles ?? [
+        "display", "visibility", "opacity", "color", "background-color",
+        "font-size", "font-weight", "width", "height", "overflow",
+      ],
+    });
+  }
+
+  async getDocumentOuterHTML(targetId: string, selector?: string): Promise<string> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    const doc = (await this.send(session, "DOM.getDocument", { depth: 0 })) as {
+      root: { nodeId: number };
+    };
+
+    let nodeId = doc.root.nodeId;
+    if (selector) {
+      const queryResult = (await this.send(session, "DOM.querySelector", {
+        nodeId: doc.root.nodeId,
+        selector,
+      })) as { nodeId: number };
+      if (!queryResult.nodeId || queryResult.nodeId === 0) {
+        throw new Error(`No element found matching selector: ${selector}`);
+      }
+      nodeId = queryResult.nodeId;
+    }
+
+    const result = (await this.send(session, "DOM.getOuterHTML", { nodeId })) as {
+      outerHTML: string;
+    };
+
+    await this.send(session, "DOM.disable").catch(() => {});
+
+    return result.outerHTML;
+  }
+
+  // ── Navigation & interaction ───────────────────────────────────
+
+  async navigate(targetId: string, url: string): Promise<{ frameId: string; errorText?: string }> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+    return (await this.send(session, "Page.navigate", { url })) as {
+      frameId: string;
+      errorText?: string;
+    };
+  }
+
+  async waitForLoad(targetId: string, timeoutMs = 30000): Promise<void> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    await this.send(session, "Page.enable");
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        cleanup();
+        reject(new Error(`Page load timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      const handler = (event: { data: unknown }) => {
+        const data = JSON.parse(String(event.data));
+        if (data.method === "Page.loadEventFired") {
+          cleanup();
+          resolve();
+        }
+      };
+
+      const cleanup = () => {
+        clearTimeout(timeout);
+        session.ws.addEventListener("message", () => {});
+      };
+
+      session.ws.addEventListener("message", handler);
+    });
+  }
+
+  async clickAtPoint(
+    targetId: string,
+    x: number,
+    y: number,
+    opts?: { button?: "left" | "right" | "middle"; clickCount?: number }
+  ): Promise<void> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    const button = opts?.button ?? "left";
+    const clickCount = opts?.clickCount ?? 1;
+
+    await this.send(session, "Input.dispatchMouseEvent", {
+      type: "mousePressed",
+      x,
+      y,
+      button,
+      clickCount,
+    });
+    await this.send(session, "Input.dispatchMouseEvent", {
+      type: "mouseReleased",
+      x,
+      y,
+      button,
+      clickCount,
+    });
+  }
+
+  async clickSelector(
+    targetId: string,
+    selector: string,
+    opts?: { button?: "left" | "right" | "middle"; clickCount?: number }
+  ): Promise<{ x: number; y: number }> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    const doc = (await this.send(session, "DOM.getDocument", { depth: 0 })) as {
+      root: { nodeId: number };
+    };
+
+    const queryResult = (await this.send(session, "DOM.querySelector", {
+      nodeId: doc.root.nodeId,
+      selector,
+    })) as { nodeId: number };
+
+    if (!queryResult.nodeId || queryResult.nodeId === 0) {
+      await this.send(session, "DOM.disable").catch(() => {});
+      throw new Error(`No element found matching selector: ${selector}`);
+    }
+
+    const boxModel = (await this.send(session, "DOM.getBoxModel", {
+      nodeId: queryResult.nodeId,
+    })) as {
+      model: { content: number[] };
+    };
+
+    await this.send(session, "DOM.disable").catch(() => {});
+
+    // Click center of content box
+    const quad = boxModel.model.content;
+    const cx = (quad[0] + quad[2] + quad[4] + quad[6]) / 4;
+    const cy = (quad[1] + quad[3] + quad[5] + quad[7]) / 4;
+
+    await this.clickAtPoint(targetId, cx, cy, opts);
+    return { x: cx, y: cy };
+  }
+
+  async typeText(targetId: string, text: string): Promise<void> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    for (const char of text) {
+      await this.send(session, "Input.dispatchKeyEvent", {
+        type: "keyDown",
+        text: char,
+        key: char,
+        unmodifiedText: char,
+      });
+      await this.send(session, "Input.dispatchKeyEvent", {
+        type: "keyUp",
+        key: char,
+      });
+    }
+  }
+
+  async pressKey(
+    targetId: string,
+    key: string,
+    opts?: { modifiers?: number }
+  ): Promise<void> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    const modifiers = opts?.modifiers ?? 0;
+
+    await this.send(session, "Input.dispatchKeyEvent", {
+      type: "keyDown",
+      key,
+      windowsVirtualKeyCode: KEY_CODES[key] ?? 0,
+      modifiers,
+    });
+    await this.send(session, "Input.dispatchKeyEvent", {
+      type: "keyUp",
+      key,
+      windowsVirtualKeyCode: KEY_CODES[key] ?? 0,
+      modifiers,
+    });
+  }
+
+  async focus(targetId: string, selector: string): Promise<void> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    const doc = (await this.send(session, "DOM.getDocument", { depth: 0 })) as {
+      root: { nodeId: number };
+    };
+
+    const queryResult = (await this.send(session, "DOM.querySelector", {
+      nodeId: doc.root.nodeId,
+      selector,
+    })) as { nodeId: number };
+
+    if (!queryResult.nodeId || queryResult.nodeId === 0) {
+      await this.send(session, "DOM.disable").catch(() => {});
+      throw new Error(`No element found matching selector: ${selector}`);
+    }
+
+    await this.send(session, "DOM.focus", { nodeId: queryResult.nodeId });
+    await this.send(session, "DOM.disable").catch(() => {});
+  }
+
+  async waitForSelector(
+    targetId: string,
+    selector: string,
+    opts?: { timeoutMs?: number; pollIntervalMs?: number; visible?: boolean }
+  ): Promise<boolean> {
+    const timeout = opts?.timeoutMs ?? 10000;
+    const interval = opts?.pollIntervalMs ?? 200;
+    const checkVisible = opts?.visible ?? false;
+    const deadline = Date.now() + timeout;
+
+    while (Date.now() < deadline) {
+      try {
+        const session = this.sessions.get(targetId);
+        if (!session) throw new Error(`Not attached to target ${targetId}`);
+
+        const result = (await this.send(session, "Runtime.evaluate", {
+          expression: checkVisible
+            ? `(() => { const el = document.querySelector(${JSON.stringify(selector)}); return el && el.offsetParent !== null; })()`
+            : `!!document.querySelector(${JSON.stringify(selector)})`,
+          returnByValue: true,
+        })) as { result: { value: boolean } };
+
+        if (result.result.value) return true;
+      } catch {
+        // target might have navigated, keep polling
+      }
+
+      await new Promise((r) => setTimeout(r, interval));
+    }
+
+    return false;
+  }
+
+  async scrollTo(
+    targetId: string,
+    opts: { x?: number; y?: number; selector?: string }
+  ): Promise<void> {
+    const session = this.sessions.get(targetId);
+    if (!session) {
+      throw new Error(`Not attached to target ${targetId}`);
+    }
+
+    if (opts.selector) {
+      await this.send(session, "Runtime.evaluate", {
+        expression: `document.querySelector(${JSON.stringify(opts.selector)})?.scrollIntoView({ behavior: 'smooth', block: 'center' })`,
+        returnByValue: true,
+      });
+    } else {
+      await this.send(session, "Runtime.evaluate", {
+        expression: `window.scrollTo(${opts.x ?? 0}, ${opts.y ?? 0})`,
+        returnByValue: true,
+      });
+    }
+  }
+
+  // ── Private helpers ─────────────────────────────────────────────
+
+  private async getWsClass(): Promise<WsConstructor> {
+    if (this.WsClass) return this.WsClass;
+    if (typeof globalThis.WebSocket !== "undefined") {
+      this.WsClass = globalThis.WebSocket as unknown as WsConstructor;
+    } else {
+      const ws = await import("ws");
+      this.WsClass = ws.default as unknown as WsConstructor;
+    }
+    return this.WsClass;
+  }
+
+  private send(session: CDPSession, method: string, params: Record<string, unknown> = {}): Promise<unknown> {
+    return new Promise((resolve, reject) => {
+      const id = session.nextId++;
+      const timeout = setTimeout(() => {
+        session.pending.delete(id);
+        reject(new Error(`CDP request ${method} timed out after 10s`));
+      }, 10000);
+      session.pending.set(id, {
+        resolve: (v) => { clearTimeout(timeout); resolve(v); },
+        reject: (e) => { clearTimeout(timeout); reject(e); },
+      });
+      session.ws.send(JSON.stringify({ id, method, params }));
+    });
+  }
+
+  private handleCDPEvent(session: CDPSession, method: string, params: Record<string, unknown>): void {
+    switch (method) {
+      case "Runtime.consoleAPICalled":
+        this.onConsoleAPI(session, params);
+        break;
+      case "Runtime.exceptionThrown":
+        this.onException(session, params);
+        break;
+      case "Log.entryAdded":
+        this.onLogEntry(session, params);
+        break;
+    }
+  }
+
+  private onConsoleAPI(session: CDPSession, params: Record<string, unknown>): void {
+    const type = params.type as string;
+    const args = params.args as Array<{ type: string; value?: unknown; description?: string; preview?: unknown }>;
+    const stackTrace = params.stackTrace as {
+      callFrames?: Array<{ url: string; lineNumber: number; columnNumber: number }>;
+    } | undefined;
+
+    const textParts = args.map((arg) => {
+      if (arg.value !== undefined) return String(arg.value);
+      if (arg.description) return arg.description;
+      if (arg.preview) return JSON.stringify(arg.preview);
+      return `[${arg.type}]`;
+    });
+
+    const topFrame = stackTrace?.callFrames?.[0];
+
+    this.addEntry({
+      source: "console-api",
+      level: type,
+      text: textParts.join(" "),
+      url: topFrame?.url,
+      lineNumber: topFrame?.lineNumber,
+      columnNumber: topFrame?.columnNumber,
+      stackTrace: stackTrace?.callFrames
+        ?.map((f) => `  at ${f.url}:${f.lineNumber}:${f.columnNumber}`)
+        .join("\n"),
+      targetId: session.targetId,
+      targetTitle: session.targetTitle,
+    });
+  }
+
+  private onException(session: CDPSession, params: Record<string, unknown>): void {
+    const details = params.exceptionDetails as {
+      text?: string;
+      exception?: { description?: string; value?: unknown };
+      url?: string;
+      lineNumber?: number;
+      columnNumber?: number;
+      stackTrace?: { callFrames?: Array<{ url: string; lineNumber: number; columnNumber: number }> };
+    };
+
+    const text =
+      details.exception?.description ||
+      details.exception?.value?.toString() ||
+      details.text ||
+      "Unknown exception";
+
+    this.addEntry({
+      source: "exception",
+      level: "error",
+      text,
+      url: details.url,
+      lineNumber: details.lineNumber,
+      columnNumber: details.columnNumber,
+      stackTrace: details.stackTrace?.callFrames
+        ?.map((f) => `  at ${f.url}:${f.lineNumber}:${f.columnNumber}`)
+        .join("\n"),
+      targetId: session.targetId,
+      targetTitle: session.targetTitle,
+    });
+  }
+
+  private onLogEntry(session: CDPSession, params: Record<string, unknown>): void {
+    const entry = params.entry as {
+      source: string;
+      level: string;
+      text: string;
+      url?: string;
+      lineNumber?: number;
+    };
+
+    this.addEntry({
+      source: "log-entry",
+      level: entry.level,
+      text: `[${entry.source}] ${entry.text}`,
+      url: entry.url,
+      lineNumber: entry.lineNumber,
+      targetId: session.targetId,
+      targetTitle: session.targetTitle,
+    });
+  }
+
+  private addEntry(entry: Omit<ConsoleEntry, "id" | "timestamp">): void {
+    const full: ConsoleEntry = {
+      ...entry,
+      id: ++this.entryId,
+      timestamp: Date.now(),
+    };
+    this.entries.push(full);
+
+    if (this.entries.length > this.maxEntries) {
+      this.entries = this.entries.slice(-Math.floor(this.maxEntries * 0.8));
+    }
+  }
+}

--- a/ui/desktop/goose-electron-tester-mcp/src/index.ts
+++ b/ui/desktop/goose-electron-tester-mcp/src/index.ts
@@ -1,0 +1,2010 @@
+#!/usr/bin/env node
+
+/**
+ * goose-electron-tester-mcp
+ *
+ * An MCP server for debugging the Goose Electron app and its Rust backend.
+ *
+ * Provides two sets of tools:
+ *   1. Electron CDP tools — connect to Electron's Chrome DevTools Protocol
+ *      endpoint for live console logs, JS evaluation, and target inspection.
+ *   2. Server log tools — read goosed server logs, MCP extension logs,
+ *      and the Electron main process log from disk.
+ *
+ * Usage:
+ *   1. Start the Goose Electron app with remote debugging enabled:
+ *        ENABLE_PLAYWRIGHT=1 npm start
+ *        ENABLE_PLAYWRIGHT=1 PLAYWRIGHT_DEBUG_PORT=9333 npm start
+ *
+ *   2. Add this MCP server to your goose config as a stdio extension:
+ *        Command: node
+ *        Args:    <path-to-this-repo>/dist/index.js
+ *        Env:     ELECTRON_DEBUG_PORT=9222
+ *
+ *   Environment variables:
+ *     ELECTRON_DEBUG_PORT  – default CDP port (default: 9222)
+ *     ELECTRON_DEBUG_HOST  – default CDP host (default: 127.0.0.1)
+ */
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+import { CDPClient } from "./cdp-client.js";
+import type { ConsoleEntry } from "./cdp-client.js";
+import { execSync } from "child_process";
+import { existsSync, writeFileSync, chmodSync } from "fs";
+import {
+  listServerSessions,
+  readServerLog,
+  listMcpLogs,
+  readMcpLog,
+  readElectronMainLog,
+  SERVER_LOGS_DIR,
+} from "./log-reader.js";
+import {
+  listChatSessions,
+  findSession,
+  getCurrentSession,
+  type ChatSession,
+} from "./session-db.js";
+
+const DEFAULT_PORT = parseInt(process.env.ELECTRON_DEBUG_PORT ?? "9222", 10);
+const DEFAULT_HOST = process.env.ELECTRON_DEBUG_HOST ?? "127.0.0.1";
+
+let cdp = new CDPClient(DEFAULT_PORT, DEFAULT_HOST);
+
+// ── App launcher helpers ────────────────────────────────────────────
+
+function isPortListening(port: number): boolean {
+  try {
+    const result = execSync(`lsof -i :${port} -sTCP:LISTEN -t 2>/dev/null`, { encoding: "utf-8" });
+    return result.trim().length > 0;
+  } catch {
+    return false;
+  }
+}
+
+async function waitForPort(port: number, timeoutMs: number = 30000): Promise<boolean> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (isPortListening(port)) return true;
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+function launchDevServer(projectDir: string, port: number): string {
+  if (!existsSync(`${projectDir}/package.json`)) {
+    throw new Error(`No package.json found in ${projectDir}`);
+  }
+
+  if (isPortListening(port)) {
+    return `Port ${port} is already in use. An app may already be running. Use electron_connect to attach.`;
+  }
+
+  // Write a .command file and open it — macOS opens .command files in Terminal.app
+  // which gives the process full WindowServer access for GUI windows.
+  // This is the only reliable way to launch Electron with visible windows
+  // from a background process on macOS.
+  const cmdFile = `/tmp/goose-tester-dev-${port}.command`;
+  writeFileSync(cmdFile, `#!/bin/bash
+cd "${projectDir}"
+export ENABLE_PLAYWRIGHT=1
+export PLAYWRIGHT_DEBUG_PORT=${port}
+exec npm run start-gui
+`);
+  chmodSync(cmdFile, 0o755);
+  execSync(`open "${cmdFile}"`);
+
+  return cmdFile;
+}
+
+function launchBundledApp(appPath: string, port: number): void {
+  if (!existsSync(appPath)) {
+    throw new Error(`App not found: ${appPath}`);
+  }
+
+  if (isPortListening(port)) {
+    throw new Error(`Port ${port} is already in use. An app may already be running. Use electron_connect to attach.`);
+  }
+
+  execSync(`open -a "${appPath}" --args --remote-debugging-port=${port}`);
+}
+let activePort = DEFAULT_PORT;
+let activeHost = DEFAULT_HOST;
+
+// ── Formatting helpers ──────────────────────────────────────────────
+
+function formatEntry(e: ConsoleEntry): string {
+  const ts = new Date(e.timestamp).toISOString().slice(11, 23);
+  const loc = e.url ? ` (${e.url}${e.lineNumber !== undefined ? `:${e.lineNumber}` : ""})` : "";
+  const levelTag = e.level.toUpperCase().padEnd(7);
+  const src = e.source === "exception" ? " ⚠ EXCEPTION" : "";
+  return `[${ts}] ${levelTag} [${e.targetTitle}]${src} ${e.text}${loc}`;
+}
+
+function formatEntries(entries: ConsoleEntry[]): string {
+  if (entries.length === 0) return "No console entries found.";
+  return entries.map(formatEntry).join("\n");
+}
+
+async function resolveTargetId(targetId?: string): Promise<string> {
+  if (targetId) return targetId;
+  const attachedIds = cdp.getAttachedTargetIds();
+  if (attachedIds.length === 0) {
+    throw new Error("Not attached to any targets. Call electron_connect first.");
+  }
+  try {
+    const targets = await cdp.listTargets();
+    const pageTarget = targets.find((t) => t.type === "page" && attachedIds.includes(t.id));
+    return pageTarget?.id ?? attachedIds[0];
+  } catch {
+    return attachedIds[0];
+  }
+}
+
+// ── MCP Server ──────────────────────────────────────────────────────
+
+const server = new Server(
+  { name: "goose-electron-tester-mcp", version: "1.3.0" },
+  { capabilities: { tools: {} } }
+);
+
+server.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: [
+    // ── App launcher tools ─────────────────────────────────────
+    {
+      name: "electron_launch_dev",
+      description:
+        "Launch the Goose Electron dev server from a project directory with remote debugging enabled, then auto-connect. Waits for the app to start before connecting.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          project_dir: {
+            type: "string",
+            description: "Path to the ui/desktop directory (must contain package.json). Example: /Users/zane/Development/goose/ui/desktop",
+          },
+          port: {
+            type: "number",
+            description: `CDP debug port (default: ${DEFAULT_PORT})`,
+          },
+        },
+        required: ["project_dir"],
+      },
+    },
+    {
+      name: "electron_launch_app",
+      description:
+        "Launch a bundled/packaged Goose .app with remote debugging enabled, then auto-connect. Works with any .app bundle. Waits for the app to start before connecting.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          app_path: {
+            type: "string",
+            description: 'Path to the .app bundle. Example: /Users/zane/Downloads/Goose.app or "/Applications/Goose.app"',
+          },
+          port: {
+            type: "number",
+            description: `CDP debug port (default: ${DEFAULT_PORT})`,
+          },
+        },
+        required: ["app_path"],
+      },
+    },
+
+    {
+      name: "electron_stop",
+      description:
+        "Stop a running Goose Electron app by killing the process on the debug port. Cleans up screen sessions for dev servers. Use before re-launching.",
+
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          port: {
+            type: "number",
+            description: `CDP debug port to stop (default: ${DEFAULT_PORT})`,
+          },
+        },
+      },
+    },
+
+    // ── Electron CDP tools ──────────────────────────────────────
+    {
+      name: "electron_connect",
+      description:
+        "Connect to the Electron app's CDP endpoint and start collecting console logs from all targets. Call this first. If already connected, disconnects and reconnects (useful to pick up new targets or switch to a different instance).",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          port: {
+            type: "number",
+            description: `CDP port (default: ${DEFAULT_PORT}). Use different ports for different Electron instances.`,
+          },
+          host: {
+            type: "string",
+            description: `CDP host (default: ${DEFAULT_HOST})`,
+          },
+        },
+      },
+    },
+    {
+      name: "electron_list_targets",
+      description:
+        "List all debuggable targets in the Electron app (renderer windows, background pages, service workers, etc).",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+    {
+      name: "electron_get_logs",
+      description:
+        "Get collected console logs from the Electron app. Supports filtering by level, target, text search, and pagination via 'since' cursor.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          level: {
+            type: "string",
+            description: "Filter by level(s), comma-separated: log, warn, error, info, debug, verbose",
+          },
+          target_id: {
+            type: "string",
+            description: "Filter to a specific target ID (from electron_list_targets)",
+          },
+          search: {
+            type: "string",
+            description: "Filter entries containing this text (case-insensitive)",
+          },
+          since: {
+            type: "number",
+            description: "Only entries with id > this value. Use last entry's id as cursor for polling.",
+          },
+          limit: {
+            type: "number",
+            description: "Max entries to return (default: 100, from the end)",
+          },
+        },
+      },
+    },
+    {
+      name: "electron_clear_logs",
+      description: "Clear all collected console log entries.",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+    {
+      name: "electron_evaluate",
+      description:
+        "Evaluate a JavaScript expression in a specific Electron renderer window. Returns the result.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          target_id: {
+            type: "string",
+            description: "Target ID (from electron_list_targets). Defaults to the first attached page.",
+          },
+          expression: {
+            type: "string",
+            description: "JavaScript expression to evaluate",
+          },
+        },
+        required: ["expression"],
+      },
+    },
+    {
+      name: "electron_version",
+      description: "Get Electron/Chromium version info from the running app.",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+
+    // ── Screenshot & DOM inspection tools ───────────────────────
+    {
+      name: "electron_screenshot",
+      description:
+        "Capture a screenshot of an Electron renderer window. Returns a base64-encoded PNG (or JPEG/WebP). " +
+        "Use this to visually inspect the current state of the UI, verify layout, or document bugs.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          target_id: {
+            type: "string",
+            description: "Target ID (from electron_list_targets). Defaults to the first attached page.",
+          },
+          format: {
+            type: "string",
+            enum: ["png", "jpeg", "webp"],
+            description: "Image format (default: png)",
+          },
+          quality: {
+            type: "number",
+            description: "Compression quality 0-100 (only for jpeg/webp, default: 80)",
+          },
+          full_page: {
+            type: "boolean",
+            description: "Capture the full scrollable page, not just the viewport (default: false)",
+          },
+          save_path: {
+            type: "string",
+            description: "Optional: save the screenshot to this file path instead of returning inline. Parent directories are created automatically.",
+          },
+        },
+      },
+    },
+    {
+      name: "electron_screenshot_element",
+      description:
+        "Capture a screenshot of a specific DOM element by CSS selector. " +
+        "Useful for focusing on a particular component (e.g., '.chat-message:last-child', '#settings-panel').",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          selector: {
+            type: "string",
+            description: "CSS selector for the element to capture",
+          },
+          target_id: {
+            type: "string",
+            description: "Target ID (from electron_list_targets). Defaults to the first attached page.",
+          },
+          format: {
+            type: "string",
+            enum: ["png", "jpeg", "webp"],
+            description: "Image format (default: png)",
+          },
+          quality: {
+            type: "number",
+            description: "Compression quality 0-100 (only for jpeg/webp)",
+          },
+          padding: {
+            type: "number",
+            description: "Extra pixels around the element (default: 0)",
+          },
+          save_path: {
+            type: "string",
+            description: "Optional: save to file instead of returning inline",
+          },
+        },
+        required: ["selector"],
+      },
+    },
+    {
+      name: "electron_dom_snapshot",
+      description:
+        "Get a structured DOM snapshot with computed styles. Returns a compact representation of the page's DOM tree " +
+        "with layout info — useful for understanding UI structure without needing to see pixels. " +
+        "Much smaller than full outerHTML.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          target_id: {
+            type: "string",
+            description: "Target ID (from electron_list_targets). Defaults to the first attached page.",
+          },
+          computed_styles: {
+            type: "array",
+            items: { type: "string" },
+            description: "CSS properties to include (default: display, visibility, opacity, color, background-color, font-size, font-weight, width, height, overflow)",
+          },
+        },
+      },
+    },
+    {
+      name: "electron_get_html",
+      description:
+        "Get the outerHTML of the document or a specific element. " +
+        "Use a selector to narrow down to a specific component (e.g., 'main', '.sidebar', '#chat-container').",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          selector: {
+            type: "string",
+            description: "CSS selector (default: returns full document HTML). Use specific selectors to keep output manageable.",
+          },
+          target_id: {
+            type: "string",
+            description: "Target ID (from electron_list_targets). Defaults to the first attached page.",
+          },
+        },
+      },
+    },
+
+    // ── Navigation & interaction tools ──────────────────────────
+    {
+      name: "electron_click",
+      description:
+        "Click on an element by CSS selector, or at specific x,y coordinates. " +
+        "When using a selector, resolves the element's bounding box and clicks its center. " +
+        "Returns the click coordinates for verification.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          selector: {
+            type: "string",
+            description: "CSS selector of element to click (e.g., '.settings-btn', '#submit', 'button[data-testid=\"send\"]')",
+          },
+          x: {
+            type: "number",
+            description: "X coordinate (used when no selector is provided)",
+          },
+          y: {
+            type: "number",
+            description: "Y coordinate (used when no selector is provided)",
+          },
+          button: {
+            type: "string",
+            enum: ["left", "right", "middle"],
+            description: "Mouse button (default: left)",
+          },
+          click_count: {
+            type: "number",
+            description: "Number of clicks (2 for double-click, default: 1)",
+          },
+          target_id: {
+            type: "string",
+            description: "Target ID. Defaults to the first attached page.",
+          },
+        },
+      },
+    },
+    {
+      name: "electron_type",
+      description:
+        "Type text into the currently focused element, or focus a selector first then type. " +
+        "Each character is dispatched as individual keyDown/keyUp events, simulating real keyboard input.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          text: {
+            type: "string",
+            description: "Text to type",
+          },
+          selector: {
+            type: "string",
+            description: "CSS selector to focus before typing (optional — types into currently focused element if omitted)",
+          },
+          clear: {
+            type: "boolean",
+            description: "Select all and delete existing content before typing (default: false)",
+          },
+          press_enter: {
+            type: "boolean",
+            description: "Press Enter after typing (default: false)",
+          },
+          target_id: {
+            type: "string",
+            description: "Target ID. Defaults to the first attached page.",
+          },
+        },
+        required: ["text"],
+      },
+    },
+    {
+      name: "electron_press_key",
+      description:
+        "Press a keyboard key (Enter, Tab, Escape, Backspace, arrow keys, etc). " +
+        "Supports modifier keys via the modifiers bitmask: 1=Alt, 2=Ctrl, 4=Meta/Cmd, 8=Shift. " +
+        "Example: Cmd+A = key:'a', modifiers:4",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          key: {
+            type: "string",
+            description: "Key name: Enter, Tab, Escape, Backspace, Delete, ArrowUp, ArrowDown, ArrowLeft, ArrowRight, Home, End, Space, a-z, F1-F12",
+          },
+          modifiers: {
+            type: "number",
+            description: "Modifier bitmask: 1=Alt, 2=Ctrl, 4=Meta/Cmd, 8=Shift. Combine with addition (e.g., Ctrl+Shift = 10)",
+          },
+          target_id: {
+            type: "string",
+            description: "Target ID. Defaults to the first attached page.",
+          },
+        },
+        required: ["key"],
+      },
+    },
+    {
+      name: "electron_navigate",
+      description:
+        "Navigate the renderer to a URL. For in-app navigation in a single-page app, " +
+        "prefer electron_click on nav elements or electron_evaluate with router APIs.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          url: {
+            type: "string",
+            description: "URL to navigate to",
+          },
+          target_id: {
+            type: "string",
+            description: "Target ID. Defaults to the first attached page.",
+          },
+        },
+        required: ["url"],
+      },
+    },
+    {
+      name: "electron_wait_for",
+      description:
+        "Wait for a CSS selector to appear (or become visible) in the DOM. " +
+        "Polls at 200ms intervals. Returns true if found within timeout, false otherwise. " +
+        "Use this after clicks/navigation to wait for UI transitions to complete before screenshotting.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          selector: {
+            type: "string",
+            description: "CSS selector to wait for",
+          },
+          timeout: {
+            type: "number",
+            description: "Max wait time in milliseconds (default: 10000)",
+          },
+          visible: {
+            type: "boolean",
+            description: "Wait for the element to be visible (not just in DOM). Default: false",
+          },
+          target_id: {
+            type: "string",
+            description: "Target ID. Defaults to the first attached page.",
+          },
+        },
+        required: ["selector"],
+      },
+    },
+    {
+      name: "electron_scroll",
+      description:
+        "Scroll the page to specific coordinates or scroll an element into view by selector.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          selector: {
+            type: "string",
+            description: "CSS selector of element to scroll into view",
+          },
+          x: {
+            type: "number",
+            description: "Scroll to X position (used when no selector)",
+          },
+          y: {
+            type: "number",
+            description: "Scroll to Y position (used when no selector)",
+          },
+          target_id: {
+            type: "string",
+            description: "Target ID. Defaults to the first attached page.",
+          },
+        },
+      },
+    },
+
+    // ── Server log tools ────────────────────────────────────────
+    {
+      name: "server_list_sessions",
+      description:
+        "List goosed server log sessions. Each session is a separate goosed process that was started (one per Electron window). Shows date, start time, file size, and path. Use this to find the session you want to inspect.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          date: {
+            type: "string",
+            description: "Filter to a specific date (YYYY-MM-DD). Default: show all recent dates.",
+          },
+          limit: {
+            type: "number",
+            description: "Max sessions to return (default: 20)",
+          },
+        },
+      },
+    },
+    {
+      name: "server_get_logs",
+      description:
+        "Read goosed server logs for a specific session. Shows tracing output with timestamps, levels, modules, and messages. By default reads the most recent session's last 200 lines.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          session: {
+            type: "string",
+            description:
+              "Session identifier — the start time prefix (e.g., '20260212_153402') or full filename. From server_list_sessions. Defaults to most recent.",
+          },
+          date: {
+            type: "string",
+            description: "Date to look in (YYYY-MM-DD). Helps narrow down which session to find.",
+          },
+          tail: {
+            type: "number",
+            description: "Read last N lines (default: 200)",
+          },
+          head: {
+            type: "number",
+            description: "Read first N lines instead of tail",
+          },
+          level: {
+            type: "string",
+            description: "Filter by level(s), comma-separated: TRACE, DEBUG, INFO, WARN, ERROR",
+          },
+          search: {
+            type: "string",
+            description: "Text search (case-insensitive)",
+          },
+          module: {
+            type: "string",
+            description: "Filter by module prefix (e.g., 'goose::agent', 'goosed::routes')",
+          },
+        },
+      },
+    },
+    {
+      name: "server_list_mcp_logs",
+      description:
+        "List available MCP extension log files. Each extension (developer, memory, etc.) writes to its own log file.",
+      inputSchema: { type: "object" as const, properties: {} },
+    },
+    {
+      name: "server_get_mcp_log",
+      description:
+        "Read an MCP extension's log file. Provide the extension name (e.g., 'developer') or full filename.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          name: {
+            type: "string",
+            description: "Extension name (e.g., 'developer', 'codesearch') or full filename (e.g., 'mcp_developer.log')",
+          },
+          tail: {
+            type: "number",
+            description: "Read last N lines (default: 200)",
+          },
+          search: {
+            type: "string",
+            description: "Text search (case-insensitive)",
+          },
+        },
+        required: ["name"],
+      },
+    },
+    {
+      name: "electron_get_main_log",
+      description:
+        "Read the Electron main process log (main.log). Contains stdout/stderr from the Electron main process, including goosed spawn messages and general app lifecycle events.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          tail: {
+            type: "number",
+            description: "Read last N lines (default: 100)",
+          },
+          search: {
+            type: "string",
+            description: "Text search (case-insensitive)",
+          },
+          level: {
+            type: "string",
+            description: "Filter by level: error, warn, info",
+          },
+        },
+      },
+    },
+
+    // ── Chat session tools (from sessions.db) ───────────────────
+    {
+      name: "server_list_chat_sessions",
+      description:
+        "List chat sessions from the sessions database. Shows session names, IDs, token counts, and status. Use this to find a session by name, then use server_get_chat_session_logs to read its server logs.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          search: {
+            type: "string",
+            description: "Search sessions by name (case-insensitive, fuzzy match)",
+          },
+          limit: {
+            type: "number",
+            description: "Max sessions to return (default: 30)",
+          },
+          active_only: {
+            type: "boolean",
+            description: "Only show currently active (in_use) sessions",
+          },
+        },
+      },
+    },
+    {
+      name: "server_get_chat_session_logs",
+      description:
+        "Read goosed server logs for a chat session, looked up by session name or ID from the sessions database. " +
+        "Finds the session in the DB, locates the server log file that contains it, and filters to only show log lines for that session. " +
+        "If no session_name or session_id is provided, uses the current active session.",
+      inputSchema: {
+        type: "object" as const,
+        properties: {
+          session_name: {
+            type: "string",
+            description: "Session name to search for (case-insensitive, fuzzy match). E.g. 'missing windows release'",
+          },
+          session_id: {
+            type: "string",
+            description: "Exact session ID from the database (e.g. '20260213_4'). Alternative to session_name.",
+          },
+          tail: {
+            type: "number",
+            description: "Read last N lines (default: 500, reads more since we filter by session)",
+          },
+          level: {
+            type: "string",
+            description: "Filter by level(s), comma-separated: TRACE, DEBUG, INFO, WARN, ERROR",
+          },
+          search: {
+            type: "string",
+            description: "Additional text search within the session's logs (case-insensitive)",
+          },
+        },
+      },
+    },
+  ],
+}));
+
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+
+  switch (name) {
+    // ═══════════════════════════════════════════════════════════════
+    // App launcher tools
+    // ═══════════════════════════════════════════════════════════════
+
+    case "electron_launch_dev": {
+      const projectDir = args?.project_dir as string;
+      const port = (args?.port as number | undefined) ?? DEFAULT_PORT;
+
+      try {
+        const result = launchDevServer(projectDir, port);
+
+        if (result.startsWith("Port")) {
+          // Already running — just connect
+          cdp.disconnectAll();
+          cdp = new CDPClient(port, DEFAULT_HOST);
+          activePort = port;
+          activeHost = DEFAULT_HOST;
+          const targets = await cdp.attachAll();
+          const summary = targets.map((t) => `  • [${t.type}] ${t.title} (${t.id})\n    ${t.url}`).join("\n");
+          return {
+            content: [{ type: "text", text: `${result}\n\nConnected to existing app on port ${port}.\nAttached to ${targets.length} target(s):\n\n${summary}` }],
+          };
+        }
+
+        const ready = await waitForPort(port, 30000);
+        if (!ready) {
+          return {
+            content: [{ type: "text", text: `Dev server launched but port ${port} didn't start listening within 30s.\n\nCheck logs: cat /tmp/goose-tester-dev-${port}.log` }],
+            isError: true,
+          };
+        }
+
+        // Auto-connect
+        cdp.disconnectAll();
+        cdp = new CDPClient(port, DEFAULT_HOST);
+        activePort = port;
+        activeHost = DEFAULT_HOST;
+
+        // Give the renderer a moment to initialize
+        await new Promise((r) => setTimeout(r, 2000));
+
+        const targets = await cdp.attachAll();
+        const summary = targets.map((t) => `  • [${t.type}] ${t.title} (${t.id})\n    ${t.url}`).join("\n");
+
+        return {
+          content: [{
+            type: "text",
+            text: `Dev server launched and connected!\n\n  Project: ${projectDir}\n  Port: ${port}\n\nAttached to ${targets.length} target(s):\n\n${summary}\n\nConsole logs are now being collected.`,
+          }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Failed to launch dev server: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_launch_app": {
+      const appPath = args?.app_path as string;
+      const port = (args?.port as number | undefined) ?? DEFAULT_PORT;
+
+      try {
+        if (isPortListening(port)) {
+          // Already running — just connect
+          cdp.disconnectAll();
+          cdp = new CDPClient(port, DEFAULT_HOST);
+          activePort = port;
+          activeHost = DEFAULT_HOST;
+          const targets = await cdp.attachAll();
+          const summary = targets.map((t) => `  • [${t.type}] ${t.title} (${t.id})\n    ${t.url}`).join("\n");
+          return {
+            content: [{ type: "text", text: `Port ${port} already in use. Connected to existing app.\nAttached to ${targets.length} target(s):\n\n${summary}` }],
+          };
+        }
+
+        launchBundledApp(appPath, port);
+
+        const ready = await waitForPort(port, 15000);
+        if (!ready) {
+          return {
+            content: [{ type: "text", text: `App launched but port ${port} didn't start listening within 15s.\n\nThe app may not support remote debugging, or it may have started on a different port.` }],
+            isError: true,
+          };
+        }
+
+        // Auto-connect
+        cdp.disconnectAll();
+        cdp = new CDPClient(port, DEFAULT_HOST);
+        activePort = port;
+        activeHost = DEFAULT_HOST;
+
+        // Give the renderer a moment to initialize
+        await new Promise((r) => setTimeout(r, 2000));
+
+        const targets = await cdp.attachAll();
+        const summary = targets.map((t) => `  • [${t.type}] ${t.title} (${t.id})\n    ${t.url}`).join("\n");
+
+        return {
+          content: [{
+            type: "text",
+            text: `Bundled app launched and connected!\n\n  App: ${appPath}\n  Port: ${port}\n\nAttached to ${targets.length} target(s):\n\n${summary}\n\nConsole logs are now being collected.`,
+          }],
+        };
+      } catch (e) {
+        return {
+          content: [{ type: "text", text: `Failed to launch app: ${e instanceof Error ? e.message : String(e)}` }],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_stop": {
+      const port = (args?.port as number | undefined) ?? DEFAULT_PORT;
+      const messages: string[] = [];
+
+      // Disconnect CDP
+      cdp.disconnectAll();
+      messages.push("Disconnected CDP client.");
+
+      // Kill process on port
+      try {
+        const pid = execSync(`lsof -ti :${port} -sTCP:LISTEN 2>/dev/null`, { encoding: "utf-8" }).trim();
+        if (pid) {
+          // Kill the process group (negative PID) to get all children
+          try { execSync(`kill -- -${pid} 2>/dev/null`); } catch { /* ignore */ }
+          execSync(`kill ${pid} 2>/dev/null`);
+          messages.push(`Killed process ${pid} on port ${port}.`);
+          // Wait a moment, force kill if needed
+          await new Promise((r) => setTimeout(r, 2000));
+          try {
+            execSync(`kill -0 ${pid} 2>/dev/null`);
+            execSync(`kill -9 ${pid} 2>/dev/null`);
+            messages.push(`Force killed process ${pid}.`);
+          } catch { /* already dead */ }
+        } else {
+          messages.push(`No process listening on port ${port}.`);
+        }
+      } catch {
+        messages.push(`No process listening on port ${port}.`);
+      }
+
+      // Clean up screen session if any
+      const sessionName = `goose-tester-dev-${port}`;
+      try {
+        execSync(`screen -S ${sessionName} -X quit 2>/dev/null`);
+        messages.push(`Cleaned up screen session '${sessionName}'.`);
+      } catch { /* no session */ }
+
+      return {
+        content: [{ type: "text", text: messages.join("\n") + `\n\n✅ Port ${port} is free.` }],
+      };
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Electron CDP tools
+    // ═══════════════════════════════════════════════════════════════
+
+    case "electron_connect": {
+      const port = (args?.port as number | undefined) ?? DEFAULT_PORT;
+      const host = (args?.host as string | undefined) ?? DEFAULT_HOST;
+
+      if (port !== activePort || host !== activeHost) {
+        cdp.disconnectAll();
+        cdp = new CDPClient(port, host);
+        activePort = port;
+        activeHost = host;
+      } else {
+        cdp.disconnectAll();
+      }
+
+      try {
+        const targets = await cdp.attachAll();
+        if (targets.length === 0) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Connected to CDP on ${activeHost}:${activePort} but no debuggable targets found.\n\nMake sure the Electron app is running with:\n  ENABLE_PLAYWRIGHT=1 npm start`,
+              },
+            ],
+          };
+        }
+
+        const summary = targets
+          .map((t) => `  • [${t.type}] ${t.title} (${t.id})\n    ${t.url}`)
+          .join("\n");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Connected to Electron on ${activeHost}:${activePort}\nAttached to ${targets.length} target(s):\n\n${summary}\n\nConsole logs are now being collected. Use electron_get_logs to view them.`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to connect to Electron CDP on ${activeHost}:${activePort}.\n\nError: ${e instanceof Error ? e.message : String(e)}\n\nMake sure the Goose Electron app is running with:\n  ENABLE_PLAYWRIGHT=1 npm start`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_list_targets": {
+      try {
+        const targets = await cdp.listTargets();
+        const attached = new Set(cdp.getAttachedTargetIds());
+
+        if (targets.length === 0) {
+          return {
+            content: [{ type: "text", text: "No targets found. Is the Electron app running?" }],
+          };
+        }
+
+        const lines = targets.map((t) => {
+          const status = attached.has(t.id) ? "✓ attached" : "  detached";
+          return `[${status}] [${t.type}] ${t.title}\n  id: ${t.id}\n  url: ${t.url}`;
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Connected to ${activeHost}:${activePort}\n${targets.length} target(s):\n\n${lines.join("\n\n")}`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to list targets: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_get_logs": {
+      const entries = cdp.getEntries({
+        targetId: args?.target_id as string | undefined,
+        level: args?.level as string | undefined,
+        since: args?.since as number | undefined,
+        limit: (args?.limit as number | undefined) ?? 100,
+        search: args?.search as string | undefined,
+      });
+
+      const lastId = entries.length > 0 ? entries[entries.length - 1].id : 0;
+
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              formatEntries(entries) +
+              (entries.length > 0
+                ? `\n\n--- ${entries.length} entries (last_id: ${lastId}, use since:${lastId} to poll) ---`
+                : "\n\nNo logs yet. Interact with the app to generate output, or call electron_connect first."),
+          },
+        ],
+      };
+    }
+
+    case "electron_clear_logs": {
+      cdp.clearEntries();
+      return {
+        content: [{ type: "text", text: "Console log buffer cleared." }],
+      };
+    }
+
+    case "electron_evaluate": {
+      const expression = args?.expression as string;
+      if (!expression) {
+        return {
+          content: [{ type: "text", text: "Missing required parameter: expression" }],
+          isError: true,
+        };
+      }
+
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const result = await cdp.evaluate(targetId, expression);
+        if (result.exceptionDetails) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Exception:\n${JSON.stringify(result.exceptionDetails, null, 2)}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+        return {
+          content: [{ type: "text", text: JSON.stringify(result.result, null, 2) }],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Evaluation failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_version": {
+      try {
+        const info = await cdp.getVersion();
+        const lines = Object.entries(info)
+          .map(([k, v]) => `${k}: ${v}`)
+          .join("\n");
+        return { content: [{ type: "text", text: lines }] };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to get version: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Screenshot & DOM inspection tools
+    // ═══════════════════════════════════════════════════════════════
+
+    case "electron_screenshot": {
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const format = (args?.format as "png" | "jpeg" | "webp" | undefined) ?? "png";
+        const quality = args?.quality as number | undefined;
+        const fullPage = args?.full_page as boolean | undefined;
+        const savePath = args?.save_path as string | undefined;
+
+        const data = await cdp.captureScreenshot(targetId, { format, quality, fullPage });
+
+        if (savePath) {
+          const { mkdir, writeFile } = await import("node:fs/promises");
+          const { dirname } = await import("node:path");
+          await mkdir(dirname(savePath), { recursive: true });
+          await writeFile(savePath, Buffer.from(data, "base64"));
+          const sizeKB = Math.round(Buffer.from(data, "base64").length / 1024);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Screenshot saved to ${savePath} (${sizeKB} KB, ${format})`,
+              },
+            ],
+          };
+        }
+
+        const mimeType = format === "jpeg" ? "image/jpeg" : format === "webp" ? "image/webp" : "image/png";
+        return {
+          content: [
+            {
+              type: "image",
+              data,
+              mimeType,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Screenshot failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_screenshot_element": {
+      const selector = args?.selector as string;
+      if (!selector) {
+        return {
+          content: [{ type: "text", text: "Missing required parameter: selector" }],
+          isError: true,
+        };
+      }
+
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const format = (args?.format as "png" | "jpeg" | "webp" | undefined) ?? "png";
+        const quality = args?.quality as number | undefined;
+        const padding = args?.padding as number | undefined;
+        const savePath = args?.save_path as string | undefined;
+
+        const result = await cdp.captureElementScreenshot(targetId, selector, { format, quality, padding });
+
+        if (savePath) {
+          const { mkdir, writeFile } = await import("node:fs/promises");
+          const { dirname } = await import("node:path");
+          await mkdir(dirname(savePath), { recursive: true });
+          await writeFile(savePath, Buffer.from(result.data, "base64"));
+          const sizeKB = Math.round(Buffer.from(result.data, "base64").length / 1024);
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Element screenshot saved to ${savePath} (${sizeKB} KB, ${format})\nBounding box: ${JSON.stringify(result.box)}`,
+              },
+            ],
+          };
+        }
+
+        const mimeType = format === "jpeg" ? "image/jpeg" : format === "webp" ? "image/webp" : "image/png";
+        return {
+          content: [
+            {
+              type: "image",
+              data: result.data,
+              mimeType,
+            },
+            {
+              type: "text",
+              text: `Element "${selector}" — bounding box: ${JSON.stringify(result.box)}`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Element screenshot failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_dom_snapshot": {
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const computedStyles = args?.computed_styles as string[] | undefined;
+
+        const snapshot = await cdp.getDomSnapshot(targetId, { computedStyles });
+
+        // The snapshot can be large — summarize it
+        const snapshotStr = JSON.stringify(snapshot, null, 2);
+        const truncated = snapshotStr.length > 50000
+          ? snapshotStr.slice(0, 50000) + `\n\n... [truncated, ${snapshotStr.length} total chars]`
+          : snapshotStr;
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: truncated,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `DOM snapshot failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_get_html": {
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const selector = args?.selector as string | undefined;
+
+        const html = await cdp.getDocumentOuterHTML(targetId, selector);
+
+        const truncated = html.length > 100000
+          ? html.slice(0, 100000) + `\n\n... [truncated, ${html.length} total chars]`
+          : html;
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: selector
+                ? `outerHTML for "${selector}" (${html.length} chars):\n\n${truncated}`
+                : `Full document HTML (${html.length} chars):\n\n${truncated}`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Get HTML failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Navigation & interaction tools
+    // ═══════════════════════════════════════════════════════════════
+
+    case "electron_click": {
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const selector = args?.selector as string | undefined;
+        const x = args?.x as number | undefined;
+        const y = args?.y as number | undefined;
+        const button = (args?.button as "left" | "right" | "middle" | undefined) ?? "left";
+        const clickCount = (args?.click_count as number | undefined) ?? 1;
+
+        if (selector) {
+          const point = await cdp.clickSelector(targetId, selector, { button, clickCount });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Clicked "${selector}" at (${Math.round(point.x)}, ${Math.round(point.y)})`,
+              },
+            ],
+          };
+        } else if (x !== undefined && y !== undefined) {
+          await cdp.clickAtPoint(targetId, x, y, { button, clickCount });
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Clicked at (${x}, ${y})`,
+              },
+            ],
+          };
+        } else {
+          return {
+            content: [{ type: "text", text: "Provide either a 'selector' or both 'x' and 'y' coordinates." }],
+            isError: true,
+          };
+        }
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Click failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_type": {
+      const text = args?.text as string;
+      if (!text) {
+        return {
+          content: [{ type: "text", text: "Missing required parameter: text" }],
+          isError: true,
+        };
+      }
+
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const selector = args?.selector as string | undefined;
+        const clear = args?.clear as boolean | undefined;
+        const pressEnter = args?.press_enter as boolean | undefined;
+
+        if (selector) {
+          await cdp.focus(targetId, selector);
+        }
+
+        if (clear) {
+          // Select all then delete
+          await cdp.pressKey(targetId, "a", { modifiers: 4 }); // Cmd+A
+          await cdp.pressKey(targetId, "Backspace");
+        }
+
+        await cdp.typeText(targetId, text);
+
+        if (pressEnter) {
+          await cdp.pressKey(targetId, "Enter");
+        }
+
+        const details = [
+          `Typed ${text.length} character(s)`,
+          selector ? `into "${selector}"` : "into focused element",
+          clear ? "(cleared first)" : "",
+          pressEnter ? "(pressed Enter)" : "",
+        ].filter(Boolean).join(" ");
+
+        return {
+          content: [{ type: "text", text: details }],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Type failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_press_key": {
+      const key = args?.key as string;
+      if (!key) {
+        return {
+          content: [{ type: "text", text: "Missing required parameter: key" }],
+          isError: true,
+        };
+      }
+
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const modifiers = args?.modifiers as number | undefined;
+
+        await cdp.pressKey(targetId, key, { modifiers });
+
+        const modNames: string[] = [];
+        if (modifiers) {
+          if (modifiers & 1) modNames.push("Alt");
+          if (modifiers & 2) modNames.push("Ctrl");
+          if (modifiers & 4) modNames.push("Cmd");
+          if (modifiers & 8) modNames.push("Shift");
+        }
+        const combo = modNames.length > 0 ? `${modNames.join("+")}+${key}` : key;
+
+        return {
+          content: [{ type: "text", text: `Pressed ${combo}` }],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Key press failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_navigate": {
+      const url = args?.url as string;
+      if (!url) {
+        return {
+          content: [{ type: "text", text: "Missing required parameter: url" }],
+          isError: true,
+        };
+      }
+
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const result = await cdp.navigate(targetId, url);
+
+        if (result.errorText) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Navigation error: ${result.errorText}`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        return {
+          content: [{ type: "text", text: `Navigated to ${url}` }],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Navigation failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_wait_for": {
+      const selector = args?.selector as string;
+      if (!selector) {
+        return {
+          content: [{ type: "text", text: "Missing required parameter: selector" }],
+          isError: true,
+        };
+      }
+
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const timeout = args?.timeout as number | undefined;
+        const visible = args?.visible as boolean | undefined;
+
+        const found = await cdp.waitForSelector(targetId, selector, {
+          timeoutMs: timeout,
+          visible,
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: found
+                ? `✓ Found "${selector}"${visible ? " (visible)" : ""}`
+                : `✗ Timed out waiting for "${selector}" after ${timeout ?? 10000}ms`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Wait failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_scroll": {
+      try {
+        const targetId = await resolveTargetId(args?.target_id as string | undefined);
+        const selector = args?.selector as string | undefined;
+        const x = args?.x as number | undefined;
+        const y = args?.y as number | undefined;
+
+        await cdp.scrollTo(targetId, { selector, x, y });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: selector
+                ? `Scrolled "${selector}" into view`
+                : `Scrolled to (${x ?? 0}, ${y ?? 0})`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Scroll failed: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Server log tools
+    // ═══════════════════════════════════════════════════════════════
+
+    case "server_list_sessions": {
+      try {
+        const sessions = await listServerSessions({
+          date: args?.date as string | undefined,
+          limit: (args?.limit as number | undefined) ?? 20,
+        });
+
+        if (sessions.length === 0) {
+          return {
+            content: [{ type: "text", text: "No server log sessions found." }],
+          };
+        }
+
+        const lines = sessions.map((s, i) => {
+          const timeFormatted = s.startTime.replace(
+            /^(\d{4})(\d{2})(\d{2})_(\d{2})(\d{2})(\d{2})$/,
+            "$1-$2-$3 $4:$5:$6"
+          );
+          return `${i + 1}. [${s.date}] ${timeFormatted}  ${s.sizeHuman.padStart(10)}  ${s.startTime}`;
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Goosed server sessions (most recent first):\n\n   Date        Started           Size  Session ID\n${lines.join("\n")}\n\nUse server_get_logs with session: "<Session ID>" to read a specific session's logs.`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to list sessions: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "server_get_logs": {
+      try {
+        const result = await readServerLog({
+          session: args?.session as string | undefined,
+          date: args?.date as string | undefined,
+          tail: args?.tail as number | undefined,
+          head: args?.head as number | undefined,
+          level: args?.level as string | undefined,
+          search: args?.search as string | undefined,
+          module: args?.module as string | undefined,
+        });
+
+        const formatted = result.lines
+          .map((l) => {
+            if (l.level) {
+              const ts = l.timestamp?.slice(11, 23) ?? "";
+              return `[${ts}] ${l.level.padEnd(5)} ${l.module ?? ""}: ${l.message ?? l.raw}`;
+            }
+            return l.raw;
+          })
+          .join("\n");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${result.filepath}\n(${result.totalLines} total lines, showing ${result.lines.length})\n\n${formatted}`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to read server logs: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "server_list_mcp_logs": {
+      try {
+        const logs = await listMcpLogs();
+
+        if (logs.length === 0) {
+          return {
+            content: [{ type: "text", text: "No MCP extension log files found." }],
+          };
+        }
+
+        const lines = logs.map(
+          (l) => `  ${l.name.padEnd(35)} ${l.sizeHuman.padStart(10)}  modified: ${l.modifiedAt.slice(0, 19)}`
+        );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `MCP extension logs:\n\n${lines.join("\n")}\n\nUse server_get_mcp_log with name: "<name>" to read.`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to list MCP logs: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "server_get_mcp_log": {
+      try {
+        const result = await readMcpLog({
+          name: args?.name as string | undefined,
+          tail: args?.tail as number | undefined,
+          search: args?.search as string | undefined,
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${result.filepath}\n(${result.totalLines} total lines, showing ${result.lines.length})\n\n${result.lines.join("\n")}`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to read MCP log: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "electron_get_main_log": {
+      try {
+        const result = await readElectronMainLog({
+          tail: args?.tail as number | undefined,
+          search: args?.search as string | undefined,
+          level: args?.level as string | undefined,
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `${result.filepath}\n(${result.totalLines} total lines, showing ${result.lines.length})\n\n${result.lines.join("\n")}`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to read Electron main log: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    // ═══════════════════════════════════════════════════════════════
+    // Chat session tools (from sessions.db)
+    // ═══════════════════════════════════════════════════════════════
+
+    case "server_list_chat_sessions": {
+      try {
+        const sessions = await listChatSessions({
+          search: args?.search as string | undefined,
+          limit: (args?.limit as number | undefined) ?? 30,
+          activeOnly: args?.active_only as boolean | undefined,
+        });
+
+        if (sessions.length === 0) {
+          return {
+            content: [{ type: "text", text: "No chat sessions found." }],
+          };
+        }
+
+        const lines = sessions.map((s) => {
+          const active = s.inUse ? " ◉ ACTIVE" : "";
+          const tokens = s.totalTokens ? `${s.totalTokens.toLocaleString()} tokens` : "no tokens";
+          return `  ${s.id.padEnd(15)} ${(s.name || "(unnamed)").padEnd(40)} ${tokens.padStart(14)}  ${s.createdAt}${active}`;
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Chat sessions (from sessions.db):\n\n  ${"ID".padEnd(15)} ${"Name".padEnd(40)} ${"Tokens".padStart(14)}  Created\n${lines.join("\n")}\n\nUse server_get_chat_session_logs with session_name or session_id to read server logs for a session.`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to list chat sessions: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    case "server_get_chat_session_logs": {
+      try {
+        const sessionName = args?.session_name as string | undefined;
+        const sessionId = args?.session_id as string | undefined;
+
+        // Resolve the chat session from the DB
+        let chatSession: ChatSession | null = null;
+
+        if (sessionId) {
+          chatSession = await findSession(sessionId);
+        } else if (sessionName) {
+          chatSession = await findSession(sessionName);
+        } else {
+          // Default: current active session
+          chatSession = await getCurrentSession();
+        }
+
+        if (!chatSession) {
+          const hint = sessionName
+            ? `No session matching "${sessionName}" found.`
+            : sessionId
+              ? `No session with ID "${sessionId}" found.`
+              : "No active session found.";
+          return {
+            content: [
+              {
+                type: "text",
+                text: `${hint}\n\nUse server_list_chat_sessions to see available sessions.`,
+              },
+            ],
+            isError: true,
+          };
+        }
+
+        // Find which server log file contains this session ID.
+        // Log files can be huge (hundreds of MB), so we search smartly:
+        // 1. Extract the date from the session ID (YYYYMMDD_N format)
+        // 2. Search that date's directory first, then adjacent dates
+        // 3. Use grep -l (not -r) on specific files to avoid scanning everything
+        const { execSync } = await import("node:child_process");
+        const { readdirSync } = await import("node:fs");
+        const { join } = await import("node:path");
+        let matchedLogPath: string | undefined;
+
+        // Extract date from session ID (e.g., "20260213_4" -> "2026-02-13")
+        const dateMatch = chatSession.id.match(/^(\d{4})(\d{2})(\d{2})_/);
+        const sessionDateStr = dateMatch
+          ? `${dateMatch[1]}-${dateMatch[2]}-${dateMatch[3]}`
+          : undefined;
+
+        // Build list of date directories to search, starting with the session date and nearby dates
+        let dateDirs: string[] = [];
+        try {
+          dateDirs = readdirSync(SERVER_LOGS_DIR)
+            .filter((d) => /^\d{4}-\d{2}-\d{2}$/.test(d))
+            .sort()
+            .reverse(); // newest first
+        } catch { /* dir doesn't exist */ }
+
+        // Prioritize: session date first, then the day before, then others
+        if (sessionDateStr) {
+          const prevDate = new Date(sessionDateStr + "T00:00:00Z");
+          prevDate.setUTCDate(prevDate.getUTCDate() - 1);
+          const prevDateStr = prevDate.toISOString().slice(0, 10);
+
+          const priority = [sessionDateStr, prevDateStr];
+          const prioritized = priority.filter((d) => dateDirs.includes(d));
+          const rest = dateDirs.filter((d) => !priority.includes(d));
+          dateDirs = [...prioritized, ...rest];
+        }
+
+        // Search each date directory's log files for the session ID
+        // Use grep -l on individual files with a short timeout per file
+        for (const dateDir of dateDirs) {
+          if (matchedLogPath) break;
+          const dirPath = join(SERVER_LOGS_DIR, dateDir);
+          let logFiles: string[] = [];
+          try {
+            logFiles = readdirSync(dirPath)
+              .filter((f) => f.endsWith("-goosed.log"))
+              .sort()
+              .reverse(); // newest first
+          } catch { continue; }
+
+          for (const logFile of logFiles) {
+            const filePath = join(dirPath, logFile);
+            try {
+              // Use grep -c to just count matches (much faster than -l on a single file)
+              // and set a generous timeout since files can be hundreds of MB
+              const countStr = execSync(
+                `grep -c "${chatSession.id}" "${filePath}" 2>/dev/null || true`,
+                { encoding: "utf-8", timeout: 120000 }
+              ).trim();
+              if (parseInt(countStr, 10) > 0) {
+                matchedLogPath = filePath;
+                break;
+              }
+            } catch {
+              // timeout or other error, skip this file
+            }
+          }
+        }
+
+        if (!matchedLogPath) {
+          // Debug: try to list what's in the logs dir
+          let debugInfo = "";
+          try {
+            const lsResult = execSync(`ls -la "${SERVER_LOGS_DIR}/" 2>&1 | head -10`, { encoding: "utf-8" });
+            debugInfo = `\n\nDebug - ls ${SERVER_LOGS_DIR}/:\n${lsResult}`;
+          } catch { /* ignore */ }
+          try {
+            const grepDebug = execSync(`grep -rl "${chatSession.id}" "${SERVER_LOGS_DIR}/" 2>&1 | head -3`, { encoding: "utf-8" });
+            debugInfo += `\nDebug - grep result: ${grepDebug}`;
+          } catch (e) {
+            debugInfo += `\nDebug - grep error: ${e instanceof Error ? e.message : String(e)}`;
+          }
+
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Found session "${chatSession.name}" (${chatSession.id}) in DB, but could not find its server log file.\n\nSession created: ${chatSession.createdAt}\nSearched: ${SERVER_LOGS_DIR}${debugInfo}`,
+              },
+            ],
+          };
+        }
+
+        // Use grep to extract only lines mentioning this session ID.
+        // TRACE lines can contain full session state dumps (hundreds of MB total),
+        // so we exclude them by default and truncate lines to 1000 chars.
+        // Users can opt into TRACE with the level filter.
+        const includeTrace = args?.level && (args.level as string).toUpperCase().includes("TRACE");
+        const grepFilter = includeTrace
+          ? `grep "${chatSession.id}" "${matchedLogPath}"`
+          : `grep "${chatSession.id}" "${matchedLogPath}" | grep -Ev "TRACE"`;
+        let matchedLines: string[] = [];
+        let grepError = "";
+        try {
+          const grepCmd = `${grepFilter} 2>&1 | cut -c1-1000`;
+          const grepLines = execSync(
+            grepCmd,
+            { encoding: "utf-8", timeout: 120000, maxBuffer: 50 * 1024 * 1024 }
+          );
+          matchedLines = grepLines.split("\n").filter((l) => l.length > 0);
+        } catch (e: unknown) {
+          const err = e as { status?: number; stderr?: string; stdout?: string; message?: string };
+          grepError = `status=${err.status}, stderr=${(err.stderr ?? "").slice(0, 300)}, stdout_len=${(err.stdout ?? "").length}, msg=${(err.message ?? "").slice(0, 300)}`;
+        }
+
+        // Get total line count for context
+        let totalLines = 0;
+        try {
+          const wcResult = execSync(`wc -l < "${matchedLogPath}"`, { encoding: "utf-8" }).trim();
+          totalLines = parseInt(wcResult, 10) || 0;
+        } catch { /* ignore */ }
+
+        // Parse matched lines
+        interface ParsedLogLine {
+          lineNumber: number;
+          raw: string;
+          timestamp: string | undefined;
+          level: string | undefined;
+          module: string | undefined;
+          message: string | undefined;
+        }
+
+        const LOG_LINE_RE = /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z)\s+(TRACE|DEBUG|INFO|WARN|ERROR)\s+(\S+):\s+\S+:\s+(.*)$/;
+        let parsedLines: ParsedLogLine[] = matchedLines.map((raw, i) => {
+          const m = raw.match(LOG_LINE_RE);
+          if (m) {
+            return { lineNumber: i + 1, raw, timestamp: m[1], level: m[2], module: m[3], message: m[4] };
+          }
+          return { lineNumber: i + 1, raw, timestamp: undefined, level: undefined, module: undefined, message: undefined };
+        });
+
+        // Apply level filter
+        if (args?.level) {
+          const levels = new Set((args.level as string).toUpperCase().split(",").map((s) => s.trim()));
+          parsedLines = parsedLines.filter((l) => l.level && levels.has(l.level));
+        }
+
+        // Apply search filter
+        if (args?.search) {
+          const term = (args.search as string).toLowerCase();
+          parsedLines = parsedLines.filter((l) => l.raw.toLowerCase().includes(term));
+        }
+
+        // Apply tail
+        const tail = (args?.tail as number | undefined) ?? 500;
+        if (parsedLines.length > tail) {
+          parsedLines = parsedLines.slice(-tail);
+        }
+
+        // Truncate very long lines (session dumps can be huge)
+        const formatted = parsedLines
+          .map((l) => {
+            if (l.level) {
+              const ts = l.timestamp?.slice(11, 23) ?? "";
+              const msg = l.message ?? l.raw;
+              const truncated = msg.length > 500 ? msg.slice(0, 500) + "... [truncated]" : msg;
+              return `[${ts}] ${l.level.padEnd(5)} ${l.module ?? ""}: ${truncated}`;
+            }
+            const truncated = l.raw.length > 500 ? l.raw.slice(0, 500) + "... [truncated]" : l.raw;
+            return truncated;
+          })
+          .join("\n");
+
+        const header = [
+          `Session: "${chatSession.name}" (${chatSession.id})`,
+          `Created: ${chatSession.createdAt}`,
+          `Tokens: ${chatSession.totalTokens?.toLocaleString() ?? "unknown"}`,
+          `Active: ${chatSession.inUse ? "yes" : "no"}`,
+          `Log file: ${matchedLogPath}`,
+          `(${totalLines} total lines in log, ${parsedLines.length} lines for this session)`,
+        ].join("\n");
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: parsedLines.length > 0
+                ? `${header}\n\n${formatted}`
+                : `${header}\n\nNo log lines found for this session after filtering.${grepError ? `\nGrep error: ${grepError}` : ""}`,
+            },
+          ],
+        };
+      } catch (e) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to get chat session logs: ${e instanceof Error ? e.message : String(e)}`,
+            },
+          ],
+          isError: true,
+        };
+      }
+    }
+
+    default:
+      return {
+        content: [{ type: "text", text: `Unknown tool: ${name}` }],
+        isError: true,
+      };
+  }
+});
+
+// ── Start ─────────────────────────────────────────────────────────
+
+const transport = new StdioServerTransport();
+await server.connect(transport);

--- a/ui/desktop/goose-electron-tester-mcp/src/log-reader.ts
+++ b/ui/desktop/goose-electron-tester-mcp/src/log-reader.ts
@@ -1,0 +1,342 @@
+/**
+ * log-reader.ts
+ *
+ * Reads goosed server logs, MCP extension logs, and the Electron main.log.
+ *
+ * Log locations:
+ *   - Goosed server:  ~/.local/state/goose/logs/server/YYYY-MM-DD/YYYYMMDD_HHMMSS-goosed.log
+ *   - MCP extensions: ~/.local/state/goose/logs/mcps/mcp_<name>.log
+ *   - Electron main:  ~/Library/Application Support/Goose/logs/main.log
+ *
+ * The server logs use tracing format:
+ *   2026-02-12T23:34:02.656146Z  INFO goosed::commands::agent: crates/goose-server/src/commands/agent.rs: listening on 127.0.0.1:61546
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { existsSync } from "node:fs";
+
+// ── Path helpers ────────────────────────────────────────────────────
+
+const HOME = homedir();
+const GOOSE_STATE_LOGS = join(HOME, ".local", "state", "goose", "logs");
+export const SERVER_LOGS_DIR = join(GOOSE_STATE_LOGS, "server");
+const MCP_LOGS_DIR = join(GOOSE_STATE_LOGS, "mcps");
+
+// Electron main.log can be in different locations depending on the app
+const ELECTRON_LOG_CANDIDATES = [
+  join(HOME, "Library", "Application Support", "Goose", "logs", "main.log"),
+  join(HOME, "Library", "Application Support", "Block.goose", "logs", "main.log"),
+  join(HOME, "Library", "Logs", "Goose", "main.log"),
+  // Linux
+  join(HOME, ".config", "Goose", "logs", "main.log"),
+];
+
+function findElectronMainLog(): string | null {
+  for (const candidate of ELECTRON_LOG_CANDIDATES) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return null;
+}
+
+// ── Types ───────────────────────────────────────────────────────────
+
+export interface ServerSession {
+  filename: string;
+  filepath: string;
+  date: string;         // YYYY-MM-DD
+  startTime: string;    // YYYYMMDD_HHMMSS
+  sizeBytes: number;
+  sizeHuman: string;
+  modifiedAt: string;
+}
+
+export interface LogLine {
+  lineNumber: number;
+  raw: string;
+  timestamp?: string;
+  level?: string;
+  module?: string;
+  message?: string;
+}
+
+// ── Size formatting ─────────────────────────────────────────────────
+
+function humanSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ── Parse a tracing log line ────────────────────────────────────────
+
+const LOG_LINE_RE = /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z)\s+(TRACE|DEBUG|INFO|WARN|ERROR)\s+(\S+):\s+\S+:\s+(.*)$/;
+
+function parseLogLine(raw: string, lineNumber: number): LogLine {
+  const m = raw.match(LOG_LINE_RE);
+  if (m) {
+    return {
+      lineNumber,
+      raw,
+      timestamp: m[1],
+      level: m[2],
+      module: m[3],
+      message: m[4],
+    };
+  }
+  return { lineNumber, raw };
+}
+
+// ── Server sessions ─────────────────────────────────────────────────
+
+export async function listServerSessions(opts?: {
+  date?: string;       // YYYY-MM-DD, default: today
+  limit?: number;      // default: 20
+}): Promise<ServerSession[]> {
+  const limit = opts?.limit ?? 20;
+  const sessions: ServerSession[] = [];
+
+  let dateDirs: string[];
+  if (opts?.date) {
+    dateDirs = [opts.date];
+  } else {
+    // List all date dirs, sorted descending
+    try {
+      const entries = await readdir(SERVER_LOGS_DIR);
+      dateDirs = entries
+        .filter((e) => /^\d{4}-\d{2}-\d{2}$/.test(e))
+        .sort()
+        .reverse();
+    } catch {
+      return [];
+    }
+  }
+
+  for (const dateDir of dateDirs) {
+    if (sessions.length >= limit) break;
+
+    const dirPath = join(SERVER_LOGS_DIR, dateDir);
+    try {
+      const files = await readdir(dirPath);
+      const logFiles = files
+        .filter((f) => f.endsWith("-goosed.log"))
+        .sort()
+        .reverse();
+
+      for (const file of logFiles) {
+        if (sessions.length >= limit) break;
+
+        const filepath = join(dirPath, file);
+        const st = await stat(filepath);
+        const startTime = file.replace("-goosed.log", "");
+
+        sessions.push({
+          filename: file,
+          filepath,
+          date: dateDir,
+          startTime,
+          sizeBytes: st.size,
+          sizeHuman: humanSize(st.size),
+          modifiedAt: st.mtime.toISOString(),
+        });
+      }
+    } catch {
+      continue;
+    }
+  }
+
+  return sessions;
+}
+
+// ── Read server log ─────────────────────────────────────────────────
+
+export async function readServerLog(opts: {
+  filepath?: string;
+  date?: string;
+  session?: string;     // filename or startTime prefix
+  tail?: number;        // read last N lines (default: 200)
+  head?: number;        // read first N lines
+  level?: string;       // filter by level(s), comma-separated
+  search?: string;      // text search (case-insensitive)
+  module?: string;      // filter by module prefix
+}): Promise<{ lines: LogLine[]; filepath: string; totalLines: number }> {
+  let filepath = opts.filepath;
+
+  // Resolve filepath from date + session
+  if (!filepath) {
+    const sessions = await listServerSessions({ date: opts.date, limit: 100 });
+    if (sessions.length === 0) {
+      throw new Error(`No server log sessions found${opts.date ? ` for date ${opts.date}` : ""}`);
+    }
+
+    if (opts.session) {
+      const match = sessions.find(
+        (s) => s.filename === opts.session || s.startTime.startsWith(opts.session!)
+      );
+      if (!match) {
+        const available = sessions.map((s) => s.startTime).join(", ");
+        throw new Error(`Session "${opts.session}" not found. Available: ${available}`);
+      }
+      filepath = match.filepath;
+    } else {
+      // Default to most recent
+      filepath = sessions[0].filepath;
+    }
+  }
+
+  const content = await readFile(filepath, "utf-8");
+  const allRawLines = content.split("\n");
+  const totalLines = allRawLines.length;
+
+  // Apply head/tail
+  let rawLines: string[];
+  let startLineNumber: number;
+  if (opts.head) {
+    rawLines = allRawLines.slice(0, opts.head);
+    startLineNumber = 1;
+  } else {
+    const tail = opts.tail ?? 200;
+    const start = Math.max(0, allRawLines.length - tail);
+    rawLines = allRawLines.slice(start);
+    startLineNumber = start + 1;
+  }
+
+  // Parse
+  let lines = rawLines.map((raw, i) => parseLogLine(raw, startLineNumber + i));
+
+  // Filter by level
+  if (opts.level) {
+    const levels = new Set(opts.level.toUpperCase().split(",").map((l) => l.trim()));
+    lines = lines.filter((l) => l.level && levels.has(l.level));
+  }
+
+  // Filter by module
+  if (opts.module) {
+    const prefix = opts.module.toLowerCase();
+    lines = lines.filter((l) => l.module && l.module.toLowerCase().startsWith(prefix));
+  }
+
+  // Filter by search
+  if (opts.search) {
+    const term = opts.search.toLowerCase();
+    lines = lines.filter((l) => l.raw.toLowerCase().includes(term));
+  }
+
+  return { lines, filepath, totalLines };
+}
+
+// ── MCP extension logs ──────────────────────────────────────────────
+
+export interface McpLogFile {
+  name: string;
+  filepath: string;
+  sizeBytes: number;
+  sizeHuman: string;
+  modifiedAt: string;
+}
+
+export async function listMcpLogs(): Promise<McpLogFile[]> {
+  try {
+    const entries = await readdir(MCP_LOGS_DIR);
+    const results: McpLogFile[] = [];
+
+    for (const entry of entries.sort()) {
+      const filepath = join(MCP_LOGS_DIR, entry);
+      const st = await stat(filepath);
+      if (st.isFile()) {
+        results.push({
+          name: entry,
+          filepath,
+          sizeBytes: st.size,
+          sizeHuman: humanSize(st.size),
+          modifiedAt: st.mtime.toISOString(),
+        });
+      }
+    }
+    return results;
+  } catch {
+    return [];
+  }
+}
+
+export async function readMcpLog(opts: {
+  name?: string;        // filename or extension name (e.g., "developer" or "mcp_developer.log")
+  filepath?: string;
+  tail?: number;
+  search?: string;
+}): Promise<{ lines: string[]; filepath: string; totalLines: number }> {
+  let filepath = opts.filepath;
+
+  if (!filepath) {
+    const logs = await listMcpLogs();
+    if (!opts.name) {
+      throw new Error("Provide either 'name' or 'filepath'");
+    }
+
+    const normalizedName = opts.name.toLowerCase();
+    const match = logs.find(
+      (l) =>
+        l.name === opts.name ||
+        l.name.toLowerCase().includes(normalizedName) ||
+        l.name === `mcp_${normalizedName}.log`
+    );
+
+    if (!match) {
+      const available = logs.map((l) => l.name).join(", ");
+      throw new Error(`MCP log "${opts.name}" not found. Available: ${available}`);
+    }
+    filepath = match.filepath;
+  }
+
+  const content = await readFile(filepath, "utf-8");
+  const allLines = content.split("\n");
+  const totalLines = allLines.length;
+
+  const tail = opts.tail ?? 200;
+  let lines = allLines.slice(Math.max(0, allLines.length - tail));
+
+  if (opts.search) {
+    const term = opts.search.toLowerCase();
+    lines = lines.filter((l) => l.toLowerCase().includes(term));
+  }
+
+  return { lines, filepath, totalLines };
+}
+
+// ── Electron main.log ───────────────────────────────────────────────
+
+export async function readElectronMainLog(opts?: {
+  tail?: number;
+  search?: string;
+  level?: string;       // filter: error, warn, info
+}): Promise<{ lines: string[]; filepath: string; totalLines: number }> {
+  const filepath = findElectronMainLog();
+  if (!filepath) {
+    throw new Error(
+      `Electron main.log not found. Searched:\n${ELECTRON_LOG_CANDIDATES.map((c) => `  ${c}`).join("\n")}`
+    );
+  }
+
+  const content = await readFile(filepath, "utf-8");
+  const allLines = content.split("\n");
+  const totalLines = allLines.length;
+
+  const tail = opts?.tail ?? 100;
+  let lines = allLines.slice(Math.max(0, allLines.length - tail));
+
+  if (opts?.level) {
+    const levels = new Set(opts.level.toLowerCase().split(",").map((l) => l.trim()));
+    lines = lines.filter((l) => {
+      const m = l.match(/\[(error|warn|info|debug|verbose|silly)\]/);
+      return m && levels.has(m[1]);
+    });
+  }
+
+  if (opts?.search) {
+    const term = opts.search.toLowerCase();
+    lines = lines.filter((l) => l.toLowerCase().includes(term));
+  }
+
+  return { lines, filepath, totalLines };
+}

--- a/ui/desktop/goose-electron-tester-mcp/src/session-db.ts
+++ b/ui/desktop/goose-electron-tester-mcp/src/session-db.ts
@@ -1,0 +1,155 @@
+/**
+ * session-db.ts
+ *
+ * Reads the goose sessions.db (SQLite) to map session names/IDs to metadata.
+ * Uses the sqlite3 CLI to avoid native module dependencies.
+ *
+ * DB location: ~/.local/share/goose/sessions/sessions.db
+ */
+
+import { execFile } from "node:child_process";
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const SESSIONS_DB = join(
+  homedir(),
+  ".local",
+  "share",
+  "goose",
+  "sessions",
+  "sessions.db"
+);
+
+export interface ChatSession {
+  id: string;
+  name: string;
+  description: string;
+  workingDir: string;
+  createdAt: string;
+  updatedAt: string;
+  totalTokens: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  inUse: boolean;
+  sessionType: string;
+  providerName: string | null;
+}
+
+async function queryDb(sql: string): Promise<string> {
+  if (!existsSync(SESSIONS_DB)) {
+    throw new Error(`Sessions database not found at ${SESSIONS_DB}`);
+  }
+
+  const { stdout } = await execFileAsync("sqlite3", [
+    "-json",
+    SESSIONS_DB,
+    sql,
+  ], { timeout: 5000 });
+
+  return stdout;
+}
+
+function parseRows(stdout: string): Record<string, unknown>[] {
+  const trimmed = stdout.trim();
+  if (!trimmed || trimmed === "[]") return [];
+  return JSON.parse(trimmed);
+}
+
+function rowToSession(row: Record<string, unknown>): ChatSession {
+  return {
+    id: row.id as string,
+    name: row.name as string ?? "",
+    description: row.description as string ?? "",
+    workingDir: row.working_dir as string ?? "",
+    createdAt: row.created_at as string ?? "",
+    updatedAt: row.updated_at as string ?? "",
+    totalTokens: row.total_tokens as number | null,
+    inputTokens: row.input_tokens as number | null,
+    outputTokens: row.output_tokens as number | null,
+    inUse: (row.in_use as number) === 1,
+    sessionType: row.session_type as string ?? "user",
+    providerName: row.provider_name as string | null,
+  };
+}
+
+/**
+ * List chat sessions from the DB, ordered by most recent first.
+ */
+export async function listChatSessions(opts?: {
+  limit?: number;
+  search?: string;
+  activeOnly?: boolean;
+}): Promise<ChatSession[]> {
+  const limit = opts?.limit ?? 30;
+
+  let where = "WHERE session_type = 'user'";
+  if (opts?.activeOnly) {
+    where += " AND in_use = 1";
+  }
+  if (opts?.search) {
+    const escaped = opts.search.replace(/'/g, "''");
+    where += ` AND (name LIKE '%${escaped}%' OR id LIKE '%${escaped}%')`;
+  }
+
+  const sql = `SELECT id, name, description, working_dir, created_at, updated_at, total_tokens, input_tokens, output_tokens, in_use, session_type, provider_name FROM sessions ${where} ORDER BY updated_at DESC LIMIT ${limit};`;
+
+  const stdout = await queryDb(sql);
+  return parseRows(stdout).map(rowToSession);
+}
+
+/**
+ * Find a session by name (fuzzy, case-insensitive) or exact ID.
+ */
+export async function findSession(nameOrId: string): Promise<ChatSession | null> {
+  // Try exact ID match first
+  const byId = await queryDb(
+    `SELECT id, name, description, working_dir, created_at, updated_at, total_tokens, input_tokens, output_tokens, in_use, session_type, provider_name FROM sessions WHERE id = '${nameOrId.replace(/'/g, "''")}' LIMIT 1;`
+  );
+  const idRows = parseRows(byId);
+  if (idRows.length > 0) return rowToSession(idRows[0]);
+
+  // Fuzzy name match
+  const escaped = nameOrId.replace(/'/g, "''");
+  const byName = await queryDb(
+    `SELECT id, name, description, working_dir, created_at, updated_at, total_tokens, input_tokens, output_tokens, in_use, session_type, provider_name FROM sessions WHERE LOWER(name) LIKE '%${escaped.toLowerCase()}%' ORDER BY updated_at DESC LIMIT 1;`
+  );
+  const nameRows = parseRows(byName);
+  if (nameRows.length > 0) return rowToSession(nameRows[0]);
+
+  return null;
+}
+
+/**
+ * Get the currently active (in_use) session, if any.
+ */
+export async function getCurrentSession(): Promise<ChatSession | null> {
+  const sessions = await listChatSessions({ activeOnly: true, limit: 1 });
+  return sessions.length > 0 ? sessions[0] : null;
+}
+
+/**
+ * Get the first user message for a session (useful for context).
+ */
+export async function getSessionFirstMessage(sessionId: string): Promise<string | null> {
+  const escaped = sessionId.replace(/'/g, "''");
+  const stdout = await queryDb(
+    `SELECT content_json FROM messages WHERE session_id = '${escaped}' AND role = 'user' ORDER BY created_timestamp ASC LIMIT 1;`
+  );
+  const rows = parseRows(stdout);
+  if (rows.length === 0) return null;
+  
+  try {
+    const content = JSON.parse(rows[0].content_json as string);
+    if (Array.isArray(content)) {
+      const textPart = content.find((p: { type: string }) => p.type === "text");
+      return textPart?.text ?? null;
+    }
+    return typeof content === "string" ? content : null;
+  } catch {
+    return rows[0].content_json as string;
+  }
+}

--- a/ui/desktop/goose-electron-tester-mcp/tsconfig.json
+++ b/ui/desktop/goose-electron-tester-mcp/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "resolveJsonModule": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/ui/desktop/src/components/ChatInput.tsx
+++ b/ui/desktop/src/components/ChatInput.tsx
@@ -1198,7 +1198,7 @@ export default function ChatInput({
       <form onSubmit={onFormSubmit} className="relative">
         <div className="relative">
           <textarea
-            data-testid="chat-input"
+            data-testid={sessionId ? `chat-input-${sessionId}` : 'chat-input-new'}
             autoFocus
             id="dynamic-textarea"
             placeholder={isRecording ? '' : getNavigationShortcutText()}
@@ -1534,6 +1534,7 @@ export default function ChatInput({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <Button
+                      data-testid="create-recipe-from-session-btn"
                       onClick={() => {
                         if (recipe) {
                           trackEditRecipeOpened();
@@ -1561,6 +1562,7 @@ export default function ChatInput({
             <Tooltip>
               <TooltipTrigger asChild>
                 <Button
+                  data-testid="diagnostics-btn"
                   type="button"
                   onClick={() => {
                     trackDiagnosticsOpened();

--- a/ui/desktop/src/components/ChatSessionsContainer.tsx
+++ b/ui/desktop/src/components/ChatSessionsContainer.tsx
@@ -46,6 +46,7 @@ export default function ChatSessionsContainer({
             key={session.sessionId}
             className={`absolute inset-0 ${isVisible ? 'block' : 'hidden'}`}
             data-session-id={session.sessionId}
+            data-session-active={isVisible ? 'true' : 'false'}
           >
             <BaseChat
               setChat={setChat}

--- a/ui/desktop/src/components/Layout/CondensedRenderer.tsx
+++ b/ui/desktop/src/components/Layout/CondensedRenderer.tsx
@@ -107,6 +107,7 @@ export const CondensedRenderer: React.FC<NavigationRendererProps> = ({
                     <DropdownMenu open={chatPopoverOpen} onOpenChange={setChatPopoverOpen}>
                       <DropdownMenuTrigger asChild>
                         <button
+                          data-testid={`nav-${item.id}`}
                           className={cn(
                             'flex items-center justify-center',
                             'rounded-lg transition-colors duration-200 no-drag',
@@ -135,6 +136,7 @@ export const CondensedRenderer: React.FC<NavigationRendererProps> = ({
                       {isChatItem && !isCondensedIconOnly ? (
                         <div className="relative">
                           <motion.button
+                            data-testid={`nav-${item.id}`}
                             onClick={onToggleChatExpanded}
                             whileHover={{ scale: 1.02 }}
                             whileTap={{ scale: 0.98 }}
@@ -184,6 +186,7 @@ export const CondensedRenderer: React.FC<NavigationRendererProps> = ({
                         </div>
                       ) : (
                         <motion.button
+                          data-testid={`nav-${item.id}`}
                           onClick={() => onNavClick(item.path)}
                           whileHover={{ scale: 1.02 }}
                           whileTap={{ scale: 0.98 }}
@@ -283,6 +286,7 @@ export const CondensedRenderer: React.FC<NavigationRendererProps> = ({
                   <DropdownMenu open={chatPopoverOpen} onOpenChange={setChatPopoverOpen}>
                     <DropdownMenuTrigger asChild>
                       <motion.button
+                        data-testid={`nav-${item.id}`}
                         whileHover={{ scale: 1.02 }}
                         whileTap={{ scale: 0.98 }}
                         className={cn(
@@ -313,6 +317,7 @@ export const CondensedRenderer: React.FC<NavigationRendererProps> = ({
                   </DropdownMenu>
                 ) : (
                   <motion.button
+                    data-testid={`nav-${item.id}`}
                     onClick={() => onNavClick(item.path)}
                     whileHover={{ scale: 1.02 }}
                     whileTap={{ scale: 0.98 }}

--- a/ui/desktop/src/components/Layout/ExpandedRenderer.tsx
+++ b/ui/desktop/src/components/Layout/ExpandedRenderer.tsx
@@ -172,6 +172,7 @@ export const ExpandedRenderer: React.FC<NavigationRendererProps> = ({
                     <div className="relative">
                       <DropdownMenuTrigger asChild>
                         <motion.div
+                          data-testid={`nav-${item.id}`}
                           className={cn(
                             'w-full relative flex flex-col rounded-lg',
                             'transition-colors duration-200 aspect-square cursor-pointer',
@@ -247,6 +248,7 @@ export const ExpandedRenderer: React.FC<NavigationRendererProps> = ({
                   )}
                 >
                   <button
+                    data-testid={`nav-${item.id}`}
                     onClick={() => onNavClick(item.path)}
                     className="flex-1 flex flex-col items-start justify-between p-5 no-drag text-left"
                   >

--- a/ui/desktop/src/components/Layout/navigation/SessionsList.tsx
+++ b/ui/desktop/src/components/Layout/navigation/SessionsList.tsx
@@ -59,6 +59,7 @@ export const SessionsList: React.FC<SessionsListProps> = ({
             {/* New Chat button as first item */}
             {onNewChat && (
               <div
+                data-testid="nav-start-new-chat"
                 onClick={onNewChat}
                 className={cn(
                   'w-full text-left py-1.5 px-2 text-xs rounded-md',
@@ -83,6 +84,7 @@ export const SessionsList: React.FC<SessionsListProps> = ({
               return (
                 <div
                   key={session.id}
+                  data-testid={`sidebar-session-${session.id}`}
                   onClick={() => {
                     if (!isEditing) {
                       clearUnread(session.id);
@@ -125,6 +127,7 @@ export const SessionsList: React.FC<SessionsListProps> = ({
             {/* Show All button at bottom */}
             {onShowAll && sessions.length > 0 && (
               <div
+                data-testid="nav-show-all-sessions"
                 onClick={onShowAll}
                 className={cn(
                   'w-full text-left py-1.5 px-2 text-xs rounded-md',

--- a/ui/desktop/src/components/sessions/SessionsInsights.tsx
+++ b/ui/desktop/src/components/sessions/SessionsInsights.tsx
@@ -324,6 +324,7 @@ export function SessionInsights() {
                   recentSessions.map((session, index) => (
                     <div
                       key={session.id}
+                      data-testid={`recent-chat-${session.id}`}
                       className="flex items-center justify-between text-sm py-1 px-2 rounded-md hover:bg-background-secondary cursor-pointer transition-colors"
                       onClick={() => handleSessionClick(session)}
                       role="button"

--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionConfigFields.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionConfigFields.tsx
@@ -24,6 +24,7 @@ export default function ExtensionConfigFields({
           <label className="text-sm font-medium mb-2 block text-text-primary">Command</label>
           <div className="relative">
             <Input
+              data-testid="extension-command-input"
               value={full_cmd}
               onChange={(e) => onChange('cmd', e.target.value)}
               placeholder="e.g. npx -y @modelcontextprotocol/my-extension <filepath>"
@@ -42,6 +43,7 @@ export default function ExtensionConfigFields({
         <label className="text-sm font-medium mb-2 block text-text-primary">Endpoint</label>
         <div className="relative">
           <Input
+            data-testid="extension-endpoint-input"
             value={endpoint}
             onChange={(e) => onChange('endpoint', e.target.value)}
             placeholder="Enter endpoint URL..."

--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionInfoFields.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionInfoFields.tsx
@@ -28,6 +28,7 @@ export default function ExtensionInfoFields({
           <label className="text-sm font-medium mb-2 block text-text-primary">Extension Name</label>
           <div className="relative">
             <Input
+              data-testid="extension-name-input"
               value={name}
               onChange={(e) => onChange('name', e.target.value)}
               placeholder="Enter extension name..."
@@ -74,6 +75,7 @@ export default function ExtensionInfoFields({
         <label className="text-sm font-medium mb-2 block text-text-primary">Description</label>
         <div className="relative">
           <Input
+            data-testid="extension-description-input"
             value={description}
             onChange={(e) => onChange('description', e.target.value)}
             placeholder="Optional description..."

--- a/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.tsx
+++ b/ui/desktop/src/components/settings/extensions/modal/ExtensionModal.tsx
@@ -427,10 +427,15 @@ export default function ExtensionModal({
           <DialogFooter className="pt-2">
             {showDeleteConfirmation ? (
               <>
-                <Button variant="outline" onClick={() => setShowDeleteConfirmation(false)}>
+                <Button
+                  data-testid="extension-delete-cancel-btn"
+                  variant="outline"
+                  onClick={() => setShowDeleteConfirmation(false)}
+                >
                   Cancel
                 </Button>
                 <Button
+                  data-testid="extension-confirm-removal-btn"
                   onClick={() => {
                     if (onDelete) {
                       onDelete(formData.name);
@@ -447,6 +452,7 @@ export default function ExtensionModal({
               <>
                 {modalType === 'edit' && onDelete && (
                   <Button
+                    data-testid="extension-remove-btn"
                     onClick={() => setShowDeleteConfirmation(true)}
                     variant="outline"
                     className="text-red-500 hover:text-red-600"
@@ -455,7 +461,7 @@ export default function ExtensionModal({
                     Remove extension
                   </Button>
                 )}
-                <Button variant="outline" onClick={handleClose}>
+                <Button data-testid="extension-cancel-btn" variant="outline" onClick={handleClose}>
                   Cancel
                 </Button>
                 <Button

--- a/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
+++ b/ui/desktop/src/components/settings/extensions/subcomponents/ExtensionItem.tsx
@@ -75,6 +75,7 @@ export default function ExtensionItem({
   return (
     <Card
       id={`extension-${kebabCase(extension.name)}`}
+      data-testid={`extension-card-${kebabCase(extension.name)}`}
       className="transition-all duration-200 min-h-[120px] overflow-hidden"
     >
       <CardHeader>
@@ -84,6 +85,7 @@ export default function ExtensionItem({
           <div className="flex items-center justify-end gap-2">
             {editable && (
               <button
+                data-testid={`extension-configure-${kebabCase(extension.name)}`}
                 className="text-text-secondary hover:text-text-primary"
                 aria-label={`Configure ${getFriendlyTitle(extension)} Extension`}
                 onClick={() => onConfigure?.(extension)}
@@ -92,6 +94,7 @@ export default function ExtensionItem({
               </button>
             )}
             <Switch
+              data-testid={`extension-toggle-${kebabCase(extension.name)}`}
               checked={(isToggling && visuallyEnabled) || extension.enabled}
               onCheckedChange={() => handleToggle(extension)}
               disabled={isToggling}

--- a/ui/desktop/src/components/ui/ConfirmationModal.tsx
+++ b/ui/desktop/src/components/ui/ConfirmationModal.tsx
@@ -46,6 +46,7 @@ export function ConfirmationModal({
 
         <DialogFooter className="pt-2 shrink-0">
           <Button
+            data-testid="confirmation-cancel-btn"
             variant="outline"
             onClick={onCancel}
             disabled={isSubmitting}
@@ -54,6 +55,7 @@ export function ConfirmationModal({
             {cancelLabel}
           </Button>
           <Button
+            data-testid="confirmation-confirm-btn"
             variant={confirmVariant}
             onClick={onConfirm}
             disabled={isSubmitting}

--- a/ui/desktop/tests/e2e/specs/README.md
+++ b/ui/desktop/tests/e2e/specs/README.md
@@ -1,0 +1,120 @@
+# 🦢🔍 Goose Tester — UI E2E Specs
+
+Business-friendly end-to-end test specifications for the Goose desktop app,
+written in [Gherkin](https://cucumber.io/docs/gherkin/) syntax.
+
+These specs are designed to be **executed by Goose itself** using the
+`Goose Electron Tester` MCP extension — not by Playwright directly.
+
+## Feature Files
+
+| File | Scenarios | Covers |
+|---|---|---|
+| `settings.feature` | 3 | Settings page, all tabs, dark mode toggle, Models tab |
+| `conversations.feature` | 5 | Start chat, recent chats, load history, follow-ups, new chat |
+| `extensions.feature` | 3 | Extensions page, add/remove Running Quotes, use in chat |
+| `recipes.feature` | 2 | Recipes page, create recipe from session (chef's hat) |
+
+## How to Run
+
+Ask Goose:
+
+> Run the settings.feature spec
+
+or
+
+> Run all the feature files
+
+Goose will:
+1. Read the `.feature` file
+2. Read `RUNNER-GUIDE.md` for step definitions and selector mappings
+3. Connect to the Electron app via `electron_connect`
+4. Execute each scenario step-by-step using Goose Electron Tester MCP tools
+5. **Take screenshots as the primary verification method**
+6. Report results with pass/fail per scenario
+
+## Verification Philosophy
+
+**Screenshots first.** Most assertions are verified visually via `electron_screenshot`.
+DOM queries are only used when a specific computed value is needed (e.g.,
+`document.documentElement.className` for theme state). This keeps execution fast
+and avoids brittle selector-based assertions.
+
+## Why Gherkin?
+
+- **Industry standard** — understood by QA, PMs, developers
+- **Tooling** — syntax highlighting, IDE plugins, linting
+- **Extensible** — can later add `playwright-bdd` to run natively too
+- **Readable** — business-friendly language, no code knowledge needed
+
+## Key Selector Findings
+
+| Area | data-testid? | Strategy |
+|---|---|---|
+| Chat elements | ✅ 3 testids | ⚠️ TWO chat-input textareas exist — find visible one (height > 0) |
+| Settings tabs | ✅ 7 testids | Direct CSS selector (may need scrollIntoView in narrow windows) |
+| Theme buttons | ✅ 3 testids | Direct CSS selector (scroll to element first — below fold) |
+| Recipe modal | ✅ 13 testids | Direct CSS selector |
+| Extension submit | ✅ 1 testid | scrollIntoView first, avoid clicking near modal edges |
+| **Sidebar main nav** | ✅ 6 testids | `nav-home`, `nav-chat`, `nav-recipes`, `nav-scheduler`, `nav-extensions`, `nav-settings` |
+| **Start New Chat** | ✅ 1 testid | `nav-start-new-chat` |
+| **Show All sessions** | ✅ 1 testid | `nav-show-all-sessions` |
+| **Sidebar sessions** | ✅ Dynamic | `sidebar-session-{session_id}` |
+| **Recent chats (Home)** | ✅ Dynamic | `recent-chat-{session_id}` |
+| **Extension cards** | ✅ Dynamic | `extension-card-{kebab-name}`, `extension-toggle-{name}`, `extension-configure-{name}` |
+| **Chef's hat (recipe)** | ✅ 1 testid | `create-recipe-from-session-btn` |
+| **Diagnostics (bug)** | ✅ 1 testid | `diagnostics-btn` |
+| **Extension modal inputs** | ✅ 4 testids | `extension-name-input`, `extension-description-input`, `extension-command-input`, `extension-endpoint-input` |
+| **Extension modal buttons** | ✅ 4 testids | `extension-submit-btn`, `extension-cancel-btn`, `extension-remove-btn`, `extension-confirm-removal-btn` |
+| **Confirmation modal** | ✅ 2 testids | `confirmation-cancel-btn`, `confirmation-confirm-btn` |
+
+## Test Run Results
+
+### Run #1 (2026-02-24 morning)
+| Feature | Result |
+|---|---|
+| dark-mode.feature | ✅ 4/4 PASS |
+| release-settings.feature | ✅ 3/3 PASS |
+| release-conversations.feature | ✅ 4/4 PASS |
+| release-extensions.feature | ✅ 2/3 PASS (Scenario 3 blocked by rate limit) |
+
+### Run #2 (2026-02-24 afternoon) — Full Release Checklist
+| Feature | Result |
+|---|---|
+| Settings (3 scenarios) | ✅ 3/3 PASS |
+| Conversations (5 scenarios) | ✅ 5/5 PASS |
+| Extensions (3 scenarios) | ✅ 2/3 PASS, 1 PARTIAL (tool not found in new session) |
+| Recipes (2 scenarios) | ✅ 2/2 PASS |
+| **Total** | **12/13 PASS, 1 PARTIAL** |
+
+### Run #3 (2026-02-24 afternoon) — With code fixes
+| Feature | Result |
+|---|---|
+| Settings (3 scenarios) | ✅ 3/3 PASS |
+| Conversations (5 scenarios) | ✅ 5/5 PASS |
+| Extensions (3 scenarios) | ✅ 3/3 PASS 🎉 (Running Quotes tool invoked!) |
+| Recipes (2 scenarios) | ✅ 2/2 PASS (chef's hat via data-testid!) |
+| **Total** | **13/13 PASS** 🎉 |
+
+**Code fixes in Run #3:**
+- `data-testid="create-recipe-from-session-btn"` on chef's hat button
+- `data-testid="diagnostics-btn"` on bug report button
+- `data-testid="chat-input-new"` for Hub input (no session)
+
+## Files
+
+```
+specs/
+├── README.md                      # This file
+├── RUNNER-GUIDE.md                # Step definitions, selectors, lessons learned
+├── dark-mode.feature              # Theme toggle tests
+├── settings-navigation.feature    # Settings tab navigation
+├── chat-interaction.feature       # Chat send/receive
+├── chat-history.feature           # Message history
+├── mcp-extension.feature          # Extension management
+├── running-quotes.feature         # MCP tool usage in chat
+├── release-settings.feature       # Release: settings verification
+├── release-conversations.feature  # Release: conversation flows
+├── release-extensions.feature     # Release: extension add/remove/use
+└── release-recipes.feature        # Release: recipe navigation/creation
+```

--- a/ui/desktop/tests/e2e/specs/RUNNER-GUIDE.md
+++ b/ui/desktop/tests/e2e/specs/RUNNER-GUIDE.md
@@ -1,0 +1,581 @@
+# 🦢🔍 Goose Tester — Spec Runner Guide
+
+This document tells Goose how to execute `.feature` (Gherkin) specs against the
+Goose desktop Electron app using the **Goose Electron Tester MCP extension**.
+
+## Launching the App
+
+Use `launch-app.sh` to start the app with remote debugging enabled:
+
+### Dev server (with Vite hot reload)
+```bash
+./launch-app.sh dev /path/to/ui/desktop [port]
+# Example:
+./launch-app.sh dev /Users/zane/Development/goose/ui/desktop 9224
+```
+Uses `screen` + `ENABLE_PLAYWRIGHT=1` to launch `npm run start-gui` with a visible Electron window.
+
+### Bundled/packaged app
+```bash
+./launch-app.sh app "/path/to/Goose.app" [port]
+# Example:
+./launch-app.sh app "/Users/zane/Downloads/Goose 43.app" 9223
+```
+Uses `open -a` with `--args --remote-debugging-port=PORT` to launch the app.
+
+### Status & Stop
+```bash
+./launch-app.sh status 9224    # Check if running
+./launch-app.sh stop 9224      # Stop the app
+```
+
+## Connecting
+
+After launching, connect via Goose Electron Tester:
+```
+electron_connect port=9224
+```
+
+## Prerequisites
+
+1. The Electron app must be running with remote debugging enabled (use `launch-app.sh`)
+2. Connect via `electron_connect` with the port you launched on
+3. Verify the app is loaded by taking a screenshot
+
+---
+
+## Verification Philosophy
+
+**Screenshots are the primary verification method.** Use DOM queries only when you
+need a specific value (e.g., class name, element count). For visual checks like
+"is the response visible?", "does the sidebar show the chat?", "is dark mode active?" —
+take a screenshot and verify visually. This keeps test execution fast.
+
+---
+
+## Selector Reference
+
+### Complete data-testid Inventory (from source code audit)
+
+#### Chat & Messages
+| Element | Selector | Component |
+|---|---|---|
+| Chat input (with session) | `[data-testid="chat-input"]` | ChatInput.tsx |
+| Chat input (new/hub, no session) | `[data-testid="chat-input-new"]` | ChatInput.tsx (via Hub.tsx) |
+| Loading indicator | `[data-testid="loading-indicator"]` | LoadingGoose.tsx |
+| Message containers | `[data-testid="message-container"]` | ProgressiveMessageList.tsx |
+
+**NOTE:** The chat input testid is now context-aware:
+- `chat-input` — used when there's an active session (in a conversation)
+- `chat-input-new` — used on the Hub/new chat page (no session yet)
+This fixes the dual-textarea issue where two `chat-input` elements existed simultaneously.
+
+#### Settings Tabs
+| Element | Selector | Component |
+|---|---|---|
+| Models tab | `[data-testid="settings-models-tab"]` | SettingsView.tsx |
+| Local Inference tab | `[data-testid="settings-local-inference-tab"]` | SettingsView.tsx |
+| Chat tab | `[data-testid="settings-chat-tab"]` | SettingsView.tsx |
+| Session tab | `[data-testid="settings-sharing-tab"]` | SettingsView.tsx |
+| Prompts tab | `[data-testid="settings-prompts-tab"]` | SettingsView.tsx |
+| Keyboard tab | `[data-testid="settings-keyboard-tab"]` | SettingsView.tsx |
+| App tab | `[data-testid="settings-app-tab"]` | SettingsView.tsx |
+
+#### Theme
+| Element | Selector | Component |
+|---|---|---|
+| Light button | `[data-testid="light-mode-button"]` | ThemeSelector.tsx |
+| Dark button | `[data-testid="dark-mode-button"]` | ThemeSelector.tsx |
+| System button | `[data-testid="system-mode-button"]` | ThemeSelector.tsx |
+
+#### Providers
+| Element | Selector | Component |
+|---|---|---|
+| Selection heading | `[data-testid="provider-selection-heading"]` | ProviderSettingsPage.tsx |
+| Launch button | `[data-testid="provider-launch-button"]` | CardButtons.tsx |
+
+#### Extensions
+| Element | Selector | Component |
+|---|---|---|
+| Submit button (modal) | `[data-testid="extension-submit-btn"]` | ExtensionModal.tsx |
+
+#### Bottom Bar Actions
+| Element | Selector | Component |
+|---|---|---|
+| Create Recipe from Session (chef's hat) | `[data-session-active="true"] [data-testid="create-recipe-from-session-btn"]` | ChatInput.tsx |
+| Diagnostics / Bug Report | `[data-session-active="true"] [data-testid="diagnostics-btn"]` | ChatInput.tsx |
+
+⚠️ **IMPORTANT**: Always scope bottom-bar buttons to `[data-session-active="true"]` because
+multiple sessions are mounted simultaneously (hidden via CSS). Without scoping, the selector
+picks the first DOM match which may be from a hidden session (zero dimensions, not clickable).
+
+#### Recipes (CreateRecipeFromSessionModal)
+| Element | Selector |
+|---|---|
+| Modal container | `[data-testid="create-recipe-modal"]` |
+| Modal header | `[data-testid="modal-header"]` |
+| Modal content | `[data-testid="modal-content"]` |
+| Modal footer | `[data-testid="modal-footer"]` |
+| Create button | `[data-testid="create-recipe-button"]` |
+| Create & Run button | `[data-testid="create-and-run-recipe-button"]` |
+| Cancel button | `[data-testid="cancel-button"]` |
+| Close button | `[data-testid="close-button"]` |
+| Form state | `[data-testid="form-state"]` |
+| Analyzing state | `[data-testid="analyzing-state"]` |
+| Analyzing title | `[data-testid="analyzing-title"]` |
+| Analysis stage | `[data-testid="analysis-stage"]` |
+| Analysis spinner | `[data-testid="analysis-spinner"]` |
+
+#### Recipe Form Fields
+| Element | Selector |
+|---|---|
+| Form container | `[data-testid="recipe-form"]` |
+| Title input | `[data-testid="title-input"]` |
+| Description input | `[data-testid="description-input"]` |
+| Prompt input | `[data-testid="prompt-input"]` |
+| Instructions input | `[data-testid="instructions-input"]` |
+| Recipe name input | `[data-testid="recipe-name-input"]` |
+
+#### Misc
+| Element | Selector | Component |
+|---|---|---|
+| Environment badge | `[data-testid="environment-badge"]` | EnvironmentBadge.tsx |
+| Geist icon | `[data-testid="geist-icon"]` | icons.tsx |
+
+### Sidebar Navigation (NOW WITH data-testid! ✅)
+
+All main nav items now have `data-testid` attributes:
+
+| Element | Selector | Notes |
+|---|---|---|
+| Home | `[data-testid="nav-home"]` | |
+| Chat | `[data-testid="nav-chat"]` | Toggles chat session list |
+| Recipes | `[data-testid="nav-recipes"]` | |
+| Scheduler | `[data-testid="nav-scheduler"]` | |
+| Extensions | `[data-testid="nav-extensions"]` | |
+| Settings | `[data-testid="nav-settings"]` | |
+| Start New Chat | `[data-testid="nav-start-new-chat"]` | Inside Chat sub-items |
+| Show All | `[data-testid="nav-show-all-sessions"]` | Inside Chat sub-items |
+
+**To click any nav item:**
+```
+electron_click selector="[data-testid='nav-settings']"
+```
+
+#### Sidebar Chat Sessions (NOW WITH data-testid! ✅)
+
+| Element | Selector | Example |
+|---|---|---|
+| Sidebar session item | `[data-testid="sidebar-session-{session_id}"]` | `sidebar-session-20260224_17` |
+
+**To click a session in the sidebar:**
+```
+electron_click selector="[data-testid='sidebar-session-20260224_17']"
+```
+
+**To find a session by name** (when you don't know the ID):
+```javascript
+(function() {
+  const items = document.querySelectorAll('[data-testid^="sidebar-session-"]');
+  for (const item of items) {
+    if (item.textContent.includes('CHAT_NAME')) {
+      item.click();
+      return 'clicked ' + item.getAttribute('data-testid');
+    }
+  }
+  return 'not found';
+})()
+```
+
+#### Recent Chats on Home Page (NOW WITH data-testid! ✅)
+
+| Element | Selector | Example |
+|---|---|---|
+| Recent chat item | `[data-testid="recent-chat-{session_id}"]` | `recent-chat-20260224_17` |
+
+**To click a recent chat:**
+```
+electron_click selector="[data-testid='recent-chat-20260224_17']"
+```
+
+**To find a recent chat by name:**
+```javascript
+(function() {
+  const items = document.querySelectorAll('[data-testid^="recent-chat-"]');
+  for (const item of items) {
+    if (item.textContent.includes('CHAT_NAME')) {
+      item.click();
+      return 'clicked ' + item.getAttribute('data-testid');
+    }
+  }
+  return 'not found';
+})()
+```
+
+#### Settings Tabs
+
+`electron_click` with `selector="[data-testid='settings-app-tab']"` works reliably.
+No coordinate-based clicking needed.
+
+#### Extension Cards (NOW WITH data-testid! ✅)
+
+Extension names are kebab-cased (e.g., "Running Quotes" → `running-quotes`).
+
+| Element | Selector | Example |
+|---|---|---|
+| Extension card | `[data-testid="extension-card-{name}"]` | `extension-card-running-quotes` |
+| Extension toggle | `[data-testid="extension-toggle-{name}"]` | `extension-toggle-running-quotes` |
+| Extension configure (gear) | `[data-testid="extension-configure-{name}"]` | `extension-configure-running-quotes` |
+
+**To click the gear icon on Running Quotes:**
+```
+electron_click selector="[data-testid='extension-configure-running-quotes']"
+```
+
+**To toggle an extension:**
+```
+electron_click selector="[data-testid='extension-toggle-running-quotes']"
+```
+
+#### Extension Modal Elements (NOW WITH data-testid! ✅)
+
+| Element | Selector |
+|---|---|
+| Extension name input | `[data-testid="extension-name-input"]` |
+| Extension description input | `[data-testid="extension-description-input"]` |
+| Extension command input (STDIO) | `[data-testid="extension-command-input"]` |
+| Extension endpoint input (HTTP/SSE) | `[data-testid="extension-endpoint-input"]` |
+| Submit button (Add/Save) | `[data-testid="extension-submit-btn"]` |
+| Cancel button | `[data-testid="extension-cancel-btn"]` |
+| Remove extension button | `[data-testid="extension-remove-btn"]` |
+| Confirm removal button | `[data-testid="extension-confirm-removal-btn"]` |
+| Delete cancel button | `[data-testid="extension-delete-cancel-btn"]` |
+
+#### Confirmation Modal (Unsaved Changes, etc.)
+
+| Element | Selector |
+|---|---|
+| Cancel / "No" button | `[data-testid="confirmation-cancel-btn"]` |
+| Confirm / "Yes" button | `[data-testid="confirmation-confirm-btn"]` |
+
+#### Models Tab Content
+
+| Element | How to find |
+|---|---|
+| Current model name | Visible text in the Models tab content area (e.g., "goose-claude-4-6-opus") |
+| Provider name | Text below model name (e.g., "Databricks") |
+| "Switch models" button | Text match |
+| "Configure providers" button | Text match |
+| "Reset Provider and Model" button | Text match (red button) |
+
+#### Bottom Status Bar (left to right)
+
+| Element | Position | How to find | Notes |
+|---|---|---|---|
+| Working directory | leftmost | Path text, clickable button | Shows current working dir |
+| Attachment icon | after dir | Button with 1-path SVG | Paperclip icon |
+| Token count | middle | Number like "0.0401" next to token icon | Updates after agent responds |
+| Green status dot | before model | Small SVG dot | |
+| Model name | center-right | Text "goose-claude-4-6-opus" | |
+| Mode indicator | after model | Text "autonomous" | |
+| Manage extensions | right | Button titled "manage extensions", shows count "4" | |
+| **Chef's hat (Create Recipe from Session)** | **2nd from right** | **Unlabeled button with 2-path SVG at ~x=972** | **Opens "Create Recipe from Session" modal with auto-filled fields** |
+| Bug report icon | rightmost | Unlabeled button with 11-path SVG | Opens "Report a Problem" dialog |
+
+**IMPORTANT:** The chef's hat icon for "Create Recipe from Session" is the **2nd button from the right** in the bottom bar. It is NOT the rightmost button (that's bug report). It has no title/aria-label — identify by position or SVG path count (2 paths).
+
+**Note:** The token count tooltip requires a real mouse hover (CDP mouse move),
+not just JS `dispatchEvent`. The visible token number in the bar updates after
+the agent finishes responding.
+
+---
+
+## Step Definitions
+
+### Navigation Steps
+
+**"Given the app is loaded and the chat input is visible"**
+```
+1. electron_wait_for selector="[data-testid='chat-input']" timeout=10000 visible=true
+2. electron_screenshot to verify
+```
+
+**"When I navigate to {page} in the sidebar"**
+```
+electron_click selector="[data-testid='nav-{page-lowercase}']"
+```
+Mapping: Home → `nav-home`, Chat → `nav-chat`, Recipes → `nav-recipes`,
+Scheduler → `nav-scheduler`, Extensions → `nav-extensions`, Settings → `nav-settings`
+
+**"When I click Start New Chat in the sidebar"**
+```
+electron_click selector="[data-testid='nav-start-new-chat']"
+```
+
+**"When I click on {name} in the recent chats list"**
+```
+1. electron_evaluate: find text node in main content area (x > 200), get coordinates
+2. electron_click at those coordinates
+3. electron_screenshot to verify conversation loaded
+```
+
+**"When I click the {tab} settings tab"**
+```
+1. electron_click selector="[data-testid='settings-{tab-lowercase}-tab']"
+2. electron_screenshot to verify tab switched
+```
+Note: Tab name to testid mapping:
+- "Models" → `settings-models-tab`
+- "Local Inference" → `settings-local-inference-tab`
+- "Chat" → `settings-chat-tab`
+- "Session" → `settings-sharing-tab` (NOT "session"!)
+- "Prompts" → `settings-prompts-tab`
+- "Keyboard" → `settings-keyboard-tab`
+- "App" → `settings-app-tab`
+
+**"When I scroll {section} into view"**
+```
+electron_evaluate:
+  (function() {
+    const els = document.querySelectorAll('h2, h3, h4, p, span, div');
+    for (const el of els) {
+      if (el.textContent.trim() === '{section}') {
+        el.scrollIntoView({ behavior: 'instant', block: 'start' });
+        return 'scrolled';
+      }
+    }
+    return 'not found';
+  })()
+```
+
+### Chat Steps
+
+**"When I type {text} into the chat input and press Enter"** (compound step)
+
+Two selectors depending on context:
+
+**In a session** (after clicking a chat or "Start New Chat"):
+```
+electron_type selector="[data-session-active='true'] textarea" text="{text}" clear=true press_enter=true
+```
+
+**On the Hub/Home page** (typing to start a brand new chat):
+```
+electron_type selector="[data-testid='chat-input-new']" text="{text}" clear=true press_enter=true
+```
+
+**How to know which to use:**
+- After `nav-start-new-chat` → session selector (it creates a session immediately)
+- After `nav-home` and typing in the home input → `chat-input-new`
+- After clicking a sidebar session or recent chat → session selector
+
+**"When I send the message {text}"** (alias for above)
+```
+Same as above
+```
+
+**"Then the agent should respond within {N} seconds"**
+```
+1. Take screenshot every 5 seconds up to {N} seconds
+2. Look for new message-container elements or visible response text
+3. Final screenshot to confirm response appeared
+```
+
+**"When I wait for the response to complete"**
+```
+1. Poll for loading-indicator to disappear (may never appear if response is fast)
+2. Fallback: poll for message-container count to increase
+3. Screenshot to verify
+```
+
+### Theme Steps
+
+**"When I click the {theme} theme button"**
+```
+electron_click selector="[data-testid='{theme-lowercase}-mode-button']"
+```
+
+**"Then the page should switch to dark/light mode"**
+```
+1. electron_evaluate: document.documentElement.className
+   // Should be "dark" or "light"
+2. electron_screenshot to visually confirm
+```
+
+### Extension Steps
+
+**"When I click the Add custom extension button"**
+```
+electron_evaluate: find button by text, click it, then screenshot to verify modal opened
+```
+
+**"When I fill the extension {field} with {value}"**
+```
+electron_type with appropriate placeholder selector:
+- name: input[placeholder="Enter extension name..."]
+- description: input[placeholder="Optional description..."]
+- command: input[placeholder*="npx"]
+```
+
+**"When I click the extension submit button"**
+```
+electron_click selector="[data-testid='extension-submit-btn']"
+```
+⚠️ **IMPORTANT**: If you click near the edge of the modal, an "Unsaved Changes"
+dialog may appear. If this happens, click "No" to stay in the modal, then retry
+the submit click using the data-testid selector.
+
+**"When I remove the {name} extension if it already exists"**
+```
+1. Check if extension exists: document.body.innerText.includes('{name}')
+2. If yes, scroll to it, click gear icon (use coordinate click from evaluate)
+3. In the "Update Extension" modal, find "Remove extension" button
+   - It may be below the fold — use scrollIntoView or find its coordinates
+4. Click "Remove extension"
+5. Confirmation dialog appears: "Delete Extension '{name}'"
+6. Click "Confirm removal"
+7. Screenshot to verify removal
+```
+
+**"When I scroll to the {name} extension"**
+```
+electron_evaluate:
+  (function() {
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    while (walker.nextNode()) {
+      if (walker.currentNode.textContent.trim() === '{name}') {
+        const parent = walker.currentNode.parentElement;
+        const rect = parent.getBoundingClientRect();
+        if (rect.x > 200) {
+          parent.scrollIntoView({ behavior: 'instant', block: 'center' });
+          return 'scrolled';
+        }
+      }
+    }
+    return 'not found';
+  })()
+```
+
+---
+
+## Execution Flow
+
+When Goose receives a command like "run the release-settings.feature spec":
+
+1. **Read** the `.feature` file to understand Scenarios and steps
+2. **Read** this RUNNER-GUIDE for step definitions and selector mappings
+3. **Connect** to the Electron app via `electron_connect`
+4. **Execute** each step using Goose Electron Tester MCP tools
+5. **Screenshot** after each significant action — this is the primary verification
+6. **Report** results per scenario with pass/fail and screenshots
+
+## Result Format
+
+```
+## Feature: {feature name}
+
+### Scenario: {scenario name}
+- Step: {step text} ✅
+- Step: {step text} ✅
+- Step: {step text} ❌ Error: {details}
+  [screenshot attached]
+
+Result: FAIL (2/3 steps passed)
+```
+
+---
+
+## Tips for Reliable Execution
+
+1. **Screenshots first**: Use screenshots as the primary verification method. Only use DOM queries when you need a specific computed value.
+2. **Sidebar nav**: All main nav items have `data-testid` — use `electron_click selector="[data-testid='nav-home']"` etc. "Start New Chat" is `[data-testid="nav-start-new-chat"]`. Chat session names still need TreeWalker text matching.
+3. **Recent chats list**: Items in the Home page "Recent chats" section are clickable but need coordinate-based clicking. Find position with TreeWalker (filter x > 200 for main content area), then `electron_click` at those coordinates.
+4. **Settings tabs**: `electron_click` with data-testid selector works reliably. Note "Session" tab has testid `settings-sharing-tab` not `settings-session-tab`.
+5. **Theme buttons**: `electron_click` with data-testid works reliably. Selected button has class `bg-background-inverse`.
+6. **Scrolling**: Use `scrollIntoView({ behavior: 'instant', block: 'start' })` via `electron_evaluate`. The `electron_scroll` tool doesn't work well because the main content has `overflow-hidden`.
+7. **Extension modals**: 
+   - "Add Extension" submit button: use `[data-testid="extension-submit-btn"]` selector
+   - Clicking near modal edges triggers "Unsaved Changes" dialog — click "No" to stay
+   - "Remove extension" button may be below the fold — find coordinates first
+   - Confirmation dialog has "Confirm removal" button (not just "Remove")
+8. **Chat input selectors**: Each session's textarea has `data-testid="chat-input-{sessionId}"`. The active session's wrapper has `data-session-active="true"`. Use `[data-session-active='true'] textarea` for sessions, `[data-testid='chat-input-new']` for Hub. `electron_type` with `press_enter=true` works directly — no native setter workaround needed.
+9. **Token count**: Visible in the bottom bar as a number (e.g., "0.0401"). Updates after agent finishes responding. Starts at "0.0000" for new conversations.
+
+### Speed Optimization Tips
+
+1. **Combine type + enter**: Use `electron_type` with `press_enter=true` — one call instead of two.
+2. **Skip unnecessary screenshots**: Only screenshot when you need visual verification. Use DOM queries for pass/fail checks.
+3. **Batch verifications**: Combine multiple checks in one `electron_evaluate` call.
+4. **Reduce waits**: Use `setTimeout` of 8s max for agent responses. For navigation, 1-2s is enough.
+5. **Scope to active session**: Always use `[data-session-active="true"]` prefix for session-scoped elements to avoid hitting hidden sessions.
+6. **Use testid selectors**: `electron_click selector="[data-testid='nav-settings']"` is faster than JS text matching.
+7. **Don't wait for loading indicators**: They appear/disappear too fast. Poll `message-container` count instead.
+10. **Loading indicator**: May appear and disappear very quickly, or not at all for fast responses. Don't rely on it — use screenshot verification or message count polling instead.
+11. **Conversation naming**: The app auto-names conversations based on content. A "Hello" chat may get renamed to something else after follow-up messages.
+12. **App tab may be off-screen**: In narrower windows, the "App" settings tab scrolls off the right edge of the tab bar. Use `tab.scrollIntoView({ inline: 'center' })` before clicking, or use `electron_evaluate` to find and click it.
+13. **Theme buttons need scrolling**: After clicking the App tab, the Theme section is below the fold. Scroll to the dark-mode-button element directly: `document.querySelector('[data-testid="dark-mode-button"]').scrollIntoView({ behavior: 'instant', block: 'center' })` before clicking.
+14. **Chef's hat icon**: The "Create Recipe from Session" button is the **2nd from right** in the bottom status bar. It has NO title or aria-label. Identify by position (~x=972) or by being the button with a 2-path SVG. The rightmost button (11-path SVG) is the bug report icon.
+15. **Extension submit "Unsaved Changes" trap**: The submit button `[data-testid="extension-submit-btn"]` may be near the bottom of the modal. If the click lands near the modal edge, an "Unsaved Changes" dialog appears. Fix: click "No" to stay, then find the button's exact position with `scrollIntoView` + `getBoundingClientRect` and click at those coordinates.
+
+---
+
+## Lessons Learned (from live test runs)
+
+### 2026-02-24: dark-mode.feature — 4/4 PASS
+
+1. `electron_click` with data-testid selectors works great for settings tabs and theme buttons
+2. Sidebar nav requires JS text matching — `textContent.trim() === 'Settings'`
+3. `scrollIntoView()` via evaluate is the reliable scroll method
+4. Theme persistence works across navigation round-trips
+5. Selected theme button detected via `bg-background-inverse` class
+
+### 2026-02-24: release-settings.feature — 3/3 PASS
+
+1. All 7 settings tabs verified visible via data-testid query
+2. Models tab shows model name, provider, "Switch models" and "Configure providers" buttons
+3. Dark/light toggle works via data-testid click
+
+### 2026-02-24: release-conversations.feature — 4/4 PASS
+
+1. **"Start New Chat" is a `<span>` not a `<button>`** — `querySelectorAll('button')` won't find it. Use TreeWalker text node search instead.
+2. **Recent chats list items need coordinate clicking** — find position with TreeWalker (filter `rect.x > 200` to ensure main content area, not sidebar), then `electron_click` at coordinates.
+3. **Token count starts at "0.0000"** and updates after agent responds (showed "0.0401" after a 2+2 exchange).
+4. **Conversations auto-rename** — "Hello" chat became "Basic math question" after a follow-up about 2+2.
+5. **New chat shows "Popular chat topics"** — includes starter prompts like "Develop a tamagotchi game".
+6. **Loading indicator may not appear** — for fast responses it comes and goes before we can catch it. Use screenshot verification instead.
+
+### 2026-02-24: release-extensions.feature — 2/3 PASS (Scenario 3 blocked by rate limit)
+
+1. **Extensions page shows Default Extensions count** — went from (4) to (5) after adding Running Quotes.
+2. **Extension removal flow**: gear icon → "Update Extension" modal → scroll to "Remove extension" → confirmation dialog "Delete Extension 'Running Quotes'" → "Confirm removal".
+3. **"Unsaved Changes" dialog trap**: Clicking near the modal edge (e.g., at y=681 which is near the bottom) can trigger an "Unsaved Changes" confirmation. Click "No" to stay, then use `[data-testid="extension-submit-btn"]` for the submit click.
+4. **Extension gear icon**: Found by navigating from the extension name text up to the card container, then finding a non-switch button with an SVG child. Use coordinate clicking.
+5. **Extension command input placeholder**: `input[placeholder*="npx"]` matches `e.g. npx -y @modelcontextprotocol/my-extension <filepath>`.
+6. **After adding extension, it appears in Default Extensions section** with toggle enabled.
+
+### 2026-02-24: Release Checklist Run #2 — 12/13 PASS, 1 PARTIAL
+
+**New findings:**
+
+1. **Dual chat-input textarea**: TWO `[data-testid="chat-input"]` exist in pair view — one hidden (0x0), one visible. CSS selectors pick the hidden one → "Element is not focusable". Fix: iterate all, check `getBoundingClientRect().height > 0`, focus the visible one.
+2. **React native setter required**: `el.value = 'text'` doesn't trigger React state. Must use `Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set` + `dispatchEvent(new Event('input', { bubbles: true }))`.
+3. **App tab off-screen in narrow windows**: Tab bar scrolls horizontally. Use `tab.scrollIntoView({ inline: 'center' })` before `electron_click`.
+4. **Theme buttons below fold on App tab**: After clicking App tab, scroll to dark-mode-button element directly before clicking.
+5. **Chef's hat = Create Recipe from Session**: Now has `data-testid="create-recipe-from-session-btn"`.
+6. **Bug report icon**: Now has `data-testid="diagnostics-btn"`.
+7. **Extension not available in new chat**: After adding Running Quotes to Default Extensions, starting a new chat may not have the tool available immediately. The agent used "Search Available Extensions" instead of `runningQuote` tool.
+8. **Reconnection needed**: CDP connection can drop. If `electron_press_key` fails with "Not attached", call `electron_connect` again.
+9. **Promise-based waits**: `new Promise(r => setTimeout(r, 5000)).then(() => ...)` works for waiting, but CDP has a 10s timeout. Keep waits under 8s or use polling.
+
+### 2026-02-24: Release Checklist Run #3 — 13/13 PASS 🎉
+
+**Code fixes applied:**
+1. Added `data-testid="create-recipe-from-session-btn"` to chef's hat button — one-click recipe test
+2. Added `data-testid="diagnostics-btn"` to bug report button — no more confusion with chef's hat
+3. Added `data-testid="chat-input-new"` for Hub/new chat input (sessionId=null) — differentiates from session input
+
+**Key improvements over Run #2:**
+1. **S3.3 Running Quotes now PASSES** — tool invocation worked, got Emil Zatopek quote
+2. **Chef's hat click is now reliable** — `[data-testid="create-recipe-from-session-btn"]` instead of position guessing
+3. **Chat input typing pattern**: For pair view, use `querySelectorAll('textarea')`, filter `height > 0`, focus + native setter + Enter. For Hub, use `[data-testid="chat-input-new"]`.
+4. **App tab**: Use `scrollIntoView({ inline: 'center' })` then `electron_click` with selector — JS `.click()` alone doesn't trigger React state change

--- a/ui/desktop/tests/e2e/specs/conversations.feature
+++ b/ui/desktop/tests/e2e/specs/conversations.feature
@@ -1,0 +1,47 @@
+@release @conversations
+Feature: Starting Conversations
+  Release checklist: verify all the ways to start and manage conversations.
+
+  Background:
+    Given the app is loaded and the chat input is visible
+
+  Scenario: Start a new conversation from home and get a response
+    # "Start New Chat" is a <span> not <button> — use TreeWalker
+    When I click "Start New Chat" in the sidebar
+    # DUAL CHAT-INPUT: find visible textarea (height > 0), use React native setter
+    And I type "Hello" into the visible chat input and press Enter
+    Then the agent should respond within 30 seconds
+    And I take a screenshot to verify:
+      - The agent response is visible and not empty
+      - A new chat session appears in the sidebar with green dot
+
+  Scenario: New conversation appears in recent chats on home page
+    When I navigate to "Home" in the sidebar
+    Then I take a screenshot to verify:
+      - "Recent chats" section is visible
+      - The conversation we just created appears in the list with today's date
+
+  Scenario: Load a conversation from history
+    When I navigate to "Home" in the sidebar
+    # Recent chat items: find by TreeWalker, filter x > 200, coordinate click
+    And I click on a chat in the recent chats list
+    Then I take a screenshot to verify:
+      - The conversation loaded with original messages visible
+      - The chat name is highlighted in the sidebar
+
+  Scenario: Add a follow-up message to an existing conversation
+    Given I have an open conversation with at least one exchange
+    # DUAL CHAT-INPUT: use visible textarea + React native setter
+    When I type "Follow-up: what is 2+2?" into the visible chat input and press Enter
+    Then the agent should respond within 30 seconds
+    And I take a screenshot to verify:
+      - The new exchange appears below the previous ones
+      - The token count in the bottom bar has increased
+
+  Scenario: Start a new conversation from the sidebar
+    # "Start New Chat" is a <span> not <button> — use TreeWalker
+    When I click "Start New Chat" in the sidebar
+    Then I take a screenshot to verify:
+      - A fresh conversation view is shown with "Popular chat topics"
+      - The chat input is visible at the bottom
+      - Token count is reset to 0.0000

--- a/ui/desktop/tests/e2e/specs/extensions.feature
+++ b/ui/desktop/tests/e2e/specs/extensions.feature
@@ -1,0 +1,45 @@
+@release @extensions
+Feature: Extensions
+  Release checklist: verify adding custom extensions and using them in chat.
+
+  Background:
+    Given the app is loaded and the chat input is visible
+
+  Scenario: Navigate to Extensions page
+    When I navigate to "Extensions" in the sidebar
+    Then I take a screenshot to verify:
+      - "Extensions" heading is visible
+      - "Add custom extension" button is visible
+      - "Browse extensions" button is visible
+      - "Default Extensions" section shows enabled extensions with toggle switches
+
+  Scenario: Add the Running Quotes custom extension
+    When I navigate to "Extensions" in the sidebar
+    # Remove if exists: check innerText, scroll to card, click gear (coordinate),
+    # click "Remove extension" (may need scrollIntoView), click "Confirm removal"
+    And I remove the "Running Quotes" extension if it already exists
+    And I click the "Add custom extension" button
+    Then a modal dialog should appear with form fields
+    When I fill the extension name with "Running Quotes"
+    And I fill the extension description with "Inspirational running quotes MCP server"
+    And I fill the extension command with "node /Users/zane/Development/goose-main/ui/desktop/tests/e2e/basic-mcp.ts"
+    # IMPORTANT: Use scrollIntoView on the submit button first, then click at
+    # exact coordinates. Clicking near modal edges triggers "Unsaved Changes" dialog.
+    # If that happens: click "No" to stay, then retry with exact coordinates.
+    And I scroll the submit button into view and click it
+    Then I take a screenshot to verify:
+      - "Running Quotes" appears in the Default Extensions section
+      - The toggle is enabled (blue)
+      - Default Extensions count increased by 1
+
+  Scenario: Use the Running Quotes extension in chat
+    Given the "Running Quotes" extension is enabled
+    # NOTE: Extension may not be immediately available in a new chat session.
+    # The agent may use "Search Available Extensions" instead of the tool directly.
+    When I click "Start New Chat" in the sidebar
+    # DUAL CHAT-INPUT: use visible textarea + React native setter
+    And I type "Give me an inspirational running quote using the runningQuote tool" into the visible chat input and press Enter
+    Then the agent should respond within 30 seconds
+    And I take a screenshot to verify:
+      - A response is visible (may include tool invocation or direct quote)
+      - The response contains a running/inspirational quote

--- a/ui/desktop/tests/e2e/specs/launch-app.sh
+++ b/ui/desktop/tests/e2e/specs/launch-app.sh
@@ -1,0 +1,211 @@
+#!/bin/bash
+#
+# 🦢🔍 Goose Tester — App Launcher
+#
+# Launches the Goose Electron app with remote debugging enabled for testing.
+# Supports both dev server and bundled/packaged apps.
+#
+# Usage:
+#   ./launch-app.sh dev [project_dir] [port]     Launch dev server with Vite hot reload
+#   ./launch-app.sh app <path-to-app> [port]     Launch a bundled .app
+#   ./launch-app.sh status [port]                Check if app is running on port
+#   ./launch-app.sh stop [port]                  Stop the app on port
+#
+# Examples:
+#   ./launch-app.sh dev /Users/zane/Development/goose/ui/desktop 9224
+#   ./launch-app.sh app "/Users/zane/Downloads/Goose 43.app" 9223
+#   ./launch-app.sh status 9224
+#   ./launch-app.sh stop 9224
+#
+
+set -e
+
+DEFAULT_PORT=9222
+SCREEN_SESSION_PREFIX="goose-tester"
+
+usage() {
+    echo "Usage:"
+    echo "  $0 dev [project_dir] [port]     Launch dev server"
+    echo "  $0 app <path-to-app> [port]     Launch bundled .app"
+    echo "  $0 status [port]                Check if running"
+    echo "  $0 stop [port]                  Stop the app"
+    exit 1
+}
+
+wait_for_port() {
+    local port=$1
+    local timeout=${2:-30}
+    local elapsed=0
+    echo "Waiting for port $port..."
+    while [ $elapsed -lt $timeout ]; do
+        if lsof -i ":$port" 2>/dev/null | grep -q LISTEN; then
+            echo "✅ Port $port is listening (${elapsed}s)"
+            return 0
+        fi
+        sleep 1
+        elapsed=$((elapsed + 1))
+    done
+    echo "❌ Timed out waiting for port $port after ${timeout}s"
+    return 1
+}
+
+cmd_dev() {
+    local project_dir="${1:-/Users/zane/Development/goose/ui/desktop}"
+    local port="${2:-$DEFAULT_PORT}"
+    local session_name="${SCREEN_SESSION_PREFIX}-dev-${port}"
+
+    # Check if already running
+    if lsof -i ":$port" 2>/dev/null | grep -q LISTEN; then
+        echo "⚠️  Port $port is already in use:"
+        lsof -i ":$port" | grep LISTEN
+        echo ""
+        echo "Use '$0 stop $port' to stop it first, or choose a different port."
+        exit 1
+    fi
+
+    # Check if screen session exists
+    if screen -ls 2>/dev/null | grep -q "$session_name"; then
+        echo "⚠️  Screen session '$session_name' already exists. Cleaning up..."
+        screen -S "$session_name" -X quit 2>/dev/null
+        sleep 1
+    fi
+
+    # Verify project directory
+    if [ ! -f "$project_dir/package.json" ]; then
+        echo "❌ No package.json found in $project_dir"
+        exit 1
+    fi
+
+    echo "🦢 Launching Goose dev server..."
+    echo "   Project: $project_dir"
+    echo "   Debug port: $port"
+    echo "   Screen session: $session_name"
+    echo ""
+
+    # Launch in a screen session with ENABLE_PLAYWRIGHT
+    screen -dmS "$session_name" bash -c "
+        cd '$project_dir'
+        export ENABLE_PLAYWRIGHT=1
+        export PLAYWRIGHT_DEBUG_PORT=$port
+        npm run start-gui 2>&1 | tee /tmp/goose-tester-dev-${port}.log
+    "
+
+    # Wait for the debug port to become available
+    if wait_for_port "$port" 30; then
+        echo ""
+        echo "🎉 Dev server is ready!"
+        echo "   Connect with: electron_connect port=$port"
+        echo "   Logs: /tmp/goose-tester-dev-${port}.log"
+        echo "   Stop with: $0 stop $port"
+    else
+        echo ""
+        echo "Check logs: cat /tmp/goose-tester-dev-${port}.log"
+        exit 1
+    fi
+}
+
+cmd_app() {
+    local app_path="$1"
+    local port="${2:-$DEFAULT_PORT}"
+
+    if [ -z "$app_path" ]; then
+        echo "❌ App path is required"
+        usage
+    fi
+
+    if [ ! -d "$app_path" ]; then
+        echo "❌ App not found: $app_path"
+        exit 1
+    fi
+
+    # Check if already running
+    if lsof -i ":$port" 2>/dev/null | grep -q LISTEN; then
+        echo "⚠️  Port $port is already in use:"
+        lsof -i ":$port" | grep LISTEN
+        echo ""
+        echo "Use '$0 stop $port' to stop it first, or choose a different port."
+        exit 1
+    fi
+
+    echo "🦢 Launching bundled Goose app..."
+    echo "   App: $app_path"
+    echo "   Debug port: $port"
+    echo ""
+
+    # Launch bundled app with --args to pass Chromium flags
+    open -a "$app_path" --args --remote-debugging-port="$port"
+
+    # Wait for the debug port to become available
+    if wait_for_port "$port" 15; then
+        echo ""
+        echo "🎉 Bundled app is ready!"
+        echo "   Connect with: electron_connect port=$port"
+        echo "   Stop with: $0 stop $port"
+    else
+        echo ""
+        echo "❌ App may not have started with debug port."
+        echo "   Try: open -a '$app_path' --args --remote-debugging-port=$port"
+        exit 1
+    fi
+}
+
+cmd_status() {
+    local port="${1:-$DEFAULT_PORT}"
+
+    echo "🔍 Checking port $port..."
+    if lsof -i ":$port" 2>/dev/null | grep -q LISTEN; then
+        echo "✅ App is running on port $port:"
+        lsof -i ":$port" | grep LISTEN
+        echo ""
+        # Check screen sessions
+        if screen -ls 2>/dev/null | grep -q "$SCREEN_SESSION_PREFIX"; then
+            echo "Screen sessions:"
+            screen -ls 2>/dev/null | grep "$SCREEN_SESSION_PREFIX"
+        fi
+    else
+        echo "❌ Nothing listening on port $port"
+    fi
+}
+
+cmd_stop() {
+    local port="${1:-$DEFAULT_PORT}"
+
+    echo "🛑 Stopping app on port $port..."
+
+    # Find and kill the process on the port
+    local pid
+    pid=$(lsof -ti ":$port" -sTCP:LISTEN 2>/dev/null)
+    if [ -n "$pid" ]; then
+        echo "   Killing PID $pid..."
+        kill "$pid" 2>/dev/null
+        sleep 2
+        # Force kill if still running
+        if kill -0 "$pid" 2>/dev/null; then
+            echo "   Force killing..."
+            kill -9 "$pid" 2>/dev/null
+        fi
+    fi
+
+    # Clean up screen sessions for this port
+    local session_name="${SCREEN_SESSION_PREFIX}-dev-${port}"
+    if screen -ls 2>/dev/null | grep -q "$session_name"; then
+        echo "   Cleaning up screen session '$session_name'..."
+        screen -S "$session_name" -X quit 2>/dev/null
+    fi
+
+    sleep 1
+    if lsof -i ":$port" 2>/dev/null | grep -q LISTEN; then
+        echo "⚠️  Port $port is still in use"
+    else
+        echo "✅ Port $port is free"
+    fi
+}
+
+# Main
+case "${1:-}" in
+    dev)    cmd_dev "$2" "$3" ;;
+    app)    cmd_app "$2" "$3" ;;
+    status) cmd_status "$2" ;;
+    stop)   cmd_stop "$2" ;;
+    *)      usage ;;
+esac

--- a/ui/desktop/tests/e2e/specs/recipes.feature
+++ b/ui/desktop/tests/e2e/specs/recipes.feature
@@ -1,0 +1,30 @@
+@release @recipes
+Feature: Recipes
+  Release checklist: verify recipe page navigation and recipe creation from session.
+
+  Background:
+    Given the app is loaded and the chat input is visible
+
+  Scenario: Navigate to Recipes page
+    When I navigate to "Recipes" in the sidebar
+    Then I take a screenshot to verify:
+      - The Recipes page is displayed with "Recipes" heading
+      - "Create Recipe" and "Import Recipe" buttons are visible
+      - Recipe list shows existing recipes (or empty state)
+
+  Scenario: Create a recipe from a chat session
+    Given I have an open conversation with at least one exchange
+    # The chef's hat icon is the 2nd button from right in the bottom status bar
+    # It has NO title or aria-label — identify by position or 2-path SVG
+    # The RIGHTMOST button (11-path SVG) is the bug report icon — NOT the chef's hat
+    When I click the chef's hat icon in the bottom bar
+    Then the "Create Recipe from Session" modal should appear
+    And I take a screenshot to verify:
+      - Title is auto-filled from the conversation
+      - Description is auto-filled
+      - Instructions are auto-filled with behavioral guidance
+      - "Create Recipe" and "Create & Run Recipe" buttons are visible
+    When I click "Cancel" to close the modal
+    # To find the chef's hat programmatically:
+    # Get all buttons with y > 560, sort by x descending, pick the 2nd one
+    # Or find the button with exactly 2 SVG path elements

--- a/ui/desktop/tests/e2e/specs/settings.feature
+++ b/ui/desktop/tests/e2e/specs/settings.feature
@@ -1,0 +1,32 @@
+@release @settings
+Feature: Settings
+  Release checklist: verify settings page loads and dark mode works.
+
+  Background:
+    Given the app is loaded and the chat input is visible
+
+  Scenario: Settings page loads and all tabs are accessible
+    When I navigate to "Settings" in the sidebar
+    Then I take a screenshot to verify "Settings" heading is visible
+    # Verify all 7 tabs via data-testid query (single evaluate call)
+    And all 7 settings tabs should be present in the DOM
+
+  Scenario: Can change dark mode setting
+    When I navigate to "Settings" in the sidebar
+    # App tab may be off-screen in narrow windows — scrollIntoView first
+    And I click the "App" settings tab via evaluate with scrollIntoView
+    # Theme buttons are below the fold — scroll to dark-mode-button directly
+    And I scroll the dark-mode-button into view
+    When I click the "Dark" theme button
+    Then document.documentElement.className should be "dark"
+    And I take a screenshot to verify dark background
+    When I click the "Light" theme button
+    Then document.documentElement.className should be "light"
+
+  Scenario: Models tab shows current provider info
+    When I navigate to "Settings" in the sidebar
+    Then I take a screenshot to verify:
+      - The current model name is displayed (e.g., "goose-claude-4-6-opus")
+      - The provider name is shown (e.g., "Databricks")
+      - "Switch models" button is visible
+      - "Configure providers" button is visible


### PR DESCRIPTION
## Summary
Goose Tester MCP + Specs

Works great, connects and tests the electron app while developing features or for smoke tests. Still needed to wrap it up in a recipe to test local vs distributed with easy activity buttons and params but ran out of time 🫡 

What
----
A new MCP extension and Gherkin-based test framework that lets Goose test its
own Electron desktop app. Goose can launch the app (dev or bundled), navigate
the UI, interact with elements, take screenshots, and verify behavior — all
through natural language.

Why
---
The existing Playwright E2E tests (app.spec.ts) require a full test runner
setup. The release checklist (RELEASE_CHECKLIST.md) is entirely manual. This
framework lets Goose execute release tests conversationally — "run the settings
feature tests against this build" — making QA faster and more accessible.

Key Components
--------------

1. MCP Extension: goose-electron-tester-mcp

Provides
   25+ tools for:

   - App launching — electron_launch_dev (dev server from project dir) and
     electron_launch_app (bundled .app), both with auto-connect
   - App lifecycle — electron_stop to kill and clean up
   - UI interaction — click, type, press keys, scroll, wait for elements
   - Verification — screenshots, DOM snapshots, HTML extraction, console logs
   - Server debugging — read goosed logs, MCP extension logs, session database

2. Gherkin Feature Specs (ui/desktop/tests/e2e/specs/)

   Four feature files covering the release checklist:

   settings.feature       3 scenarios  All tabs load, dark mode toggle, models tab
   conversations.feature  5 scenarios  New chat, recent chats, load history, follow-ups
   extensions.feature     3 scenarios  Extensions page, add/use Running Quotes
   recipes.feature        2 scenarios  Recipes page, create recipe from session

   Plus a RUNNER-GUIDE.md with complete selector inventory and step definitions.

3. UI Testability Improvements

   Added data-testid attributes across 11 component files to make the app
   reliably testable:

   - Navigation — nav-home, nav-chat, nav-settings, nav-extensions,
     nav-recipes, nav-scheduler, nav-start-new-chat, nav-show-all-sessions
   - Chat input — chat-input-{sessionId} (session) and chat-input-new (hub),
     with data-session-active on the container to scope to the visible session
   - Extensions — extension-card-{name}, extension-toggle-{name},
     extension-configure-{name}, plus all modal form inputs and buttons
   - Bottom bar — create-recipe-from-session-btn, diagnostics-btn
   - Sessions — sidebar-session-{id}, recent-chat-{id}
   - Confirmation dialogs — confirmation-cancel-btn, confirmation-confirm-btn

Test Results
------------
13/13 scenarios passing across 5 test runs during development, tested against
both dev server and bundled app builds.

How to Use
----------
In a Goose session with the extension enabled:

  "Launch the dev app from /Users/zane/Development/goose/ui/desktop"
  "Run the settings feature tests"
  "Launch the app at /Users/zane/Downloads/Goose 45.app and run all feature tests"


