### PR TITLE
fix: persist manage_extensions changes to config.yaml

### DIFF
--- a/crates/goose/src/agents/platform_extensions/ext_manager.rs
+++ b/crates/goose/src/agents/platform_extensions/ext_manager.rs
@@ -1,6 +1,7 @@
 use crate::agents::extension::PlatformExtensionContext;
 use crate::agents::mcp_client::{Error, McpClientTrait};
-use crate::config::get_extension_by_name;
+use crate::config::extensions::name_to_key;
+use crate::config::{get_extension_by_name, set_extension_enabled};
 use anyhow::Result;
 use async_trait::async_trait;
 use indoc::indoc;
@@ -165,6 +166,7 @@ impl ExtensionManagerClient {
                 .remove_extension(&extension_name)
                 .await
                 .map(|_| {
+                    set_extension_enabled(&name_to_key(&extension_name), false);
                     vec![Content::text(format!(
                         "The extension '{}' has been disabled successfully",
                         extension_name
@@ -191,6 +193,7 @@ impl ExtensionManagerClient {
             .add_extension(config, None, None, None)
             .await
             .map(|_| {
+                set_extension_enabled(&name_to_key(&extension_name), true);
                 vec![Content::text(format!(
                     "The extension '{}' has been installed successfully",
                     extension_name


### PR DESCRIPTION
## Summary

The manage_extensions tool disables/enables extensions at runtime but doesn't 
persist the change to config.yaml. Next session, the extension reverts to its 
previous state. This adds a call to the existing `set_extension_enabled()` 
function after each successful enable/disable so the change is saved to disk.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
- `cargo check -p goose` passes
- The fix uses existing `set_extension_enabled()` and `name_to_key()` functions 
  that are already tested elsewhere in the codebase

### Related Issues
New bug — no existing issue.