### PR TITLE
fix: only add viewable channels to bot context

### DIFF
--- a/services/ask-ai-bot/utils/discord/server-context.ts
+++ b/services/ask-ai-bot/utils/discord/server-context.ts
@@ -8,7 +8,7 @@ export async function buildServerContext(guild: Guild): Promise<string> {
     const textChannels = Array.from(channels.values())
       .filter(
         (ch): ch is TextChannel =>
-          ch?.type === ChannelType.GuildText && ch !== null,
+          ch?.type === ChannelType.GuildText && ch !== null && ch.viewable,
       )
       .sort((a, b) => (a.position ?? 0) - (b.position ?? 0));
 


### PR DESCRIPTION
## Summary
The Discord bot can see private channels. This PR should fix that, so it can only see public channels.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
Untested.

