### PR TITLE
fix(ui): sync sidebar sessions after chat history deletion

### DIFF
--- a/ui/desktop/src/hooks/useNavigationSessions.ts
+++ b/ui/desktop/src/hooks/useNavigationSessions.ts
@@ -140,8 +140,7 @@ export function useNavigationSessions(options: UseNavigationSessionsOptions = {}
 
   useEffect(() => {
     const handleSessionDeleted = (event: Event) => {
-      const { sessionId } = (event as CustomEvent<{ sessionId?: string }>).detail || {};
-      if (!sessionId) return;
+      const { sessionId } = (event as CustomEvent<{ sessionId: string }>).detail;
 
       setRecentSessions((prev) => prev.filter((session) => session.id !== sessionId));
       sessionsRef.current = sessionsRef.current.filter((session) => session.id !== sessionId);
@@ -149,14 +148,11 @@ export function useNavigationSessions(options: UseNavigationSessionsOptions = {}
       if (lastSessionIdRef.current === sessionId) {
         lastSessionIdRef.current = null;
       }
-
-      void fetchSessions();
     };
 
     const handleSessionRenamed = (event: Event) => {
       const { sessionId, newName } =
-        (event as CustomEvent<{ sessionId?: string; newName?: string }>).detail || {};
-      if (!sessionId || !newName) return;
+        (event as CustomEvent<{ sessionId: string; newName: string }>).detail;
 
       setRecentSessions((prev) =>
         prev.map((session) => (session.id === sessionId ? { ...session, name: newName } : session))
@@ -173,7 +169,7 @@ export function useNavigationSessions(options: UseNavigationSessionsOptions = {}
       window.removeEventListener(AppEvents.SESSION_DELETED, handleSessionDeleted);
       window.removeEventListener(AppEvents.SESSION_RENAMED, handleSessionRenamed);
     };
-  }, [fetchSessions]);
+  }, []);
 
   const handleNavClick = useCallback(
     (path: string) => {


### PR DESCRIPTION
## Summary
This PR fixes a UI sync issue where deleting a chat from `Chat -> Show All -> Chat History` did not immediately remove that topic from the sidebar list until app restart.


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [x] This PR was created or reviewed with AI assistance