### PR TITLE
Only show up to 50 lines of source code

### DIFF
--- a/crates/goose-cli/src/session/streaming_buffer.rs
+++ b/crates/goose-cli/src/session/streaming_buffer.rs
@@ -668,5 +668,4 @@ mod tests {
     fn test_incomplete_constructs(chunks: &[&str], expected: &[&str]) {
         assert_eq!(stream(chunks), expected);
     }
-
 }


### PR DESCRIPTION
## Summary

Small quality of live improvement for the CLI - only show a limited number of lines when outputing code