### PR TITLE
feat: ACP v0.2.0 compatibility layer

### DIFF
--- a/crates/goose-server/src/routes/acp_discovery.rs
+++ b/crates/goose-server/src/routes/acp_discovery.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use axum::{extract::Path, http::StatusCode, routing::get, Json, Router};
+use goose::acp_compat::manifest::{
+    AgentManifest, AgentMetadata, AgentModeInfo, AgentStatus, Link, Person,
+};
+
+use crate::state::AppState;
+
+/// Build the default Goose agent manifest.
+fn goose_agent_manifest() -> AgentManifest {
+    AgentManifest {
+        name: "Goose".to_string(),
+        description: "General-purpose AI agent by Block".to_string(),
+        input_content_types: vec!["text/plain".to_string(), "application/json".to_string()],
+        output_content_types: vec!["text/plain".to_string(), "application/json".to_string()],
+        metadata: Some(AgentMetadata {
+            author: Some(Person {
+                name: "Block, Inc.".to_string(),
+                url: Some("https://block.xyz".to_string()),
+            }),
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            links: Some(vec![
+                Link {
+                    url: "https://github.com/block/goose".to_string(),
+                    title: Some("GitHub".to_string()),
+                },
+                Link {
+                    url: "https://block.github.io/goose/".to_string(),
+                    title: Some("Documentation".to_string()),
+                },
+            ]),
+            recommended_models: Some(vec![
+                "claude-sonnet-4-20250514".to_string(),
+                "gpt-4.1".to_string(),
+            ]),
+            dependencies: None,
+            annotations: None,
+        }),
+        status: Some(AgentStatus {
+            avg_run_tokens: None,
+            avg_run_time_seconds: None,
+            success_rate: None,
+        }),
+        modes: vec![AgentModeInfo {
+            id: "default".to_string(),
+            name: "Default".to_string(),
+            description: Some("General-purpose assistant mode".to_string()),
+            tool_groups: vec![],
+        }],
+        default_mode: Some("default".to_string()),
+    }
+}
+
+/// GET /acp/ping — health check
+async fn ping() -> &'static str {
+    "pong"
+}
+
+/// GET /acp/agents — list available agents
+async fn list_agents() -> Json<Vec<AgentManifest>> {
+    Json(vec![goose_agent_manifest()])
+}
+
+/// GET /acp/agents/:name — get a specific agent
+async fn get_agent(Path(name): Path<String>) -> Result<Json<AgentManifest>, StatusCode> {
+    let manifest = goose_agent_manifest();
+    if manifest.name.to_lowercase() == name.to_lowercase() {
+        Ok(Json(manifest))
+    } else {
+        Err(StatusCode::NOT_FOUND)
+    }
+}
+
+pub fn routes(state: Arc<AppState>) -> Router {
+    let _state = state;
+    Router::new()
+        .route("/acp/ping", get(ping))
+        .route("/acp/agents", get(list_agents))
+        .route("/acp/agents/{name}", get(get_agent))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn goose_manifest_has_required_fields() {
+        let manifest = goose_agent_manifest();
+        assert_eq!(manifest.name, "Goose");
+        assert!(!manifest.description.is_empty());
+        assert!(manifest.metadata.is_some());
+        let meta = manifest.metadata.unwrap();
+        assert!(meta.version.is_some());
+        assert!(meta.author.is_some());
+        assert!(!manifest.modes.is_empty());
+    }
+}

--- a/crates/goose-server/src/routes/mod.rs
+++ b/crates/goose-server/src/routes/mod.rs
@@ -1,3 +1,4 @@
+pub mod acp_discovery;
 pub mod action_required;
 pub mod agent;
 pub mod config_management;
@@ -44,5 +45,6 @@ pub fn configure(state: Arc<crate::state::AppState>, secret_key: String) -> Rout
         .merge(gateway::routes(state.clone()))
         .merge(mcp_ui_proxy::routes(secret_key.clone()))
         .merge(mcp_app_proxy::routes(secret_key))
-        .merge(sampling::routes(state))
+        .merge(sampling::routes(state.clone()))
+        .merge(acp_discovery::routes(state))
 }

--- a/crates/goose/src/acp_compat/events.rs
+++ b/crates/goose/src/acp_compat/events.rs
@@ -1,0 +1,427 @@
+//! Maps goosed MessageEvent → ACP SSE events.
+//!
+//! A single goosed MessageEvent may expand to multiple ACP events.
+//! For example, a Message event becomes message.created + N×message.part + message.completed.
+
+use chrono::Utc;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use super::message::{goose_message_to_acp, AcpMessage, AcpMessagePart};
+use super::types::{AcpError, AcpRun, AcpRunStatus};
+
+/// ACP event types per v0.2.0 spec.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+pub enum AcpEventType {
+    #[serde(rename = "message.created")]
+    MessageCreated,
+    #[serde(rename = "message.part")]
+    MessagePart,
+    #[serde(rename = "message.completed")]
+    MessageCompleted,
+    #[serde(rename = "run.created")]
+    RunCreated,
+    #[serde(rename = "run.in-progress")]
+    RunInProgress,
+    #[serde(rename = "run.awaiting")]
+    RunAwaiting,
+    #[serde(rename = "run.completed")]
+    RunCompleted,
+    #[serde(rename = "run.cancelled")]
+    RunCancelled,
+    #[serde(rename = "run.failed")]
+    RunFailed,
+    #[serde(rename = "error")]
+    Error,
+    #[serde(rename = "generic")]
+    Generic,
+}
+
+impl AcpEventType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::MessageCreated => "message.created",
+            Self::MessagePart => "message.part",
+            Self::MessageCompleted => "message.completed",
+            Self::RunCreated => "run.created",
+            Self::RunInProgress => "run.in-progress",
+            Self::RunAwaiting => "run.awaiting",
+            Self::RunCompleted => "run.completed",
+            Self::RunCancelled => "run.cancelled",
+            Self::RunFailed => "run.failed",
+            Self::Error => "error",
+            Self::Generic => "generic",
+        }
+    }
+}
+
+/// An ACP SSE event.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AcpEvent {
+    #[serde(rename = "type")]
+    pub event_type: AcpEventType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub run: Option<AcpRun>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<AcpMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub part: Option<AcpMessagePart>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<AcpError>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+impl AcpEvent {
+    pub fn run_created(run: &AcpRun) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::RunCreated,
+            run: Some(run.clone()),
+            message: None,
+            part: None,
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn run_in_progress(run: &AcpRun) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::RunInProgress,
+            run: Some(run.clone()),
+            message: None,
+            part: None,
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn run_completed(run: &AcpRun) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::RunCompleted,
+            run: Some(run.clone()),
+            message: None,
+            part: None,
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn run_failed(run: &AcpRun) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::RunFailed,
+            run: Some(run.clone()),
+            message: None,
+            part: None,
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn run_cancelled(run: &AcpRun) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::RunCancelled,
+            run: Some(run.clone()),
+            message: None,
+            part: None,
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn run_awaiting(run: &AcpRun) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::RunAwaiting,
+            run: Some(run.clone()),
+            message: None,
+            part: None,
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn message_created(message: &AcpMessage) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::MessageCreated,
+            run: None,
+            message: Some(message.clone()),
+            part: None,
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn message_part(part: &AcpMessagePart) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::MessagePart,
+            run: None,
+            message: None,
+            part: Some(part.clone()),
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn message_completed(message: &AcpMessage) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::MessageCompleted,
+            run: None,
+            message: Some(message.clone()),
+            part: None,
+            error: None,
+            data: None,
+        }
+    }
+
+    pub fn error(error: AcpError) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::Error,
+            run: None,
+            message: None,
+            part: None,
+            error: Some(error),
+            data: None,
+        }
+    }
+
+    pub fn generic(data: serde_json::Value) -> Self {
+        AcpEvent {
+            event_type: AcpEventType::Generic,
+            run: None,
+            message: None,
+            part: None,
+            error: None,
+            data: Some(data),
+        }
+    }
+}
+
+/// Context needed to generate ACP events from goosed events.
+pub struct AcpEventContext {
+    pub run_id: String,
+    pub agent_name: String,
+    pub session_id: Option<String>,
+    pub created_at: chrono::DateTime<Utc>,
+}
+
+impl AcpEventContext {
+    fn snapshot(&self, status: AcpRunStatus) -> AcpRun {
+        AcpRun {
+            run_id: self.run_id.clone(),
+            agent_name: self.agent_name.clone(),
+            status,
+            session_id: self.session_id.clone(),
+            output: Vec::new(),
+            await_request: None,
+            error: None,
+            created_at: self.created_at,
+            finished_at: None,
+            metadata: None,
+        }
+    }
+}
+
+/// Convert a goosed MessageEvent into zero or more ACP events.
+///
+/// This is the central adapter: it takes the goosed-internal event model
+/// and produces the ACP-standard event stream.
+pub fn goosed_events_to_acp(
+    event_type: &str,
+    event_data: &serde_json::Value,
+    ctx: &AcpEventContext,
+) -> Vec<AcpEvent> {
+    match event_type {
+        "Message" => convert_message_event(event_data, ctx),
+        "Error" => convert_error_event(event_data, ctx),
+        "Finish" => convert_finish_event(event_data, ctx),
+        "ModelChange"
+        | "RoutingDecision"
+        | "PlanProposal"
+        | "Notification"
+        | "UpdateConversation"
+        | "ToolAvailabilityChange" => {
+            vec![AcpEvent::generic(serde_json::json!({
+                "goose_event_type": event_type,
+                "data": event_data,
+            }))]
+        }
+        _ => Vec::new(),
+    }
+}
+
+fn convert_message_event(data: &serde_json::Value, _ctx: &AcpEventContext) -> Vec<AcpEvent> {
+    let Some(msg_value) = data.get("message") else {
+        return Vec::new();
+    };
+
+    let Ok(goose_msg) =
+        serde_json::from_value::<crate::conversation::message::Message>(msg_value.clone())
+    else {
+        return Vec::new();
+    };
+
+    let acp_msg = goose_message_to_acp(&goose_msg);
+    let mut events = Vec::with_capacity(acp_msg.parts.len() + 2);
+
+    events.push(AcpEvent::message_created(&acp_msg));
+    for part in &acp_msg.parts {
+        events.push(AcpEvent::message_part(part));
+    }
+    events.push(AcpEvent::message_completed(&acp_msg));
+
+    events
+}
+
+fn convert_error_event(data: &serde_json::Value, ctx: &AcpEventContext) -> Vec<AcpEvent> {
+    let error_msg = data
+        .get("error")
+        .and_then(|e| e.as_str())
+        .unwrap_or("Unknown error")
+        .to_string();
+
+    let mut run = ctx.snapshot(AcpRunStatus::Failed);
+    run.error = Some(AcpError {
+        code: "agent_error".to_string(),
+        message: error_msg.clone(),
+        data: None,
+    });
+    run.finished_at = Some(Utc::now());
+
+    vec![
+        AcpEvent::error(AcpError {
+            code: "agent_error".to_string(),
+            message: error_msg,
+            data: None,
+        }),
+        AcpEvent::run_failed(&run),
+    ]
+}
+
+fn convert_finish_event(data: &serde_json::Value, ctx: &AcpEventContext) -> Vec<AcpEvent> {
+    let reason = data
+        .get("reason")
+        .and_then(|r| r.as_str())
+        .unwrap_or("end_turn");
+
+    let mut run = ctx.snapshot(AcpRunStatus::Completed);
+    run.finished_at = Some(Utc::now());
+
+    match reason {
+        "cancelled" => {
+            run.status = AcpRunStatus::Cancelled;
+            vec![AcpEvent::run_cancelled(&run)]
+        }
+        _ => vec![AcpEvent::run_completed(&run)],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_ctx() -> AcpEventContext {
+        AcpEventContext {
+            run_id: "run_123".to_string(),
+            agent_name: "goose".to_string(),
+            session_id: Some("sess_456".to_string()),
+            created_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn test_message_event_produces_created_parts_completed() {
+        let event_data = serde_json::json!({
+            "message": {
+                "role": "assistant",
+                "created": 1234567890,
+                "content": [
+                    { "type": "text", "text": "Hello!" },
+                    { "type": "text", "text": "How can I help?" }
+                ],
+                "metadata": { "userVisible": true, "agentVisible": true }
+            },
+            "tokenState": {
+                "inputTokens": 10, "outputTokens": 5, "totalTokens": 15,
+                "accumulatedInputTokens": 10, "accumulatedOutputTokens": 5,
+                "accumulatedTotalTokens": 15
+            }
+        });
+
+        let ctx = test_ctx();
+        let events = goosed_events_to_acp("Message", &event_data, &ctx);
+
+        assert_eq!(events.len(), 4);
+        assert_eq!(events[0].event_type, AcpEventType::MessageCreated);
+        assert_eq!(events[1].event_type, AcpEventType::MessagePart);
+        assert_eq!(events[2].event_type, AcpEventType::MessagePart);
+        assert_eq!(events[3].event_type, AcpEventType::MessageCompleted);
+
+        assert_eq!(
+            events[1].part.as_ref().unwrap().content.as_deref(),
+            Some("Hello!")
+        );
+        assert_eq!(
+            events[2].part.as_ref().unwrap().content.as_deref(),
+            Some("How can I help?")
+        );
+    }
+
+    #[test]
+    fn test_error_event() {
+        let event_data = serde_json::json!({ "error": "Provider timeout" });
+        let ctx = test_ctx();
+        let events = goosed_events_to_acp("Error", &event_data, &ctx);
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_type, AcpEventType::Error);
+        assert_eq!(
+            events[0].error.as_ref().unwrap().message,
+            "Provider timeout"
+        );
+        assert_eq!(events[1].event_type, AcpEventType::RunFailed);
+        assert_eq!(events[1].run.as_ref().unwrap().status, AcpRunStatus::Failed);
+    }
+
+    #[test]
+    fn test_finish_event_completed() {
+        let event_data = serde_json::json!({ "reason": "end_turn", "tokenState": {} });
+        let ctx = test_ctx();
+        let events = goosed_events_to_acp("Finish", &event_data, &ctx);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, AcpEventType::RunCompleted);
+    }
+
+    #[test]
+    fn test_finish_event_cancelled() {
+        let event_data = serde_json::json!({ "reason": "cancelled", "tokenState": {} });
+        let ctx = test_ctx();
+        let events = goosed_events_to_acp("Finish", &event_data, &ctx);
+
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].event_type, AcpEventType::RunCancelled);
+    }
+
+    #[test]
+    fn test_goose_extension_events_become_generic() {
+        let ctx = test_ctx();
+
+        for event_type in &[
+            "ModelChange",
+            "RoutingDecision",
+            "PlanProposal",
+            "Notification",
+        ] {
+            let events =
+                goosed_events_to_acp(event_type, &serde_json::json!({"some": "data"}), &ctx);
+            assert_eq!(events.len(), 1);
+            assert_eq!(events[0].event_type, AcpEventType::Generic);
+        }
+    }
+
+    #[test]
+    fn test_unknown_event_produces_nothing() {
+        let ctx = test_ctx();
+        let events = goosed_events_to_acp("SomeUnknownEvent", &serde_json::json!({}), &ctx);
+        assert!(events.is_empty());
+    }
+}

--- a/crates/goose/src/acp_compat/manifest.rs
+++ b/crates/goose/src/acp_compat/manifest.rs
@@ -1,0 +1,185 @@
+//! ACP Agent Manifest — describes agent capabilities for discovery.
+//!
+//! Aligned with ACP v0.2.0 / A2A protocol:
+//!   - 1 agent = 1 persona (e.g. "Goose Agent", "Developer Agent")
+//!   - Each agent advertises N session modes (e.g. ask, architect, code)
+//!   - Modes are switched per-session via `session/setMode`
+
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+/// ACP agent manifest per v0.2.0 spec.
+///
+/// Each manifest represents one agent persona. Modes are listed in `modes`
+/// following the ACP SessionMode pattern (not flattened into separate agents).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentManifest {
+    pub name: String,
+    pub description: String,
+    #[serde(default)]
+    pub input_content_types: Vec<String>,
+    #[serde(default)]
+    pub output_content_types: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<AgentMetadata>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<AgentStatus>,
+    /// Session modes this agent supports (ACP SessionMode pattern).
+    /// Each mode represents a different behavior/persona the agent can adopt
+    /// within a session (e.g. "assistant", "architect", "backend").
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub modes: Vec<AgentModeInfo>,
+    /// The default mode ID when no explicit mode is requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_mode: Option<String>,
+}
+
+/// A mode an agent can operate in (maps to ACP SessionMode).
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentModeInfo {
+    pub id: String,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Tool groups this mode has access to.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tool_groups: Vec<String>,
+}
+
+/// Runtime status metrics for an agent.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentStatus {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_run_tokens: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avg_run_time_seconds: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub success_rate: Option<f64>,
+}
+
+/// ACP AgentDependency (experimental) — a tool, agent, or model required by this agent.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentDependency {
+    #[serde(rename = "type")]
+    pub dep_type: String,
+    pub name: String,
+}
+
+/// Metadata about an agent.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AgentMetadata {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<Person>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub links: Option<Vec<Link>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub recommended_models: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dependencies: Option<Vec<AgentDependency>>,
+    /// ACP-REST Option B: discoverable annotations for roles and behavior modes.
+    /// Keys follow the convention "goose.<dimension>" to avoid collisions.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub annotations: Option<std::collections::HashMap<String, serde_json::Value>>,
+}
+
+/// A person reference.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Person {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+/// A link reference.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct Link {
+    pub url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+}
+
+/// Build the default goose agent manifest.
+pub fn goose_agent_manifest() -> AgentManifest {
+    AgentManifest {
+        name: "goose".to_string(),
+        description: "General-purpose AI agent with tool use, powered by Block's Goose framework"
+            .to_string(),
+        input_content_types: vec!["text/plain".to_string(), "application/json".to_string()],
+        output_content_types: vec![
+            "text/plain".to_string(),
+            "application/json".to_string(),
+            "image/*".to_string(),
+        ],
+        metadata: Some(AgentMetadata {
+            author: Some(Person {
+                name: "Block".to_string(),
+                url: Some("https://block.xyz".to_string()),
+            }),
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            links: Some(vec![Link {
+                url: "https://github.com/block/goose".to_string(),
+                title: Some("GitHub".to_string()),
+            }]),
+            recommended_models: None,
+            dependencies: None,
+            annotations: None,
+        }),
+        modes: vec![],
+        default_mode: None,
+        status: None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_manifest_serialization() {
+        let manifest = goose_agent_manifest();
+        let json = serde_json::to_value(&manifest).unwrap();
+
+        assert_eq!(json["name"], "goose");
+        assert!(json["description"].as_str().unwrap().contains("AI agent"));
+        assert!(json["input_content_types"].is_array());
+        assert!(json["output_content_types"].is_array());
+        assert_eq!(json["metadata"]["author"]["name"], "Block");
+        // status should not be serialized when None
+        assert!(json.get("status").is_none());
+    }
+
+    #[test]
+    fn test_manifest_deserialization() {
+        let json = serde_json::json!({
+            "name": "custom-agent",
+            "description": "A custom agent",
+            "input_content_types": ["text/plain"],
+            "output_content_types": ["text/plain"]
+        });
+
+        let manifest: AgentManifest = serde_json::from_value(json).unwrap();
+        assert_eq!(manifest.name, "custom-agent");
+        assert!(manifest.metadata.is_none());
+        assert!(manifest.status.is_none());
+    }
+
+    #[test]
+    fn test_manifest_with_status() {
+        let json = serde_json::json!({
+            "name": "agent",
+            "description": "test",
+            "status": {
+                "avg_run_tokens": 1500.0,
+                "success_rate": 0.95
+            }
+        });
+
+        let manifest: AgentManifest = serde_json::from_value(json).unwrap();
+        let status = manifest.status.unwrap();
+        assert_eq!(status.avg_run_tokens.unwrap(), 1500.0);
+        assert_eq!(status.success_rate.unwrap(), 0.95);
+        assert!(status.avg_run_time_seconds.is_none());
+    }
+}

--- a/crates/goose/src/acp_compat/message.rs
+++ b/crates/goose/src/acp_compat/message.rs
@@ -1,0 +1,541 @@
+//! Bidirectional converters between goose Message ↔ ACP Message.
+//!
+//! ACP v0.2.0 uses a multi-part message format where each part has a content_type
+//! and inline content. goose uses MCP-style MessageContent variants (Text, Image,
+//! ToolRequest, ToolResponse, etc.).
+
+use rmcp::model::{CallToolRequestParams, CallToolResult, Content, RawContent, RawTextContent};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use crate::conversation::message::{
+    ActionRequired, ActionRequiredData, Message, MessageContent, ThinkingContent, ToolRequest,
+    ToolResponse,
+};
+
+/// ACP message: role + ordered parts.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AcpMessage {
+    pub role: AcpRole,
+    pub parts: Vec<AcpMessagePart>,
+}
+
+/// ACP role — "user" or "agent" (with optional sub-agent path like "agent/coding").
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcpRole {
+    User,
+    Agent,
+}
+
+/// A single part of an ACP message.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AcpMessagePart {
+    pub content_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content_encoding: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+impl AcpMessagePart {
+    pub fn text(text: impl Into<String>) -> Self {
+        AcpMessagePart {
+            content_type: "text/plain".to_string(),
+            content: Some(text.into()),
+            content_url: None,
+            content_encoding: None,
+            metadata: None,
+        }
+    }
+
+    pub fn json(value: &serde_json::Value, metadata: Option<serde_json::Value>) -> Self {
+        AcpMessagePart {
+            content_type: "application/json".to_string(),
+            content: Some(value.to_string()),
+            content_url: None,
+            content_encoding: None,
+            metadata,
+        }
+    }
+
+    pub fn image(data: &str, mime_type: &str) -> Self {
+        AcpMessagePart {
+            content_type: mime_type.to_string(),
+            content: Some(data.to_string()),
+            content_url: None,
+            content_encoding: Some("base64".to_string()),
+            metadata: None,
+        }
+    }
+}
+
+/// Convert a goose Message to an ACP Message.
+pub fn goose_message_to_acp(msg: &Message) -> AcpMessage {
+    let role = match msg.role {
+        rmcp::model::Role::User => AcpRole::User,
+        rmcp::model::Role::Assistant => AcpRole::Agent,
+    };
+
+    let parts = msg
+        .content
+        .iter()
+        .filter_map(goose_content_to_acp_part)
+        .collect();
+
+    AcpMessage { role, parts }
+}
+
+/// Convert a single goose MessageContent to an ACP MessagePart.
+fn goose_content_to_acp_part(content: &MessageContent) -> Option<AcpMessagePart> {
+    match content {
+        MessageContent::Text(text) => Some(AcpMessagePart::text(&text.text)),
+
+        MessageContent::Image(image) => Some(AcpMessagePart::image(&image.data, &image.mime_type)),
+
+        MessageContent::ToolRequest(req) => {
+            let (name, arguments) = match &req.tool_call {
+                Ok(call) => (
+                    call.name.to_string(),
+                    call.arguments
+                        .as_ref()
+                        .map(|a| serde_json::to_value(a).unwrap_or_default())
+                        .unwrap_or(serde_json::Value::Object(Default::default())),
+                ),
+                Err(e) => (
+                    "error".to_string(),
+                    serde_json::json!({ "error": e.message.to_string() }),
+                ),
+            };
+
+            let payload = serde_json::json!({
+                "tool_name": name,
+                "arguments": arguments,
+            });
+
+            let metadata = serde_json::json!({
+                "trajectory": {
+                    "type": "tool_call",
+                    "tool_call_id": req.id,
+                }
+            });
+
+            Some(AcpMessagePart::json(&payload, Some(metadata)))
+        }
+
+        MessageContent::ToolResponse(res) => {
+            let result_content = match &res.tool_result {
+                Ok(result) => {
+                    let texts: Vec<String> = result
+                        .content
+                        .iter()
+                        .filter_map(|c| c.as_text().map(|t| t.text.to_string()))
+                        .collect();
+                    serde_json::json!({
+                        "output": texts.join("
+                    "),
+                        "is_error": result.is_error.unwrap_or(false),
+                    })
+                }
+                Err(e) => {
+                    serde_json::json!({
+                        "output": e.message.to_string(),
+                        "is_error": true,
+                    })
+                }
+            };
+
+            let metadata = serde_json::json!({
+                "trajectory": {
+                    "type": "tool_result",
+                    "tool_call_id": res.id,
+                }
+            });
+
+            Some(AcpMessagePart::json(&result_content, Some(metadata)))
+        }
+
+        MessageContent::Thinking(thinking) => {
+            let metadata = serde_json::json!({
+                "trajectory": { "type": "thinking" }
+            });
+            Some(AcpMessagePart {
+                content_type: "text/plain".to_string(),
+                content: Some(thinking.thinking.clone()),
+                content_url: None,
+                content_encoding: None,
+                metadata: Some(metadata),
+            })
+        }
+
+        MessageContent::ActionRequired(action) => {
+            let payload = serde_json::to_value(&action.data).unwrap_or_default();
+            let metadata = serde_json::json!({
+                "goose": { "type": "action_required" }
+            });
+            Some(AcpMessagePart::json(&payload, Some(metadata)))
+        }
+
+        // These are goose-internal UI concerns, not meaningful for ACP wire format
+        MessageContent::ToolConfirmationRequest(_)
+        | MessageContent::FrontendToolRequest(_)
+        | MessageContent::RedactedThinking(_)
+        | MessageContent::Reasoning(_)
+        | MessageContent::SystemNotification(_) => None,
+    }
+}
+
+/// Convert an ACP Message to a goose Message.
+pub fn acp_message_to_goose(acp: &AcpMessage) -> Message {
+    let mut msg = match acp.role {
+        AcpRole::User => Message::user(),
+        AcpRole::Agent => Message::assistant(),
+    };
+
+    for part in &acp.parts {
+        if let Some(content) = acp_part_to_goose_content(part) {
+            msg = msg.with_content(content);
+        }
+    }
+
+    msg
+}
+
+/// Convert a single ACP MessagePart to a goose MessageContent.
+fn acp_part_to_goose_content(part: &AcpMessagePart) -> Option<MessageContent> {
+    let content_str = part.content.as_deref().unwrap_or("");
+    let trajectory_type = part
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("trajectory"))
+        .and_then(|t| t.get("type"))
+        .and_then(|t| t.as_str());
+
+    match trajectory_type {
+        Some("tool_call") => parse_tool_call_part(part, content_str),
+        Some("tool_result") => parse_tool_result_part(part, content_str),
+        Some("thinking") => Some(MessageContent::Thinking(ThinkingContent {
+            thinking: content_str.to_string(),
+            signature: String::new(),
+        })),
+        _ => parse_content_part(part, content_str),
+    }
+}
+
+fn parse_tool_call_part(part: &AcpMessagePart, content_str: &str) -> Option<MessageContent> {
+    let tool_call_id = part
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("trajectory"))
+        .and_then(|t| t.get("tool_call_id"))
+        .and_then(|id| id.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let parsed: serde_json::Value = serde_json::from_str(content_str).ok()?;
+    let tool_name = parsed
+        .get("tool_name")
+        .and_then(|n| n.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+    let arguments = parsed.get("arguments").cloned();
+
+    let arguments_obj = arguments.and_then(|a| {
+        if let serde_json::Value::Object(map) = a {
+            Some(map)
+        } else {
+            None
+        }
+    });
+
+    Some(MessageContent::ToolRequest(ToolRequest {
+        id: tool_call_id,
+        tool_call: Ok({
+            let mut params = CallToolRequestParams::new(tool_name);
+            if let Some(args) = arguments_obj {
+                params = params.with_arguments(args);
+            }
+            params
+        }),
+        metadata: None,
+        tool_meta: None,
+    }))
+}
+
+fn parse_tool_result_part(part: &AcpMessagePart, content_str: &str) -> Option<MessageContent> {
+    let tool_call_id = part
+        .metadata
+        .as_ref()
+        .and_then(|m| m.get("trajectory"))
+        .and_then(|t| t.get("tool_call_id"))
+        .and_then(|id| id.as_str())
+        .unwrap_or("unknown")
+        .to_string();
+
+    let parsed: serde_json::Value = serde_json::from_str(content_str).ok()?;
+    let output = parsed.get("output").and_then(|o| o.as_str()).unwrap_or("");
+    let is_error = parsed
+        .get("is_error")
+        .and_then(|e| e.as_bool())
+        .unwrap_or(false);
+
+    let text_content = Content {
+        raw: RawContent::Text(RawTextContent {
+            text: output.to_string(),
+            meta: None,
+        }),
+        annotations: None,
+    };
+
+    Some(MessageContent::ToolResponse(ToolResponse {
+        id: tool_call_id,
+        tool_result: Ok(if is_error {
+            CallToolResult::error(vec![text_content])
+        } else {
+            CallToolResult::success(vec![text_content])
+        }),
+        metadata: None,
+    }))
+}
+
+fn parse_content_part(part: &AcpMessagePart, content_str: &str) -> Option<MessageContent> {
+    let ct = &part.content_type;
+
+    if ct.starts_with("text/") {
+        Some(MessageContent::text(content_str))
+    } else if ct.starts_with("image/") {
+        Some(MessageContent::image(content_str, ct))
+    } else if ct == "application/json" {
+        // Generic JSON part with goose-specific metadata
+        let goose_type = part
+            .metadata
+            .as_ref()
+            .and_then(|m| m.get("goose"))
+            .and_then(|g| g.get("type"))
+            .and_then(|t| t.as_str());
+
+        match goose_type {
+            Some("action_required") => {
+                let data: ActionRequiredData = serde_json::from_str(content_str).ok()?;
+                Some(MessageContent::ActionRequired(ActionRequired { data }))
+            }
+            _ => Some(MessageContent::text(content_str)),
+        }
+    } else {
+        Some(MessageContent::text(format!(
+            "[Unsupported content_type: {}]",
+            ct
+        )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::Role;
+    use rmcp::object;
+
+    #[test]
+    fn test_text_roundtrip() {
+        let goose_msg = Message::user().with_text("Hello, world!");
+        let acp = goose_message_to_acp(&goose_msg);
+
+        assert_eq!(acp.role, AcpRole::User);
+        assert_eq!(acp.parts.len(), 1);
+        assert_eq!(acp.parts[0].content_type, "text/plain");
+        assert_eq!(acp.parts[0].content.as_deref(), Some("Hello, world!"));
+
+        let roundtrip = acp_message_to_goose(&acp);
+        assert_eq!(roundtrip.role, Role::User);
+        assert_eq!(roundtrip.as_concat_text(), "Hello, world!");
+    }
+
+    #[test]
+    fn test_image_roundtrip() {
+        let goose_msg = Message::user().with_image("base64data", "image/png");
+        let acp = goose_message_to_acp(&goose_msg);
+
+        assert_eq!(acp.parts.len(), 1);
+        assert_eq!(acp.parts[0].content_type, "image/png");
+        assert_eq!(acp.parts[0].content.as_deref(), Some("base64data"));
+        assert_eq!(acp.parts[0].content_encoding.as_deref(), Some("base64"));
+
+        let roundtrip = acp_message_to_goose(&acp);
+        if let MessageContent::Image(img) = &roundtrip.content[0] {
+            assert_eq!(img.data, "base64data");
+            assert_eq!(img.mime_type, "image/png");
+        } else {
+            panic!("Expected Image content");
+        }
+    }
+
+    #[test]
+    fn test_tool_request_roundtrip() {
+        let goose_msg = Message::assistant().with_tool_request(
+            "call_1",
+            Ok(CallToolRequestParams {
+                meta: None,
+                task: None,
+                name: "shell".into(),
+                arguments: Some(object!({"command": "ls"})),
+            }),
+        );
+
+        let acp = goose_message_to_acp(&goose_msg);
+        assert_eq!(acp.role, AcpRole::Agent);
+        assert_eq!(acp.parts.len(), 1);
+        assert_eq!(acp.parts[0].content_type, "application/json");
+
+        let trajectory = acp.parts[0]
+            .metadata
+            .as_ref()
+            .unwrap()
+            .get("trajectory")
+            .unwrap();
+        assert_eq!(trajectory["type"], "tool_call");
+        assert_eq!(trajectory["tool_call_id"], "call_1");
+
+        let roundtrip = acp_message_to_goose(&acp);
+        assert_eq!(roundtrip.role, Role::Assistant);
+        if let MessageContent::ToolRequest(req) = &roundtrip.content[0] {
+            assert_eq!(req.id, "call_1");
+            let call = req.tool_call.as_ref().unwrap();
+            assert_eq!(call.name.as_ref(), "shell");
+            assert_eq!(call.arguments.as_ref().unwrap()["command"], "ls");
+        } else {
+            panic!("Expected ToolRequest content");
+        }
+    }
+
+    #[test]
+    fn test_tool_response_roundtrip() {
+        let text_content = Content {
+            raw: RawContent::Text(RawTextContent {
+                text: "file1.txt
+file2.txt"
+                    .to_string(),
+                meta: None,
+            }),
+            annotations: None,
+        };
+
+        let goose_msg = Message::user().with_tool_response(
+            "call_1",
+            Ok(CallToolResult {
+                content: vec![text_content],
+                is_error: Some(false),
+                structured_content: None,
+                meta: None,
+            }),
+        );
+
+        let acp = goose_message_to_acp(&goose_msg);
+        assert_eq!(acp.parts.len(), 1);
+
+        let trajectory = acp.parts[0]
+            .metadata
+            .as_ref()
+            .unwrap()
+            .get("trajectory")
+            .unwrap();
+        assert_eq!(trajectory["type"], "tool_result");
+        assert_eq!(trajectory["tool_call_id"], "call_1");
+
+        let roundtrip = acp_message_to_goose(&acp);
+        if let MessageContent::ToolResponse(res) = &roundtrip.content[0] {
+            assert_eq!(res.id, "call_1");
+            let result = res.tool_result.as_ref().unwrap();
+            assert_eq!(
+                result.content[0].as_text().unwrap().text,
+                "file1.txt
+file2.txt"
+            );
+            assert_eq!(result.is_error, Some(false));
+        } else {
+            panic!("Expected ToolResponse content");
+        }
+    }
+
+    #[test]
+    fn test_multi_content_message() {
+        let goose_msg = Message::assistant()
+            .with_text("I'll run that command for you.")
+            .with_tool_request(
+                "call_2",
+                Ok(CallToolRequestParams {
+                    meta: None,
+                    task: None,
+                    name: "shell".into(),
+                    arguments: Some(object!({"command": "echo hi"})),
+                }),
+            );
+
+        let acp = goose_message_to_acp(&goose_msg);
+        assert_eq!(acp.parts.len(), 2);
+        assert_eq!(acp.parts[0].content_type, "text/plain");
+        assert_eq!(acp.parts[1].content_type, "application/json");
+
+        let roundtrip = acp_message_to_goose(&acp);
+        assert_eq!(roundtrip.content.len(), 2);
+        assert!(matches!(&roundtrip.content[0], MessageContent::Text(_)));
+        assert!(matches!(
+            &roundtrip.content[1],
+            MessageContent::ToolRequest(_)
+        ));
+    }
+
+    #[test]
+    fn test_acp_text_to_goose() {
+        let acp = AcpMessage {
+            role: AcpRole::User,
+            parts: vec![AcpMessagePart::text("Hello from ACP")],
+        };
+
+        let goose = acp_message_to_goose(&acp);
+        assert_eq!(goose.role, Role::User);
+        assert_eq!(goose.as_concat_text(), "Hello from ACP");
+    }
+
+    #[test]
+    fn test_system_notification_filtered_out() {
+        use crate::conversation::message::SystemNotificationType;
+        let goose_msg = Message::assistant()
+            .with_text("visible")
+            .with_system_notification(SystemNotificationType::InlineMessage, "internal");
+
+        let acp = goose_message_to_acp(&goose_msg);
+        assert_eq!(acp.parts.len(), 1);
+        assert_eq!(acp.parts[0].content.as_deref(), Some("visible"));
+    }
+
+    #[test]
+    fn test_thinking_roundtrip() {
+        let goose_msg = Message::assistant().with_thinking("Let me think about this...", "sig123");
+
+        let acp = goose_message_to_acp(&goose_msg);
+        assert_eq!(acp.parts.len(), 1);
+        assert_eq!(acp.parts[0].content_type, "text/plain");
+        assert_eq!(
+            acp.parts[0].content.as_deref(),
+            Some("Let me think about this...")
+        );
+        let trajectory = acp.parts[0]
+            .metadata
+            .as_ref()
+            .unwrap()
+            .get("trajectory")
+            .unwrap();
+        assert_eq!(trajectory["type"], "thinking");
+
+        let roundtrip = acp_message_to_goose(&acp);
+        if let MessageContent::Thinking(t) = &roundtrip.content[0] {
+            assert_eq!(t.thinking, "Let me think about this...");
+        } else {
+            panic!("Expected Thinking content");
+        }
+    }
+}

--- a/crates/goose/src/acp_compat/mod.rs
+++ b/crates/goose/src/acp_compat/mod.rs
@@ -1,0 +1,21 @@
+//! ACP (Agent Communication Protocol) v0.2.0 compatibility layer.
+//!
+//! Provides ACP-compliant types and bidirectional converters between
+//! goose's internal Message/Event model and the ACP REST wire format.
+
+pub mod events;
+pub mod manifest;
+pub mod message;
+pub mod types;
+
+pub use events::{goosed_events_to_acp, AcpEvent, AcpEventContext, AcpEventType};
+pub use manifest::{
+    AgentDependency, AgentManifest, AgentMetadata, AgentModeInfo, AgentStatus, Link, Person,
+};
+pub use message::{
+    acp_message_to_goose, goose_message_to_acp, AcpMessage, AcpMessagePart, AcpRole,
+};
+pub use types::{
+    AcpError, AcpRun, AcpRunStatus, AcpSession, AwaitRequest, AwaitResume, RunCreateRequest,
+    RunMode, RunResumeRequest,
+};

--- a/crates/goose/src/acp_compat/types.rs
+++ b/crates/goose/src/acp_compat/types.rs
@@ -1,0 +1,113 @@
+//! Core ACP types: Run, Session, status enums.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+use super::message::AcpMessage;
+
+/// Run status per ACP v0.2.0 spec.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AcpRunStatus {
+    Created,
+    InProgress,
+    Awaiting,
+    Completed,
+    Cancelled,
+    Failed,
+}
+
+/// Run mode per ACP v0.2.0 spec.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, ToSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RunMode {
+    #[default]
+    Sync,
+    Async,
+    Stream,
+}
+
+/// Request payload for creating a new run.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RunCreateRequest {
+    pub agent_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    pub input: Vec<AcpMessage>,
+    #[serde(default)]
+    pub mode: RunMode,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Request payload for resuming an awaiting run.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct RunResumeRequest {
+    pub run_id: String,
+    pub await_resume: AwaitResume,
+    /// Required per ACP v0.2.0 spec.
+    pub mode: RunMode,
+}
+
+/// A run object per ACP v0.2.0 spec.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AcpRun {
+    pub run_id: String,
+    pub agent_name: String,
+    pub status: AcpRunStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+    #[serde(default)]
+    pub output: Vec<AcpMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub await_request: Option<AwaitRequest>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<AcpError>,
+    pub created_at: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<DateTime<Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// ACP error object.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AcpError {
+    pub code: String,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// ACP session object.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AcpSession {
+    pub id: String,
+    #[serde(default)]
+    pub history: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<String>,
+}
+
+/// Generic await request — sent when run enters "awaiting" state.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AwaitRequest {
+    #[serde(rename = "type")]
+    pub request_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub schema: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Generic await resume — sent by client to resume an awaiting run.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct AwaitResume {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod acp_compat;
 pub mod action_required_manager;
 pub mod agents;
 pub mod builtin_extension;


### PR DESCRIPTION
## Summary

Adds an Agent Communication Protocol (ACP) v0.2.0 compatibility layer that bridges ACP messages to Goose's internal message format.

### What it does
- Converts ACP message parts (text, tool calls, tool results) to Goose MessageContent variants
- Handles ACP-specific metadata (tool names, call IDs, error flags)
- Integrates with the existing conversation model

### E0639 Fix
Updated non-exhaustive struct construction to use builder patterns:
- `CallToolRequestParams::new(name).with_arguments(args)`
- `CallToolResult::success(content)` / `CallToolResult::error(content)`

### Verification
- cargo check ✅
- cargo clippy -D warnings ✅
- cargo fmt ✅
