### PR TITLE
Clean up stale references to removed components

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,18 +41,17 @@ cd ui/desktop && npm test    # test UI
 ## Structure
 ```
 crates/
-├── goose             # core logic
-├── goose-bench       # benchmarking
-├── goose-cli         # CLI entry
-├── goose-server      # backend (binary: goosed)
-├── goose-mcp         # MCP extensions
-├── goose-test        # test utilities
-├── mcp-client        # MCP client
-├── mcp-core          # MCP shared
-└── mcp-server        # MCP server
+├── goose              # core logic
+├── goose-acp          # Agent Client Protocol
+├── goose-acp-macros   # ACP proc macros
+├── goose-cli          # CLI entry
+├── goose-server       # backend (binary: goosed)
+├── goose-mcp          # MCP extensions
+├── goose-test         # test utilities
+└── goose-test-support # test helpers
 
-temporal-service/     # Go scheduler
-ui/desktop/           # Electron app
+evals/open-model-gym/  # benchmarking / evals
+ui/desktop/            # Electron app
 ```
 
 ## Development Loop

--- a/flake.nix
+++ b/flake.nix
@@ -88,7 +88,7 @@
             cargo-edit
             clippy
             gemini-cli # potentially useful during dev/testing
-            go_1_25 # 'just' run-ui (temporal-service)
+            go_1_25 # 'just' run-ui
             just # used in dev/test
             nodejs_24 # 'just' run-ui
             ripgrep


### PR DESCRIPTION
## Summary
<!-- Describe your change -->

Update AGENTS.md structure section to reflect actual crates directory contents: remove references to goose-bench, mcp-client, mcp-core, mcp-server (none exist), and temporal-service (removed; scheduling is now in-process via tokio-cron-scheduler). Add missing crates goose-acp, goose-acp-macros, goose-test-support, and the evals directory.

Remove stale temporal-service comment from flake.nix.

Made-with: Cursor

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to None.  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

