### PR TITLE
refactor: simplify tokenizer initialization — remove unnecessary Result wrapper

### DIFF
--- a/crates/goose/src/token_counter.rs
+++ b/crates/goose/src/token_counter.rs
@@ -8,7 +8,7 @@ use tokio::sync::OnceCell;
 
 use crate::conversation::message::Message;
 
-static TOKENIZER: OnceCell<Result<Arc<CoreBPE>, String>> = OnceCell::const_new();
+static TOKENIZER: OnceCell<Arc<CoreBPE>> = OnceCell::const_new();
 
 const MAX_TOKEN_CACHE_SIZE: usize = 10_000;
 
@@ -182,15 +182,13 @@ impl TokenCounter {
 }
 
 async fn get_tokenizer() -> Result<Arc<CoreBPE>, String> {
-    TOKENIZER
+    Ok(TOKENIZER
         .get_or_init(|| async {
-            match tiktoken_rs::o200k_base() {
-                Ok(bpe) => Ok(Arc::new(bpe)),
-                Err(e) => Err(format!("Failed to initialize o200k_base tokenizer: {}", e)),
-            }
+            let bpe = tiktoken_rs::o200k_base().expect("Failed to initialize o200k_base tokenizer");
+            Arc::new(bpe)
         })
         .await
-        .clone()
+        .clone())
 }
 
 pub async fn create_token_counter() -> Result<TokenCounter, String> {


### PR DESCRIPTION
## Summary

Simplifies `token_counter.rs` by removing an unnecessary `Result` wrapper from the static `TOKENIZER`.

### Before
```rust
static TOKENIZER: OnceCell<Result<Arc<CoreBPE>, String>> = OnceCell::const_new();
```

### After
```rust  
static TOKENIZER: OnceCell<Arc<CoreBPE>> = OnceCell::const_new();
```

### Rationale
- Tokenizer init failure is unrecoverable (`o200k_base` BPE ships with the crate)
- All callers already unwrap the Result
- Removes one layer of wrapping, net -2 lines

### Verification
- ✅ cargo check
- ✅ cargo clippy (0 warnings)  
- ✅ cargo test (5 token_counter tests pass)
- ✅ cargo fmt

**1 file changed, 5 insertions, 7 deletions**