### PR TITLE
feat: add Tensorix as a declarative provider

### DIFF
--- a/crates/goose/src/providers/declarative/tensorix.json
+++ b/crates/goose/src/providers/declarative/tensorix.json
@@ -1,0 +1,53 @@
+{
+  "name": "custom_tensorix",
+  "engine": "openai",
+  "display_name": "Tensorix",
+  "description": "50+ open-source models with EU-hosted inference and zero data retention",
+  "api_key_env": "TENSORIX_API_KEY",
+  "base_url": "https://api.tensorix.ai/v1",
+  "models": [
+    {
+      "name": "z-ai/glm-5",
+      "context_limit": 203000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "deepseek/deepseek-chat-v3.1",
+      "context_limit": 164000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "deepseek/deepseek-r1-0528",
+      "context_limit": 164000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "minimax/minimax-m2.5",
+      "context_limit": 197000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    },
+    {
+      "name": "moonshotai/kimi-k2.5",
+      "context_limit": 262000,
+      "input_token_cost": null,
+      "output_token_cost": null,
+      "currency": null,
+      "supports_cache_control": null
+    }
+  ],
+  "headers": null,
+  "timeout_seconds": null,
+  "supports_streaming": true
+}


### PR DESCRIPTION
## Summary

Adds [Tensorix](https://tensorix.ai) as a declarative provider, following the same JSON format as existing providers (DeepSeek, Groq, Mistral, etc.).

## What is Tensorix?

Tensorix is an OpenAI-compatible API gateway providing 50+ open-source models with:
- **EU-hosted inference** (Frankfurt data center)
- **Zero data retention** — prompts and completions are never stored
- **OpenAI-compatible API** at `https://api.tensorix.ai/v1`

## Changes

- Added `crates/goose/src/providers/declarative/tensorix.json`

## Models Included

| Model | Context |
|-------|---------|
| `z-ai/glm-5` | 203K |
| `deepseek/deepseek-chat-v3.1` | 164K |
| `deepseek/deepseek-r1-0528` | 164K |
| `minimax/minimax-m2.5` | 197K |
| `moonshotai/kimi-k2.5` | 262K |

## Authentication

Users set `TENSORIX_API_KEY` in their environment, consistent with the `api_key_env` convention used by other declarative providers.

## Testing

The JSON file follows the exact schema of existing declarative providers and requires no code changes — just the new JSON file in the `declarative/` directory.