### PR TITLE
fix: remove dead read handler from DeveloperClient

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -6,7 +6,7 @@ use crate::agents::extension::PlatformExtensionContext;
 use crate::agents::mcp_client::{Error, McpClientTrait};
 use anyhow::Result;
 use async_trait::async_trait;
-use edit::{EditTools, FileEditParams, FileReadParams, FileWriteParams};
+use edit::{EditTools, FileEditParams, FileWriteParams};
 use indoc::indoc;
 use rmcp::model::{
     CallToolResult, Content, Implementation, InitializeResult, JsonObject, ListToolsResult,
@@ -154,13 +154,6 @@ impl McpClientTrait for DeveloperClient {
     ) -> Result<CallToolResult, Error> {
         let working_dir = working_dir.map(Path::new);
         match name {
-            "read" => match Self::parse_args::<FileReadParams>(arguments) {
-                Ok(params) => Ok(self.edit_tools.file_read_with_cwd(params, working_dir)),
-                Err(error) => Ok(CallToolResult::error(vec![Content::text(format!(
-                    "Error: {error}"
-                ))
-                .with_priority(0.0)])),
-            },
             "shell" => match Self::parse_args::<ShellParams>(arguments) {
                 Ok(params) => Ok(self.shell_tool.shell_with_cwd(params, working_dir).await),
                 Err(error) => Ok(ShellTool::error_result(&format!("Error: {error}"), None)),


### PR DESCRIPTION
## Summary

Remove unreachable `read` handler from `DeveloperClient::call_tool`. `read` is only offered in ACP mode via `AcpTools::list_tools`; the extension manager validates tool names against `get_tools()`, so this handler was never called.

### Type of Change
- [x] Refactor / Code quality

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

Existing tests pass — `developer_tools_are_flat` already asserts `["write", "edit", "shell", "tree"]`.

### Related Issues
Follow-up to #7668