### PR TITLE
Handle Bedrock 'prompt is too long' error

### DIFF
--- a/crates/goose/src/providers/bedrock.rs
+++ b/crates/goose/src/providers/bedrock.rs
@@ -284,10 +284,11 @@ impl BedrockProvider {
                     ProviderError::Authentication(format!("Failed to call Bedrock: {:?}", err))
                 }
                 ConverseError::ValidationException(err)
-                    if err
-                        .message()
-                        .unwrap_or_default()
-                        .contains("Input is too long for requested model.") =>
+                    if {
+                        let msg = err.message().unwrap_or_default();
+                        msg.contains("Input is too long for requested model.")
+                            || msg.contains("prompt is too long")
+                    } =>
                 {
                     ProviderError::ContextLengthExceeded(format!(
                         "Failed to call Bedrock: {:?}",


### PR DESCRIPTION
Extend Bedrock provider validation handling to treat messages containing "prompt is too long" as a context-length-exceeded error. The code now extracts the validation message into a local variable and checks both the existing "Input is too long for requested model." phrase and the new "prompt is too long" phrase, mapping either to ProviderError::ContextLengthExceeded.



Remove build.sh from tracking

## Summary
<!-- Describe your change -->


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [V] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
Tested it locally to ensure bug is not reproduced after fix fix

### Related Issues
Relates to #7442 
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

