### PR TITLE
Restore goosed logging

### DIFF
--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -332,6 +332,8 @@ export const startGoosed = async (options: StartGoosedOptions): Promise<GoosedRe
         errorLog.push(line);
         if (isFatalError(line)) {
           logger.error(`goosed stderr for port ${port} and dir ${workingDir}: ${line}`);
+        } else {
+          logger.info(`goosed stderr for port ${port} and dir ${workingDir}: ${line}`);
         }
       }
     }


### PR DESCRIPTION
#7178 made it so that only errors from goosed are logged, this restores the original behaviour of also logging the rest of the stderr output