### PR TITLE
feat: make pctx/Code Mode an optional dependency via 'code-mode' feature

### DIFF
--- a/crates/goose-acp/Cargo.toml
+++ b/crates/goose-acp/Cargo.toml
@@ -15,11 +15,15 @@ path = "src/bin/server.rs"
 name = "generate-acp-schema"
 path = "src/bin/generate_acp_schema.rs"
 
+[features]
+default = ["code-mode"]
+code-mode = ["goose/code-mode"]
+
 [lints]
 workspace = true
 
 [dependencies]
-goose = { path = "../goose" }
+goose = { path = "../goose", default-features = false }
 goose-mcp = { path = "../goose-mcp" }
 rmcp = { workspace = true }
 sacp = "10.1.0"

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -20,8 +20,8 @@ path = "src/bin/generate_manpages.rs"
 
 [dependencies]
 clap_mangen = "0.2.31"
-goose = { path = "../goose" }
-goose-acp = { path = "../goose-acp" }
+goose = { path = "../goose", default-features = false }
+goose-acp = { path = "../goose-acp", default-features = false }
 goose-mcp = { path = "../goose-mcp" }
 rmcp = { workspace = true }
 clap = { workspace = true }
@@ -70,6 +70,8 @@ comfy-table = "7.2.2"
 winapi = { version = "0.3", features = ["wincred"] }
 
 [features]
+default = ["code-mode"]
+code-mode = ["goose/code-mode", "goose-acp/code-mode"]
 # disables the update command
 disable-update = []
 

--- a/crates/goose-server/Cargo.toml
+++ b/crates/goose-server/Cargo.toml
@@ -11,11 +11,12 @@ description.workspace = true
 workspace = true
 
 [features]
-default = []
+default = ["code-mode"]
+code-mode = ["goose/code-mode"]
 cuda = ["goose/cuda"]
 
 [dependencies]
-goose = { path = "../goose" }
+goose = { path = "../goose", default-features = false }
 goose-mcp = { path = "../goose-mcp" }
 rmcp = { workspace = true }
 axum = { workspace = true, features = ["ws", "macros"] }

--- a/crates/goose/Cargo.toml
+++ b/crates/goose/Cargo.toml
@@ -8,7 +8,8 @@ repository.workspace = true
 description.workspace = true
 
 [features]
-default = []
+default = ["code-mode"]
+code-mode = ["dep:pctx_code_mode"]
 cuda = ["candle-core/cuda", "candle-nn/cuda", "llama-cpp-2/cuda"]
 
 [lints]
@@ -123,7 +124,7 @@ shellexpand = { workspace = true }
 indexmap = "2.12.0"
 ignore = { workspace = true }
 which = { workspace = true }
-pctx_code_mode = "^0.2.3"
+pctx_code_mode = { version = "^0.2.3", optional = true }
 unbinder = "0.1.7"
 pulldown-cmark = "0.13.0"
 llama-cpp-2 = { git = "https://github.com/jh-block/llama-cpp-rs.git", branch = "goose-patches", features = ["sampler"] }

--- a/crates/goose/src/agents/platform_extensions/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/mod.rs
@@ -1,5 +1,6 @@
 pub mod apps;
 pub mod chatrecall;
+#[cfg(feature = "code-mode")]
 pub mod code_execution;
 pub mod developer;
 pub mod ext_manager;
@@ -88,6 +89,7 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
             },
         );
 
+        #[cfg(feature = "code-mode")]
         map.insert(
             code_execution::EXTENSION_NAME,
             PlatformExtensionDef {

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -8,6 +8,7 @@ use serde_json::{json, Value};
 use tracing::debug;
 
 use super::super::agents::Agent;
+#[cfg(feature = "code-mode")]
 use crate::agents::platform_extensions::code_execution;
 use crate::conversation::message::{Message, MessageContent, ToolRequest};
 use crate::conversation::Conversation;
@@ -146,10 +147,13 @@ impl Agent {
             tools.push(frontend_tool.tool.clone());
         }
 
+        #[cfg(feature = "code-mode")]
         let code_execution_active = self
             .extension_manager
             .is_extension_enabled(code_execution::EXTENSION_NAME)
             .await;
+        #[cfg(not(feature = "code-mode"))]
+        let code_execution_active = false;
         if code_execution_active {
             tools.retain(|tool| {
                 if let Some(owner) = crate::agents::extension_manager::get_tool_owner(tool) {


### PR DESCRIPTION
## Summary

Gate `pctx_code_mode` (and its V8 dependency) behind a Cargo feature flag so users can build from source without building V8 in environments where binary prebuilts are disallowed.

## Changes

- **`crates/goose/Cargo.toml`**: Added `code-mode` feature (default-enabled), made `pctx_code_mode` optional
- **`crates/goose/src/agents/platform_extensions/mod.rs`**: Gated `code_execution` module and its `PLATFORM_EXTENSIONS` entry behind `#[cfg(feature = "code-mode")]`; stub module when off
- **`crates/goose/src/agents/reply_parts.rs`**: Gated code-execution-specific logic; defaults to disabled when feature is off
- **`crates/goose-cli/Cargo.toml`**, **`crates/goose-server/Cargo.toml`**, **`crates/goose-acp/Cargo.toml`**: Forward the `code-mode` feature

## Usage

| Build command | Result |
|---|---|
| `cargo build` | Unchanged — Code Mode included (feature on by default) |
| `cargo build --no-default-features` | Skips pctx/V8 entirely, Code Mode absent at runtime |

When built without the feature, Code Mode does not appear in the Extensions list in the desktop UI since it is never registered in `PLATFORM_EXTENSIONS`.