### PR TITLE
test(acp): align provider and server test parity

### DIFF
--- a/crates/goose-acp/tests/common_tests/mod.rs
+++ b/crates/goose-acp/tests/common_tests/mod.rs
@@ -5,14 +5,12 @@
 #[path = "../fixtures/mod.rs"]
 pub mod fixtures;
 use fixtures::{
-    initialize_agent, Connection, FsFixture, OpenAiFixture, PermissionDecision, Session,
-    TestConnectionConfig,
+    Connection, FsFixture, OpenAiFixture, PermissionDecision, Session, TestConnectionConfig,
 };
 use fs_err as fs;
 use goose::config::base::CONFIG_YAML_NAME;
 use goose::config::GooseMode;
 use goose::providers::provider_registry::ProviderConstructor;
-use goose_acp::server::GooseAcpAgent;
 use goose_test_support::{ExpectedSessionId, McpFixture, FAKE_CODE, TEST_IMAGE_B64, TEST_MODEL};
 use sacp::schema::{McpServer, McpServerHttp, ModelId, ToolCallStatus};
 use std::sync::Arc;
@@ -188,34 +186,6 @@ pub async fn run_initialize_doesnt_hit_provider<C: Connection>() {
     assert!(!conn.auth_methods().is_empty());
     assert!(conn
         .auth_methods()
-        .iter()
-        .any(|m| &*m.id.0 == "goose-provider"));
-}
-
-#[allow(dead_code)]
-pub async fn run_initialize_without_provider() {
-    let temp_dir = tempfile::tempdir().unwrap();
-
-    let provider_factory: ProviderConstructor =
-        Arc::new(|_, _| Box::pin(async { Err(anyhow::anyhow!("no provider configured")) }));
-
-    let agent = Arc::new(
-        GooseAcpAgent::new(
-            provider_factory,
-            vec![],
-            temp_dir.path().to_path_buf(),
-            temp_dir.path().to_path_buf(),
-            GooseMode::Auto,
-            false,
-        )
-        .await
-        .unwrap(),
-    );
-
-    let resp = initialize_agent(agent).await;
-    assert!(!resp.auth_methods.is_empty());
-    assert!(resp
-        .auth_methods
         .iter()
         .any(|m| &*m.id.0 == "goose-provider"));
 }

--- a/crates/goose-acp/tests/fixtures/mod.rs
+++ b/crates/goose-acp/tests/fixtures/mod.rs
@@ -346,27 +346,5 @@ where
     }
 }
 
-/// Connects to the given agent via in-process duplex streams, sends an
-/// `InitializeRequest`, and returns the response.
-#[allow(dead_code)]
-pub async fn initialize_agent(agent: Arc<GooseAcpAgent>) -> sacp::schema::InitializeResponse {
-    let (transport, _handle) = serve_agent_in_process(agent).await;
-    sacp::ClientToAgent::builder()
-        .connect_to(transport)
-        .unwrap()
-        .run_until(|cx: sacp::JrConnectionCx<sacp::ClientToAgent>| async move {
-            let resp = cx
-                .send_request(sacp::schema::InitializeRequest::new(
-                    sacp::schema::ProtocolVersion::LATEST,
-                ))
-                .block_task()
-                .await
-                .unwrap();
-            Ok::<_, sacp::Error>(resp)
-        })
-        .await
-        .unwrap()
-}
-
 pub mod provider;
 pub mod server;

--- a/crates/goose-acp/tests/provider_test.rs
+++ b/crates/goose-acp/tests/provider_test.rs
@@ -12,80 +12,80 @@ use common_tests::{
 };
 
 #[test]
-fn test_provider_config_mcp() {
+fn test_config_mcp() {
     run_test(async { run_config_mcp::<ClientToProviderConnection>().await });
 }
 
 #[test]
-#[ignore = "TODO: AcpProvider does not yet send ClientCapabilities with FileSystemCapability"]
-fn test_provider_fs_read_text_file_true() {
+#[ignore = "provider is a plug-in to the goose CLI, UI and terminal clients, none of which handle buffered changes to files"]
+fn test_fs_read_text_file_true() {
     run_test(async { run_fs_read_text_file_true::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_fs_write_text_file_false() {
+fn test_fs_write_text_file_false() {
     run_test(async { run_fs_write_text_file_false::<ClientToProviderConnection>().await });
 }
 
 #[test]
-#[ignore = "TODO: AcpProvider does not yet send ClientCapabilities with FileSystemCapability"]
-fn test_provider_fs_write_text_file_true() {
+#[ignore = "provider is a plug-in to the goose CLI, UI and terminal clients, none of which handle buffered changes to files"]
+fn test_fs_write_text_file_true() {
     run_test(async { run_fs_write_text_file_true::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_initialize_doesnt_hit_provider() {
+fn test_initialize_doesnt_hit_provider() {
     run_test(async { run_initialize_doesnt_hit_provider::<ClientToProviderConnection>().await });
 }
 
 #[test]
 #[ignore = "TODO: implement load_session in ACP provider"]
-fn test_provider_load_model() {
+fn test_load_model() {
     run_test(async { run_load_model::<ClientToProviderConnection>().await });
 }
 
 #[test]
 #[ignore = "TODO: implement load_session in ACP provider"]
-fn test_provider_load_session_mcp() {
+fn test_load_session_mcp() {
     run_test(async { run_load_session_mcp::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_model_list() {
+fn test_model_list() {
     run_test(async { run_model_list::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_model_set() {
+fn test_model_set() {
     run_test(async { run_model_set::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_permission_persistence() {
+fn test_permission_persistence() {
     run_test(async { run_permission_persistence::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_prompt_basic() {
+fn test_prompt_basic() {
     run_test(async { run_prompt_basic::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_prompt_codemode() {
+fn test_prompt_codemode() {
     run_test(async { run_prompt_codemode::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_prompt_image() {
+fn test_prompt_image() {
     run_test(async { run_prompt_image::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_prompt_image_attachment() {
+fn test_prompt_image_attachment() {
     run_test(async { run_prompt_image_attachment::<ClientToProviderConnection>().await });
 }
 
 #[test]
-fn test_provider_prompt_mcp() {
+fn test_prompt_mcp() {
     run_test(async { run_prompt_mcp::<ClientToProviderConnection>().await });
 }

--- a/crates/goose-acp/tests/server_test.rs
+++ b/crates/goose-acp/tests/server_test.rs
@@ -3,10 +3,10 @@ use common_tests::fixtures::run_test;
 use common_tests::fixtures::server::ClientToAgentConnection;
 use common_tests::{
     run_config_mcp, run_fs_read_text_file_true, run_fs_write_text_file_false,
-    run_fs_write_text_file_true, run_initialize_doesnt_hit_provider,
-    run_initialize_without_provider, run_load_model, run_load_session_mcp, run_model_list,
-    run_model_set, run_permission_persistence, run_prompt_basic, run_prompt_codemode,
-    run_prompt_image, run_prompt_image_attachment, run_prompt_mcp,
+    run_fs_write_text_file_true, run_initialize_doesnt_hit_provider, run_load_model,
+    run_load_session_mcp, run_model_list, run_model_set, run_permission_persistence,
+    run_prompt_basic, run_prompt_codemode, run_prompt_image, run_prompt_image_attachment,
+    run_prompt_mcp,
 };
 
 #[test]
@@ -35,13 +35,13 @@ fn test_initialize_doesnt_hit_provider() {
 }
 
 #[test]
-fn test_initialize_without_provider() {
-    run_test(async { run_initialize_without_provider().await });
+fn test_load_model() {
+    run_test(async { run_load_model::<ClientToAgentConnection>().await });
 }
 
 #[test]
-fn test_load_model() {
-    run_test(async { run_load_model::<ClientToAgentConnection>().await });
+fn test_load_session_mcp() {
+    run_test(async { run_load_session_mcp::<ClientToAgentConnection>().await });
 }
 
 #[test]
@@ -77,11 +77,6 @@ fn test_prompt_image() {
 #[test]
 fn test_prompt_image_attachment() {
     run_test(async { run_prompt_image_attachment::<ClientToAgentConnection>().await });
-}
-
-#[test]
-fn test_load_session_mcp() {
-    run_test(async { run_load_session_mcp::<ClientToAgentConnection>().await });
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Remove redundant `run_initialize_without_provider` (duplicate of `run_initialize_doesnt_hit_provider`), drop `_provider` infix from provider_test.rs function names to match server_test.rs 1:1, and fix stale `#[ignore]` comments on fs_true provider tests.

### Type of Change
- [x] Refactor / Code quality
- [x] Tests

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

All tests pass

### Related Issues
Follow-up to #7668