### PR TITLE
Add human-in-the-loop workflow recipe examples

### DIFF
--- a/documentation/docs/guides/recipes/human-in-the-loop-workflows.md
+++ b/documentation/docs/guides/recipes/human-in-the-loop-workflows.md
@@ -1,0 +1,78 @@
+---
+title: Human-in-the-Loop Workflow Recipes
+description: Build approval-gated Goose recipes that stay broadly useful and locally testable
+---
+
+Goose recipes are often used as task starters, but they also work well for **approval-gated workflows** where the agent should investigate first, produce an artifact, and only continue after an explicit human decision.
+
+This pattern is useful when the task is high-trust or hard to reverse, such as:
+
+- reviewing a risky shell command before execution
+- preparing a release recommendation before signoff
+- summarizing a proposed change before any file edits
+
+For external approval systems, see the [gotoHuman MCP tutorial](/docs/mcp/gotohuman-mcp). The recipes in this guide focus on **local-first**, **maintainer-testable** workflows that only require Goose's built-in tools.
+
+## Pattern
+
+A mergeable human-in-the-loop recipe should usually follow this sequence:
+
+1. Inspect local state and gather evidence.
+2. Write a review artifact to a deterministic file path.
+3. Present a concise summary to the user.
+4. Ask for an explicit approval phrase such as `APPROVE` or `REJECT`.
+5. Only perform the gated action after approval.
+
+This keeps the workflow safe and makes it easy for maintainers to evaluate the recipe without credentials, SaaS accounts, or organization-specific context.
+
+## Local Testability
+
+When contributing approval-gated recipes to the cookbook, optimize for local verification:
+
+- Prefer built-in extensions like `developer`.
+- Write a report file with a predictable name such as `command_review.md`.
+- Keep approval inputs explicit and easy to inspect.
+- Avoid remote APIs, paid services, and browser logins.
+- Add a simple `retry.checks` rule so success can be validated automatically.
+
+Even if a reviewer does not continue past the approval gate, they can still verify that the recipe created the expected review artifact and followed the workflow correctly.
+
+## Example Recipes
+
+This repository includes two local-first examples:
+
+- [Risky Command Review](https://raw.githubusercontent.com/block/goose/main/documentation/src/pages/recipes/data/recipes/risky-command-review.yaml)
+- [Release Signoff](https://raw.githubusercontent.com/block/goose/main/documentation/src/pages/recipes/data/recipes/release-signoff.yaml)
+
+## Suggested Validation Flow
+
+Validate the recipe schema first:
+
+```bash
+goose recipe validate documentation/src/pages/recipes/data/recipes/risky-command-review.yaml
+goose recipe validate documentation/src/pages/recipes/data/recipes/release-signoff.yaml
+```
+
+Then run a local review flow against a small sample workspace or repository:
+
+```bash
+goose run \
+  --recipe documentation/src/pages/recipes/data/recipes/risky-command-review.yaml \
+  --params 'workspace_path=/path/to/workspace' \
+  --params 'command=touch approved.txt' \
+  --params 'objective=Create a marker file only after explicit review'
+```
+
+```bash
+goose run \
+  --recipe documentation/src/pages/recipes/data/recipes/release-signoff.yaml \
+  --params 'repo_path=/path/to/repo' \
+  --params 'release_context=v1.2.3 release candidate for local verification'
+```
+
+In both cases, the expected first checkpoint is the generated report file:
+
+- `/path/to/workspace/command_review.md`
+- `/path/to/repo/release_signoff.md`
+
+That makes the workflow easy to review even before the approval step is completed.

--- a/documentation/src/pages/recipes/data/recipes/release-signoff.yaml
+++ b/documentation/src/pages/recipes/data/recipes/release-signoff.yaml
@@ -1,0 +1,75 @@
+version: 1.0.0
+id: release-signoff
+title: Release Signoff
+author:
+  contact: VasuBansal7576
+description: Reviews a local release candidate, writes a signoff summary, and pauses for explicit approval before finalizing the release recommendation.
+instructions: |
+  You are a release reviewer operating on a local repository.
+
+  Your job is to inspect the release candidate described by the user, summarize the current state of the repository and available checks, and prepare a signoff artifact before any final recommendation is accepted.
+
+  Rules:
+  - Work only inside `{{ repo_path }}`.
+  - Write your report to `{{ repo_path }}/release_signoff.md`.
+  - Base your review on local repository state, available docs, and locally runnable checks.
+  - Do not create tags, publish artifacts, push commits, or make remote changes.
+  - Ask for explicit `APPROVE` or `REJECT` after writing the report.
+
+activities:
+  - Inspect the local release candidate
+  - Review repo state, diffs, and available checks
+  - Write a release_signoff.md summary
+  - Pause for explicit approval or rejection
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  Review the release candidate in `{{ repo_path }}`.
+
+  Release context:
+  {{ release_context }}
+
+  Follow this process:
+
+  1. Inspect the repository state relevant to the release, including the current branch, uncommitted changes, recent commits, release notes, changelog files, and any obvious risky areas.
+  2. Determine which local validation commands are already defined by the repository. Prefer the smallest relevant checks first.
+  3. Run the most relevant local checks you can without adding new dependencies or requiring external services.
+  4. Write `{{ repo_path }}/release_signoff.md` with:
+     - release context
+     - repository state summary
+     - files and sources inspected
+     - commands executed
+     - pass/fail outcomes
+     - notable risks or open questions
+     - a clear recommendation: APPROVE or REJECT
+  5. Present a concise summary and ask the user to reply with exactly `APPROVE` or `REJECT`.
+  6. If the user replies `APPROVE`, append a final approved signoff section to `release_signoff.md`.
+  7. If the user replies `REJECT` or does not approve, stop after writing the report.
+
+  Constraints:
+  - Do not publish, deploy, tag, or push anything.
+  - Keep the workflow local and maintainable.
+  - If checks cannot run because setup is missing, record that clearly in the report instead of guessing.
+
+parameters:
+  - key: repo_path
+    input_type: string
+    requirement: required
+    description: Absolute or relative path to the local repository being reviewed for release.
+
+  - key: release_context
+    input_type: string
+    requirement: required
+    description: Version, scope, or short notes describing the release candidate to review.
+
+retry:
+  max_retries: 2
+  checks:
+    - type: shell
+      command: test -f "{{ repo_path }}/release_signoff.md"

--- a/documentation/src/pages/recipes/data/recipes/risky-command-review.yaml
+++ b/documentation/src/pages/recipes/data/recipes/risky-command-review.yaml
@@ -1,0 +1,87 @@
+version: 1.0.0
+id: risky-command-review
+title: Risky Command Review
+author:
+  contact: VasuBansal7576
+description: Reviews a potentially risky shell command, writes a decision memo, and requires explicit approval before execution.
+instructions: |
+  You are a careful command reviewer operating in a local workspace.
+
+  Your job is to inspect a proposed shell command, understand the surrounding repository or directory context, and prepare a human-readable review before any execution happens.
+
+  Rules:
+  - Work only inside `{{ workspace_path }}`.
+  - Never execute the proposed command before explicit user approval.
+  - Write your review to `{{ workspace_path }}/command_review.md`.
+  - The review must stand on its own so a maintainer can verify the workflow without special setup.
+  - If the user does not approve, stop without making changes beyond the review file.
+  - If the user approves, execute exactly the provided command without rewriting it.
+
+activities:
+  - Review a command before execution
+  - Summarize risk, prerequisites, and rollback steps
+  - Wait for explicit APPROVE or REJECT input
+  - Execute only after approval
+
+extensions:
+  - type: builtin
+    name: developer
+    display_name: Developer
+    timeout: 300
+    bundled: true
+
+prompt: |
+  Review this command in the local workspace at `{{ workspace_path }}`.
+
+  Objective:
+  {{ objective }}
+
+  Proposed command:
+  ```sh
+  {{ command }}
+  ```
+
+  Follow this process:
+
+  1. Inspect the workspace and identify the files, tools, or repository state relevant to the proposed command.
+  2. Determine what the command is expected to do, including likely side effects, failure modes, and whether it appears destructive, irreversible, or noisy.
+  3. Write `{{ workspace_path }}/command_review.md` with:
+     - objective
+     - exact command under review
+     - relevant files or directories inspected
+     - expected effects
+     - risks and assumptions
+     - prerequisites or checks to run first
+     - rollback or recovery notes if the command fails
+     - a clear recommendation: APPROVE or REJECT
+  4. Present a concise summary to the user and ask them to reply with exactly `APPROVE` or `REJECT`.
+  5. If the user replies `APPROVE`, execute the exact command in `{{ workspace_path }}` and append the observed result to `command_review.md`.
+  6. If the user replies `REJECT` or does not approve, stop after writing the review.
+
+  Constraints:
+  - Do not invent extra setup outside the workspace.
+  - Prefer deterministic local inspection.
+  - Do not use network-dependent tools unless the command itself explicitly requires them and the user approves execution.
+
+parameters:
+  - key: workspace_path
+    input_type: string
+    requirement: required
+    description: Absolute or relative path to the local workspace where the command would run.
+
+  - key: command
+    input_type: string
+    requirement: required
+    description: The exact shell command to review and, if approved, execute.
+
+  - key: objective
+    input_type: string
+    requirement: optional
+    default: Explain what this command is supposed to achieve and whether it is safe to run.
+    description: Short explanation of what the command is intended to accomplish.
+
+retry:
+  max_retries: 2
+  checks:
+    - type: shell
+      command: test -f "{{ workspace_path }}/command_review.md"


### PR DESCRIPTION
### Summary
`Adds two approval-gated recipe examples and a companion guide for building locally testable human-in-the-loop workflows in Goose.`

This PR includes:
- `risky-command-review.yaml`
- `release-signoff.yaml`
- a short guide for building approval-gated recipes that stay broadly useful and easy to validate locally

The goal is to contribute a reusable workflow pattern rather than a domain-specific business recipe. These examples show how Goose recipes can inspect local state, write a deterministic review artifact, pause for explicit approval, and remain easy for maintainers to test without external services or credentials.

### Type of Change
- [x] Feature
- [x] Documentation

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Validated both new recipes with Goose CLI:

```bash
cargo run -p goose-cli --bin goose -- recipe validate documentation/src/pages/recipes/data/recipes/risky-command-review.yaml
cargo run -p goose-cli --bin goose -- recipe validate documentation/src/pages/recipes/data/recipes/release-signoff.yaml

Both validations completed successfully.

### Related Issues
Relates to #7788
Discussion: none
