### PR TITLE
fix: add analyzer extension in recipe to maintain backwards compatibility 

### DIFF
--- a/crates/goose/src/recipe/mod.rs
+++ b/crates/goose/src/recipe/mod.rs
@@ -226,6 +226,31 @@ pub struct RecipeBuilder {
 }
 
 impl Recipe {
+    /// When a recipe has the old builtin developer extension but not analyze, auto-inject analyze.
+    fn ensure_analyze_for_developer(&mut self) {
+        let has_builtin_developer = self.extensions.as_ref().is_some_and(|exts| {
+            exts.iter()
+                .any(|e| matches!(e, ExtensionConfig::Builtin { name, .. } if name == "developer"))
+        });
+        let has_analyze = self
+            .extensions
+            .as_ref()
+            .is_some_and(|exts| exts.iter().any(|e| e.name() == "analyze"));
+
+        if has_builtin_developer && !has_analyze {
+            let analyze = ExtensionConfig::Platform {
+                name: "analyze".to_string(),
+                description: String::new(),
+                display_name: None,
+                bundled: None,
+                available_tools: vec![],
+            };
+            if let Some(exts) = &mut self.extensions {
+                exts.push(analyze);
+            }
+        }
+    }
+
     fn ensure_summon_for_subrecipes(&mut self) {
         if self.sub_recipes.is_none() {
             return;
@@ -309,6 +334,7 @@ impl Recipe {
                 .map_err(|e| anyhow::anyhow!("{}", strip_error_location(&e.to_string())))?,
         };
 
+        recipe.ensure_analyze_for_developer();
         recipe.ensure_summon_for_subrecipes();
         Ok(recipe)
     }


### PR DESCRIPTION
## Summary
Add backwards compatibility for recipe with developer and analyzer extensions.  The buitlin developer extension include the analyzer tool but now the analyzer is a sepearate extension. So we should include them in the recipe for backward compatibility 


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [X] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)


### Testing
Manual testing