### PR TITLE
fix: compare extension configs before skipping add_extension

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -538,20 +538,14 @@ impl ExtensionManager {
     ) -> ExtensionResult<()> {
         let sanitized_name = config.key();
 
-        {
-            let mut extensions = self.extensions.lock().await;
-            if let Some(existing) = extensions.get(&sanitized_name) {
-                if existing.config == config {
-                    return Ok(());
-                }
-                tracing::debug!(
-                    name = sanitized_name,
-                    "extension config changed, restarting with updated config"
-                );
-                extensions.remove(&sanitized_name);
-                drop(extensions);
-                self.invalidate_tools_cache_and_bump_version().await;
+        if let Some(existing) = self.extensions.lock().await.get(&sanitized_name) {
+            if existing.config == config {
+                return Ok(());
             }
+            tracing::debug!(
+                name = sanitized_name,
+                "extension config changed, restarting with updated config"
+            );
         }
 
         let mut temp_dir = None;
@@ -2322,14 +2316,15 @@ mod tests {
         .await;
         assert_eq!(em.extensions.lock().await.len(), 1);
 
-        // add_extension with changed config must remove the old entry (before failing to
-        // re-create because Frontend configs cannot be added as server extensions).
+        // add_extension with changed config attempts to create a new client (fails here
+        // because Frontend configs cannot be added as server extensions), but must preserve
+        // the old extension so the session isn't left without it.
         let result = em.add_extension(config_b, None, None, None).await;
         assert!(result.is_err(), "Frontend add_extension must return Err");
         assert_eq!(
             em.extensions.lock().await.len(),
-            0,
-            "stale extension must be removed when config changes"
+            1,
+            "old extension must be preserved when replacement client creation fails"
         );
     }
 }


### PR DESCRIPTION
## Summary

- `add_extension` silently dropped config updates when an extension with the same name was already loaded, returning `Ok(())` regardless of whether the config differed
- Now compares incoming `ExtensionConfig` against the existing one using derived `PartialEq` — identical configs still no-op, differing configs remove the stale extension and re-add with the new config
- Adds debug-level logging when a config change triggers an extension restart

## Motivation

In the internal Block slackbot, per-session env vars (`SLACK_ORIGIN_CHANNEL`) are injected into the Slack MCP extension config via `add_extension`. But `load_extensions_from_session` typically wins the race and loads the extension from stored session config (without the env var) before the caller's `add_extension` arrives. The caller's config update was silently dropped.

The workaround (`remove_extension` + `add_extension`) restarts the subprocess on every session setup, adding latency and unnecessary churn.

Closes #7647

## Test plan

- [x] `test_add_extension_noop_on_identical_config` — verifies identical config returns `Ok(())` without removing the extension
- [x] `test_add_extension_replaces_extension_on_config_change` — verifies differing config removes the stale extension before attempting re-add
- [x] CI passes (local build environment currently has an unrelated Xcode/v8 linker issue)