### PR TITLE
fix: reduce server log verbosity — skip session in instrument, defaul…

### DIFF
--- a/crates/goose-server/src/logging.rs
+++ b/crates/goose-server/src/logging.rs
@@ -35,7 +35,7 @@ pub fn setup_logging(name: Option<&str>) -> Result<()> {
     let base_env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| {
         EnvFilter::new("")
             .add_directive("mcp_client=info".parse().unwrap())
-            .add_directive("goose=debug".parse().unwrap())
+            .add_directive("goose=info".parse().unwrap())
             .add_directive("goose_server=info".parse().unwrap())
             .add_directive("tower_http=info".parse().unwrap())
             .add_directive(LevelFilter::WARN.into())

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -495,7 +495,7 @@ impl Agent {
     }
 
     /// Dispatch a single tool call to the appropriate client
-    #[instrument(skip(self, tool_call, request_id), fields(input, output))]
+    #[instrument(skip(self, tool_call, request_id, session), fields(input, output, session_id = %session.id))]
     pub async fn dispatch_tool_call(
         &self,
         tool_call: CallToolRequestParams,


### PR DESCRIPTION


## Summary

Two small changes to reduce server log bloat for heavy Goose users:

1. **Skip `session` in `dispatch_tool_call`'s `#[instrument]`** — the full `Session` struct (including all message history and base64 image data) was being serialised into every DEBUG log line. Log just `session.id` instead.
2. **Change server default log level from `goose=debug` to `goose=info`** — mirrors the CLI fix in #7569.

The `dispatch_tool_call` function's `#[instrument]` macro skips `self`, `tool_call`, and `request_id`, but not `session`. Since `Session` implements `Debug` and contains the full conversation history, every tool call produces two log lines (enter + exit) containing the entire session. Late in a long session with screenshots, individual log lines reach 8+ MB. On my machine, 14 days of server logs totalled 17 GB.

Users can still enable debug logging via `RUST_LOG=goose=debug`.

### Type of Change
- [x] Bug fix
- [x] Performance improvement

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

Verified the two target lines exist on `main` and confirmed the changes are syntactically correct. The `#[instrument]` skip list change is additive (no behaviour change except smaller logs). The log level change matches the identical fix merged for CLI in #7569.

No new tests added — this is a logging config change. Could be validated by checking server log output size before/after.

### Related Issues
Relates to #4965 — "logs up to 630 GB per file" (closed, led to rotation fix in #5561)
Relates to #7569 — CLI default changed from debug to info (this PR does the same for the server)
Complements #7490 — propagating `session.id` to OTel spans (open)