### PR TITLE
fix: sanitize streamable HTTP extension names derived from URLs

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -34,6 +34,7 @@ use completion::GooseCompleter;
 use goose::agents::extension::{Envs, ExtensionConfig, PLATFORM_EXTENSIONS};
 use goose::agents::types::RetryConfig;
 use goose::agents::{Agent, SessionConfig, COMPACT_TRIGGERS};
+use goose::config::extensions::name_to_key;
 use goose::config::{Config, GooseMode};
 use input::InputResult;
 use rmcp::model::PromptMessage;
@@ -326,7 +327,7 @@ impl CliSession {
                     s.push('_');
                     s.push_str(path);
                 }
-                s
+                name_to_key(&s)
             })
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| "unnamed".to_string());
@@ -2029,7 +2030,7 @@ mod tests {
     #[test_case(
         "https://mcp.kiwi.com", 300,
         ExtensionConfig::StreamableHttp {
-            name: "mcp.kiwi.com".into(),
+            name: "mcp_kiwi_com".into(),
             uri: "https://mcp.kiwi.com".into(),
             envs: Envs::default(),
             env_keys: vec![],


### PR DESCRIPTION
## Summary

Streamable HTTP extension names derived from URLs (e.g. `https://mcp.kiwi.com`) contain dots, which silently break ACP agents that validate MCP server names against `^[a-zA-Z0-9_-]+$`.

`parse_streamable_http_extension` was pushing the raw hostname into the name (`mcp.kiwi.com`), but goose already has `name_to_key()` which sanitizes names for exactly this purpose. This fix pipes the generated name through `name_to_key()` so `mcp.kiwi.com` becomes `mcp_kiwi_com`.

The constraint is in codex-rs [`validate_mcp_server_name`](https://github.com/openai/codex/blob/main/codex-rs/core/src/mcp_connection_manager.rs) — names failing this regex cause `McpServerConfig { required: false }` servers to be silently dropped, so the agent never sees the tools.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

```
$ cargo test -p goose-cli test_parse_streamable_http_extension -- --nocapture

running 3 tests
test session::tests::test_parse_streamable_http_extension::port_and_path ... ok
test session::tests::test_parse_streamable_http_extension::name_from_host ... ok
test session::tests::test_parse_streamable_http_extension::different_port_and_path ... ok

test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 149 filtered out; finished in 0.00s
```