### PR TITLE
Add @angiejones as CODEOWNER for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Documentation owned by DevRel
-/documentation/ @blackgirlbytes
+/documentation/ @blackgirlbytes @angiejones
 


### PR DESCRIPTION
This PR adds @angiejones as a CODEOWNER for the `/documentation/` directory alongside @blackgirlbytes.

## Changes
- Updated `.github/CODEOWNERS` to include @angiejones for documentation ownership