### PR TITLE
fix(desktop): harden settings.json read/write path

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -30,7 +30,11 @@ import { ensureWinShims } from './utils/winShims';
 import { addRecentDir, loadRecentDirs } from './utils/recentDirs';
 import { formatAppName, errorMessage } from './utils/conversionUtils';
 import type { Settings } from './utils/settings';
-import { defaultKeyboardShortcuts, getKeyboardShortcuts } from './utils/settings';
+import { getKeyboardShortcuts } from './utils/settings';
+import {
+  getSettings as getSettingsFromFile,
+  updateSettings as updateSettingsFromFile,
+} from './utils/settingsManager';
 import * as crypto from 'crypto';
 import * as yaml from 'yaml';
 import windowStateKeeper from 'electron-window-state';
@@ -56,26 +60,12 @@ function shouldSetupUpdater(): boolean {
 // Settings management
 const SETTINGS_FILE = path.join(app.getPath('userData'), 'settings.json');
 
-const defaultSettings: Settings = {
-  showMenuBarIcon: true,
-  showDockIcon: true,
-  enableWakelock: false,
-  spellcheckEnabled: true,
-  keyboardShortcuts: defaultKeyboardShortcuts,
-};
-
 function getSettings(): Settings {
-  if (fsSync.existsSync(SETTINGS_FILE)) {
-    const data = fsSync.readFileSync(SETTINGS_FILE, 'utf8');
-    return JSON.parse(data);
-  }
-  return defaultSettings;
+  return getSettingsFromFile(SETTINGS_FILE);
 }
 
 function updateSettings(modifier: (settings: Settings) => void): void {
-  const settings = getSettings();
-  modifier(settings);
-  fsSync.writeFileSync(SETTINGS_FILE, JSON.stringify(settings, null, 2));
+  updateSettingsFromFile(SETTINGS_FILE, modifier);
 }
 
 async function configureProxy() {

--- a/ui/desktop/src/utils/__tests__/settingsManager.test.ts
+++ b/ui/desktop/src/utils/__tests__/settingsManager.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fsSync from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { getSettings, updateSettings, defaultSettings } from '../settingsManager';
+
+// Each test gets its own temp directory to avoid interference
+let tmpDir: string;
+let settingsFile: string;
+
+beforeEach(() => {
+  tmpDir = fsSync.mkdtempSync(path.join(os.tmpdir(), 'goose-settings-test-'));
+  settingsFile = path.join(tmpDir, 'settings.json');
+});
+
+afterEach(() => {
+  fsSync.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('getSettings — bug verification', () => {
+  it('returns default settings when settings file does not exist', () => {
+    const result = getSettings(settingsFile);
+    expect(result).toEqual(defaultSettings);
+  });
+
+  it('reads valid settings from file', () => {
+    const custom = { ...defaultSettings, showDockIcon: false };
+    fsSync.writeFileSync(settingsFile, JSON.stringify(custom, null, 2));
+    const result = getSettings(settingsFile);
+    expect(result.showDockIcon).toBe(false);
+  });
+
+  // BUG: corrupted JSON should NOT crash the app — it should return defaults.
+  // This test verifies the bug exists by checking that getSettings throws.
+  it('should NOT throw on corrupted JSON (returns defaults instead)', () => {
+    fsSync.writeFileSync(settingsFile, '{corrupted json!!!');
+    // If getSettings throws here, the bug is confirmed — JSON.parse is unguarded
+    expect(() => getSettings(settingsFile)).not.toThrow();
+    expect(getSettings(settingsFile)).toEqual(defaultSettings);
+  });
+
+  it('should NOT throw on empty file (returns defaults instead)', () => {
+    fsSync.writeFileSync(settingsFile, '');
+    expect(() => getSettings(settingsFile)).not.toThrow();
+    expect(getSettings(settingsFile)).toEqual(defaultSettings);
+  });
+
+  it('should NOT throw on truncated JSON (returns defaults instead)', () => {
+    fsSync.writeFileSync(settingsFile, '{"showMenuBarIcon": tru');
+    expect(() => getSettings(settingsFile)).not.toThrow();
+    expect(getSettings(settingsFile)).toEqual(defaultSettings);
+  });
+});
+
+describe('updateSettings — bug verification', () => {
+  it('persists a settings change', () => {
+    const result = getSettings(settingsFile);
+    expect(result).toEqual(defaultSettings);
+
+    updateSettings(settingsFile, (s) => {
+      s.enableWakelock = true;
+    });
+
+    const updated = getSettings(settingsFile);
+    expect(updated.enableWakelock).toBe(true);
+  });
+
+  // BUG: updateSettings writes directly to the target path with writeFileSync.
+  // It should instead write to a temp file and rename for atomicity.
+  // We verify the bug by spying on fs and checking the call pattern.
+  it('should use atomic write (temp file + rename) instead of direct writeFileSync', () => {
+    const writeSpy = vi.spyOn(fsSync, 'writeFileSync');
+    const renameSpy = vi.spyOn(fsSync, 'renameSync');
+
+    updateSettings(settingsFile, (s) => {
+      s.showMenuBarIcon = false;
+    });
+
+    // If the write is atomic, writeFileSync should target a .tmp file,
+    // and renameSync should move it to the final path.
+    const writeCall = writeSpy.mock.calls[0];
+    const writtenPath = writeCall[0] as string;
+
+    // Check that renameSync was called (atomic pattern)
+    expect(renameSpy).toHaveBeenCalled();
+
+    // Check that writeFileSync wrote to a temp file, NOT the settings file directly
+    expect(writtenPath).not.toBe(settingsFile);
+    expect(writtenPath).toContain('.tmp');
+
+    writeSpy.mockRestore();
+    renameSpy.mockRestore();
+  });
+});

--- a/ui/desktop/src/utils/settingsManager.ts
+++ b/ui/desktop/src/utils/settingsManager.ts
@@ -1,0 +1,43 @@
+import fsSync from 'node:fs';
+import type { Settings } from './settings';
+import { defaultKeyboardShortcuts } from './settings';
+
+// Default settings used when no settings file exists or when parsing fails
+export const defaultSettings: Settings = {
+  showMenuBarIcon: true,
+  showDockIcon: true,
+  enableWakelock: false,
+  spellcheckEnabled: true,
+  keyboardShortcuts: defaultKeyboardShortcuts,
+};
+
+// Reads and parses the settings file at the given path.
+// Returns defaultSettings if the file does not exist or contains invalid JSON.
+export function getSettings(settingsFilePath: string): Settings {
+  if (fsSync.existsSync(settingsFilePath)) {
+    try {
+      const data = fsSync.readFileSync(settingsFilePath, 'utf8');
+      return JSON.parse(data);
+    } catch {
+      console.warn(
+        `[Settings] Failed to parse ${settingsFilePath}, falling back to defaults`
+      );
+      return defaultSettings;
+    }
+  }
+  return defaultSettings;
+}
+
+// Applies a modifier function to the current settings, then writes atomically
+// via a temp file + rename to prevent partial writes on crash/power loss.
+export function updateSettings(
+  settingsFilePath: string,
+  modifier: (settings: Settings) => void
+): void {
+  const settings = getSettings(settingsFilePath);
+  modifier(settings);
+
+  const tmpPath = settingsFilePath + '.tmp';
+  fsSync.writeFileSync(tmpPath, JSON.stringify(settings, null, 2));
+  fsSync.renameSync(tmpPath, settingsFilePath);
+}


### PR DESCRIPTION
Closes https://github.com/block/goose/issues/7556

## Problem

`getSettings()` in `ui/desktop/src/main.ts` reads `settings.json` with a bare `JSON.parse` and no try/catch. A single corrupted, truncated, or empty settings file crashes the app at startup and locks the user out until they manually find and delete the file.

`updateSettings()` writes the file directly with `writeFileSync`, meaning a crash or power loss during the write can leave a partially-written (corrupt) file on disk.

## Changes

- Extracted `getSettings` and `updateSettings` into a new testable module `ui/desktop/src/utils/settingsManager.ts`, parameterized by file path.
- Wrapped `JSON.parse` in a try/catch in `getSettings`. On parse failure, logs a warning and returns `defaultSettings` instead of crashing.
- Changed `updateSettings` to write atomically: writes to a `.tmp` file first, then uses `renameSync` to move it to the target path. This prevents partial writes from corrupting `settings.json`.
- Updated `main.ts` to delegate to the new module.

## Tests

Added `ui/desktop/src/utils/__tests__/settingsManager.test.ts` with 7 tests covering:
- Returns defaults when no settings file exists
- Reads valid settings from file
- Does not throw on corrupted JSON (returns defaults)
- Does not throw on empty file (returns defaults)
- Does not throw on truncated JSON (returns defaults)
- Persists a settings change
- Uses atomic write (temp file + rename) instead of direct writeFileSync

## Reproduction steps

1. `cd ui/desktop && npm install`
2. Run tests: `npx vitest run src/utils/__tests__/settingsManager.test.ts`
3. All 7 tests pass
4. Full suite: `npx vitest run` -- 305 tests pass, 0 regressions
5. `npm run lint:check` passes clean