### PR TITLE
fix: preserve pairings when stopping gateway

### DIFF
--- a/crates/goose/src/gateway/manager.rs
+++ b/crates/goose/src/gateway/manager.rs
@@ -121,7 +121,7 @@ impl GatewayManager {
         Ok(())
     }
 
-    /// Stop a gateway and clear its pairings. Config is kept so it can be restarted.
+    /// Stop a gateway while preserving pairings so it can be restarted.
     pub async fn stop_gateway(&self, gateway_type: &str) -> anyhow::Result<()> {
         let instance = self
             .gateways
@@ -132,20 +132,6 @@ impl GatewayManager {
 
         instance.cancel.cancel();
         let _ = instance.handle.await;
-
-        match self
-            .pairing_store
-            .remove_all_for_platform(gateway_type)
-            .await
-        {
-            Ok(count) if count > 0 => {
-                tracing::info!(gateway = %gateway_type, count, "cleared pairings on stop");
-            }
-            Err(e) => {
-                tracing::warn!(gateway = %gateway_type, error = %e, "failed to clear pairings on stop");
-            }
-            _ => {}
-        }
 
         tracing::info!(gateway = %gateway_type, "gateway stopped");
         Ok(())
@@ -239,13 +225,6 @@ impl GatewayManager {
         for (gateway_type, instance) in instances {
             instance.cancel.cancel();
             let _ = instance.handle.await;
-            if let Err(e) = self
-                .pairing_store
-                .remove_all_for_platform(&gateway_type)
-                .await
-            {
-                tracing::warn!(gateway = %gateway_type, error = %e, "failed to clear pairings on stop");
-            }
             tracing::info!(gateway = %gateway_type, "gateway stopped");
         }
     }


### PR DESCRIPTION
Fixes #7732 by _not_ removing pairings when the gateway is stopped.