### PR TITLE
fix: resolve {{ recipe_dir }} in nested sub-recipe paths during secret discovery

### DIFF
--- a/crates/goose-cli/src/recipes/secret_discovery.rs
+++ b/crates/goose-cli/src/recipes/secret_discovery.rs
@@ -1,6 +1,7 @@
 use crate::recipes::search_recipe::load_recipe_file;
 use goose::agents::extension::ExtensionConfig;
 use goose::recipe::Recipe;
+use regex::{NoExpand, Regex};
 use std::collections::HashSet;
 
 /// Represents a secret requirement discovered from a recipe extension
@@ -96,9 +97,9 @@ fn discover_recipe_secrets_recursive(
             visited_recipes.insert(sub_recipe.path.clone());
 
             match load_sub_recipe(&sub_recipe.path) {
-                Ok(loaded_recipe) => {
+                Ok((loaded_recipe, parent_dir)) => {
                     let sub_secrets =
-                        discover_recipe_secrets_recursive(&loaded_recipe, visited_recipes);
+                        discover_sub_recipe_secrets(&loaded_recipe, &parent_dir, visited_recipes);
                     for sub_secret in sub_secrets {
                         if seen_keys.insert(sub_secret.key.clone()) {
                             secrets.push(sub_secret);
@@ -115,14 +116,32 @@ fn discover_recipe_secrets_recursive(
     secrets
 }
 
-/// Loads a recipe from a file path for sub-recipe secret discovery
+/// Discovers secrets from a loaded sub-recipe, resolving `{{ recipe_dir }}` in nested
+/// sub-recipe paths so they can be loaded without triggering confusing lookup failures.
+fn discover_sub_recipe_secrets(
+    recipe: &Recipe,
+    parent_dir: &str,
+    visited_recipes: &mut HashSet<String>,
+) -> Vec<SecretRequirement> {
+    let re = Regex::new(r"\{\{\s*recipe_dir\s*\}\}").expect("valid regex");
+    let mut resolved = recipe.clone();
+    if let Some(ref mut sub_recipes) = resolved.sub_recipes {
+        for sr in sub_recipes.iter_mut() {
+            sr.path = re.replace_all(&sr.path, NoExpand(parent_dir)).into_owned();
+        }
+    }
+    discover_recipe_secrets_recursive(&resolved, visited_recipes)
+}
+
+/// Loads a recipe from a file path for sub-recipe secret discovery.
 ///
-/// For secret discovery, we only need the recipe structure (extensions and env_keys),
-/// not parameter-substituted content, so we parse the raw YAML directly for speed and robustness.
-fn load_sub_recipe(recipe_path: &str) -> Result<Recipe, Box<dyn std::error::Error>> {
+/// Returns the parsed recipe along with its parent directory path, which is
+/// needed to resolve `{{ recipe_dir }}` in any nested sub-recipe paths.
+fn load_sub_recipe(recipe_path: &str) -> Result<(Recipe, String), Box<dyn std::error::Error>> {
     let recipe_file = load_recipe_file(recipe_path)?;
     let recipe: Recipe = serde_yaml::from_str(&recipe_file.content)?;
-    Ok(recipe)
+    let parent_dir = recipe_file.parent_dir.display().to_string();
+    Ok((recipe, parent_dir))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes #5040

When a recipe has nested sub-recipes that use `{{ recipe_dir }}` in their paths, the secret discovery phase would try to load files with the literal unresolved template string as the path. This caused confusing output like:

```
📦 Looking for recipe "{{ recipe_dir }}/leaf.yaml" in github repo: squareup/goose-recipes
fatal: not a valid object name: origin/main:{{ recipe_dir }}/leaf.yaml
```

It also meant secrets from deeply nested sub-recipes were never discovered.

## Root Cause

`discover_recipe_secrets_recursive` loads sub-recipe files as raw YAML (no template rendering). When those sub-recipes themselves have `sub_recipes` entries with `{{ recipe_dir }}` in the path, the recursive call uses the literal unrendered string as a file path, which fails local lookup and falls through to a confusing GitHub repository search.

## Fix

When recursing into a loaded sub-recipe, resolve `{{ recipe_dir }}` (with any whitespace variation) to the sub-recipe file's actual parent directory before the recursive call. This is done via a new `discover_sub_recipe_secrets` helper that uses a regex replacement with `NoExpand` to treat the directory path as a literal string (preventing `$` in paths from being misinterpreted as capture group references).

## Testing

Validated with a 3-level recipe hierarchy (top → middle → leaf) where the middle and leaf recipes use `{{ recipe_dir }}` in sub-recipe paths:

**Before (main):** Found only 1 of 2 secrets, produced confusing GitHub lookup output for `{{ recipe_dir }}/leaf.yaml`

**After (this PR):** Found all 2 secrets, no confusing output

<details>
<summary>Reproduction script</summary>

```bash
#!/usr/bin/env bash
#
# Test for https://github.com/block/goose/issues/5040
#
# Verifies that nested sub-recipes using {{ recipe_dir }} in their paths
# don't produce confusing "Looking for recipe" / GitHub lookup output
# during secret discovery.
#
set -euo pipefail

GOOSE_DIR="${GOOSE_DIR:-$HOME/proj/wt-goose-3}"
RECIPE_DIR=$(mktemp -d)
trap 'rm -rf "$RECIPE_DIR"' EXIT

echo "=== Setting up test recipes in $RECIPE_DIR ==="

# Level 2: a leaf sub-recipe with an extension that declares env_keys
cat > "$RECIPE_DIR/leaf.yaml" <<'EOF'
version: "1.0.0"
title: "Leaf Sub-Recipe"
description: "A leaf recipe with secrets"
instructions: "You are a helper."
extensions:
  - name: "leaf-service"
    type: "streamable_http"
    uri: "http://localhost:9999/mcp"
    env_keys:
      - "LEAF_SECRET_TOKEN"
EOF

# Level 1: a mid-level sub-recipe that references the leaf via {{ recipe_dir }}
cat > "$RECIPE_DIR/middle.yaml" <<'EOF'
version: "1.0.0"
title: "Middle Sub-Recipe"
description: "A mid-level recipe that nests another sub-recipe"
instructions: "You are a helper."
extensions:
  - name: "middle-service"
    type: "streamable_http"
    uri: "http://localhost:9998/mcp"
    env_keys:
      - "MIDDLE_SECRET_TOKEN"
sub_recipes:
  - name: "leaf"
    path: "{{ recipe_dir }}/leaf.yaml"
EOF

# Level 0: the top-level recipe that references the middle recipe
cat > "$RECIPE_DIR/top.yaml" <<EOF
version: "1.0.0"
title: "Top-Level Recipe"
description: "A recipe that tests nested sub-recipe secret discovery"
prompt: "Say exactly: done"
extensions:
  - name: "developer"
    type: "builtin"
sub_recipes:
  - name: "middle"
    path: "{{ recipe_dir }}/middle.yaml"
EOF

echo "=== Recipe files ==="
ls -la "$RECIPE_DIR"
echo

echo "=== Building goose ==="
cd "$GOOSE_DIR"
source bin/activate-hermit
cargo build --bin goose 2>&1 | tail -3
echo

echo "=== Running recipe ==="
OUTPUT_FILE=$(mktemp)
# Run the recipe with max-turns 1 so it finishes quickly.
# Capture all output (stdout + stderr) to check for the bug.
set +e
GOOSE_PROVIDER="${GOOSE_PROVIDER:-anthropic}" \
GOOSE_MODEL="${GOOSE_MODEL:-claude-sonnet-4-20250514}" \
cargo run --bin goose -- run \
    --recipe "$RECIPE_DIR/top.yaml" \
    --no-profile \
    --max-turns 1 \
    --quiet \
    > "$OUTPUT_FILE" 2>&1
EXIT_CODE=$?
set -e

echo
echo "=== Checking output for issue #5040 symptoms ==="
FAILED=0

# The bug manifests as lines like:
#   📦 Looking for recipe "{{ recipe_dir }}/leaf.yaml" in github repo: ...
#   fatal: not a valid object name: origin/main:{{ recipe_dir }}/...
if grep -q "Looking for recipe.*recipe_dir" "$OUTPUT_FILE"; then
    echo "❌ FAIL: Found confusing GitHub lookup for unresolved {{ recipe_dir }} path"
    echo "   Matching lines:"
    grep "Looking for recipe.*recipe_dir" "$OUTPUT_FILE" | sed 's/^/   /'
    FAILED=1
fi

if grep -q "fatal:.*recipe_dir" "$OUTPUT_FILE"; then
    echo "❌ FAIL: Found git fatal error for unresolved {{ recipe_dir }} path"
    echo "   Matching lines:"
    grep "fatal:.*recipe_dir" "$OUTPUT_FILE" | sed 's/^/   /'
    FAILED=1
fi

if grep -q '{{.*recipe_dir.*}}' "$OUTPUT_FILE"; then
    echo "❌ FAIL: Found unresolved {{ recipe_dir }} in output"
    echo "   Matching lines:"
    grep '{{.*recipe_dir.*}}' "$OUTPUT_FILE" | sed 's/^/   /'
    FAILED=1
fi

if [ "$FAILED" -eq 0 ]; then
    echo "✅ PASS: No confusing {{ recipe_dir }} lookup output detected"
fi

echo
echo "=== Full output (for reference) ==="
cat "$OUTPUT_FILE"
rm -f "$OUTPUT_FILE"

exit "$FAILED"
```

</details>

## Changes

- `crates/goose-cli/src/recipes/secret_discovery.rs`: 
  - `load_sub_recipe` now returns the parent directory alongside the recipe
  - New `discover_sub_recipe_secrets` resolves `{{ recipe_dir }}` before recursing
  - Uses `regex::NoExpand` for safe literal replacement
