### PR TITLE
Add @DOsinga as CODEOWNER for documentation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Documentation owned by DevRel
-/documentation/ @blackgirlbytes @angiejones
+/documentation/ @blackgirlbytes @angiejones @DOsinga
 


### PR DESCRIPTION
Adds @DOsinga as a code owner for the documentation directory alongside @blackgirlbytes and @angiejones.