### PR TITLE
fix: restore provider and extensions for LRU-evicted sessions

### DIFF
--- a/crates/goose/src/execution/manager.rs
+++ b/crates/goose/src/execution/manager.rs
@@ -95,10 +95,30 @@ impl AgentManager {
             GoosePlatform::GooseDesktop,
         );
         let agent = Arc::new(Agent::with_config(config));
-        if let Some(provider) = &*self.default_provider.read().await {
-            agent
-                .update_provider(Arc::clone(provider), &session_id)
-                .await?;
+
+        if let Ok(session) = self.session_manager.get_session(&session_id, false).await {
+            if session.provider_name.is_some() {
+                info!(
+                    "Restoring evicted session {} (provider: {:?})",
+                    session_id, session.provider_name
+                );
+                if let Err(e) = agent.restore_provider_from_session(&session).await {
+                    tracing::warn!(
+                        "Failed to restore provider for session {}: {}",
+                        session_id,
+                        e
+                    );
+                }
+            }
+            agent.load_extensions_from_session(&session).await;
+        }
+
+        if agent.provider().await.is_err() {
+            if let Some(provider) = &*self.default_provider.read().await {
+                agent
+                    .update_provider(Arc::clone(provider), &session_id)
+                    .await?;
+            }
         }
 
         let mut sessions = self.sessions.write().await;


### PR DESCRIPTION
Restores provider and MCP extensions for sessions re-created after LRU eviction. When `AgentManager::get_or_create_agent` creates a new agent for an evicted session, the new agent was a blank shell — the session data was persisted in SQLite but never read back, causing `/reply` to immediately fail with "Provider not set". This fix makes `get_or_create_agent` session-aware.

- In `get_or_create_agent`, load session from DB when creating a new agent; if `provider_name` is persisted, call `restore_provider_from_session` and `load_extensions_from_session` concurrently
- Fall through to `default_provider` only if no session state was found (preserving behavior for genuinely new sessions)
- Provider restoration failure logs a warning and continues; the default provider fallback still applies

Closes #7615