### PR TITLE
feat(summon): make skill supporting files individually loadable via load()

### DIFF
--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -169,6 +169,14 @@ fn parse_frontmatter<T: for<'de> Deserialize<'de>>(content: &str) -> Option<(T, 
 fn parse_skill_content(content: &str, path: PathBuf) -> Option<Source> {
     let (metadata, body): (SkillMetadata, String) = parse_frontmatter(content)?;
 
+    if metadata.name.contains('/') {
+        warn!(
+            "Skill name '{}' contains '/' which is not allowed, skipping",
+            metadata.name
+        );
+        return None;
+    }
+
     Some(Source {
         name: metadata.name,
         kind: SourceKind::Skill,
@@ -703,7 +711,8 @@ impl SummonClient {
             return Ok(Some(source));
         }
 
-        if let Some((skill_name, relative_path)) = name.split_once('/') {
+        if let Some((skill_name, raw_relative_path)) = name.split_once('/') {
+            let relative_path = raw_relative_path.replace('\\', "/");
             if let Some(skill) = sources.iter().find(|s| {
                 s.name == skill_name
                     && matches!(s.kind, SourceKind::Skill | SourceKind::BuiltinSkill)
@@ -717,17 +726,16 @@ impl SummonClient {
                     if let Ok(rel) = file_path.strip_prefix(&skill.path) {
                         let rel_normalized = rel.to_string_lossy().replace('\\', "/");
                         if rel_normalized == relative_path {
-                            let safe = file_path
+                            let canonical_file = file_path
                                 .canonicalize()
-                                .map(|p| p.starts_with(&canonical_skill_dir))
-                                .unwrap_or(false);
-                            if !safe {
+                                .map_err(|e| format!("Failed to resolve '{}': {}", name, e))?;
+                            if !canonical_file.starts_with(&canonical_skill_dir) {
                                 return Err(format!(
                                     "Refusing to load '{}': file resolves outside the skill directory",
                                     name
                                 ));
                             }
-                            return match std::fs::read_to_string(file_path) {
+                            return match std::fs::read_to_string(&canonical_file) {
                                 Ok(content) => Ok(Some(Source {
                                     name: name.to_string(),
                                     kind: SourceKind::Skill,
@@ -1122,7 +1130,10 @@ impl SummonClient {
                 let sources = self.get_sources(session_id, working_dir).await;
 
                 if let Some((skill_name, _)) = name.split_once('/') {
-                    if let Some(skill) = sources.iter().find(|s| s.name == skill_name) {
+                    if let Some(skill) = sources.iter().find(|s| {
+                        s.name == skill_name
+                            && matches!(s.kind, SourceKind::Skill | SourceKind::BuiltinSkill)
+                    }) {
                         let available: Vec<String> = skill
                             .supporting_files
                             .iter()
@@ -1133,11 +1144,19 @@ impl SummonClient {
                             })
                             .collect();
                         if !available.is_empty() {
+                            let total = available.len();
+                            let display: Vec<_> = available.into_iter().take(10).collect();
+                            let suffix = if total > 10 {
+                                format!(" (and {} more)", total - 10)
+                            } else {
+                                String::new()
+                            };
                             return Err(format!(
-                                "Source '{}' not found. Available files for {}: {}",
+                                "Source '{}' not found. Available files for {}: {}{}",
                                 name,
                                 skill_name,
-                                available.join(", ")
+                                display.join(", "),
+                                suffix
                             ));
                         } else {
                             return Err(format!("Skill '{}' has no supporting files.", skill_name));
@@ -1318,6 +1337,15 @@ impl SummonClient {
             .resolve_source(session_id, source_name, working_dir)
             .await?
             .ok_or_else(|| format!("Source '{}' not found", source_name))?;
+
+        if source_name.contains('/')
+            && matches!(source.kind, SourceKind::Skill | SourceKind::BuiltinSkill)
+        {
+            return Err(format!(
+                "Cannot delegate to supporting file '{}'. Use load() to read it instead.",
+                source_name
+            ));
+        }
 
         let mut recipe = match source.kind {
             SourceKind::Recipe | SourceKind::Subrecipe => {
@@ -2124,6 +2152,92 @@ You review code."#;
             err.contains("my-skill"),
             "error should name the skill: {}",
             err
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_resolve_source_blocks_symlink_outside_skill_dir() {
+        let temp_dir = TempDir::new().unwrap();
+        let outside_dir = TempDir::new().unwrap();
+
+        let skill_dir = temp_dir.path().join(".goose/skills/my-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: A skill\n---\nContent.",
+        )
+        .unwrap();
+
+        let secret_file = outside_dir.path().join("secret.txt");
+        fs::write(&secret_file, "top secret data").unwrap();
+        std::os::unix::fs::symlink(&secret_file, skill_dir.join("evil.md")).unwrap();
+
+        let client = SummonClient::new(create_test_context()).unwrap();
+        let result = client
+            .handle_load_source("test", "my-skill/evil.md", temp_dir.path())
+            .await;
+
+        assert!(
+            result.is_err(),
+            "symlink outside skill dir should be blocked"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("resolves outside the skill directory"),
+            "error should mention path traversal: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_source_blocks_path_traversal_input() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let skill_dir = temp_dir.path().join(".goose/skills/my-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: my-skill\ndescription: A skill\n---\nContent.",
+        )
+        .unwrap();
+        fs::write(skill_dir.join("legit.md"), "legit content").unwrap();
+
+        let client = SummonClient::new(create_test_context()).unwrap();
+
+        // ../../../etc/passwd won't match any supporting_files entry, so it returns Ok (not found)
+        // which becomes the "not found" error path in handle_load_source
+        let result = client
+            .handle_load_source("test", "my-skill/../../../etc/passwd", temp_dir.path())
+            .await;
+
+        assert!(result.is_err(), "traversal path should not load content");
+        let err = result.unwrap_err();
+        assert!(
+            !err.contains("root:"),
+            "should not contain /etc/passwd content: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_skill_name_with_slash_is_rejected() {
+        let temp_dir = TempDir::new().unwrap();
+
+        let skill_dir = temp_dir.path().join(".goose/skills/bad-skill");
+        fs::create_dir_all(&skill_dir).unwrap();
+        fs::write(
+            skill_dir.join("SKILL.md"),
+            "---\nname: bad/skill\ndescription: A skill with slash\n---\nContent.",
+        )
+        .unwrap();
+
+        let client = SummonClient::new(create_test_context()).unwrap();
+        let sources = client.get_sources("test", temp_dir.path()).await;
+
+        assert!(
+            !sources.iter().any(|s| s.name == "bad/skill"),
+            "skill with '/' in name should be rejected"
         );
     }
 

--- a/ui/desktop/package-lock.json
+++ b/ui/desktop/package-lock.json
@@ -123,7 +123,7 @@
       }
     },
     "../acp": {
-      "name": "goose-acp-types",
+      "name": "@block/goose-acp",
       "version": "0.1.0",
       "dependencies": {
         "zod": "^3.25.76"
@@ -10328,32 +10328,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
-    "node_modules/encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {


### PR DESCRIPTION
## Summary

- Supporting files in a skill directory are now individually loadable via `load(source: "skill-name/relative/path")` — e.g. `load(source: "oncall-buddy-help/references/technical-ops.md")`
- Loading a skill (`load(source: "skill-name")`) now lists available supporting files with their `load()` names rather than inlining their content
- All file types (markdown, scripts, configs) are loadable this way, not just `.md` files
- Path traversal protection: canonicalization check prevents symlinks from reading files outside the skill directory
- When a namespaced path isn't found, the error message lists available files for that skill

## Problem

Skill environments without filesystem access (e.g. Block-internal Goose Slackbot deployments) had no way to reach supporting reference files. The previous approach — listing paths with "Use the file tools to read these files" — only worked for environments with the developer extension.

## Behavior

```
load(source: "oncall-buddy-help")
```
Now outputs:
```
## Supporting Files

Skill directory: ~/.claude/skills/oncall-buddy-help

The following supporting files are available:
- references/technical-ops.md → load(source: "oncall-buddy-help/references/technical-ops.md")
- references/diagnostics.md → load(source: "oncall-buddy-help/references/diagnostics.md")

Use load(source: "<skill-name>/<path>") to load individual files into context, or use file tools to read/run them directly.
```

The LLM can then selectively load only the reference it needs, preserving progressive disclosure while remaining fully functional in filesystem-restricted environments.