### PR TITLE
fix(desktop): harden settings.json read/write path

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -135,7 +135,6 @@ function updateSettings(modifier: (settings: Settings) => void): void {
     fsSync.renameSync(SETTINGS_FILE, backupSettingsFile);
     try {
       fsSync.renameSync(tempSettingsFile, SETTINGS_FILE);
-      fsSync.unlinkSync(backupSettingsFile);
     } catch (replaceError) {
       if (fsSync.existsSync(backupSettingsFile)) {
         if (fsSync.existsSync(SETTINGS_FILE)) {
@@ -144,6 +143,18 @@ function updateSettings(modifier: (settings: Settings) => void): void {
         fsSync.renameSync(backupSettingsFile, SETTINGS_FILE);
       }
       throw replaceError;
+    }
+
+    // Best-effort cleanup after replacement is committed.
+    if (fsSync.existsSync(backupSettingsFile)) {
+      try {
+        fsSync.unlinkSync(backupSettingsFile);
+      } catch (cleanupError) {
+        console.warn(
+          `[Main] Failed to delete backup settings file at ${backupSettingsFile}.`,
+          cleanupError,
+        );
+      }
     }
   } finally {
     if (fsSync.existsSync(tempSettingsFile)) {


### PR DESCRIPTION
# PR Title

fix(desktop): guard settings.json parse and write settings atomically

# PR Body

## Summary

Fixes a desktop startup robustness issue where a corrupted `settings.json` can crash app startup.

## Problem

`getSettings()` in `ui/desktop/src/main.ts` directly parsed `settings.json` with no parse guard.  
A truncated/corrupted file could throw during startup and block the app from launching.

`updateSettings()` also wrote directly to `settings.json`, which increases risk of partial writes during interruption.

## Changes

- Add safe fallback in `getSettings()`:
  - return defaults when file is missing
  - wrap parse/read in `try/catch`
  - log warning and fallback to `defaultSettings` on parse failure
- Harden `updateSettings()` write path:
  - write to `settings.json.tmp` first
  - replace via `rename`
  - handle Windows replace edge cases (`EEXIST` / `EPERM` / `ENOTEMPTY`) by removing destination then renaming
  - clean up temp file in `finally`

## Validation

### Repro on unpatched code

1. Write invalid JSON to `%APPDATA%/Goose/settings.json`
2. Start desktop app
3. Startup flow fails in main process path

### Verify on patched code

1. Keep invalid `%APPDATA%/Goose/settings.json`
2. Start desktop app
3. App launches successfully; settings fallback is applied

Also ran:

- `npm run typecheck` in `ui/desktop` (pass)

## Risk

Low:

- Changes are isolated to settings read/write logic in desktop main process
- Existing behavior is preserved for valid settings files
- Failure mode is improved from startup crash to safe defaults

Fixes #7556
