### PR TITLE
build(ui): add @/ path alias to tsconfig and Vite renderer config

### DIFF
--- a/ui/desktop/tsconfig.json
+++ b/ui/desktop/tsconfig.json
@@ -13,6 +13,12 @@
     "noEmit": true,
     "jsx": "react-jsx",
 
+    /* Path aliases */
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+
     /* Linting */
     "strict": true,
     "noUnusedLocals": true,

--- a/ui/desktop/vite.renderer.config.mts
+++ b/ui/desktop/vite.renderer.config.mts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vite';
 import tailwindcss from '@tailwindcss/vite';
+import { resolve } from 'node:path';
 
 // https://vitejs.dev/config
 export default defineConfig({
@@ -10,6 +11,12 @@ export default defineConfig({
   },
 
   plugins: [tailwindcss()],
+
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, './src'),
+    },
+  },
 
   build: {
     target: 'esnext'


### PR DESCRIPTION
## Summary

Add consistent `@/` path alias resolution across all build tools, ensuring `@/` imports work everywhere:

| Tool | Config File | Status |
|------|------------|--------|
| **tsc** (type-checking) | `tsconfig.json` | ✅ Added |
| **Vite** (Electron renderer build) | `vite.renderer.config.mts` | ✅ Added |
| **Vitest** (unit tests) | `vitest.config.ts` | ✅ Already had it |

## Changes

- `tsconfig.json`: Added `baseUrl` and `paths` mapping `@/*` → `./src/*`
- `vite.renderer.config.mts`: Added `resolve.alias` mapping `@` → `./src`

Addresses Codex review: both type-checking AND builds now resolve `@/` imports consistently.

## Verification

- [x] `tsc --noEmit` passes (0 errors)
- [x] `npm run lint:check` passes
- [x] `npm run test:run` passes (317 tests, 3 skipped)
- [x] Zero changes to existing source code — only build config