### PR TITLE
fix: return ContextLengthExceeded when prompt exceeds effective KV cache size

### DIFF
--- a/crates/goose/src/providers/local_inference/inference_engine.rs
+++ b/crates/goose/src/providers/local_inference/inference_engine.rs
@@ -226,6 +226,13 @@ pub(super) fn validate_and_compute_context(
             )));
         }
     }
+    if prompt_token_count >= effective_ctx {
+        return Err(ProviderError::ContextLengthExceeded(format!(
+            "Prompt ({} tokens) exceeds context limit ({} tokens). \
+             Try reducing conversation length.",
+            prompt_token_count, effective_ctx,
+        )));
+    }
     Ok((prompt_token_count, effective_ctx))
 }
 


### PR DESCRIPTION
## Problem

When using local inference with llama.cpp, if the prompt token count exceeds the effective context size (which can be capped by `context_limit`, `n_ctx_train`, or available memory), the KV cache is allocated with fewer slots than the prompt requires. Attempting to prefill more tokens than the cache can hold causes llama.cpp to return an opaque error:

```
Execution error: Prefill decode failed: Decode Error 1: NoKvCacheSlot
```

This happens because `validate_and_compute_context` only checked the prompt against the memory-based limit, but not against the final `effective_ctx` value. For example, with `prompt_token_count = 5000` and `effective_ctx = 4096`, a 4096-token KV cache is created and then 5000 tokens are fed into it — failing around token 4096.

## Fix

Add a guard in `validate_and_compute_context` that checks `prompt_token_count >= effective_ctx` and returns a clear `ContextLengthExceeded` error with an actionable message, instead of letting the decode fail with an opaque KV cache error.

## Testing

- All existing `inference_engine` unit tests pass
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt` clean