### PR TITLE
fix: prevent abort in local inference 

### DIFF
--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -72,6 +72,7 @@ winapi = { version = "0.3", features = ["wincred"] }
 [features]
 default = ["code-mode"]
 code-mode = ["goose/code-mode", "goose-acp/code-mode"]
+cuda = ["goose/cuda"]
 # disables the update command
 disable-update = []
 

--- a/crates/goose/src/providers/local_inference/inference_emulated_tools.rs
+++ b/crates/goose/src/providers/local_inference/inference_emulated_tools.rs
@@ -359,10 +359,19 @@ pub(super) fn generate_with_emulated_tools(
     ctx: &mut GenerationContext<'_>,
     code_mode_enabled: bool,
 ) -> Result<(), ProviderError> {
+    // Use oaicompat variant — its C++ wrapper catches exceptions that would
+    // otherwise abort the process when other native libs disturb the C++ ABI.
     let prompt = ctx
         .loaded
         .model
-        .apply_chat_template(&ctx.loaded.template, ctx.chat_messages, true)
+        .apply_chat_template_with_tools_oaicompat(
+            &ctx.loaded.template,
+            ctx.chat_messages,
+            None, // no tools for emulated path
+            None, // no json_schema
+            true, // add_generation_prompt
+        )
+        .map(|r| r.prompt)
         .map_err(|e| {
             ProviderError::ExecutionError(format!("Failed to apply chat template: {}", e))
         })?;

--- a/crates/goose/tests/local_inference_integration.rs
+++ b/crates/goose/tests/local_inference_integration.rs
@@ -1,20 +1,30 @@
 //! Integration tests for LocalInferenceProvider.
 //!
 //! These tests require a downloaded GGUF model and are ignored by default.
-//! Run with: cargo test -p goose --test local_inference_integration -- --ignored
+//! Download a model first:
+//!   goose local-models download bartowski/Llama-3.2-1B-Instruct-GGUF:Q4_K_M
+//!
+//! Run with the default model:
+//!   cargo test -p goose --test local_inference_integration -- --ignored
+//!
+//! Run with a specific model:
+//!   TEST_MODEL="bartowski/Qwen_Qwen3-32B-GGUF:Q4_K_M" cargo test -p goose --test local_inference_integration -- --ignored
 
 use futures::StreamExt;
 use goose::conversation::message::Message;
 use goose::model::ModelConfig;
 use goose::providers::create;
-use std::time::Instant;
 
-const TEST_MODEL: &str = "llama-3.2-1b";
+const DEFAULT_TEST_MODEL: &str = "bartowski/Llama-3.2-1B-Instruct-GGUF:Q4_K_M";
+
+fn test_model() -> String {
+    std::env::var("TEST_MODEL").unwrap_or_else(|_| DEFAULT_TEST_MODEL.to_string())
+}
 
 #[tokio::test]
 #[ignore]
 async fn test_local_inference_stream_produces_output() {
-    let model_config = ModelConfig::new(TEST_MODEL).expect("valid model config");
+    let model_config = ModelConfig::new(&test_model()).expect("valid model config");
     let provider = create("local", model_config.clone(), Vec::new())
         .await
         .expect("provider creation should succeed");
@@ -55,53 +65,10 @@ async fn test_local_inference_stream_produces_output() {
 
 #[tokio::test]
 #[ignore]
-async fn test_local_inference_cold_and_warm_performance() {
-    let model_config = ModelConfig::new(TEST_MODEL).expect("valid model config");
-    let provider = create("local", model_config.clone(), Vec::new())
-        .await
-        .expect("provider creation should succeed");
-
-    // Cold start (includes model loading)
-    let messages = vec![Message::user().with_text("what is the capital of Moldova?")];
-    let start = Instant::now();
-    let (response, _usage) = provider
-        .complete(&model_config, "test-session", "", &messages, &[])
-        .await
-        .expect("cold completion should succeed");
-    let cold_elapsed = start.elapsed();
-
-    let text = response.as_concat_text();
-    assert!(!text.is_empty(), "cold start should produce a response");
-    println!(
-        "Cold start: {cold_elapsed:.2?}, response length: {}",
-        text.len()
-    );
-
-    // Warm run (model already loaded)
-    let messages2 = vec![Message::user().with_text("what is the capital of France?")];
-    let start2 = Instant::now();
-    let (response2, _usage2) = provider
-        .complete(&model_config, "test-session", "", &messages2, &[])
-        .await
-        .expect("warm completion should succeed");
-    let warm_elapsed = start2.elapsed();
-
-    let text2 = response2.as_concat_text();
-    assert!(!text2.is_empty(), "warm run should produce a response");
-    println!(
-        "Warm run: {warm_elapsed:.2?}, response length: {}",
-        text2.len()
-    );
-    assert!(
-        warm_elapsed < cold_elapsed,
-        "warm run ({warm_elapsed:.2?}) should be faster than cold start ({cold_elapsed:.2?})"
-    );
-}
-
-#[tokio::test]
-#[ignore]
 async fn test_local_inference_large_prompt() {
-    let model_config = ModelConfig::new(TEST_MODEL).expect("valid model config");
+    let model_config = ModelConfig::new(&test_model())
+        .expect("valid model config")
+        .with_max_tokens(Some(20));
     let provider = create("local", model_config.clone(), Vec::new())
         .await
         .expect("provider creation should succeed");
@@ -111,7 +78,7 @@ async fn test_local_inference_large_prompt() {
     let prompt = format!("{padding}\nNow answer this: what is the capital of Moldova?");
     let messages = vec![Message::user().with_text(&prompt)];
 
-    let start = Instant::now();
+    let start = std::time::Instant::now();
     let (response, _usage) = provider
         .complete(&model_config, "test-session", "", &messages, &[])
         .await

--- a/crates/goose/tests/local_inference_perf.rs
+++ b/crates/goose/tests/local_inference_perf.rs
@@ -1,0 +1,66 @@
+//! Performance benchmarks for LocalInferenceProvider.
+//!
+//! These tests require a downloaded GGUF model and are ignored by default.
+//! Download a model first:
+//!   goose local-models download bartowski/Llama-3.2-1B-Instruct-GGUF:Q4_K_M
+//!
+//! Run with the default model:
+//!   cargo test -p goose --test local_inference_perf -- --ignored --nocapture
+//!
+//! Run with a specific model:
+//!   TEST_MODEL="bartowski/Qwen_Qwen3-32B-GGUF:Q4_K_M" cargo test -p goose --test local_inference_perf -- --ignored --nocapture
+
+use goose::conversation::message::Message;
+use goose::model::ModelConfig;
+use goose::providers::create;
+use std::time::Instant;
+
+const DEFAULT_TEST_MODEL: &str = "bartowski/Llama-3.2-1B-Instruct-GGUF:Q4_K_M";
+
+fn test_model() -> String {
+    std::env::var("TEST_MODEL").unwrap_or_else(|_| DEFAULT_TEST_MODEL.to_string())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_local_inference_cold_vs_warm() {
+    let model_config = ModelConfig::new(&test_model())
+        .expect("valid model config")
+        .with_max_tokens(Some(20));
+    let provider = create("local", model_config.clone(), Vec::new())
+        .await
+        .expect("provider creation should succeed");
+
+    // Cold start — includes model loading from disk.
+    let messages = vec![Message::user().with_text("What is 2+2?")];
+    let start = Instant::now();
+    let (response, _) = provider
+        .complete(&model_config, "perf-session", "", &messages, &[])
+        .await
+        .expect("cold completion should succeed");
+    let cold_elapsed = start.elapsed();
+
+    let text = response.as_concat_text();
+    assert!(!text.is_empty(), "cold start should produce a response");
+    println!("Cold start: {cold_elapsed:.2?}, response: {}", text.len());
+
+    // Warm run — model already loaded, only inference.
+    let messages2 = vec![Message::user().with_text("What is 3+3?")];
+    let start2 = Instant::now();
+    let (response2, _) = provider
+        .complete(&model_config, "perf-session", "", &messages2, &[])
+        .await
+        .expect("warm completion should succeed");
+    let warm_elapsed = start2.elapsed();
+
+    let text2 = response2.as_concat_text();
+    assert!(!text2.is_empty(), "warm run should produce a response");
+    println!("Warm run:   {warm_elapsed:.2?}, response: {}", text2.len());
+
+    if warm_elapsed < cold_elapsed {
+        let speedup = cold_elapsed.as_secs_f64() / warm_elapsed.as_secs_f64();
+        println!("Warm is {speedup:.1}x faster than cold");
+    } else {
+        println!("Warning: warm was not faster (model may have been pre-loaded by another test)");
+    }
+}


### PR DESCRIPTION
Fix a bug "Rust cannot catch foreign exceptions" abort that occurs when using Local Inference with models that have long Jinja2 chat templates (e.g. Qwen3 GGUF models).

### The problem

1.  `apply_chat_template()` calls `llama_chat_apply_template()` which internally does a C++ map `.at()` lookup on the template string. 
2. When the string is a full Jinja2 template (not a short name like "chatml"), this throws `std::out_of_range`. 
3. The exception is normally caught in C++, but when goose's other native dependencies are linked into the binary, the C++ exception-handling ABI breaks and the exception propagates across the Rust FFI boundary, causing a process abort.

### The solution

Switch from `apply_chat_template()` to  `apply_chat_template_with_tools_oaicompat()` in `inference_emulated_tools.rs`

### Why?

This function has its own C++ try-catch wrapper. When called with `tools=None`, it produces the same prompt. This aligns the emulated tools path with the native tools path, which already uses the oaicompat variant.
 

### Testing

A few integration tests were improved, the integration tests for the local inference had been abandoned and marked with `#[ignore]`, this is problematic because I could not understand very clearly how to actually test my changes. The changes in testing are as follows:

1. Fix broken model ID in local_inference_integration.rs, add TEST_MODEL env var override, removed perf assertion since it would never pass because the model was never truly in a cold start state.
2. Separate cold vs warm perf benchmark with TEST_MODEL env var support in `local_inference_perf.rs`

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality 
- [ ] Performance improvement
- [ ] Documentation
- [x] Tests
- [ ] Security fix
- [x] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance
- 56 unit tests pass (parsing, engine, hf_models)
- Integration tests pass with Llama 1B and Qwen3 32B, on both CPU and CUDA
- Qwen3 32B was the crashing model now works

 ### Testing
 - Tested end-to-end with `bartowski/Qwen_Qwen3-32B-GGUF:Q4_K_M` via `test_provider_configuration` —
 previously aborted, now passes.
 - Verified the crash is specific to the goose binary (standalone llama-cpp-2 tests pass because the
 C++ ABI isn't disturbed by additional native deps).
 - Verified that short template names ("chatml") never triggered the crash — only full Jinja2
 template strings.
 - Existing unit tests for emulated tools parsing, tool parsing, and inference engine all continue to
  pass (they test downstream of the template step).

 ### Related Issues

- Related to #7410 same root cause (C++ exception-handling ABI clash between llama-cpp and other native deps). That issue manifests as a Windows MSVC link failure; this one manifests as a Linux runtime abort.
- Follow-up to #7511 which fixed the Windows MSVC link-time side of the v8/llama-cpp C++ ABI conflict (`/FORCE:MULTIPLE` for duplicate `std::exception_ptr` symbols). This PR addresses the Linux runtime side where the exception *links* but doesn't *propagate* correctly across the Rust FFI boundary.
- Discovered an issue where `CUDA` will crash when context_size is null in registry which falls through to n_ctx_train, despite the fact that estimate_max_context_for_memory should cap it.

 ### Screenshots/Demos (for UX changes)
<img width="1440" height="1367" alt="image" src="https://github.com/user-attachments/assets/0fa432cf-163c-463d-b6ec-ebfd87992837" />

After: Model loads and generates normally.
<img width="1440" height="2284" alt="image" src="https://github.com/user-attachments/assets/2a47b132-c7b1-473b-b141-4b192169bcd7" />

With `CUDA`: 
<img width="1440" height="2284" alt="Screenshot_20260304_023801" src="https://github.com/user-attachments/assets/d7e1a736-1f9d-4750-8454-43e913172a61" />