### PR TITLE
feat: Extension Registry — discovery, install, and lifecycle management

### DIFF
--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -21,6 +21,7 @@ pub mod prompt_template;
 pub mod providers;
 pub mod recipe;
 pub mod recipe_deeplink;
+pub mod registry;
 pub mod scheduler;
 pub mod scheduler_trait;
 pub mod security;

--- a/crates/goose/src/registry/formats.rs
+++ b/crates/goose/src/registry/formats.rs
@@ -1,0 +1,845 @@
+//! Multi-format parsing and generation for agent manifests.
+//!
+//! Supports:
+//! - **ACP Client Protocol** `agent.json` (parse + generate)
+//! - **A2A Protocol** `agent-card.json` (generate from RegistryEntry)
+//! - **Goose native** `agent.yaml` (already handled by manifest.rs)
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+use crate::registry::manifest::{
+    AgentDetail, AgentDistribution, AgentSkill, AuthorInfo, BinaryTarget, PackageDistribution,
+    RegistryEntry, RegistryEntryDetail, RegistryEntryKind, SecurityScheme,
+};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// ACP Client Protocol agent.json
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// ACP Client Protocol agent.json format.
+///
+/// Spec: <https://agentclientprotocol.com/rfds/acp-agent-registry>
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpClientAgentJson {
+    pub id: String,
+    pub name: String,
+    pub version: String,
+    pub description: String,
+    pub distribution: AcpDistribution,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authors: Vec<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AcpDistribution {
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub binary: HashMap<String, AcpBinaryTarget>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub npx: Option<AcpPackageTarget>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uvx: Option<AcpPackageTarget>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpBinaryTarget {
+    pub archive: String,
+    pub cmd: String,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AcpPackageTarget {
+    pub package: String,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+}
+
+/// Parse an ACP Client agent.json into a RegistryEntry.
+pub fn parse_acp_client_agent_json(json_str: &str) -> anyhow::Result<RegistryEntry> {
+    let acp: AcpClientAgentJson = serde_json::from_str(json_str)?;
+
+    let author = if !acp.authors.is_empty() {
+        Some(AuthorInfo {
+            name: Some(acp.authors.join(", ")),
+            ..Default::default()
+        })
+    } else {
+        None
+    };
+
+    // Convert ACP binary targets to Goose BinaryTarget HashMap
+    let binary: HashMap<String, BinaryTarget> = acp
+        .distribution
+        .binary
+        .into_iter()
+        .map(|(platform, t)| {
+            (
+                platform,
+                BinaryTarget {
+                    archive: t.archive,
+                    cmd: t.cmd,
+                    args: t.args,
+                    env: t.env,
+                },
+            )
+        })
+        .collect();
+
+    let distribution = Some(AgentDistribution {
+        binary,
+        npx: acp.distribution.npx.map(|p| PackageDistribution {
+            package: p.package,
+            args: Some(p.args).filter(|a| !a.is_empty()),
+            env: p.env,
+        }),
+        uvx: acp.distribution.uvx.map(|p| PackageDistribution {
+            package: p.package,
+            args: Some(p.args).filter(|a| !a.is_empty()),
+            env: p.env,
+        }),
+        cargo: None,
+        docker: None,
+    });
+
+    Ok(RegistryEntry {
+        name: acp.name,
+        kind: RegistryEntryKind::Agent,
+        description: acp.description,
+        version: Some(acp.version),
+        author,
+        license: acp.license,
+        icon: acp.icon,
+        repository: acp.repository,
+        detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+            distribution,
+            ..Default::default()
+        })),
+        metadata: {
+            let mut m = HashMap::new();
+            m.insert("acp_client_id".to_string(), acp.id);
+            m.insert("format".to_string(), "acp-client".to_string());
+            m
+        },
+        ..Default::default()
+    })
+}
+
+/// Generate an ACP Client agent.json from a RegistryEntry.
+pub fn generate_acp_client_agent_json(entry: &RegistryEntry) -> anyhow::Result<String> {
+    let id = entry
+        .metadata
+        .get("acp_client_id")
+        .cloned()
+        .unwrap_or_else(|| slug_from_name(&entry.name));
+
+    let authors: Vec<String> = entry
+        .author
+        .as_ref()
+        .and_then(|a| a.name.clone())
+        .map(|n| vec![n])
+        .unwrap_or_default();
+
+    let distribution = if let RegistryEntryDetail::Agent(ref detail) = entry.detail {
+        if let Some(ref dist) = detail.distribution {
+            AcpDistribution {
+                binary: dist
+                    .binary
+                    .iter()
+                    .map(|(platform, t)| {
+                        (
+                            platform.clone(),
+                            AcpBinaryTarget {
+                                archive: t.archive.clone(),
+                                cmd: t.cmd.clone(),
+                                args: t.args.clone(),
+                                env: t.env.clone(),
+                            },
+                        )
+                    })
+                    .collect(),
+                npx: dist.npx.as_ref().map(|p| AcpPackageTarget {
+                    package: p.package.clone(),
+                    args: p.args.clone().unwrap_or_default(),
+                    env: p.env.clone(),
+                }),
+                uvx: dist.uvx.as_ref().map(|p| AcpPackageTarget {
+                    package: p.package.clone(),
+                    args: p.args.clone().unwrap_or_default(),
+                    env: p.env.clone(),
+                }),
+            }
+        } else {
+            AcpDistribution::default()
+        }
+    } else {
+        AcpDistribution::default()
+    };
+
+    let acp = AcpClientAgentJson {
+        id,
+        name: entry.name.clone(),
+        version: entry.version.clone().unwrap_or_else(|| "0.1.0".to_string()),
+        description: entry.description.clone(),
+        distribution,
+        repository: entry.repository.clone(),
+        authors,
+        license: entry.license.clone(),
+        icon: entry.icon.clone(),
+    };
+
+    Ok(serde_json::to_string_pretty(&acp)?)
+}
+
+fn slug_from_name(name: &str) -> String {
+    name.to_lowercase()
+        .replace(' ', "-")
+        .chars()
+        .filter(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || *c == '-')
+        .collect()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// A2A Protocol agent-card.json
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A2A Protocol Agent Card.
+///
+/// Spec: <https://a2a-protocol.org/latest/specification/#5-agent-card>
+/// Discovery: `/.well-known/agent-card.json`
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct A2aAgentCard {
+    pub name: String,
+    pub description: String,
+    pub version: String,
+    pub supported_interfaces: Vec<A2aAgentInterface>,
+    pub default_input_modes: Vec<String>,
+    pub default_output_modes: Vec<String>,
+    pub skills: Vec<A2aAgentSkill>,
+    pub capabilities: A2aAgentCapabilities,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<A2aAgentProvider>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation_url: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
+
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub security_schemes: HashMap<String, A2aSecurityScheme>,
+
+    /// A2A extensions declared by this agent (MCP extensions mapped to A2A AgentExtension).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<A2aAgentExtension>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct A2aAgentInterface {
+    pub url: String,
+    pub protocol_binding: String,
+    pub protocol_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct A2aAgentProvider {
+    pub organization: String,
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct A2aAgentCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub streaming: Option<bool>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_notifications: Option<bool>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct A2aAgentSkill {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<String>,
+}
+
+/// A2A AgentExtension — declares an extension (MCP tool provider) available to this agent.
+/// Maps to A2A spec §4.4.4 AgentExtension.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct A2aAgentExtension {
+    /// URI identifying the extension (e.g., "mcp://developer", "mcp://memory").
+    pub uri: String,
+
+    /// Human-readable description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Whether this extension is required for the agent to function.
+    #[serde(default)]
+    pub required: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct A2aSecurityScheme {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key_security_scheme: Option<A2aApiKeySecurity>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub http_auth_security_scheme: Option<A2aHttpAuthSecurity>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub oauth2_security_scheme: Option<A2aOAuth2Security>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct A2aApiKeySecurity {
+    pub location: String,
+    pub name: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct A2aHttpAuthSecurity {
+    pub scheme: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub bearer_format: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct A2aOAuth2Security {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flows: Option<serde_json::Value>,
+}
+
+/// Generate an A2A agent-card.json from a RegistryEntry.
+pub fn generate_a2a_agent_card(entry: &RegistryEntry, agent_url: &str) -> anyhow::Result<String> {
+    let (skills, input_types, output_types, security_schemes) =
+        if let RegistryEntryDetail::Agent(ref detail) = entry.detail {
+            let skills: Vec<A2aAgentSkill> = if detail.skills.is_empty() {
+                // Fall back to capabilities as skills
+                detail
+                    .capabilities
+                    .iter()
+                    .enumerate()
+                    .map(|(i, cap)| A2aAgentSkill {
+                        id: format!("cap-{i}"),
+                        name: cap.clone(),
+                        description: cap.clone(),
+                        tags: detail.domains.clone(),
+                        examples: Vec::new(),
+                    })
+                    .collect()
+            } else {
+                detail
+                    .skills
+                    .iter()
+                    .map(|s| A2aAgentSkill {
+                        id: s.id.clone(),
+                        name: s.name.clone(),
+                        description: s.description.clone().unwrap_or_default(),
+                        tags: s.tags.clone(),
+                        examples: s.examples.clone(),
+                    })
+                    .collect()
+            };
+
+            let input_types = if detail.input_content_types.is_empty() {
+                vec!["text/plain".to_string()]
+            } else {
+                detail.input_content_types.clone()
+            };
+
+            let output_types = if detail.output_content_types.is_empty() {
+                vec!["text/plain".to_string()]
+            } else {
+                detail.output_content_types.clone()
+            };
+
+            let mut sec_schemes = HashMap::new();
+            for scheme in &detail.security {
+                match scheme {
+                    SecurityScheme::ApiKey {
+                        header,
+                        query_param,
+                    } => {
+                        let (location, name) = if let Some(h) = header {
+                            ("header".to_string(), h.clone())
+                        } else if let Some(q) = query_param {
+                            ("query".to_string(), q.clone())
+                        } else {
+                            continue;
+                        };
+                        sec_schemes.insert(
+                            "apiKey".to_string(),
+                            A2aSecurityScheme {
+                                api_key_security_scheme: Some(A2aApiKeySecurity { location, name }),
+                                http_auth_security_scheme: None,
+                                oauth2_security_scheme: None,
+                            },
+                        );
+                    }
+                    SecurityScheme::Http { scheme: s } => {
+                        sec_schemes.insert(
+                            "http".to_string(),
+                            A2aSecurityScheme {
+                                api_key_security_scheme: None,
+                                http_auth_security_scheme: Some(A2aHttpAuthSecurity {
+                                    scheme: s.clone(),
+                                    bearer_format: None,
+                                }),
+                                oauth2_security_scheme: None,
+                            },
+                        );
+                    }
+                    SecurityScheme::OAuth2 {
+                        authorization_url,
+                        token_url,
+                        scopes,
+                    } => {
+                        let mut scope_map = serde_json::Map::new();
+                        for s in scopes {
+                            scope_map.insert(s.clone(), serde_json::Value::String(s.clone()));
+                        }
+                        let flows = serde_json::json!({
+                            "authorizationCode": {
+                                "authorizationUrl": authorization_url,
+                                "tokenUrl": token_url,
+                                "scopes": scope_map
+                            }
+                        });
+                        sec_schemes.insert(
+                            "oauth2".to_string(),
+                            A2aSecurityScheme {
+                                api_key_security_scheme: None,
+                                http_auth_security_scheme: None,
+                                oauth2_security_scheme: Some(A2aOAuth2Security {
+                                    flows: Some(flows),
+                                }),
+                            },
+                        );
+                    }
+                }
+            }
+
+            (skills, input_types, output_types, sec_schemes)
+        } else {
+            (
+                Vec::new(),
+                vec!["text/plain".to_string()],
+                vec!["text/plain".to_string()],
+                HashMap::new(),
+            )
+        };
+
+    let provider = entry.author.as_ref().and_then(|a| {
+        a.name.as_ref().map(|name| A2aAgentProvider {
+            organization: name.clone(),
+            url: a.url.clone().unwrap_or_default(),
+        })
+    });
+
+    let card = A2aAgentCard {
+        name: entry.name.clone(),
+        description: entry.description.clone(),
+        version: entry.version.clone().unwrap_or_else(|| "0.1.0".to_string()),
+        supported_interfaces: vec![A2aAgentInterface {
+            url: agent_url.to_string(),
+            protocol_binding: "HTTP+JSON".to_string(),
+            protocol_version: "1.0".to_string(),
+        }],
+        default_input_modes: input_types,
+        default_output_modes: output_types,
+        skills,
+        capabilities: A2aAgentCapabilities {
+            streaming: Some(true),
+            push_notifications: None,
+        },
+        provider,
+        documentation_url: entry.repository.clone(),
+        icon_url: entry.icon.clone(),
+        security_schemes,
+        extensions: Vec::new(),
+    };
+
+    Ok(serde_json::to_string_pretty(&card)?)
+}
+
+/// Parse an A2A agent-card.json into a RegistryEntry.
+pub fn parse_a2a_agent_card(json_str: &str) -> anyhow::Result<RegistryEntry> {
+    let card: A2aAgentCard = serde_json::from_str(json_str)?;
+
+    let author = card.provider.as_ref().map(|p| AuthorInfo {
+        name: Some(p.organization.clone()),
+        url: Some(p.url.clone()),
+        ..Default::default()
+    });
+
+    let skills: Vec<AgentSkill> = card
+        .skills
+        .iter()
+        .map(|s| AgentSkill {
+            id: s.id.clone(),
+            name: s.name.clone(),
+            description: Some(s.description.clone()),
+            tags: s.tags.clone(),
+            examples: s.examples.clone(),
+        })
+        .collect();
+
+    let capabilities: Vec<String> = card.skills.iter().map(|s| s.name.clone()).collect();
+    let domains: Vec<String> = {
+        let mut tags: Vec<String> = card.skills.iter().flat_map(|s| s.tags.clone()).collect();
+        tags.sort();
+        tags.dedup();
+        tags
+    };
+
+    let mut security = Vec::new();
+    for scheme in card.security_schemes.values() {
+        if let Some(ref api_key) = scheme.api_key_security_scheme {
+            security.push(SecurityScheme::ApiKey {
+                header: if api_key.location == "header" {
+                    Some(api_key.name.clone())
+                } else {
+                    None
+                },
+                query_param: if api_key.location == "query" {
+                    Some(api_key.name.clone())
+                } else {
+                    None
+                },
+            });
+        }
+        if let Some(ref http) = scheme.http_auth_security_scheme {
+            security.push(SecurityScheme::Http {
+                scheme: http.scheme.clone(),
+            });
+        }
+        if let Some(ref oauth) = scheme.oauth2_security_scheme {
+            let (auth_url, token_url, scopes) = oauth
+                .flows
+                .as_ref()
+                .and_then(|f| {
+                    f.get("authorizationCode").map(|ac| {
+                        let auth = ac
+                            .get("authorizationUrl")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let token = ac
+                            .get("tokenUrl")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        let scopes: Vec<String> = ac
+                            .get("scopes")
+                            .and_then(|v| v.as_object())
+                            .map(|m| m.keys().cloned().collect())
+                            .unwrap_or_default();
+                        (auth, token, scopes)
+                    })
+                })
+                .unwrap_or_default();
+            security.push(SecurityScheme::OAuth2 {
+                authorization_url: auth_url,
+                token_url,
+                scopes,
+            });
+        }
+    }
+
+    let source_uri = card.supported_interfaces.first().map(|i| i.url.clone());
+
+    Ok(RegistryEntry {
+        name: card.name,
+        kind: RegistryEntryKind::Agent,
+        description: card.description,
+        version: Some(card.version),
+        author,
+        icon: card.icon_url,
+        repository: card.documentation_url,
+        source_uri,
+        detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+            capabilities,
+            domains,
+            skills,
+            security,
+            input_content_types: card.default_input_modes,
+            output_content_types: card.default_output_modes,
+            ..Default::default()
+        })),
+        metadata: {
+            let mut m = HashMap::new();
+            m.insert("format".to_string(), "a2a".to_string());
+            m
+        },
+        ..Default::default()
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_acp_client_binary_agent() {
+        let json = r#"{
+            "id": "goose-dev",
+            "name": "Goose Developer",
+            "version": "1.0.0",
+            "description": "AI coding agent",
+            "repository": "https://github.com/block/goose",
+            "authors": ["Block"],
+            "license": "Apache-2.0",
+            "icon": "icon.svg",
+            "distribution": {
+                "binary": {
+                    "linux-x86_64": {
+                        "archive": "https://example.com/goose-linux.tar.gz",
+                        "cmd": "./goose",
+                        "args": ["acp"]
+                    }
+                }
+            }
+        }"#;
+
+        let entry = parse_acp_client_agent_json(json).unwrap();
+        assert_eq!(entry.name, "Goose Developer");
+        assert_eq!(entry.kind, RegistryEntryKind::Agent);
+        assert_eq!(entry.version, Some("1.0.0".to_string()));
+        assert_eq!(entry.license, Some("Apache-2.0".to_string()));
+        assert_eq!(
+            entry.metadata.get("acp_client_id"),
+            Some(&"goose-dev".to_string())
+        );
+
+        if let RegistryEntryDetail::Agent(ref detail) = entry.detail {
+            assert!(detail.distribution.is_some());
+            let dist = detail.distribution.as_ref().unwrap();
+            assert_eq!(dist.binary.len(), 1);
+        } else {
+            panic!("Expected Agent detail");
+        }
+    }
+
+    #[test]
+    fn parse_acp_client_npx_agent() {
+        let json = r#"{
+            "id": "node-agent",
+            "name": "Node Agent",
+            "version": "2.1.0",
+            "description": "A Node.js agent",
+            "distribution": {
+                "npx": {
+                    "package": "node-agent@latest",
+                    "args": ["--stdio"]
+                }
+            }
+        }"#;
+
+        let entry = parse_acp_client_agent_json(json).unwrap();
+        assert_eq!(entry.name, "Node Agent");
+
+        if let RegistryEntryDetail::Agent(ref detail) = entry.detail {
+            let dist = detail.distribution.as_ref().unwrap();
+            assert!(dist.npx.is_some());
+            assert_eq!(dist.npx.as_ref().unwrap().package, "node-agent@latest");
+        } else {
+            panic!("Expected Agent detail");
+        }
+    }
+
+    #[test]
+    fn acp_client_roundtrip() {
+        let json = r#"{
+            "id": "test-agent",
+            "name": "Test Agent",
+            "version": "1.0.0",
+            "description": "A test agent",
+            "authors": ["Test Corp"],
+            "license": "MIT",
+            "distribution": {
+                "uvx": {
+                    "package": "test-agent@1.0.0",
+                    "args": ["--mode", "acp"]
+                }
+            }
+        }"#;
+
+        let entry = parse_acp_client_agent_json(json).unwrap();
+        let regenerated = generate_acp_client_agent_json(&entry).unwrap();
+        let reparsed = parse_acp_client_agent_json(&regenerated).unwrap();
+
+        assert_eq!(entry.name, reparsed.name);
+        assert_eq!(entry.version, reparsed.version);
+        assert_eq!(entry.license, reparsed.license);
+    }
+
+    #[test]
+    fn generate_a2a_card_from_agent() {
+        let entry = RegistryEntry {
+            name: "Goose Developer".to_string(),
+            kind: RegistryEntryKind::Agent,
+            description: "AI coding agent".to_string(),
+            version: Some("1.0.0".to_string()),
+            author: Some(AuthorInfo {
+                name: Some("Block".to_string()),
+                url: Some("https://block.xyz".to_string()),
+                ..Default::default()
+            }),
+            detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                capabilities: vec!["Code Generation".to_string(), "Code Review".to_string()],
+                domains: vec!["software-development".to_string()],
+                input_content_types: vec!["text/plain".to_string()],
+                output_content_types: vec![
+                    "text/plain".to_string(),
+                    "application/json".to_string(),
+                ],
+                security: vec![SecurityScheme::ApiKey {
+                    header: Some("X-Agent-Key".to_string()),
+                    query_param: None,
+                }],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let json = generate_a2a_agent_card(&entry, "https://goose.example.com/a2a").unwrap();
+        assert!(json.contains("Goose Developer"));
+        assert!(json.contains("supportedInterfaces"));
+        assert!(json.contains("https://goose.example.com/a2a"));
+        assert!(json.contains("Code Generation"));
+        assert!(json.contains("X-Agent-Key"));
+
+        let card: A2aAgentCard = serde_json::from_str(&json).unwrap();
+        assert_eq!(card.skills.len(), 2);
+        assert_eq!(card.provider.unwrap().organization, "Block");
+    }
+
+    #[test]
+    fn parse_a2a_agent_card_test() {
+        let json = r#"{
+            "name": "Remote Agent",
+            "description": "A remote coding agent",
+            "version": "2.0.0",
+            "supportedInterfaces": [
+                {
+                    "url": "https://agent.example.com/a2a",
+                    "protocolBinding": "HTTP+JSON",
+                    "protocolVersion": "1.0"
+                }
+            ],
+            "defaultInputModes": ["text/plain"],
+            "defaultOutputModes": ["text/plain", "application/json"],
+            "skills": [
+                {
+                    "id": "code-gen",
+                    "name": "Code Generation",
+                    "description": "Generates code",
+                    "tags": ["coding", "rust"]
+                }
+            ],
+            "capabilities": {
+                "streaming": true
+            },
+            "provider": {
+                "organization": "Example Corp",
+                "url": "https://example.com"
+            },
+            "securitySchemes": {
+                "bearer": {
+                    "httpAuthSecurityScheme": {
+                        "scheme": "Bearer"
+                    }
+                }
+            }
+        }"#;
+
+        let entry = parse_a2a_agent_card(json).unwrap();
+        assert_eq!(entry.name, "Remote Agent");
+        assert_eq!(entry.kind, RegistryEntryKind::Agent);
+        assert_eq!(entry.version, Some("2.0.0".to_string()));
+        assert_eq!(
+            entry.source_uri,
+            Some("https://agent.example.com/a2a".to_string())
+        );
+
+        if let RegistryEntryDetail::Agent(ref detail) = entry.detail {
+            assert_eq!(detail.skills.len(), 1);
+            assert_eq!(detail.skills[0].id, "code-gen");
+            assert_eq!(detail.security.len(), 1);
+            assert!(matches!(detail.security[0], SecurityScheme::Http { .. }));
+        } else {
+            panic!("Expected Agent detail");
+        }
+    }
+
+    #[test]
+    fn a2a_roundtrip() {
+        let entry = RegistryEntry {
+            name: "Roundtrip Agent".to_string(),
+            kind: RegistryEntryKind::Agent,
+            description: "Testing roundtrip".to_string(),
+            version: Some("1.0.0".to_string()),
+            detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                skills: vec![AgentSkill {
+                    id: "test".to_string(),
+                    name: "Testing".to_string(),
+                    description: Some("A test skill".to_string()),
+                    tags: vec!["test".to_string()],
+                    examples: vec!["Run tests".to_string()],
+                }],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let card_json = generate_a2a_agent_card(&entry, "https://example.com/a2a").unwrap();
+        let reparsed = parse_a2a_agent_card(&card_json).unwrap();
+
+        assert_eq!(entry.name, reparsed.name);
+        assert_eq!(entry.version, reparsed.version);
+    }
+
+    #[test]
+    fn slug_generation() {
+        assert_eq!(slug_from_name("Goose Developer"), "goose-developer");
+        assert_eq!(slug_from_name("My Agent 2.0!"), "my-agent-20");
+        assert_eq!(slug_from_name("simple"), "simple");
+    }
+}

--- a/crates/goose/src/registry/install.rs
+++ b/crates/goose/src/registry/install.rs
@@ -1,0 +1,390 @@
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use super::manifest::{RegistryEntry, RegistryEntryDetail, RegistryEntryKind};
+use crate::agents::ExtensionConfig;
+use crate::config::extensions::{set_extension, ExtensionEntry};
+
+/// Get the global install directory for a given artifact kind
+pub fn install_dir(kind: RegistryEntryKind) -> Result<PathBuf> {
+    let config_dir = dirs::config_dir()
+        .context("Could not determine config directory")?
+        .join("goose");
+
+    let subdir = match kind {
+        RegistryEntryKind::Skill => "skills",
+        RegistryEntryKind::Agent => "agents",
+        RegistryEntryKind::Recipe => "recipes",
+        RegistryEntryKind::Tool => "extensions",
+    };
+
+    Ok(config_dir.join(subdir))
+}
+
+/// Install a registry entry to the local filesystem
+pub fn install_entry(entry: &RegistryEntry) -> Result<PathBuf> {
+    match entry.kind {
+        RegistryEntryKind::Skill => install_skill(entry),
+        RegistryEntryKind::Agent => install_agent(entry),
+        RegistryEntryKind::Recipe => install_recipe(entry),
+        RegistryEntryKind::Tool => install_tool(entry),
+    }
+}
+
+/// Remove an installed entry
+pub fn remove_entry(name: &str, kind: RegistryEntryKind) -> Result<()> {
+    match kind {
+        RegistryEntryKind::Skill => remove_skill(name),
+        RegistryEntryKind::Agent => remove_agent(name),
+        RegistryEntryKind::Recipe => remove_recipe(name),
+        RegistryEntryKind::Tool => remove_tool(name),
+    }
+}
+
+/// Check if an entry is installed
+pub fn is_installed(name: &str, kind: RegistryEntryKind) -> bool {
+    match kind {
+        RegistryEntryKind::Skill => {
+            let dir = install_dir(kind).ok();
+            dir.is_some_and(|d| d.join(name).join("SKILL.md").exists())
+        }
+        RegistryEntryKind::Agent => {
+            let dir = install_dir(kind).ok();
+            dir.is_some_and(|d| d.join(format!("{}.md", name)).exists())
+        }
+        RegistryEntryKind::Recipe => {
+            let dir = install_dir(kind).ok();
+            dir.is_some_and(|d| d.join(format!("{}.yaml", name)).exists())
+        }
+        RegistryEntryKind::Tool => crate::config::extensions::get_extension_by_name(name).is_some(),
+    }
+}
+
+/// List installed entries of a given kind
+pub fn list_installed(kind: RegistryEntryKind) -> Result<Vec<String>> {
+    match kind {
+        RegistryEntryKind::Tool => Ok(crate::config::extensions::get_all_extension_names()),
+        RegistryEntryKind::Skill => {
+            let dir = install_dir(kind)?;
+            list_subdirs(&dir)
+        }
+        RegistryEntryKind::Agent => {
+            let dir = install_dir(kind)?;
+            list_files_with_ext(&dir, "md")
+        }
+        RegistryEntryKind::Recipe => {
+            let dir = install_dir(kind)?;
+            list_files_with_ext(&dir, "yaml")
+        }
+    }
+}
+
+fn install_skill(entry: &RegistryEntry) -> Result<PathBuf> {
+    let dir = install_dir(RegistryEntryKind::Skill)?.join(&entry.name);
+    fs::create_dir_all(&dir)?;
+
+    let content = match &entry.detail {
+        RegistryEntryDetail::Skill(detail) => {
+            format!(
+                "---\nname: {}\ndescription: {}\n---\n\n{}",
+                entry.name, entry.description, detail.content
+            )
+        }
+        _ => format!(
+            "---\nname: {}\ndescription: {}\n---\n",
+            entry.name, entry.description
+        ),
+    };
+
+    let path = dir.join("SKILL.md");
+    fs::write(&path, &content)?;
+    Ok(path)
+}
+
+fn install_agent(entry: &RegistryEntry) -> Result<PathBuf> {
+    let dir = install_dir(RegistryEntryKind::Agent)?;
+    fs::create_dir_all(&dir)?;
+
+    let content = match &entry.detail {
+        RegistryEntryDetail::Agent(detail) => {
+            let mut front = format!(
+                "---\nname: {}\ndescription: {}",
+                entry.name, entry.description
+            );
+            if let Some(model) = &detail.model {
+                front.push_str(&format!("\nmodel: {}", model));
+            }
+            front.push_str("\n---\n\n");
+            front.push_str(&detail.instructions);
+            front
+        }
+        _ => format!(
+            "---\nname: {}\ndescription: {}\n---\n",
+            entry.name, entry.description
+        ),
+    };
+
+    let path = dir.join(format!("{}.md", entry.name));
+    fs::write(&path, &content)?;
+    Ok(path)
+}
+
+fn install_recipe(entry: &RegistryEntry) -> Result<PathBuf> {
+    let dir = install_dir(RegistryEntryKind::Recipe)?;
+    fs::create_dir_all(&dir)?;
+
+    // If we have the original local path, copy the file
+    if let Some(local_path) = &entry.local_path {
+        if local_path.exists() {
+            let dest = dir.join(format!("{}.yaml", entry.name));
+            fs::copy(local_path, &dest)?;
+            return Ok(dest);
+        }
+    }
+
+    // Otherwise generate a minimal recipe YAML
+    let yaml = match &entry.detail {
+        RegistryEntryDetail::Recipe(detail) => {
+            let mut y = format!(
+                "version: \"1.0.0\"\ntitle: {}\ndescription: {}",
+                entry.name, entry.description
+            );
+            if let Some(instructions) = &detail.instructions {
+                y.push_str(&format!("\ninstructions: {}", instructions));
+            }
+            if let Some(prompt) = &detail.prompt {
+                y.push_str(&format!("\nprompt: {}", prompt));
+            }
+            y
+        }
+        _ => format!(
+            "version: \"1.0.0\"\ntitle: {}\ndescription: {}",
+            entry.name, entry.description
+        ),
+    };
+
+    let path = dir.join(format!("{}.yaml", entry.name));
+    fs::write(&path, &yaml)?;
+    Ok(path)
+}
+
+fn install_tool(entry: &RegistryEntry) -> Result<PathBuf> {
+    // For tools, we add to the goose config
+    if let RegistryEntryDetail::Tool(detail) = &entry.detail {
+        let config = match &detail.transport {
+            super::manifest::ToolTransport::Stdio { cmd, args } => ExtensionConfig::Stdio {
+                name: entry.name.clone(),
+                description: entry.description.clone(),
+                cmd: cmd.clone(),
+                args: args.clone(),
+                envs: Default::default(),
+                env_keys: detail.env_keys.clone(),
+                timeout: None,
+                bundled: Some(false),
+                available_tools: Vec::new(),
+            },
+            super::manifest::ToolTransport::StreamableHttp { uri } => {
+                ExtensionConfig::StreamableHttp {
+                    name: entry.name.clone(),
+                    description: entry.description.clone(),
+                    uri: uri.clone(),
+                    envs: Default::default(),
+                    env_keys: detail.env_keys.clone(),
+                    headers: Default::default(),
+                    timeout: None,
+                    bundled: Some(false),
+                    available_tools: Vec::new(),
+                }
+            }
+            super::manifest::ToolTransport::Builtin => ExtensionConfig::Builtin {
+                name: entry.name.clone(),
+                description: entry.description.clone(),
+                display_name: None,
+                timeout: None,
+                bundled: Some(true),
+                available_tools: Vec::new(),
+            },
+        };
+
+        set_extension(ExtensionEntry {
+            enabled: true,
+            config,
+        });
+    }
+
+    let config_path = dirs::config_dir()
+        .context("Could not determine config directory")?
+        .join("goose")
+        .join("config.yaml");
+    Ok(config_path)
+}
+
+fn remove_skill(name: &str) -> Result<()> {
+    let dir = install_dir(RegistryEntryKind::Skill)?.join(name);
+    if dir.exists() {
+        fs::remove_dir_all(&dir)?;
+    }
+    Ok(())
+}
+
+fn remove_agent(name: &str) -> Result<()> {
+    let path = install_dir(RegistryEntryKind::Agent)?.join(format!("{}.md", name));
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+fn remove_recipe(name: &str) -> Result<()> {
+    let path = install_dir(RegistryEntryKind::Recipe)?.join(format!("{}.yaml", name));
+    if path.exists() {
+        fs::remove_file(&path)?;
+    }
+    Ok(())
+}
+
+fn remove_tool(name: &str) -> Result<()> {
+    crate::config::extensions::remove_extension(name);
+    Ok(())
+}
+
+fn list_subdirs(dir: &Path) -> Result<Vec<String>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut names = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            if let Some(name) = entry.file_name().to_str() {
+                names.push(name.to_string());
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+fn list_files_with_ext(dir: &Path, ext: &str) -> Result<Vec<String>> {
+    if !dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut names = Vec::new();
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().is_some_and(|e| e == ext) {
+            if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                names.push(stem.to_string());
+            }
+        }
+    }
+    names.sort();
+    Ok(names)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::registry::manifest::{AgentDetail, SkillDetail};
+
+    #[test]
+    fn test_install_and_remove_skill() {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills").join("test-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+
+        let entry = RegistryEntry {
+            name: "test-skill".into(),
+            kind: RegistryEntryKind::Skill,
+            description: "A test skill".into(),
+            detail: RegistryEntryDetail::Skill(SkillDetail {
+                content: "Do something useful".into(),
+                builtin: false,
+            }),
+            ..Default::default()
+        };
+
+        // Install to the temp dir
+        let skill_path = skill_dir.join("SKILL.md");
+        let content = format!(
+            "---\nname: {}\ndescription: {}\n---\n\n{}",
+            entry.name, entry.description, "Do something useful"
+        );
+        std::fs::write(&skill_path, &content).unwrap();
+
+        assert!(skill_path.exists());
+
+        // Remove
+        std::fs::remove_dir_all(&skill_dir).unwrap();
+        assert!(!skill_dir.exists());
+    }
+
+    #[test]
+    fn test_install_and_remove_agent() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents_dir = dir.path().join("agents");
+        std::fs::create_dir_all(&agents_dir).unwrap();
+
+        let entry = RegistryEntry {
+            name: "test-agent".into(),
+            kind: RegistryEntryKind::Agent,
+            description: "A test agent".into(),
+            detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                instructions: "You are a helpful agent".into(),
+                model: Some("gpt-4o".into()),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let agent_path = agents_dir.join("test-agent.md");
+        let content = format!(
+            "---\nname: {}\ndescription: {}\nmodel: gpt-4o\n---\n\nYou are a helpful agent",
+            entry.name, entry.description
+        );
+        std::fs::write(&agent_path, &content).unwrap();
+
+        assert!(agent_path.exists());
+        let read = std::fs::read_to_string(&agent_path).unwrap();
+        assert!(read.contains("test-agent"));
+        assert!(read.contains("gpt-4o"));
+
+        std::fs::remove_file(&agent_path).unwrap();
+        assert!(!agent_path.exists());
+    }
+
+    #[test]
+    fn test_list_installed_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let agents_dir = dir.path();
+
+        // Create some .md files
+        std::fs::write(agents_dir.join("alpha.md"), "agent alpha").unwrap();
+        std::fs::write(agents_dir.join("beta.md"), "agent beta").unwrap();
+        std::fs::write(agents_dir.join("not-an-agent.txt"), "ignore me").unwrap();
+
+        let names = list_files_with_ext(agents_dir, "md").unwrap();
+        assert_eq!(names, vec!["alpha", "beta"]);
+    }
+
+    #[test]
+    fn test_list_installed_subdirs() {
+        let dir = tempfile::tempdir().unwrap();
+        let skills_dir = dir.path();
+
+        std::fs::create_dir_all(skills_dir.join("skill-a")).unwrap();
+        std::fs::create_dir_all(skills_dir.join("skill-b")).unwrap();
+        std::fs::write(skills_dir.join("not-a-dir.txt"), "ignore").unwrap();
+
+        let names = list_subdirs(skills_dir).unwrap();
+        assert_eq!(names, vec!["skill-a", "skill-b"]);
+    }
+
+    #[test]
+    fn test_list_nonexistent_dir() {
+        let names = list_files_with_ext(Path::new("/nonexistent/path"), "md").unwrap();
+        assert!(names.is_empty());
+    }
+}

--- a/crates/goose/src/registry/manifest.rs
+++ b/crates/goose/src/registry/manifest.rs
@@ -1,0 +1,966 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// The four kinds of artifacts in the registry.
+///
+/// Aligns with the existing `SourceKind` enum in summon_extension.rs
+/// but adds Tool (which is managed separately by ExtensionManager today).
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum RegistryEntryKind {
+    #[default]
+    Tool,
+    Skill,
+    Agent,
+    Recipe,
+}
+
+impl std::fmt::Display for RegistryEntryKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Tool => write!(f, "tool"),
+            Self::Skill => write!(f, "skill"),
+            Self::Agent => write!(f, "agent"),
+            Self::Recipe => write!(f, "recipe"),
+        }
+    }
+}
+
+/// A unified registry entry that can represent any of the 4 artifact types.
+///
+/// Designed to be the common currency across all registry sources (local, GitHub, HTTP).
+/// Schema is a superset of:
+/// - ACP Client Protocol agent.json (distribution, version, id)
+/// - ACP Communication Protocol manifest (metadata, dependencies, content types)
+/// - A2A Agent Card (skills, security, discovery)
+/// - Kilo Code modes (behavioral configurations)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct RegistryEntry {
+    pub name: String,
+    pub kind: RegistryEntryKind,
+    pub description: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<AuthorInfo>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon: Option<String>,
+
+    /// Where this entry was resolved from.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_uri: Option<String>,
+
+    /// Local path if available (e.g. from filesystem scan).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[schema(value_type = Option<String>)]
+    pub local_path: Option<PathBuf>,
+
+    /// Tags for search and categorization.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+
+    /// Kind-specific payload.
+    #[serde(flatten)]
+    pub detail: RegistryEntryDetail,
+
+    /// Additional metadata from external registries.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub metadata: HashMap<String, String>,
+}
+
+impl RegistryEntry {
+    /// Merge metadata from another entry with the same name+kind.
+    pub fn merge_metadata(&mut self, other: &RegistryEntry) {
+        for (k, v) in &other.metadata {
+            self.metadata.entry(k.clone()).or_insert_with(|| v.clone());
+        }
+        if self.version.is_none() {
+            self.version.clone_from(&other.version);
+        }
+        if self.author.is_none() {
+            self.author.clone_from(&other.author);
+        }
+        if self.license.is_none() {
+            self.license.clone_from(&other.license);
+        }
+        if self.repository.is_none() {
+            self.repository.clone_from(&other.repository);
+        }
+    }
+
+    /// Check if this entry has enough metadata to be published to a registry.
+    pub fn validate_for_publish(&self) -> Vec<String> {
+        let mut issues = Vec::new();
+
+        if self.name.is_empty() {
+            issues.push("name is required".into());
+        }
+        if self.description.is_empty() {
+            issues.push("description is required".into());
+        }
+        if self.version.is_none() {
+            issues.push("version is required for publishing".into());
+        }
+        if self.author.is_none() {
+            issues.push("author is recommended for publishing".into());
+        }
+        if self.license.is_none() {
+            issues.push("license is recommended for publishing".into());
+        }
+
+        if let RegistryEntryDetail::Agent(ref agent) = self.detail {
+            if agent.instructions.is_empty() {
+                issues.push("agent instructions are required".into());
+            }
+            if agent.capabilities.is_empty() {
+                issues.push("at least one capability is recommended".into());
+            }
+        }
+
+        issues
+    }
+}
+
+/// Kind-specific details for each registry entry type.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "detail_type")]
+pub enum RegistryEntryDetail {
+    #[serde(rename = "tool")]
+    Tool(ToolDetail),
+    #[serde(rename = "skill")]
+    Skill(SkillDetail),
+    #[serde(rename = "agent")]
+    Agent(Box<AgentDetail>),
+    #[serde(rename = "recipe")]
+    Recipe(RecipeDetail),
+}
+
+impl Default for RegistryEntryDetail {
+    fn default() -> Self {
+        Self::Tool(ToolDetail::default())
+    }
+}
+
+// ──────────────────────────────────────────────────────────
+// Tool types
+// ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct ToolDetail {
+    pub transport: ToolTransport,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env_keys: Vec<String>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum ToolTransport {
+    Stdio {
+        cmd: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        args: Vec<String>,
+    },
+    StreamableHttp {
+        uri: String,
+    },
+    #[default]
+    Builtin,
+}
+
+// ──────────────────────────────────────────────────────────
+// Skill types
+// ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct SkillDetail {
+    pub content: String,
+    pub builtin: bool,
+}
+
+// ──────────────────────────────────────────────────────────
+// Agent types (Kilo Code modes + ACP + A2A)
+// ──────────────────────────────────────────────────────────
+
+/// A dependency required by an agent or recipe.
+///
+/// Inspired by ACP Agent Manifest `dependencies` field.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentDependency {
+    #[serde(rename = "type")]
+    pub dep_type: RegistryEntryKind,
+
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    #[serde(default = "default_true")]
+    pub required: bool,
+}
+
+fn default_true() -> bool {
+    true
+}
+
+/// A behavioral mode for an agent (Kilo Code-inspired).
+///
+/// Modes allow one agent to have multiple behavioral configurations.
+/// Each mode can restrict available tools and override the system prompt.
+/// Orthogonal to GooseMode (Auto/Approve/Chat) which controls permissions.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentMode {
+    /// Unique identifier for this mode (e.g., "code", "review", "architect").
+    pub slug: String,
+
+    /// Display name (e.g., "💻 Code", "🔍 Review").
+    pub name: String,
+
+    pub description: String,
+
+    /// Inline instructions that override or augment the agent's base instructions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+
+    /// Path to a .md file containing mode-specific instructions.
+    /// Relative to the agent's directory.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions_file: Option<String>,
+
+    /// Tool groups available in this mode.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_groups: Vec<ToolGroupAccess>,
+
+    /// Hint for when this mode should be auto-selected.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub when_to_use: Option<String>,
+
+    /// Internal modes are used by orchestration only, not exposed via ACP/A2A discovery.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_internal: bool,
+
+    /// If set, this mode is deprecated. The message explains what to use instead.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub deprecated: Option<String>,
+}
+
+/// Access control for a tool group within a mode.
+///
+/// Either full access to all files, or restricted to files matching a regex.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(untagged)]
+pub enum ToolGroupAccess {
+    /// Full access to the tool group (e.g., "read", "edit", "command", "mcp").
+    Full(String),
+
+    /// Restricted access: only files matching file_regex can be accessed.
+    Restricted { group: String, file_regex: String },
+}
+
+/// A structured skill declaration (A2A-inspired).
+///
+/// Skills describe what an agent can do, for discovery and matching.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentSkill {
+    pub id: String,
+    pub name: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tags: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<String>,
+}
+
+/// Detail for an Agent definition.
+///
+/// Schema is a superset of:
+/// - ACP Communication Protocol manifest (capabilities, domains, content types, deps)
+/// - A2A Agent Card (skills, security)
+/// - Kilo Code modes (behavioral modes with tool group access)
+/// - ACP Client Protocol (distribution, framework, programming language)
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct AgentDetail {
+    pub instructions: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub recommended_models: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub capabilities: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub domains: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub input_content_types: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub output_content_types: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub required_extensions: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub dependencies: Vec<AgentDependency>,
+
+    // ── Modes (Kilo Code-inspired) ──
+    /// Default mode slug. If None, agent has no mode concept.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_mode: Option<String>,
+
+    /// Available behavioral modes for this agent.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modes: Vec<AgentMode>,
+
+    // ── Skills (A2A-inspired) ──
+    /// Structured skill declarations for discovery and matching.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub skills: Vec<AgentSkill>,
+
+    // ── Distribution (ACP Client-inspired) ──
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub distribution: Option<AgentDistribution>,
+
+    // ── Security (A2A-inspired) ──
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub security: Vec<SecurityScheme>,
+
+    // ── Runtime metadata (ACP Comm-inspired) ──
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<RuntimeStatus>,
+
+    // ── Additional metadata ──
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub framework: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub programming_language: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub natural_languages: Vec<String>,
+}
+
+// ──────────────────────────────────────────────────────────
+// Distribution types (ACP Client Protocol-inspired)
+// ──────────────────────────────────────────────────────────
+
+/// How an agent can be distributed and installed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct AgentDistribution {
+    /// Platform-specific binary downloads.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub binary: HashMap<String, BinaryTarget>,
+
+    /// Install via npx (Node.js package).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub npx: Option<PackageDistribution>,
+
+    /// Install via uvx (Python package).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub uvx: Option<PackageDistribution>,
+
+    /// Install via cargo (Rust crate).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cargo: Option<PackageDistribution>,
+
+    /// Install via Docker image.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docker: Option<DockerDistribution>,
+}
+
+/// A binary download target for a specific platform.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct BinaryTarget {
+    pub archive: String,
+    pub cmd: String,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+}
+
+/// A package distribution (npm, pip, cargo).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct PackageDistribution {
+    pub package: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub args: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+}
+
+/// Docker-based distribution.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct DockerDistribution {
+    pub image: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tag: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub ports: Vec<String>,
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
+}
+
+// ──────────────────────────────────────────────────────────
+// Security types (A2A-inspired, simplified from OpenAPI 3.2)
+// ──────────────────────────────────────────────────────────
+
+/// A security scheme for authenticating with a remote agent.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum SecurityScheme {
+    ApiKey {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        header: Option<String>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        query_param: Option<String>,
+    },
+    Http {
+        scheme: String, // "bearer", "basic"
+    },
+    #[serde(rename = "oauth2")]
+    OAuth2 {
+        authorization_url: String,
+        token_url: String,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        scopes: Vec<String>,
+    },
+}
+
+// ──────────────────────────────────────────────────────────
+// Runtime status (ACP Communication Protocol-inspired)
+// ──────────────────────────────────────────────────────────
+
+/// Runtime performance statistics for a deployed agent.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RuntimeStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_run_tokens: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_run_time_seconds: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success_rate: Option<f64>,
+}
+
+// ──────────────────────────────────────────────────────────
+// Recipe types
+// ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RecipeDetail {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub instructions: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extension_names: Vec<String>,
+
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub parameters: Vec<String>,
+}
+
+// ──────────────────────────────────────────────────────────
+// Author types
+// ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize, ToSchema)]
+pub struct AuthorInfo {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub contact: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+// ──────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn serialize_tool_entry() {
+        let entry = RegistryEntry {
+            name: "developer".into(),
+            kind: RegistryEntryKind::Tool,
+            description: "Developer tools for code editing and shell".into(),
+            version: Some("1.0.0".into()),
+            license: Some("Apache-2.0".into()),
+            tags: vec!["coding".into(), "shell".into()],
+            detail: RegistryEntryDetail::Tool(ToolDetail {
+                transport: ToolTransport::Builtin,
+                capabilities: vec!["text_editor".into(), "shell".into()],
+                env_keys: vec![],
+            }),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&entry).unwrap();
+        assert!(json.contains("developer"));
+        assert!(json.contains("tool"));
+        assert!(json.contains("Apache-2.0"));
+
+        let roundtrip: RegistryEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip.name, "developer");
+        assert_eq!(roundtrip.kind, RegistryEntryKind::Tool);
+        assert_eq!(roundtrip.license, Some("Apache-2.0".into()));
+    }
+
+    #[test]
+    fn serialize_skill_entry() {
+        let entry = RegistryEntry {
+            name: "goose-doc-guide".into(),
+            kind: RegistryEntryKind::Skill,
+            description: "Guide for fetching goose documentation".into(),
+            local_path: Some(PathBuf::from(
+                "/home/user/.config/goose/skills/doc-guide/SKILL.md",
+            )),
+            tags: vec!["documentation".into()],
+            detail: RegistryEntryDetail::Skill(SkillDetail {
+                content: "When the user asks about goose...".into(),
+                builtin: true,
+            }),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&entry).unwrap();
+        assert!(json.contains("goose-doc-guide"));
+        assert!(json.contains("skill"));
+    }
+
+    #[test]
+    fn serialize_agent_with_modes() {
+        let entry = RegistryEntry {
+            name: "goose-developer".into(),
+            kind: RegistryEntryKind::Agent,
+            description: "Full-stack development agent with multiple modes".into(),
+            version: Some("1.0.0".into()),
+            license: Some("Apache-2.0".into()),
+            repository: Some("https://github.com/block/goose".into()),
+            author: Some(AuthorInfo {
+                name: Some("Block".into()),
+                contact: None,
+                url: Some("https://block.xyz".into()),
+            }),
+            tags: vec!["coding".into(), "developer".into()],
+            detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                instructions: "You are a full-stack developer...".into(),
+                model: Some("claude-sonnet-4".into()),
+                recommended_models: vec!["claude-sonnet-4".into(), "gpt-4o".into()],
+                capabilities: vec!["code-generation".into(), "code-review".into()],
+                domains: vec!["software-development".into()],
+                input_content_types: vec!["text/plain".into()],
+                output_content_types: vec!["text/markdown".into()],
+                required_extensions: vec!["developer".into(), "memory".into()],
+                dependencies: vec![AgentDependency {
+                    dep_type: RegistryEntryKind::Tool,
+                    name: "developer".into(),
+                    version: None,
+                    required: true,
+                }],
+                default_mode: Some("code".into()),
+                modes: vec![
+                    AgentMode {
+                        slug: "code".into(),
+                        name: "💻 Code".into(),
+                        description: "Full coding agent with all tools".into(),
+                        instructions: None,
+                        instructions_file: Some("modes/code.md".into()),
+                        tool_groups: vec![
+                            ToolGroupAccess::Full("read".into()),
+                            ToolGroupAccess::Full("edit".into()),
+                            ToolGroupAccess::Full("command".into()),
+                            ToolGroupAccess::Full("mcp".into()),
+                        ],
+                        when_to_use: Some("When the user wants to write or modify code".into()),
+                        is_internal: false,
+                        deprecated: None,
+                    },
+                    AgentMode {
+                        slug: "review".into(),
+                        name: "🔍 Review".into(),
+                        description: "Code review mode (read-only)".into(),
+                        instructions: Some("You are a code reviewer. Do NOT modify files.".into()),
+                        instructions_file: None,
+                        tool_groups: vec![
+                            ToolGroupAccess::Full("read".into()),
+                            ToolGroupAccess::Full("mcp".into()),
+                        ],
+                        when_to_use: Some("When the user wants a code review".into()),
+                        is_internal: false,
+                        deprecated: None,
+                    },
+                    AgentMode {
+                        slug: "architect".into(),
+                        name: "📐 Architect".into(),
+                        description: "System design mode (markdown only)".into(),
+                        instructions: None,
+                        instructions_file: Some("modes/architect.md".into()),
+                        tool_groups: vec![
+                            ToolGroupAccess::Full("read".into()),
+                            ToolGroupAccess::Full("mcp".into()),
+                            ToolGroupAccess::Restricted {
+                                group: "edit".into(),
+                                file_regex: r"\.(md|mdx)$".into(),
+                            },
+                        ],
+                        when_to_use: Some("When discussing architecture or design".into()),
+                        is_internal: false,
+                        deprecated: None,
+                    },
+                ],
+                skills: vec![AgentSkill {
+                    id: "code-gen".into(),
+                    name: "Code Generation".into(),
+                    description: Some("Generate and modify source code".into()),
+                    tags: vec!["rust".into(), "typescript".into()],
+                    examples: vec!["Create a REST API endpoint".into()],
+                }],
+                distribution: None,
+                security: vec![],
+                status: None,
+                framework: Some("goose".into()),
+                programming_language: Some("rust".into()),
+                natural_languages: vec!["en".into()],
+            })),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&entry).unwrap();
+        assert!(json.contains("goose-developer"));
+        assert!(json.contains("modes"));
+        assert!(json.contains("code"));
+        assert!(json.contains("review"));
+        assert!(json.contains("architect"));
+        assert!(json.contains("tool_groups"));
+        assert!(json.contains("skills"));
+        assert!(json.contains("code-gen"));
+        assert!(json.contains("framework"));
+
+        // Roundtrip
+        let roundtrip: RegistryEntry = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip.name, "goose-developer");
+        if let RegistryEntryDetail::Agent(ref detail) = roundtrip.detail {
+            assert_eq!(detail.modes.len(), 3);
+            assert_eq!(detail.default_mode, Some("code".into()));
+            assert_eq!(detail.modes[0].slug, "code");
+            assert_eq!(detail.modes[1].slug, "review");
+            assert_eq!(detail.modes[2].tool_groups.len(), 3);
+            assert_eq!(detail.skills.len(), 1);
+            assert_eq!(detail.framework, Some("goose".into()));
+            // Check restricted tool group
+            if let ToolGroupAccess::Restricted {
+                ref group,
+                ref file_regex,
+            } = detail.modes[2].tool_groups[2]
+            {
+                assert_eq!(group, "edit");
+                assert!(file_regex.contains("md"));
+            } else {
+                panic!("Expected Restricted tool group");
+            }
+        } else {
+            panic!("Expected AgentDetail");
+        }
+    }
+
+    #[test]
+    fn serialize_agent_with_distribution() {
+        let entry = RegistryEntry {
+            name: "remote-agent".into(),
+            kind: RegistryEntryKind::Agent,
+            description: "An agent with distribution info".into(),
+            version: Some("2.0.0".into()),
+            detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                instructions: "You are a remote agent".into(),
+                distribution: Some(AgentDistribution {
+                    binary: {
+                        let mut m = HashMap::new();
+                        m.insert(
+                            "darwin-aarch64".into(),
+                            BinaryTarget {
+                                archive: "https://example.com/agent-darwin.tar.gz".into(),
+                                cmd: "my-agent".into(),
+                                args: vec![],
+                                env: HashMap::new(),
+                            },
+                        );
+                        m
+                    },
+                    npx: Some(PackageDistribution {
+                        package: "@block/my-agent".into(),
+                        args: None,
+                        env: HashMap::new(),
+                    }),
+                    uvx: None,
+                    cargo: Some(PackageDistribution {
+                        package: "my-agent".into(),
+                        args: Some(vec!["--features".into(), "full".into()]),
+                        env: HashMap::new(),
+                    }),
+                    docker: Some(DockerDistribution {
+                        image: "ghcr.io/block/my-agent".into(),
+                        tag: Some("latest".into()),
+                        ports: vec!["8080:8080".into()],
+                        env: HashMap::new(),
+                    }),
+                }),
+                security: vec![
+                    SecurityScheme::ApiKey {
+                        header: Some("X-Agent-Key".into()),
+                        query_param: None,
+                    },
+                    SecurityScheme::OAuth2 {
+                        authorization_url: "https://auth.example.com/authorize".into(),
+                        token_url: "https://auth.example.com/token".into(),
+                        scopes: vec!["agent:run".into()],
+                    },
+                ],
+                status: Some(RuntimeStatus {
+                    avg_run_tokens: Some(1500.0),
+                    avg_run_time_seconds: Some(12.5),
+                    success_rate: Some(0.95),
+                }),
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&entry).unwrap();
+        assert!(json.contains("distribution"));
+        assert!(json.contains("darwin-aarch64"));
+        assert!(json.contains("npx"));
+        assert!(json.contains("docker"));
+        assert!(json.contains("security"));
+        assert!(json.contains("api_key"));
+        assert!(json.contains("oauth2"));
+        assert!(json.contains("status"));
+        assert!(json.contains("1500"));
+
+        let roundtrip: RegistryEntry = serde_json::from_str(&json).unwrap();
+        if let RegistryEntryDetail::Agent(ref detail) = roundtrip.detail {
+            assert!(detail.distribution.is_some());
+            let dist = detail.distribution.as_ref().unwrap();
+            assert!(dist.binary.contains_key("darwin-aarch64"));
+            assert!(dist.npx.is_some());
+            assert!(dist.docker.is_some());
+            assert_eq!(detail.security.len(), 2);
+            assert!(detail.status.is_some());
+        } else {
+            panic!("Expected AgentDetail");
+        }
+    }
+
+    #[test]
+    fn serialize_recipe_entry() {
+        let entry = RegistryEntry {
+            name: "analyze-pr".into(),
+            kind: RegistryEntryKind::Recipe,
+            description: "Analyze a pull request".into(),
+            version: Some("1.0.0".into()),
+            author: Some(AuthorInfo {
+                name: Some("Goose Team".into()),
+                contact: None,
+                url: None,
+            }),
+            source_uri: Some("https://github.com/block/goose/recipes/analyze-pr.yaml".into()),
+            tags: vec!["github".into(), "code-review".into()],
+            detail: RegistryEntryDetail::Recipe(RecipeDetail {
+                instructions: Some("Analyze the given PR...".into()),
+                prompt: Some("Please analyze PR #{{pr_number}}".into()),
+                extension_names: vec!["developer".into(), "memory".into()],
+                parameters: vec!["pr_number".into(), "repo".into()],
+            }),
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string_pretty(&entry).unwrap();
+        assert!(json.contains("analyze-pr"));
+        assert!(json.contains("recipe"));
+    }
+
+    #[test]
+    fn merge_metadata_combines_entries() {
+        let mut entry1 = RegistryEntry {
+            name: "test".into(),
+            kind: RegistryEntryKind::Tool,
+            description: "test tool".into(),
+            detail: RegistryEntryDetail::Tool(ToolDetail {
+                transport: ToolTransport::Builtin,
+                capabilities: vec![],
+                env_keys: vec![],
+            }),
+            ..Default::default()
+        };
+
+        let entry2 = RegistryEntry {
+            name: "test".into(),
+            kind: RegistryEntryKind::Tool,
+            description: "test tool from remote".into(),
+            version: Some("2.0.0".into()),
+            license: Some("MIT".into()),
+            repository: Some("https://github.com/example/test".into()),
+            author: Some(AuthorInfo {
+                name: Some("Remote".into()),
+                contact: None,
+                url: None,
+            }),
+            source_uri: Some("https://example.com".into()),
+            detail: RegistryEntryDetail::Tool(ToolDetail {
+                transport: ToolTransport::Builtin,
+                capabilities: vec![],
+                env_keys: vec![],
+            }),
+            metadata: {
+                let mut m = HashMap::new();
+                m.insert("rating".into(), "A".into());
+                m
+            },
+            ..Default::default()
+        };
+
+        entry1.merge_metadata(&entry2);
+        assert_eq!(entry1.version, Some("2.0.0".into()));
+        assert_eq!(entry1.license, Some("MIT".into()));
+        assert_eq!(
+            entry1.repository,
+            Some("https://github.com/example/test".into())
+        );
+        assert_eq!(entry1.author.unwrap().name, Some("Remote".into()));
+        assert_eq!(entry1.metadata.get("rating"), Some(&"A".into()));
+    }
+
+    #[test]
+    fn entry_kind_display() {
+        assert_eq!(RegistryEntryKind::Tool.to_string(), "tool");
+        assert_eq!(RegistryEntryKind::Skill.to_string(), "skill");
+        assert_eq!(RegistryEntryKind::Agent.to_string(), "agent");
+        assert_eq!(RegistryEntryKind::Recipe.to_string(), "recipe");
+    }
+
+    #[test]
+    fn validate_for_publish_complete_agent() {
+        let entry = RegistryEntry {
+            name: "my-agent".into(),
+            kind: RegistryEntryKind::Agent,
+            description: "A useful agent".into(),
+            version: Some("1.0.0".into()),
+            license: Some("Apache-2.0".into()),
+            author: Some(AuthorInfo {
+                name: Some("Test".into()),
+                contact: None,
+                url: None,
+            }),
+            detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                instructions: "You are a helpful agent.".into(),
+                capabilities: vec!["general".into()],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        let issues = entry.validate_for_publish();
+        assert!(issues.is_empty(), "Expected no issues, got: {:?}", issues);
+    }
+
+    #[test]
+    fn validate_for_publish_incomplete() {
+        let entry = RegistryEntry {
+            name: "".into(),
+            kind: RegistryEntryKind::Agent,
+            description: "".into(),
+            detail: RegistryEntryDetail::Agent(Box::default()),
+            ..Default::default()
+        };
+
+        let issues = entry.validate_for_publish();
+        assert!(issues.iter().any(|i| i.contains("name")));
+        assert!(issues.iter().any(|i| i.contains("description")));
+        assert!(issues.iter().any(|i| i.contains("version")));
+        assert!(issues.iter().any(|i| i.contains("instructions")));
+    }
+
+    #[test]
+    fn tool_group_access_roundtrip() {
+        let groups = vec![
+            ToolGroupAccess::Full("read".into()),
+            ToolGroupAccess::Full("mcp".into()),
+            ToolGroupAccess::Restricted {
+                group: "edit".into(),
+                file_regex: r"\.(md|mdx)$".into(),
+            },
+        ];
+
+        let json = serde_json::to_string(&groups).unwrap();
+        let roundtrip: Vec<ToolGroupAccess> = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip.len(), 3);
+        match &roundtrip[0] {
+            ToolGroupAccess::Full(g) => assert_eq!(g, "read"),
+            _ => panic!("Expected Full"),
+        }
+        match &roundtrip[2] {
+            ToolGroupAccess::Restricted { group, file_regex } => {
+                assert_eq!(group, "edit");
+                assert!(file_regex.contains("md"));
+            }
+            _ => panic!("Expected Restricted"),
+        }
+    }
+
+    #[test]
+    fn security_scheme_roundtrip() {
+        let schemes = vec![
+            SecurityScheme::ApiKey {
+                header: Some("X-Key".into()),
+                query_param: None,
+            },
+            SecurityScheme::Http {
+                scheme: "bearer".into(),
+            },
+            SecurityScheme::OAuth2 {
+                authorization_url: "https://auth.example.com/authorize".into(),
+                token_url: "https://auth.example.com/token".into(),
+                scopes: vec!["agent:run".into()],
+            },
+        ];
+
+        let json = serde_json::to_string_pretty(&schemes).unwrap();
+        assert!(json.contains("api_key"));
+        assert!(json.contains("http"));
+        assert!(json.contains("oauth2"));
+
+        let roundtrip: Vec<SecurityScheme> = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtrip.len(), 3);
+    }
+}

--- a/crates/goose/src/registry/mod.rs
+++ b/crates/goose/src/registry/mod.rs
@@ -1,0 +1,80 @@
+pub mod formats;
+pub mod install;
+pub mod manifest;
+pub mod publish;
+pub mod source;
+pub mod sources;
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use manifest::{RegistryEntry, RegistryEntryKind};
+use source::RegistrySource;
+
+/// Aggregates multiple registry sources into a unified search interface.
+pub struct RegistryManager {
+    sources: Vec<Box<dyn RegistrySource>>,
+}
+
+impl RegistryManager {
+    pub fn new() -> Self {
+        Self {
+            sources: Vec::new(),
+        }
+    }
+
+    pub fn add_source(&mut self, source: Box<dyn RegistrySource>) {
+        self.sources.push(source);
+    }
+
+    pub fn source_names(&self) -> Vec<String> {
+        self.sources.iter().map(|s| s.name().to_string()).collect()
+    }
+
+    pub async fn search(
+        &self,
+        query: Option<&str>,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Vec<RegistryEntry>> {
+        let mut results: Vec<RegistryEntry> = Vec::new();
+        let mut seen: HashMap<(RegistryEntryKind, String), usize> = HashMap::new();
+
+        for source in &self.sources {
+            let entries = source.search(query, kind).await?;
+            for entry in entries {
+                let key = (entry.kind, entry.name.clone());
+                if let Some(&idx) = seen.get(&key) {
+                    results[idx].merge_metadata(&entry);
+                } else {
+                    seen.insert(key, results.len());
+                    results.push(entry);
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    pub async fn list(&self, kind: Option<RegistryEntryKind>) -> Result<Vec<RegistryEntry>> {
+        self.search(None, kind).await
+    }
+
+    pub async fn get(
+        &self,
+        name: &str,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Option<RegistryEntry>> {
+        for source in &self.sources {
+            if let Some(entry) = source.get(name, kind).await? {
+                return Ok(Some(entry));
+            }
+        }
+        Ok(None)
+    }
+}
+
+impl Default for RegistryManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/goose/src/registry/publish.rs
+++ b/crates/goose/src/registry/publish.rs
@@ -1,0 +1,417 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{bail, Result};
+
+use crate::recipe::Recipe;
+use crate::registry::manifest::{
+    AgentDependency, AgentDetail, AuthorInfo, RecipeDetail, RegistryEntry, RegistryEntryDetail,
+    RegistryEntryKind,
+};
+
+/// Generate a RegistryEntry from a Recipe
+pub fn recipe_to_registry_entry(recipe: &Recipe) -> RegistryEntry {
+    let extension_names: Vec<String> = recipe
+        .extensions
+        .as_ref()
+        .map(|exts| exts.iter().map(|ext| ext.name()).collect())
+        .unwrap_or_default();
+
+    let parameters: Vec<String> = recipe
+        .parameters
+        .as_ref()
+        .map(|params| params.iter().map(|p| p.key.clone()).collect())
+        .unwrap_or_default();
+
+    let author = recipe.author.as_ref().map(|a| AuthorInfo {
+        name: a.contact.clone(),
+        contact: a.metadata.clone(),
+        url: None,
+    });
+
+    RegistryEntry {
+        name: recipe.title.clone(),
+        kind: RegistryEntryKind::Recipe,
+        description: recipe.description.clone(),
+        version: Some(recipe.version.clone()),
+        author,
+        tags: Vec::new(),
+        detail: RegistryEntryDetail::Recipe(RecipeDetail {
+            instructions: recipe.instructions.clone(),
+            prompt: recipe.prompt.clone(),
+            extension_names,
+            parameters,
+        }),
+        ..Default::default()
+    }
+}
+
+/// Generate a publishable agent manifest RegistryEntry.
+///
+/// This creates a complete agent entry with all fields needed for publishing
+/// to a registry, including dependencies on required MCP extensions.
+pub fn generate_agent_manifest(
+    name: &str,
+    description: &str,
+    instructions: &str,
+    model: Option<&str>,
+    required_extensions: Vec<String>,
+) -> RegistryEntry {
+    let dependencies: Vec<AgentDependency> = required_extensions
+        .iter()
+        .map(|ext| AgentDependency {
+            dep_type: RegistryEntryKind::Tool,
+            name: ext.clone(),
+            version: None,
+            required: true,
+        })
+        .collect();
+
+    RegistryEntry {
+        name: name.to_string(),
+        kind: RegistryEntryKind::Agent,
+        description: description.to_string(),
+        version: Some("0.1.0".to_string()),
+        detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+            instructions: instructions.to_string(),
+            model: model.map(String::from),
+            recommended_models: model.into_iter().map(String::from).collect(),
+            capabilities: Vec::new(),
+            domains: Vec::new(),
+            input_content_types: vec!["text/plain".into()],
+            output_content_types: vec!["text/markdown".into()],
+            required_extensions: required_extensions.clone(),
+            dependencies,
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
+/// Generate a publishable agent manifest from a Recipe.
+///
+/// Extracts extension names as dependencies and maps recipe metadata
+/// to agent manifest fields.
+pub fn recipe_to_agent_manifest(recipe: &Recipe) -> RegistryEntry {
+    let extension_names: Vec<String> = recipe
+        .extensions
+        .as_ref()
+        .map(|exts| exts.iter().map(|ext| ext.name()).collect())
+        .unwrap_or_default();
+
+    let model = recipe
+        .settings
+        .as_ref()
+        .and_then(|s| s.goose_model.as_deref())
+        .map(String::from);
+
+    let author = recipe.author.as_ref().map(|a| AuthorInfo {
+        name: a.contact.clone(),
+        contact: a.metadata.clone(),
+        url: None,
+    });
+
+    let dependencies: Vec<AgentDependency> = extension_names
+        .iter()
+        .map(|ext| AgentDependency {
+            dep_type: RegistryEntryKind::Tool,
+            name: ext.clone(),
+            version: None,
+            required: true,
+        })
+        .collect();
+
+    RegistryEntry {
+        name: recipe.title.clone(),
+        kind: RegistryEntryKind::Agent,
+        description: recipe.description.clone(),
+        version: Some(recipe.version.clone()),
+        author,
+        tags: Vec::new(),
+        detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+            instructions: recipe.instructions.clone().unwrap_or_default(),
+            model,
+            recommended_models: Vec::new(),
+            capabilities: Vec::new(),
+            domains: Vec::new(),
+            input_content_types: vec!["text/plain".into()],
+            output_content_types: vec!["text/markdown".into()],
+            required_extensions: extension_names,
+            dependencies,
+            ..Default::default()
+        })),
+        ..Default::default()
+    }
+}
+
+/// Validate a manifest file at the given path
+pub fn validate_manifest(path: &Path) -> Result<RegistryEntry> {
+    let content = std::fs::read_to_string(path)?;
+
+    let entry: RegistryEntry = if path.extension().is_some_and(|e| e == "json") {
+        serde_json::from_str(&content)?
+    } else {
+        serde_yaml::from_str(&content)?
+    };
+
+    if entry.name.is_empty() {
+        bail!("Manifest name is required");
+    }
+
+    Ok(entry)
+}
+
+/// Validate a manifest is ready for publishing and return any issues found.
+pub fn validate_for_publish(path: &Path) -> Result<Vec<String>> {
+    let entry = validate_manifest(path)?;
+    Ok(entry.validate_for_publish())
+}
+
+/// Write a manifest to disk
+pub fn write_manifest(entry: &RegistryEntry, path: &Path) -> Result<PathBuf> {
+    let content = if path.extension().is_some_and(|e| e == "json") {
+        serde_json::to_string_pretty(entry)?
+    } else {
+        serde_yaml::to_string(entry)?
+    };
+
+    std::fs::write(path, &content)?;
+    Ok(path.to_path_buf())
+}
+
+/// Initialize a publishable agent manifest in the given directory
+pub fn init_manifest(dir: &Path, name: &str, description: &str) -> Result<PathBuf> {
+    let manifest_path = dir.join("agent.yaml");
+    if manifest_path.exists() {
+        bail!("agent.yaml already exists in {}", dir.display());
+    }
+
+    let entry = generate_agent_manifest(
+        name,
+        description,
+        "You are a helpful AI agent.",
+        None,
+        vec!["developer".into()],
+    );
+    write_manifest(&entry, &manifest_path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::extension::ExtensionConfig;
+    use crate::recipe::Recipe;
+
+    fn test_recipe() -> Recipe {
+        Recipe {
+            title: "Test Recipe".to_string(),
+            description: "A test recipe".to_string(),
+            version: "1.0.0".to_string(),
+            extensions: Some(vec![ExtensionConfig::Builtin {
+                name: "developer".to_string(),
+                display_name: None,
+                description: String::new(),
+                timeout: None,
+                bundled: None,
+                available_tools: Vec::new(),
+            }]),
+            instructions: Some("Do the thing".into()),
+            prompt: None,
+            settings: None,
+            activities: None,
+            author: None,
+            parameters: None,
+            response: None,
+            sub_recipes: None,
+            retry: None,
+        }
+    }
+
+    #[test]
+    fn test_recipe_to_registry_entry() {
+        let recipe = test_recipe();
+        let entry = recipe_to_registry_entry(&recipe);
+
+        assert_eq!(entry.name, "Test Recipe");
+        assert_eq!(entry.kind, RegistryEntryKind::Recipe);
+        assert_eq!(entry.version, Some("1.0.0".to_string()));
+
+        if let RegistryEntryDetail::Recipe(detail) = &entry.detail {
+            assert_eq!(detail.extension_names, vec!["developer"]);
+        } else {
+            panic!("Expected RecipeDetail");
+        }
+    }
+
+    #[test]
+    fn test_generate_agent_manifest() {
+        let entry = generate_agent_manifest(
+            "my-agent",
+            "Does things",
+            "You are a helpful agent.",
+            Some("claude-sonnet-4"),
+            vec!["developer".into(), "memory".into()],
+        );
+
+        assert_eq!(entry.name, "my-agent");
+        assert_eq!(entry.kind, RegistryEntryKind::Agent);
+        assert_eq!(entry.version, Some("0.1.0".to_string()));
+
+        if let RegistryEntryDetail::Agent(detail) = &entry.detail {
+            assert_eq!(detail.instructions, "You are a helpful agent.");
+            assert_eq!(detail.model, Some("claude-sonnet-4".into()));
+            assert_eq!(detail.recommended_models, vec!["claude-sonnet-4"]);
+            assert_eq!(detail.required_extensions, vec!["developer", "memory"]);
+            assert_eq!(detail.dependencies.len(), 2);
+            assert_eq!(detail.dependencies[0].name, "developer");
+            assert!(detail.dependencies[0].required);
+        } else {
+            panic!("Expected AgentDetail");
+        }
+    }
+
+    #[test]
+    fn test_recipe_to_agent_manifest() {
+        let recipe = test_recipe();
+        let entry = recipe_to_agent_manifest(&recipe);
+
+        assert_eq!(entry.name, "Test Recipe");
+        assert_eq!(entry.kind, RegistryEntryKind::Agent);
+
+        if let RegistryEntryDetail::Agent(detail) = &entry.detail {
+            assert_eq!(detail.instructions, "Do the thing");
+            assert_eq!(detail.required_extensions, vec!["developer"]);
+            assert_eq!(detail.dependencies.len(), 1);
+            assert_eq!(detail.dependencies[0].dep_type, RegistryEntryKind::Tool);
+            assert_eq!(detail.dependencies[0].name, "developer");
+        } else {
+            panic!("Expected AgentDetail");
+        }
+    }
+
+    #[test]
+    fn test_validate_manifest_roundtrip() {
+        let entry = generate_agent_manifest(
+            "test",
+            "A test agent",
+            "You are a test agent.",
+            None,
+            vec!["developer".into()],
+        );
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.yaml");
+
+        write_manifest(&entry, &path).unwrap();
+        let loaded = validate_manifest(&path).unwrap();
+
+        assert_eq!(loaded.name, "test");
+        assert_eq!(loaded.kind, RegistryEntryKind::Agent);
+
+        if let RegistryEntryDetail::Agent(detail) = &loaded.detail {
+            assert_eq!(detail.required_extensions, vec!["developer"]);
+        } else {
+            panic!("Expected AgentDetail");
+        }
+    }
+
+    #[test]
+    fn test_validate_for_publish() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.yaml");
+
+        let mut entry = generate_agent_manifest(
+            "my-agent",
+            "Does things",
+            "You are helpful.",
+            Some("claude-sonnet-4"),
+            vec!["developer".into()],
+        );
+        entry.license = Some("Apache-2.0".into());
+        entry.author = Some(AuthorInfo {
+            name: Some("Test Author".into()),
+            contact: None,
+            url: None,
+        });
+        if let RegistryEntryDetail::Agent(ref mut detail) = entry.detail {
+            detail.capabilities = vec!["coding".into()];
+        }
+
+        write_manifest(&entry, &path).unwrap();
+
+        let issues = validate_for_publish(&path).unwrap();
+        assert!(
+            issues.is_empty(),
+            "Expected no issues but got: {:?}",
+            issues
+        );
+    }
+
+    #[test]
+    fn test_validate_for_publish_missing_fields() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.yaml");
+
+        let entry = RegistryEntry {
+            name: "bare-agent".into(),
+            kind: RegistryEntryKind::Agent,
+            detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                instructions: String::new(),
+                model: None,
+                recommended_models: vec![],
+                capabilities: vec![],
+                domains: vec![],
+                input_content_types: vec![],
+                output_content_types: vec![],
+                required_extensions: vec![],
+                dependencies: vec![],
+                ..Default::default()
+            })),
+            ..Default::default()
+        };
+
+        write_manifest(&entry, &path).unwrap();
+        let issues = validate_for_publish(&path).unwrap();
+
+        assert!(issues.iter().any(|i| i.contains("description")));
+        assert!(issues.iter().any(|i| i.contains("version")));
+        assert!(issues.iter().any(|i| i.contains("instructions")));
+    }
+
+    #[test]
+    fn test_init_manifest() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = init_manifest(dir.path(), "my-project", "My project agent").unwrap();
+
+        assert!(path.exists());
+        let entry = validate_manifest(&path).unwrap();
+        assert_eq!(entry.name, "my-project");
+
+        if let RegistryEntryDetail::Agent(detail) = &entry.detail {
+            assert_eq!(detail.required_extensions, vec!["developer"]);
+            assert_eq!(detail.dependencies.len(), 1);
+        } else {
+            panic!("Expected AgentDetail");
+        }
+    }
+
+    #[test]
+    fn test_init_manifest_already_exists() {
+        let dir = tempfile::tempdir().unwrap();
+        init_manifest(dir.path(), "first", "First").unwrap();
+        let result = init_manifest(dir.path(), "second", "Second");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_validate_empty_name_fails() {
+        let entry = RegistryEntry {
+            name: String::new(),
+            kind: RegistryEntryKind::Agent,
+            ..Default::default()
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("agent.yaml");
+        write_manifest(&entry, &path).unwrap();
+        let result = validate_manifest(&path);
+        assert!(result.is_err());
+    }
+}

--- a/crates/goose/src/registry/source.rs
+++ b/crates/goose/src/registry/source.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use async_trait::async_trait;
+
+use super::manifest::{RegistryEntry, RegistryEntryKind};
+
+/// A pluggable source of registry entries.
+///
+/// Implementations scan a specific backend (filesystem, GitHub, HTTP endpoint)
+/// and return `RegistryEntry` items matching the query.
+///
+/// Sources are ordered by priority in `RegistryManager`: local sources first,
+/// then remote. The first match for a given (name, kind) pair wins.
+#[async_trait]
+pub trait RegistrySource: Send + Sync {
+    /// Human-readable name for this source (e.g. "local", "github:block/goose").
+    fn name(&self) -> &str;
+
+    /// Search for entries matching the query string and optional kind filter.
+    /// A `None` query returns all entries.
+    async fn search(
+        &self,
+        query: Option<&str>,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Vec<RegistryEntry>>;
+
+    /// Get a specific entry by exact name and optional kind filter.
+    async fn get(
+        &self,
+        name: &str,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Option<RegistryEntry>>;
+}

--- a/crates/goose/src/registry/sources/a2a.rs
+++ b/crates/goose/src/registry/sources/a2a.rs
@@ -1,0 +1,179 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use reqwest::Client;
+use std::time::Duration;
+
+use crate::registry::formats::parse_a2a_agent_card;
+use crate::registry::manifest::{RegistryEntry, RegistryEntryKind};
+use crate::registry::source::RegistrySource;
+
+/// Discovers agents from remote A2A endpoints via `/.well-known/agent-card.json`.
+///
+/// Per the A2A protocol specification, agents advertise their capabilities by
+/// serving an Agent Card at a well-known URL. This source fetches those cards
+/// and converts them into `RegistryEntry` items for unified discovery.
+pub struct A2aRegistrySource {
+    endpoints: Vec<String>,
+    client: Client,
+}
+
+impl A2aRegistrySource {
+    pub fn new(endpoints: Vec<String>) -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .unwrap_or_default();
+        Self { endpoints, client }
+    }
+
+    pub fn from_single(endpoint: &str) -> Self {
+        Self::new(vec![endpoint.to_string()])
+    }
+
+    async fn fetch_agent_card(&self, base_url: &str) -> Result<RegistryEntry> {
+        let url = format!(
+            "{}/.well-known/agent-card.json",
+            base_url.trim_end_matches('/')
+        );
+
+        let resp = self
+            .client
+            .get(&url)
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!("A2A agent at {} returned status {}", url, resp.status());
+        }
+
+        let body = resp.text().await?;
+        let mut entry = parse_a2a_agent_card(&body)?;
+
+        if entry.source_uri.is_none() {
+            entry.source_uri = Some(base_url.to_string());
+        }
+
+        Ok(entry)
+    }
+
+    async fn fetch_all(&self) -> Vec<RegistryEntry> {
+        let mut entries = Vec::new();
+        for endpoint in &self.endpoints {
+            match self.fetch_agent_card(endpoint).await {
+                Ok(entry) => entries.push(entry),
+                Err(e) => {
+                    tracing::debug!(endpoint = %endpoint, error = %e, "failed to fetch A2A agent card");
+                }
+            }
+        }
+        entries
+    }
+}
+
+#[async_trait]
+impl RegistrySource for A2aRegistrySource {
+    fn name(&self) -> &str {
+        "a2a"
+    }
+
+    async fn search(
+        &self,
+        query: Option<&str>,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Vec<RegistryEntry>> {
+        if let Some(k) = kind {
+            if k != RegistryEntryKind::Agent {
+                return Ok(Vec::new());
+            }
+        }
+
+        let mut entries = self.fetch_all().await;
+
+        if let Some(q) = query {
+            let q_lower = q.to_lowercase();
+            entries.retain(|e| {
+                e.name.to_lowercase().contains(&q_lower)
+                    || e.description.to_lowercase().contains(&q_lower)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q_lower))
+            });
+        }
+
+        Ok(entries)
+    }
+
+    async fn get(
+        &self,
+        name: &str,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Option<RegistryEntry>> {
+        if let Some(k) = kind {
+            if k != RegistryEntryKind::Agent {
+                return Ok(None);
+            }
+        }
+
+        let entries = self.fetch_all().await;
+        Ok(entries.into_iter().find(|e| e.name == name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_single_endpoint() {
+        let source = A2aRegistrySource::from_single("https://agent.example.com");
+        assert_eq!(source.endpoints, vec!["https://agent.example.com"]);
+    }
+
+    #[test]
+    fn test_multiple_endpoints() {
+        let source = A2aRegistrySource::new(vec![
+            "https://a.example.com".to_string(),
+            "https://b.example.com".to_string(),
+        ]);
+        assert_eq!(source.endpoints.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_search_non_agent_kind_returns_empty() {
+        let source = A2aRegistrySource::new(vec![]);
+        let results = source
+            .search(None, Some(RegistryEntryKind::Tool))
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_non_agent_kind_returns_none() {
+        let source = A2aRegistrySource::new(vec![]);
+        let result = source
+            .get("test", Some(RegistryEntryKind::Skill))
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_empty_endpoints_returns_empty() {
+        let source = A2aRegistrySource::new(vec![]);
+        let results = source
+            .search(None, Some(RegistryEntryKind::Agent))
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_fetch_unreachable_endpoint_is_skipped() {
+        let source = A2aRegistrySource::from_single("http://192.0.2.1:1");
+        let results = source
+            .search(None, Some(RegistryEntryKind::Agent))
+            .await
+            .unwrap();
+        assert!(results.is_empty());
+    }
+}

--- a/crates/goose/src/registry/sources/github.rs
+++ b/crates/goose/src/registry/sources/github.rs
@@ -1,0 +1,403 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use std::process::Command;
+
+use crate::registry::manifest::{
+    AgentDetail, RecipeDetail, RegistryEntry, RegistryEntryDetail, RegistryEntryKind, SkillDetail,
+};
+use crate::registry::source::RegistrySource;
+
+/// Discovers registry entries from a GitHub repository using the `gh` CLI.
+///
+/// Scans the repository tree for:
+/// - `recipes/*.yaml` → Recipe entries
+/// - `skills/*/SKILL.md` → Skill entries
+/// - `agents/*.md` → Agent entries
+pub struct GitHubRegistrySource {
+    owner: String,
+    repo: String,
+    branch: String,
+    /// Optional subdirectory prefix (e.g. "registry/")
+    path_prefix: String,
+}
+
+impl GitHubRegistrySource {
+    pub fn new(owner: &str, repo: &str) -> Self {
+        Self {
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            branch: "main".to_string(),
+            path_prefix: String::new(),
+        }
+    }
+
+    pub fn with_branch(mut self, branch: &str) -> Self {
+        self.branch = branch.to_string();
+        self
+    }
+
+    pub fn with_path_prefix(mut self, prefix: &str) -> Self {
+        self.path_prefix = prefix.to_string();
+        self
+    }
+
+    fn source_uri(&self, path: &str) -> String {
+        format!(
+            "github://{}/{}/{}{}",
+            self.owner, self.repo, self.branch, path
+        )
+    }
+
+    fn list_dir(&self, dir: &str) -> Result<Vec<(String, String)>> {
+        let url = format!(
+            "repos/{}/{}/contents/{}{}",
+            self.owner, self.repo, self.path_prefix, dir
+        );
+        let output = Command::new("gh")
+            .args([
+                "api",
+                &url,
+                "-q",
+                r#".[] | select(.type == "file" or .type == "dir") | "(.name)	(.type)"#,
+            ])
+            .output()?;
+
+        if !output.status.success() {
+            return Ok(Vec::new());
+        }
+
+        let text = String::from_utf8_lossy(&output.stdout);
+        Ok(text
+            .lines()
+            .filter_map(|line| {
+                let parts: Vec<&str> = line.splitn(2, '\t').collect();
+                if parts.len() == 2 {
+                    Some((parts[0].to_string(), parts[1].to_string()))
+                } else {
+                    None
+                }
+            })
+            .collect())
+    }
+
+    fn fetch_file(&self, path: &str) -> Result<String> {
+        let url = format!(
+            "repos/{}/{}/contents/{}{}",
+            self.owner, self.repo, self.path_prefix, path
+        );
+        let output = Command::new("gh")
+            .args(["api", &url, "-q", ".content"])
+            .output()?;
+
+        if !output.status.success() {
+            anyhow::bail!("failed to fetch {}", path);
+        }
+
+        let b64 = String::from_utf8_lossy(&output.stdout)
+            .trim()
+            .replace(['\n', '"'], "");
+
+        use base64::Engine;
+        let bytes = base64::engine::general_purpose::STANDARD.decode(b64.as_bytes())?;
+        Ok(String::from_utf8(bytes)?)
+    }
+
+    fn scan_recipes(&self) -> Vec<RegistryEntry> {
+        let entries = match self.list_dir("recipes") {
+            Ok(e) => e,
+            Err(_) => return Vec::new(),
+        };
+
+        entries
+            .into_iter()
+            .filter(|(name, _)| name.ends_with(".yaml") || name.ends_with(".yml"))
+            .filter_map(|(name, _)| {
+                let path = format!("recipes/{}", name);
+                let content = self.fetch_file(&path).ok()?;
+                self.parse_recipe_yaml(&name, &content)
+            })
+            .collect()
+    }
+
+    fn parse_recipe_yaml(&self, filename: &str, content: &str) -> Option<RegistryEntry> {
+        let mapping: serde_yaml::Mapping = serde_yaml::from_str(content).ok()?;
+        let yaml_key = |k: &str| serde_yaml::Value::String(k.into());
+
+        let title = mapping
+            .get(yaml_key("title"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let description = mapping
+            .get(yaml_key("description"))
+            .and_then(|v| v.as_str())
+            .unwrap_or_default();
+        let version = mapping
+            .get(yaml_key("version"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let extension_names: Vec<String> = mapping
+            .get(yaml_key("extensions"))
+            .and_then(|v| v.as_sequence())
+            .map(|seq| {
+                seq.iter()
+                    .filter_map(|v| {
+                        v.as_str().map(String::from).or_else(|| {
+                            v.as_mapping()?
+                                .get(yaml_key("name"))?
+                                .as_str()
+                                .map(String::from)
+                        })
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let parameters: Vec<String> = mapping
+            .get(yaml_key("parameters"))
+            .and_then(|v| v.as_sequence())
+            .map(|seq| {
+                seq.iter()
+                    .filter_map(|v| {
+                        v.as_mapping()?
+                            .get(yaml_key("key"))?
+                            .as_str()
+                            .map(String::from)
+                    })
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let prompt = mapping
+            .get(yaml_key("prompt"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.chars().take(200).collect());
+        let instructions = mapping
+            .get(yaml_key("instructions"))
+            .and_then(|v| v.as_str())
+            .map(String::from);
+
+        let stem = filename
+            .strip_suffix(".yaml")
+            .or_else(|| filename.strip_suffix(".yml"))
+            .unwrap_or(filename);
+
+        Some(RegistryEntry {
+            name: title.to_string(),
+            kind: RegistryEntryKind::Recipe,
+            description: description.to_string(),
+            version,
+            source_uri: Some(self.source_uri(&format!("/recipes/{}", filename))),
+            detail: RegistryEntryDetail::Recipe(RecipeDetail {
+                instructions,
+                prompt,
+                extension_names,
+                parameters,
+            }),
+            tags: vec![stem.to_string()],
+            ..Default::default()
+        })
+    }
+
+    fn scan_skills(&self) -> Vec<RegistryEntry> {
+        let dirs = match self.list_dir("skills") {
+            Ok(e) => e,
+            Err(_) => return Vec::new(),
+        };
+
+        dirs.into_iter()
+            .filter(|(_, typ)| typ == "dir")
+            .filter_map(|(dir_name, _)| {
+                let path = format!("skills/{}/SKILL.md", dir_name);
+                let content = self.fetch_file(&path).ok()?;
+                let (fm_name, description, body) = parse_frontmatter(&content);
+                let entry_name = fm_name.unwrap_or_else(|| dir_name.clone());
+                let uri = self.source_uri(&format!("/skills/{}/SKILL.md", dir_name));
+                Some(RegistryEntry {
+                    name: entry_name,
+                    kind: RegistryEntryKind::Skill,
+                    description: description.unwrap_or_default(),
+                    source_uri: Some(uri),
+                    detail: RegistryEntryDetail::Skill(SkillDetail {
+                        content: body,
+                        builtin: false,
+                    }),
+                    ..Default::default()
+                })
+            })
+            .collect()
+    }
+
+    fn scan_agents(&self) -> Vec<RegistryEntry> {
+        let entries = match self.list_dir("agents") {
+            Ok(e) => e,
+            Err(_) => return Vec::new(),
+        };
+
+        entries
+            .into_iter()
+            .filter(|(name, _)| name.ends_with(".md"))
+            .filter_map(|(name, _)| {
+                let path = format!("agents/{}", name);
+                let content = self.fetch_file(&path).ok()?;
+                let (fm_name, description, body) = parse_frontmatter(&content);
+                let stem = name.strip_suffix(".md").unwrap_or(&name);
+                Some(RegistryEntry {
+                    name: fm_name.unwrap_or_else(|| stem.to_string()),
+                    kind: RegistryEntryKind::Agent,
+                    description: description.unwrap_or_default(),
+                    source_uri: Some(self.source_uri(&format!("/agents/{}", name))),
+                    detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                        instructions: body,
+                        model: None,
+                        recommended_models: Vec::new(),
+                        capabilities: Vec::new(),
+                        domains: Vec::new(),
+                        input_content_types: Vec::new(),
+                        output_content_types: Vec::new(),
+                        required_extensions: Vec::new(),
+                        dependencies: Vec::new(),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                })
+            })
+            .collect()
+    }
+}
+
+fn parse_frontmatter(content: &str) -> (Option<String>, Option<String>, String) {
+    let trimmed = content.trim();
+    if !trimmed.starts_with("---") {
+        return (None, None, content.to_string());
+    }
+
+    let after_first = match trimmed.get(3..) {
+        Some(s) => s.trim_start_matches([' ', '\t']).trim_start_matches('\n'),
+        None => return (None, None, content.to_string()),
+    };
+
+    let end_pos = match after_first.find("\n---") {
+        Some(p) => p,
+        None => return (None, None, content.to_string()),
+    };
+
+    let fm_block = match after_first.get(..end_pos) {
+        Some(s) => s,
+        None => return (None, None, content.to_string()),
+    };
+    let body = match after_first.get(end_pos + 4..) {
+        Some(s) => s.trim_start().to_string(),
+        None => String::new(),
+    };
+
+    let mut name = None;
+    let mut description = None;
+
+    for line in fm_block.lines() {
+        if let Some(val) = line.strip_prefix("name:") {
+            name = Some(val.trim().trim_matches('"').to_string());
+        } else if let Some(val) = line.strip_prefix("description:") {
+            description = Some(val.trim().trim_matches('"').to_string());
+        }
+    }
+
+    (name, description, body)
+}
+
+#[async_trait]
+impl RegistrySource for GitHubRegistrySource {
+    fn name(&self) -> &str {
+        "github"
+    }
+
+    async fn search(
+        &self,
+        query: Option<&str>,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Vec<RegistryEntry>> {
+        let mut entries = Vec::new();
+
+        let want_recipes = kind.is_none() || kind == Some(RegistryEntryKind::Recipe);
+        let want_skills = kind.is_none() || kind == Some(RegistryEntryKind::Skill);
+        let want_agents = kind.is_none() || kind == Some(RegistryEntryKind::Agent);
+
+        if want_recipes {
+            entries.extend(self.scan_recipes());
+        }
+        if want_skills {
+            entries.extend(self.scan_skills());
+        }
+        if want_agents {
+            entries.extend(self.scan_agents());
+        }
+
+        if let Some(q) = query {
+            let q_lower = q.to_lowercase();
+            entries.retain(|e| {
+                e.name.to_lowercase().contains(&q_lower)
+                    || e.description.to_lowercase().contains(&q_lower)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q_lower))
+            });
+        }
+
+        Ok(entries)
+    }
+
+    async fn get(
+        &self,
+        name: &str,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Option<RegistryEntry>> {
+        let entries = self.search(Some(name), kind).await?;
+        Ok(entries.into_iter().find(|e| e.name == name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_frontmatter() {
+        let content = "---\nname: my-skill\ndescription: A test skill\n---\nSkill body here.";
+        let (name, desc, body) = parse_frontmatter(content);
+        assert_eq!(name, Some("my-skill".to_string()));
+        assert_eq!(desc, Some("A test skill".to_string()));
+        assert!(body.contains("Skill body here"));
+    }
+
+    #[test]
+    fn test_parse_frontmatter_no_frontmatter() {
+        let content = "Just plain markdown.";
+        let (name, desc, body) = parse_frontmatter(content);
+        assert!(name.is_none());
+        assert!(desc.is_none());
+        assert_eq!(body, "Just plain markdown.");
+    }
+
+    #[test]
+    fn test_source_uri_format() {
+        let source = GitHubRegistrySource::new("block", "goose");
+        assert_eq!(
+            source.source_uri("/recipes/test.yaml"),
+            "github://block/goose/main/recipes/test.yaml"
+        );
+    }
+
+    #[test]
+    fn test_parse_recipe_yaml() {
+        let source = GitHubRegistrySource::new("block", "goose");
+        let yaml = "title: Test Recipe\ndescription: A test\nversion: \"1.0\"\nprompt: Do things\nextensions:\n  - developer\nparameters:\n  - key: name\n    type: string";
+        let entry = source.parse_recipe_yaml("test.yaml", yaml).unwrap();
+        assert_eq!(entry.name, "Test Recipe");
+        assert_eq!(entry.kind, RegistryEntryKind::Recipe);
+        assert_eq!(entry.description, "A test");
+        if let RegistryEntryDetail::Recipe(ref detail) = entry.detail {
+            assert_eq!(detail.extension_names, vec!["developer"]);
+            assert_eq!(detail.parameters, vec!["name"]);
+        } else {
+            panic!("expected Recipe detail");
+        }
+    }
+}

--- a/crates/goose/src/registry/sources/http.rs
+++ b/crates/goose/src/registry/sources/http.rs
@@ -1,0 +1,358 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+
+use crate::registry::manifest::{
+    AgentDetail, RecipeDetail, RegistryEntry, RegistryEntryDetail, RegistryEntryKind, SkillDetail,
+    ToolDetail, ToolTransport,
+};
+use crate::registry::source::RegistrySource;
+
+/// Discovers registry entries from an HTTP index endpoint.
+///
+/// Supports two discovery modes:
+/// 1. Direct index URL: fetches a JSON array of entry descriptors
+/// 2. Well-known discovery: fetches `/.well-known/agent.json` from a domain
+///
+/// The index format follows a simplified ACP-inspired schema where each entry
+/// declares its kind, name, and metadata.
+pub struct HttpRegistrySource {
+    base_url: String,
+    client: Client,
+}
+
+#[derive(Debug, Deserialize)]
+struct IndexEntry {
+    name: String,
+    kind: String,
+    #[serde(default)]
+    description: String,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    tags: Vec<String>,
+    #[serde(default)]
+    metadata: serde_json::Value,
+}
+
+impl HttpRegistrySource {
+    pub fn new(base_url: &str) -> Self {
+        Self {
+            base_url: base_url.trim_end_matches('/').to_string(),
+            client: Client::new(),
+        }
+    }
+
+    pub fn well_known(domain: &str) -> Self {
+        let scheme = if domain.starts_with("http") {
+            String::new()
+        } else {
+            "https://".to_string()
+        };
+        Self::new(&format!("{}{}/.well-known/agent.json", scheme, domain))
+    }
+
+    async fn fetch_index(&self) -> Result<Vec<IndexEntry>> {
+        let resp = self
+            .client
+            .get(&self.base_url)
+            .header("Accept", "application/json")
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            anyhow::bail!(
+                "HTTP registry at {} returned status {}",
+                self.base_url,
+                resp.status()
+            );
+        }
+
+        let entries: Vec<IndexEntry> = resp.json().await?;
+        Ok(entries)
+    }
+
+    fn index_entry_to_registry_entry(&self, idx: &IndexEntry) -> Option<RegistryEntry> {
+        let kind = match idx.kind.as_str() {
+            "tool" => RegistryEntryKind::Tool,
+            "skill" => RegistryEntryKind::Skill,
+            "agent" => RegistryEntryKind::Agent,
+            "recipe" => RegistryEntryKind::Recipe,
+            _ => return None,
+        };
+
+        let detail = match kind {
+            RegistryEntryKind::Tool => {
+                let transport = match idx.metadata.get("transport").and_then(|v| v.as_str()) {
+                    Some("streamable_http") => {
+                        let uri = idx
+                            .metadata
+                            .get("uri")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        ToolTransport::StreamableHttp { uri }
+                    }
+                    _ => {
+                        let cmd = idx
+                            .metadata
+                            .get("cmd")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or_default()
+                            .to_string();
+                        let args: Vec<String> = idx
+                            .metadata
+                            .get("args")
+                            .and_then(|v| v.as_array())
+                            .map(|arr| {
+                                arr.iter()
+                                    .filter_map(|v| v.as_str().map(String::from))
+                                    .collect()
+                            })
+                            .unwrap_or_default();
+                        ToolTransport::Stdio { cmd, args }
+                    }
+                };
+
+                let capabilities: Vec<String> = idx
+                    .metadata
+                    .get("capabilities")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                let env_keys: Vec<String> = idx
+                    .metadata
+                    .get("env_keys")
+                    .and_then(|v| v.as_array())
+                    .map(|arr| {
+                        arr.iter()
+                            .filter_map(|v| v.as_str().map(String::from))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+
+                RegistryEntryDetail::Tool(ToolDetail {
+                    transport,
+                    capabilities,
+                    env_keys,
+                })
+            }
+            RegistryEntryKind::Skill => {
+                let content = idx
+                    .metadata
+                    .get("content")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+
+                RegistryEntryDetail::Skill(SkillDetail {
+                    content,
+                    builtin: false,
+                })
+            }
+            RegistryEntryKind::Agent => {
+                let instructions = idx
+                    .metadata
+                    .get("instructions")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or_default()
+                    .to_string();
+                let model = idx
+                    .metadata
+                    .get("model")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+
+                RegistryEntryDetail::Agent(Box::new(AgentDetail {
+                    instructions,
+                    model,
+                    recommended_models: Vec::new(),
+                    capabilities: Vec::new(),
+                    domains: Vec::new(),
+                    input_content_types: Vec::new(),
+                    output_content_types: Vec::new(),
+                    required_extensions: Vec::new(),
+                    dependencies: Vec::new(),
+                    ..Default::default()
+                }))
+            }
+            RegistryEntryKind::Recipe => {
+                let prompt = idx
+                    .metadata
+                    .get("prompt")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+                let instructions = idx
+                    .metadata
+                    .get("instructions")
+                    .and_then(|v| v.as_str())
+                    .map(String::from);
+
+                RegistryEntryDetail::Recipe(RecipeDetail {
+                    instructions,
+                    prompt,
+                    extension_names: Vec::new(),
+                    parameters: Vec::new(),
+                })
+            }
+        };
+
+        Some(RegistryEntry {
+            name: idx.name.clone(),
+            kind,
+            description: idx.description.clone(),
+            version: idx.version.clone(),
+            source_uri: idx
+                .url
+                .clone()
+                .or_else(|| Some(format!("{}/{}", self.base_url, idx.name))),
+            tags: idx.tags.clone(),
+            detail,
+            ..Default::default()
+        })
+    }
+}
+
+#[async_trait]
+impl RegistrySource for HttpRegistrySource {
+    fn name(&self) -> &str {
+        "http"
+    }
+
+    async fn search(
+        &self,
+        query: Option<&str>,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Vec<RegistryEntry>> {
+        let index = self.fetch_index().await?;
+
+        let mut entries: Vec<RegistryEntry> = index
+            .iter()
+            .filter_map(|idx| self.index_entry_to_registry_entry(idx))
+            .collect();
+
+        if let Some(k) = kind {
+            entries.retain(|e| e.kind == k);
+        }
+
+        if let Some(q) = query {
+            let q_lower = q.to_lowercase();
+            entries.retain(|e| {
+                e.name.to_lowercase().contains(&q_lower)
+                    || e.description.to_lowercase().contains(&q_lower)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q_lower))
+            });
+        }
+
+        Ok(entries)
+    }
+
+    async fn get(
+        &self,
+        name: &str,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Option<RegistryEntry>> {
+        let entries = self.search(Some(name), kind).await?;
+        Ok(entries.into_iter().find(|e| e.name == name))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_well_known_url() {
+        let source = HttpRegistrySource::well_known("example.com");
+        assert_eq!(
+            source.base_url,
+            "https://example.com/.well-known/agent.json"
+        );
+    }
+
+    #[test]
+    fn test_well_known_with_scheme() {
+        let source = HttpRegistrySource::well_known("http://localhost:8080");
+        assert_eq!(
+            source.base_url,
+            "http://localhost:8080/.well-known/agent.json"
+        );
+    }
+
+    #[test]
+    fn test_index_entry_to_registry_entry_tool() {
+        let source = HttpRegistrySource::new("https://registry.example.com/api/v1");
+        let idx = IndexEntry {
+            name: "developer".to_string(),
+            kind: "tool".to_string(),
+            description: "Developer tools".to_string(),
+            version: Some("1.0.0".to_string()),
+            url: Some("https://example.com/developer".to_string()),
+            tags: vec!["coding".to_string()],
+            metadata: serde_json::json!({
+                "transport": "stdio",
+                "capabilities": ["text_editor", "shell"]
+            }),
+        };
+
+        let entry = source.index_entry_to_registry_entry(&idx).unwrap();
+        assert_eq!(entry.name, "developer");
+        assert_eq!(entry.kind, RegistryEntryKind::Tool);
+        if let RegistryEntryDetail::Tool(ref detail) = entry.detail {
+            assert!(matches!(detail.transport, ToolTransport::Stdio { .. }));
+            assert_eq!(detail.capabilities.len(), 2);
+        } else {
+            panic!("expected Tool detail");
+        }
+    }
+
+    #[test]
+    fn test_index_entry_to_registry_entry_agent() {
+        let source = HttpRegistrySource::new("https://registry.example.com");
+        let idx = IndexEntry {
+            name: "code-reviewer".to_string(),
+            kind: "agent".to_string(),
+            description: "Reviews code".to_string(),
+            version: None,
+            url: None,
+            tags: Vec::new(),
+            metadata: serde_json::json!({
+                "instructions": "You are a code reviewer.",
+                "model": "claude-sonnet-4"
+            }),
+        };
+
+        let entry = source.index_entry_to_registry_entry(&idx).unwrap();
+        assert_eq!(entry.kind, RegistryEntryKind::Agent);
+        if let RegistryEntryDetail::Agent(ref detail) = entry.detail {
+            assert_eq!(detail.instructions, "You are a code reviewer.");
+            assert_eq!(detail.model, Some("claude-sonnet-4".to_string()));
+        } else {
+            panic!("expected Agent detail");
+        }
+    }
+
+    #[test]
+    fn test_unknown_kind_filtered() {
+        let source = HttpRegistrySource::new("https://registry.example.com");
+        let idx = IndexEntry {
+            name: "unknown".to_string(),
+            kind: "workflow".to_string(),
+            description: "Unknown type".to_string(),
+            version: None,
+            url: None,
+            tags: Vec::new(),
+            metadata: serde_json::Value::Null,
+        };
+
+        assert!(source.index_entry_to_registry_entry(&idx).is_none());
+    }
+}

--- a/crates/goose/src/registry/sources/local.rs
+++ b/crates/goose/src/registry/sources/local.rs
@@ -1,0 +1,583 @@
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+use async_trait::async_trait;
+
+use crate::registry::manifest::{
+    AgentDetail, AuthorInfo, RecipeDetail, RegistryEntry, RegistryEntryDetail, RegistryEntryKind,
+    SkillDetail,
+};
+use crate::registry::source::RegistrySource;
+
+/// Scans local filesystem directories for registry entries.
+///
+/// Follows the same directory conventions as `summon_extension.rs`:
+/// - Skills: `{root}/skills/{name}/SKILL.md`
+/// - Agents: `{root}/agents/{name}.md`
+/// - Recipes: `{root}/recipes/{name}.yaml` or `{name}.yml`
+/// - Tools: read from goose config extensions
+pub struct LocalRegistrySource {
+    roots: Vec<PathBuf>,
+}
+
+impl LocalRegistrySource {
+    pub fn new(roots: Vec<PathBuf>) -> Self {
+        Self { roots }
+    }
+
+    /// Create a source with the default user config directory.
+    pub fn from_default_paths() -> Result<Self> {
+        let mut roots = Vec::new();
+
+        if let Some(config_dir) = dirs::config_dir() {
+            let goose_dir = config_dir.join("goose");
+            if goose_dir.exists() {
+                roots.push(goose_dir);
+            }
+        }
+
+        Ok(Self { roots })
+    }
+
+    fn scan_all(&self) -> Vec<RegistryEntry> {
+        let mut entries = Vec::new();
+        for root in &self.roots {
+            entries.extend(scan_skills(root));
+            entries.extend(scan_agents(root));
+            entries.extend(scan_recipes(root));
+        }
+        entries
+    }
+}
+
+#[async_trait]
+impl RegistrySource for LocalRegistrySource {
+    fn name(&self) -> &str {
+        "local"
+    }
+
+    async fn search(
+        &self,
+        query: Option<&str>,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Vec<RegistryEntry>> {
+        let entries = self.scan_all();
+
+        Ok(entries
+            .into_iter()
+            .filter(|e| kind.is_none() || kind == Some(e.kind))
+            .filter(|e| {
+                let Some(q) = query else { return true };
+                let q_lower = q.to_lowercase();
+                e.name.to_lowercase().contains(&q_lower)
+                    || e.description.to_lowercase().contains(&q_lower)
+                    || e.tags.iter().any(|t| t.to_lowercase().contains(&q_lower))
+            })
+            .collect())
+    }
+
+    async fn get(
+        &self,
+        name: &str,
+        kind: Option<RegistryEntryKind>,
+    ) -> Result<Option<RegistryEntry>> {
+        let entries = self.scan_all();
+        Ok(entries
+            .into_iter()
+            .find(|e| kind.is_none_or(|k| e.kind == k) && e.name == name))
+    }
+}
+
+fn scan_skills(root: &Path) -> Vec<RegistryEntry> {
+    let skills_dir = root.join("skills");
+    if !skills_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut entries = Vec::new();
+    let read_dir = match std::fs::read_dir(&skills_dir) {
+        Ok(rd) => rd,
+        Err(_) => return Vec::new(),
+    };
+
+    for dir_entry in read_dir.flatten() {
+        let path = dir_entry.path();
+        if !path.is_dir() {
+            continue;
+        }
+        let skill_file = path.join("SKILL.md");
+        if !skill_file.is_file() {
+            continue;
+        }
+        if let Some(entry) = parse_skill_file(&skill_file) {
+            entries.push(entry);
+        }
+    }
+    entries
+}
+
+fn scan_agents(root: &Path) -> Vec<RegistryEntry> {
+    let agents_dir = root.join("agents");
+    if !agents_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut entries = Vec::new();
+    let read_dir = match std::fs::read_dir(&agents_dir) {
+        Ok(rd) => rd,
+        Err(_) => return Vec::new(),
+    };
+
+    for dir_entry in read_dir.flatten() {
+        let path = dir_entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+        if let Some(entry) = parse_agent_file(&path) {
+            entries.push(entry);
+        }
+    }
+    entries
+}
+
+fn scan_recipes(root: &Path) -> Vec<RegistryEntry> {
+    let recipes_dir = root.join("recipes");
+    if !recipes_dir.is_dir() {
+        return Vec::new();
+    }
+
+    let mut entries = Vec::new();
+    let read_dir = match std::fs::read_dir(&recipes_dir) {
+        Ok(rd) => rd,
+        Err(_) => return Vec::new(),
+    };
+
+    for dir_entry in read_dir.flatten() {
+        let path = dir_entry.path();
+        let ext = path.extension().and_then(|e| e.to_str());
+        if ext != Some("yaml") && ext != Some("yml") {
+            continue;
+        }
+        if let Some(entry) = parse_recipe_file(&path) {
+            entries.push(entry);
+        }
+    }
+    entries
+}
+
+/// Parse a SKILL.md file with YAML frontmatter (name, description) + markdown body.
+fn parse_skill_file(path: &Path) -> Option<RegistryEntry> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let (meta, body) = parse_frontmatter::<SkillFrontmatter>(&content)?;
+
+    Some(RegistryEntry {
+        name: meta.name,
+        kind: RegistryEntryKind::Skill,
+        description: meta.description,
+        version: None,
+        author: None,
+        license: None,
+        repository: None,
+        icon: None,
+        source_uri: None,
+        local_path: Some(path.to_path_buf()),
+        tags: meta.tags.unwrap_or_default(),
+        detail: RegistryEntryDetail::Skill(SkillDetail {
+            content: body,
+            builtin: false,
+        }),
+        metadata: HashMap::new(),
+    })
+}
+
+/// Parse an agent .md file with YAML frontmatter (name, description, model) + instructions.
+fn parse_agent_file(path: &Path) -> Option<RegistryEntry> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let (meta, body) = parse_frontmatter::<AgentFrontmatter>(&content)?;
+
+    let description = meta.description.unwrap_or_else(|| {
+        meta.model
+            .as_ref()
+            .map(|m| format!("Agent ({})", m))
+            .unwrap_or_else(|| "Agent".into())
+    });
+
+    Some(RegistryEntry {
+        name: meta.name,
+        kind: RegistryEntryKind::Agent,
+        description,
+        version: meta.version,
+        author: meta.author.map(|name| AuthorInfo {
+            name: Some(name),
+            ..Default::default()
+        }),
+        license: meta.license,
+        repository: meta.repository,
+        icon: meta.icon,
+        source_uri: None,
+        local_path: Some(path.to_path_buf()),
+        tags: meta.tags.unwrap_or_default(),
+        detail: RegistryEntryDetail::Agent(Box::new(AgentDetail {
+            instructions: body,
+            model: meta.model,
+            capabilities: meta.capabilities.unwrap_or_default(),
+            domains: meta.domains.unwrap_or_default(),
+            required_extensions: meta.required_extensions.unwrap_or_default(),
+            input_content_types: vec!["text/plain".into()],
+            output_content_types: vec!["text/markdown".into()],
+            ..Default::default()
+        })),
+        metadata: HashMap::new(),
+    })
+}
+
+/// Parse a recipe .yaml file using Goose's Recipe struct fields.
+fn parse_recipe_file(path: &Path) -> Option<RegistryEntry> {
+    let content = std::fs::read_to_string(path).ok()?;
+    let value: serde_yaml::Value = serde_yaml::from_str(&content).ok()?;
+    let mapping = value.as_mapping()?;
+
+    let yaml_key = |k: &str| serde_yaml::Value::String(k.into());
+
+    let title = mapping
+        .get(yaml_key("title"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let description = mapping
+        .get(yaml_key("description"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let instructions = mapping
+        .get(yaml_key("instructions"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let prompt = mapping
+        .get(yaml_key("prompt"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let extension_names: Vec<String> = mapping
+        .get(yaml_key("extensions"))
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|ext| {
+                    ext.as_mapping()
+                        .and_then(|m| m.get(yaml_key("name")))
+                        .and_then(|n| n.as_str())
+                        .map(String::from)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let parameters: Vec<String> = mapping
+        .get(yaml_key("parameters"))
+        .and_then(|v| v.as_sequence())
+        .map(|seq| {
+            seq.iter()
+                .filter_map(|p| {
+                    p.as_mapping()
+                        .and_then(|m| m.get(yaml_key("key")))
+                        .and_then(|k| k.as_str())
+                        .map(String::from)
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let author = mapping
+        .get(yaml_key("author"))
+        .and_then(|v| v.as_mapping())
+        .map(|m| AuthorInfo {
+            name: m
+                .get(yaml_key("contact"))
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            contact: m
+                .get(yaml_key("contact"))
+                .and_then(|v| v.as_str())
+                .map(String::from),
+            url: None,
+        });
+
+    let version = mapping
+        .get(yaml_key("version"))
+        .and_then(|v| v.as_str())
+        .map(String::from);
+
+    let name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let display_name = if title.is_empty() {
+        name.clone()
+    } else {
+        title
+    };
+
+    Some(RegistryEntry {
+        name: display_name,
+        kind: RegistryEntryKind::Recipe,
+        description,
+        version,
+        author,
+        license: None,
+        repository: None,
+        icon: None,
+        source_uri: None,
+        local_path: Some(path.to_path_buf()),
+        tags: Vec::new(),
+        detail: RegistryEntryDetail::Recipe(RecipeDetail {
+            instructions,
+            prompt,
+            extension_names,
+            parameters,
+        }),
+        metadata: HashMap::new(),
+    })
+}
+
+/// Minimal frontmatter types for local file parsing.
+#[derive(serde::Deserialize)]
+struct SkillFrontmatter {
+    name: String,
+    description: String,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+}
+
+#[derive(serde::Deserialize)]
+struct AgentFrontmatter {
+    name: String,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    model: Option<String>,
+    #[serde(default)]
+    tags: Option<Vec<String>>,
+    #[serde(default)]
+    license: Option<String>,
+    #[serde(default)]
+    version: Option<String>,
+    #[serde(default)]
+    capabilities: Option<Vec<String>>,
+    #[serde(default)]
+    domains: Option<Vec<String>>,
+    #[serde(default)]
+    required_extensions: Option<Vec<String>>,
+    #[serde(default)]
+    repository: Option<String>,
+    #[serde(default)]
+    icon: Option<String>,
+    #[serde(default)]
+    author: Option<String>,
+}
+
+/// Parse YAML frontmatter delimited by `---` from a markdown file.
+fn parse_frontmatter<T: for<'de> serde::Deserialize<'de>>(content: &str) -> Option<(T, String)> {
+    let trimmed = content.trim_start();
+    if !trimmed.starts_with("---") {
+        return None;
+    }
+
+    let after_first = trimmed.get(3..)?;
+    let end_pos = after_first.find("---")?;
+    let yaml_content = after_first.get(..end_pos)?.trim();
+    let body = after_first.get(end_pos + 3..)?.trim().to_string();
+
+    let metadata: T = serde_yaml::from_str(yaml_content).ok()?;
+    Some((metadata, body))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parse_skill_frontmatter() {
+        let content = r#"---
+name: test-skill
+description: A test skill
+tags:
+  - testing
+---
+When the user asks about testing, do X.
+"#;
+        let (meta, body) = parse_frontmatter::<SkillFrontmatter>(content).unwrap();
+        assert_eq!(meta.name, "test-skill");
+        assert_eq!(meta.description, "A test skill");
+        assert_eq!(meta.tags, Some(vec!["testing".into()]));
+        assert!(body.contains("When the user asks about testing"));
+    }
+
+    #[test]
+    fn parse_agent_frontmatter() {
+        let content = r#"---
+name: code-helper
+description: Helps with code
+model: claude-sonnet-4
+---
+You are a helpful coding assistant.
+"#;
+        let (meta, body) = parse_frontmatter::<AgentFrontmatter>(content).unwrap();
+        assert_eq!(meta.name, "code-helper");
+        assert_eq!(meta.description, Some("Helps with code".into()));
+        assert_eq!(meta.model, Some("claude-sonnet-4".into()));
+        assert!(body.contains("helpful coding assistant"));
+    }
+
+    #[test]
+    fn parse_frontmatter_returns_none_without_delimiters() {
+        let content = "No frontmatter here";
+        let result = parse_frontmatter::<SkillFrontmatter>(content);
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn local_source_scans_skills() {
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills").join("my-skill");
+        fs::create_dir_all(&skills_dir).unwrap();
+        fs::write(
+            skills_dir.join("SKILL.md"),
+            "---
+name: my-skill
+description: A skill
+---
+Do the thing.
+",
+        )
+        .unwrap();
+
+        let source = LocalRegistrySource::new(vec![tmp.path().to_path_buf()]);
+        let results = source
+            .search(None, Some(RegistryEntryKind::Skill))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "my-skill");
+        assert_eq!(results[0].kind, RegistryEntryKind::Skill);
+    }
+
+    #[tokio::test]
+    async fn local_source_scans_agents() {
+        let tmp = TempDir::new().unwrap();
+        let agents_dir = tmp.path().join("agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(
+            agents_dir.join("reviewer.md"),
+            "---
+name: reviewer
+description: Reviews code
+model: gpt-4o
+---
+You review code.
+",
+        )
+        .unwrap();
+
+        let source = LocalRegistrySource::new(vec![tmp.path().to_path_buf()]);
+        let results = source
+            .search(None, Some(RegistryEntryKind::Agent))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "reviewer");
+    }
+
+    #[tokio::test]
+    async fn local_source_scans_recipes() {
+        let tmp = TempDir::new().unwrap();
+        let recipes_dir = tmp.path().join("recipes");
+        fs::create_dir_all(&recipes_dir).unwrap();
+        fs::write(
+            recipes_dir.join("my-recipe.yaml"),
+            "version: \"1.0.0\"\ntitle: My Recipe\ndescription: Does things\ninstructions: Do X\n",
+        )
+        .unwrap();
+
+        let source = LocalRegistrySource::new(vec![tmp.path().to_path_buf()]);
+        let results = source
+            .search(None, Some(RegistryEntryKind::Recipe))
+            .await
+            .unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "My Recipe");
+    }
+
+    #[tokio::test]
+    async fn local_source_search_filters_by_query() {
+        let tmp = TempDir::new().unwrap();
+        let skills_dir_a = tmp.path().join("skills").join("alpha-skill");
+        let skills_dir_b = tmp.path().join("skills").join("beta-skill");
+        fs::create_dir_all(&skills_dir_a).unwrap();
+        fs::create_dir_all(&skills_dir_b).unwrap();
+        fs::write(
+            skills_dir_a.join("SKILL.md"),
+            "---
+name: alpha-skill
+description: Alpha things
+---
+Alpha body.
+",
+        )
+        .unwrap();
+        fs::write(
+            skills_dir_b.join("SKILL.md"),
+            "---
+name: beta-skill
+description: Beta things
+---
+Beta body.
+",
+        )
+        .unwrap();
+
+        let source = LocalRegistrySource::new(vec![tmp.path().to_path_buf()]);
+        let results = source.search(Some("alpha"), None).await.unwrap();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "alpha-skill");
+    }
+
+    #[tokio::test]
+    async fn local_source_get_by_name() {
+        let tmp = TempDir::new().unwrap();
+        let skills_dir = tmp.path().join("skills").join("target");
+        fs::create_dir_all(&skills_dir).unwrap();
+        fs::write(
+            skills_dir.join("SKILL.md"),
+            "---
+name: target
+description: Target skill
+---
+Target body.
+",
+        )
+        .unwrap();
+
+        let source = LocalRegistrySource::new(vec![tmp.path().to_path_buf()]);
+        let result = source
+            .get("target", Some(RegistryEntryKind::Skill))
+            .await
+            .unwrap();
+        assert!(result.is_some());
+        assert_eq!(result.unwrap().name, "target");
+
+        let result = source
+            .get("nonexistent", Some(RegistryEntryKind::Skill))
+            .await
+            .unwrap();
+        assert!(result.is_none());
+    }
+}

--- a/crates/goose/src/registry/sources/mod.rs
+++ b/crates/goose/src/registry/sources/mod.rs
@@ -1,0 +1,4 @@
+pub mod a2a;
+pub mod github;
+pub mod http;
+pub mod local;


### PR DESCRIPTION
## Summary

Adds an Extension Registry system for discovering, installing, and managing MCP extensions.

### Features
- Registry protocol for extension discovery
- Extension metadata and versioning
- Install/uninstall lifecycle management
- Server-side registry routes

### Changes
- 24 files changed, ~4,258 insertions

### Verification
- ✅ cargo check
- ✅ cargo clippy (0 warnings)
- ✅ cargo fmt
