### PR TITLE
Add base_path field to custom provider config

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -2027,6 +2027,7 @@ fn add_provider() -> anyhow::Result<()> {
         headers,
         requires_auth,
         catalog_provider_id: None,
+        base_path: None,
     })?;
 
     cliclack::outro(format!("Custom provider added: {}", display_name))?;

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -100,6 +100,8 @@ pub struct UpdateCustomProviderRequest {
     pub requires_auth: bool,
     #[serde(default)]
     pub catalog_provider_id: Option<String>,
+    #[serde(default)]
+    pub base_path: Option<String>,
 }
 
 fn default_requires_auth() -> bool {
@@ -655,6 +657,7 @@ pub async fn create_custom_provider(
             headers: request.headers,
             requires_auth: request.requires_auth,
             catalog_provider_id: request.catalog_provider_id,
+            base_path: request.base_path,
         },
     )?;
 
@@ -726,6 +729,7 @@ pub async fn update_custom_provider(
             headers: request.headers,
             requires_auth: request.requires_auth,
             catalog_provider_id: request.catalog_provider_id,
+            base_path: request.base_path,
         },
     )?;
 

--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -44,6 +44,8 @@ pub struct DeclarativeProviderConfig {
     pub requires_auth: bool,
     #[serde(default)]
     pub catalog_provider_id: Option<String>,
+    #[serde(default)]
+    pub base_path: Option<String>,
 }
 
 fn default_requires_auth() -> bool {
@@ -105,6 +107,7 @@ pub struct CreateCustomProviderParams {
     pub headers: Option<HashMap<String, String>>,
     pub requires_auth: bool,
     pub catalog_provider_id: Option<String>,
+    pub base_path: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -119,6 +122,7 @@ pub struct UpdateCustomProviderParams {
     pub headers: Option<HashMap<String, String>>,
     pub requires_auth: bool,
     pub catalog_provider_id: Option<String>,
+    pub base_path: Option<String>,
 }
 
 pub fn create_custom_provider(
@@ -159,6 +163,7 @@ pub fn create_custom_provider(
         supports_streaming: params.supports_streaming,
         requires_auth: params.requires_auth,
         catalog_provider_id: params.catalog_provider_id,
+        base_path: params.base_path,
     };
 
     let custom_providers_dir = custom_providers_dir();
@@ -221,6 +226,7 @@ pub fn update_custom_provider(params: UpdateCustomProviderParams) -> Result<()> 
             supports_streaming: params.supports_streaming,
             requires_auth: params.requires_auth,
             catalog_provider_id: params.catalog_provider_id,
+            base_path: params.base_path,
         };
 
         let file_path = custom_providers_dir().join(format!("{}.json", updated_config.name));

--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -168,11 +168,15 @@ impl OpenAiProvider {
         } else {
             format!("{}://{}", url.scheme(), url.host_str().unwrap_or(""))
         };
-        let base_path = url.path().trim_start_matches('/').to_string();
-        let base_path = if base_path.is_empty() || base_path == "v1" || base_path == "v1/" {
-            "v1/chat/completions".to_string()
+        let base_path = if let Some(ref explicit_path) = config.base_path {
+            explicit_path.trim_start_matches('/').to_string()
         } else {
-            base_path
+            let url_path = url.path().trim_start_matches('/').to_string();
+            if url_path.is_empty() || url_path == "v1" || url_path == "v1/" {
+                "v1/chat/completions".to_string()
+            } else {
+                url_path
+            }
         };
 
         let timeout_secs = config.timeout_seconds.unwrap_or(600);

--- a/ui/desktop/openapi.json
+++ b/ui/desktop/openapi.json
@@ -4177,6 +4177,10 @@
           "api_key_env": {
             "type": "string"
           },
+          "base_path": {
+            "type": "string",
+            "nullable": true
+          },
           "base_url": {
             "type": "string"
           },
@@ -8158,6 +8162,10 @@
           },
           "api_url": {
             "type": "string"
+          },
+          "base_path": {
+            "type": "string",
+            "nullable": true
           },
           "catalog_provider_id": {
             "type": "string",

--- a/ui/desktop/src/api/types.gen.ts
+++ b/ui/desktop/src/api/types.gen.ts
@@ -173,6 +173,7 @@ export type CspMetadata = {
 
 export type DeclarativeProviderConfig = {
     api_key_env?: string;
+    base_path?: string | null;
     base_url: string;
     catalog_provider_id?: string | null;
     description?: string | null;
@@ -1477,6 +1478,7 @@ export type UiMetadata = {
 export type UpdateCustomProviderRequest = {
     api_key: string;
     api_url: string;
+    base_path?: string | null;
     catalog_provider_id?: string | null;
     display_name: string;
     engine: string;


### PR DESCRIPTION
## Summary

Allow custom providers using the OpenAI engine to explicitly set the API path (e.g. "v1/responses" vs "v1/chat/completions") instead of relying on URL path parsing or the default. This enables pointing a custom provider at an OpenAI-compatible endpoint that serves the Responses API without needing to embed the path in the base_url.

The new optional base_path field is threaded through the declarative provider config, CLI, and server routes. When set, it takes priority over both the URL-derived path and the model-name heuristic in should_use_responses_api().

Using a custom provider is preferred rather than using the openai provider directly and overriding OPENAI_BASE_PATH as doing the latter has other side effects (secondary LLM configuration etc) which isn't
always present.

A use case for this configuration would be using goose with lightspeed-core/lightspeed-stack. (the reason for this PR)

### Type of Change
<!-- Select all that apply -->
- [x ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x ] This PR was created or reviewed with AI assistance

### Testing
Yes. Functionally tested against lightspeed-stack. Was able to use the /v1/responses API with a custom hosted offline/airgapped LLM hosted in this fastion with a goose custom provider configuration.