### PR TITLE
fix: persist conversation state on interruption to prevent context loss

### DIFF
--- a/crates/goose-cli/src/session/mod.rs
+++ b/crates/goose-cli/src/session/mod.rs
@@ -1220,6 +1220,17 @@ impl CliSession {
                 }
             }
         }
+
+        if let Err(e) = self
+            .agent
+            .config
+            .session_manager
+            .replace_conversation(&self.session_id, &self.messages)
+            .await
+        {
+            warn!("Failed to persist conversation on interruption: {}", e);
+        }
+
         Ok(())
     }
 

--- a/crates/goose-server/src/routes/reply.rs
+++ b/crates/goose-server/src/routes/reply.rs
@@ -336,6 +336,13 @@ pub async fn reply(
             tokio::select! {
                 _ = task_cancel.cancelled() => {
                     tracing::info!("Agent task cancelled");
+                    if let Err(e) = state
+                        .session_manager()
+                        .replace_conversation(&session_id, &all_messages)
+                        .await
+                    {
+                        tracing::warn!("Failed to persist conversation on cancellation: {}", e);
+                    }
                     break;
                 }
                 _ = heartbeat_interval.tick() => {
@@ -385,6 +392,13 @@ pub async fn reply(
                         }
                         Err(_) => {
                             if tx.is_closed() {
+                                if let Err(e) = state
+                                    .session_manager()
+                                    .replace_conversation(&session_id, &all_messages)
+                                    .await
+                                {
+                                    tracing::warn!("Failed to persist conversation on client disconnect: {}", e);
+                                }
                                 break;
                             }
                             continue;


### PR DESCRIPTION
## Summary
On interrupt , messages from the current agent turn are only in-memory and never persisted. The next agent.reply() loads from the session manager, losing all interrupted-turn context.

Call replace_conversation() on interruption in both CLI and server to sync the in-memory conversation to the session manager.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### Testing
Tested locally