### PR TITLE
docs: update recipe usage step to reflect auto-submit behavior

### DIFF
--- a/documentation/docs/guides/recipes/session-recipes.md
+++ b/documentation/docs/guides/recipes/session-recipes.md
@@ -246,7 +246,7 @@ You can customize how goose generates recipes by editing the `recipe.md` [prompt
      - **Required parameters** are marked with red asterisks (*)
      - **Optional parameters** show default values that can be changed
 
-  4. To run the recipe, click an activity bubble or send the prompt.
+  4. The recipe automatically submits and goose begins execution. If the recipe includes a [prompt](#core-components), it's sent as the first message. If not, you can click an activity bubble or send a prompt to get started.
 
   :::info Privacy & Isolation
   - Each person gets their own private session


### PR DESCRIPTION
## Summary

Update the "Use Recipe" Desktop instructions in `session-recipes.md` to reflect the auto-submit behavior introduced in PR #6325.

## What changed

Recipes now automatically submit and begin execution after acceptance in the Desktop UI. The docs previously told users to "click an activity bubble or send the prompt" as a separate step. This update reflects the new streamlined flow.

**Before:**
> 4. To run the recipe, click an activity bubble or send the prompt.

**After:**
> 4. The recipe automatically submits and goose begins execution. If the recipe includes a prompt, it's sent as the first message. If not, you can click an activity bubble or send a prompt to get started.

## Related

- #6325 - feat: add auto submit for recipes that have been accepted