### PR TITLE
fix: add #[serde(default)] to description field on 4 ExtensionConfig variants

### DIFF
--- a/crates/goose/src/agents/extension.rs
+++ b/crates/goose/src/agents/extension.rs
@@ -206,6 +206,7 @@ pub enum ExtensionConfig {
     Platform {
         /// The name used to identify this extension
         name: String,
+        #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
         #[schema(required)]
         description: String,
@@ -220,6 +221,7 @@ pub enum ExtensionConfig {
     StreamableHttp {
         /// The name used to identify this extension
         name: String,
+        #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
         #[schema(required)]
         description: String,
@@ -243,6 +245,7 @@ pub enum ExtensionConfig {
     Frontend {
         /// The name used to identify this extension
         name: String,
+        #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
         #[schema(required)]
         description: String,
@@ -260,6 +263,7 @@ pub enum ExtensionConfig {
     InlinePython {
         /// The name used to identify this extension
         name: String,
+        #[serde(default)]
         #[serde(deserialize_with = "deserialize_null_with_default")]
         #[schema(required)]
         description: String,


### PR DESCRIPTION
Clients omitting `description` from extension configs (e.g. `POST /agent/add_extension` with a `streamable_http` payload) received HTTP 422 with "missing field 'description'".

`deserialize_null_with_default` handles null values but does not imply the field is optional — `#[serde(default)]` is separately required to allow the field to be absent from the JSON entirely. The `Sse`, `Stdio`, and `Builtin` variants already had both attributes; this adds the missing `#[serde(default)]` to the remaining four.

- Add `#[serde(default)]` to `description` on `Platform`, `StreamableHttp`, `Frontend`, and `InlinePython` variants in `crates/goose/src/agents/extension.rs`