### PR TITLE
Stop collecting goosed stderr after startup

### DIFF
--- a/ui/desktop/src/goosed.ts
+++ b/ui/desktop/src/goosed.ts
@@ -159,6 +159,7 @@ export interface GoosedResult {
   workingDir: string;
   process: ChildProcess | null;
   errorLog: string[];
+  stopErrorLogCollection: () => void;
   cleanup: () => Promise<void>;
   client: Client;
   certFingerprint: string | null;
@@ -199,6 +200,7 @@ export const startGoosed = async (options: StartGoosedOptions): Promise<GoosedRe
       workingDir,
       process: null,
       errorLog,
+      stopErrorLogCollection: () => {},
       cleanup: async () => {
         logger.info('Not killing external process that is managed externally');
       },
@@ -217,6 +219,7 @@ export const startGoosed = async (options: StartGoosedOptions): Promise<GoosedRe
       workingDir,
       process: null,
       errorLog,
+      stopErrorLogCollection: () => {},
       cleanup: async () => {
         logger.info('Not killing external process that is managed externally');
       },
@@ -300,19 +303,22 @@ export const startGoosed = async (options: StartGoosedOptions): Promise<GoosedRe
     });
   });
 
-  goosedProcess.stderr?.on('data', (data: Buffer) => {
+  const onStderrData = (data: Buffer) => {
     const lines = data.toString().split('\n');
     for (const line of lines) {
       if (line.trim()) {
         errorLog.push(line);
         if (isFatalError(line)) {
           logger.error(`goosed stderr for port ${port} and dir ${workingDir}: ${line}`);
-        } else {
-          logger.info(`goosed stderr for port ${port} and dir ${workingDir}: ${line}`);
         }
       }
     }
-  });
+  };
+  goosedProcess.stderr?.on('data', onStderrData);
+
+  const stopErrorLogCollection = () => {
+    goosedProcess.stderr?.off('data', onStderrData);
+  };
 
   goosedProcess.on('exit', (code) => {
     logger.info(`goosed process exited with code ${code} for port ${port} and dir ${workingDir}`);
@@ -363,6 +369,7 @@ export const startGoosed = async (options: StartGoosedOptions): Promise<GoosedRe
     workingDir,
     process: goosedProcess,
     errorLog,
+    stopErrorLogCollection,
     cleanup,
     client: goosedClientForUrlAndSecret(baseUrl, serverSecret),
     certFingerprint,

--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -594,7 +594,13 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     await goosedResult.cleanup();
   });
 
-  const { baseUrl, workingDir, process: goosedProcess, errorLog } = goosedResult;
+  const {
+    baseUrl,
+    workingDir,
+    process: goosedProcess,
+    errorLog,
+    stopErrorLogCollection,
+  } = goosedResult;
 
   const mainWindowState = windowStateKeeper({
     defaultWidth: 940,
@@ -697,6 +703,11 @@ const createChat = async (app: App, options: CreateChatOptions = {}) => {
     }
     app.quit();
   }
+
+  // errorLog is only needed during startup to detect fatal errors.
+  // Stop collecting stderr to avoid unbounded memory growth over long sessions.
+  stopErrorLogCollection();
+  errorLog.length = 0;
 
   // Let windowStateKeeper manage the window
   mainWindowState.manage(mainWindow);


### PR DESCRIPTION
Fixes https://github.com/block/goose/issues/7793

`errorLog` in `goosed.ts` grows unbounded over long sessions — every line goosed emits to stderr gets pushed into an array and never removed. Over 20+ hour sessions this means hundreds of thousands of retained strings, plus every non-fatal line was being re-logged via `logger.info()` causing additional string allocation.

The array is only used during the ~10 second startup health check to detect fatal errors, and in the error dialog if startup fails. After startup succeeds it serves no purpose.

**Changes:**
- Add `stopErrorLogCollection()` to `GoosedResult` — sets a flag that makes the stderr handler return immediately
- Call it in `main.ts` after `checkServerStatus` succeeds, and clear the array
- Stop re-logging non-fatal stderr lines (goosed already writes to its own log files)

This is defensive cleanup rather than a confirmed crash fix — the `EXC_BREAKPOINT` crash in #7793 is deep in V8 GC internals and may require an Electron upgrade to fully resolve. But the unbounded growth is a real memory leak that should be fixed regardless.