### PR TITLE
docs: add available_tools field to extension config documentation

### DIFF
--- a/documentation/docs/guides/config-files.md
+++ b/documentation/docs/guides/config-files.md
@@ -121,6 +121,7 @@ extensions:
     name: "extension_name"    # Internal name
     timeout: 300              # Operation timeout in seconds
     type: "builtin"/"stdio"   # Extension type
+    available_tools: []       # Filter to specific tools (empty = all)
     
     # Additional settings for stdio extensions:
     cmd: "command"            # Command to execute
@@ -129,6 +130,10 @@ extensions:
     env_keys: []              # Required environment variables
     envs: {}                  # Environment values
 ```
+
+### Tool Filtering
+
+Use the `available_tools` field to limit which tools are loaded from an extension. List the tool names you want — only those will be available to goose. Leave it empty (the default) to load all tools. This can help reduce token overhead in sessions where you only need a subset of an extension's capabilities.
 
 ## Search Path Configuration
 


### PR DESCRIPTION
## Summary

The `available_tools` field exists on all extension types and already filters tools at both listing and execution time, but isn't mentioned in the config docs. This adds it to the example and explains what it does.

### Type of Change
- [x] Documentation

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Documentation only — no code changes.

### Related Issues
Relates to #5703