### PR TITLE
fix: disable all platform extensions by default except for developer

### DIFF
--- a/crates/goose/src/agents/platform_extensions/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/mod.rs
@@ -34,7 +34,7 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
                 display_name: "Analyze",
                 description:
                     "Analyze code structure with tree-sitter: directory overviews, file details, symbol call graphs",
-                default_enabled: true,
+                default_enabled: false,
                 unprefixed_tools: true,
                 client_factory: |ctx| Box::new(analyze::AnalyzeClient::new(ctx).unwrap()),
             },
@@ -60,7 +60,7 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
                 display_name: "Apps",
                 description:
                     "Create and manage custom Goose apps through chat. Apps are HTML/CSS/JavaScript and run in sandboxed windows.",
-                default_enabled: true,
+                default_enabled: false,
                 unprefixed_tools: false,
                 client_factory: |ctx| Box::new(apps::AppsManagerClient::new(ctx).unwrap()),
             },
@@ -86,7 +86,7 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
                 display_name: "Extension Manager",
                 description:
                     "Enable extension management tools for discovering, enabling, and disabling extensions",
-                default_enabled: true,
+                default_enabled: false,
                 unprefixed_tools: false,
                 client_factory: |ctx| Box::new(ext_manager::ExtensionManagerClient::new(ctx).unwrap()),
             },
@@ -98,7 +98,7 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
                 name: summon::EXTENSION_NAME,
                 display_name: "Summon",
                 description: "Load knowledge and delegate tasks to subagents",
-                default_enabled: true,
+                default_enabled: false,
                 unprefixed_tools: true,
                 client_factory: |ctx| Box::new(summon::SummonClient::new(ctx).unwrap()),
             },
@@ -139,7 +139,7 @@ pub static PLATFORM_EXTENSIONS: Lazy<HashMap<&'static str, PlatformExtensionDef>
                 display_name: "Top Of Mind",
                 description:
                     "Inject custom context into every turn via GOOSE_MOIM_MESSAGE_TEXT and GOOSE_MOIM_MESSAGE_FILE environment variables",
-                default_enabled: true,
+                default_enabled: false,
                 unprefixed_tools: false,
                 client_factory: |ctx| Box::new(tom::TomClient::new(ctx).unwrap()),
             },


### PR DESCRIPTION
Anecdotally I find many people are using goose only with `developer` enabled and it works well

Putting this up for consideration to make that the only platform extension enabled by default