### PR TITLE
fix: disable some computercontroller functionality when no $DISPLAY detected

### DIFF
--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -346,8 +346,10 @@ impl ComputerControllerServer {
         let system_automation: Arc<Box<dyn SystemAutomation + Send + Sync>> =
             Arc::new(create_system_automation());
 
-        let os_specific_instructions = match std::env::consts::OS {
-            "windows" => indoc! {r#"
+        let has_display = system_automation.has_display();
+
+        let os_specific_instructions = match (std::env::consts::OS, has_display) {
+            ("windows", _) => indoc! {r#"
             Here are some extra tools:
             automation_script
               - Create and run PowerShell or Batch scripts
@@ -363,7 +365,7 @@ impl ComputerControllerServer {
               - System automation using PowerShell
               - Consider the screenshot tool to work out what is on screen and what to do to help with the control task.
             "#},
-            "macos" => indoc! {r#"
+            ("macos", _) => indoc! {r#"
             Here are some extra tools:
             automation_script
               - Create and run Shell, Ruby, or AppleScript scripts
@@ -457,7 +459,7 @@ impl ComputerControllerServer {
               - If something fails, check `permissions status` for missing permissions
               - Use `capture_screenshot: true` on click/type/press actions to verify the result
             "#},
-            _ => indoc! {r#"
+            (_, true) => indoc! {r#"
             Here are some extra tools:
             automation_script
               - Create and run Shell scripts
@@ -480,6 +482,19 @@ impl ComputerControllerServer {
               - Simulating keyboard/mouse input
               - Automating UI interactions
               - Desktop environment control
+            "#},
+            (_, false) => indoc! {r#"
+            Here are some extra tools:
+            automation_script
+              - Create and run Shell scripts
+              - Shell (bash) is recommended for most tasks
+              - Scripts can save their output to files
+              - Linux-specific features:
+                - System automation through shell scripting
+                - D-Bus system services integration
+
+            Note: No display server detected (headless mode). The computer_control tool
+            is not available in this environment. Use automation_script for shell-based tasks.
             "#},
         };
 
@@ -517,8 +532,13 @@ impl ComputerControllerServer {
             cache_dir = cache_dir.display()
         };
 
+        let mut tool_router = Self::tool_router();
+        if !has_display {
+            tool_router.remove_route("computer_control");
+        }
+
         Self {
-            tool_router: Self::tool_router(),
+            tool_router,
             cache_dir,
             active_resources: Arc::new(Mutex::new(HashMap::new())),
             http_client: Client::builder().user_agent("goose/1.0").build().unwrap(),

--- a/crates/goose-mcp/src/computercontroller/platform/linux.rs
+++ b/crates/goose-mcp/src/computercontroller/platform/linux.rs
@@ -31,13 +31,19 @@ impl LinuxAutomation {
             display_server: Self::detect_display_server(),
         };
 
-        INIT.call_once(|| {
-            automation.initialize().unwrap_or_else(|e| {
-                eprintln!("Warning: Failed to initialize Linux automation: {}", e);
+        if automation.has_display() {
+            INIT.call_once(|| {
+                automation.initialize().unwrap_or_else(|e| {
+                    eprintln!("Warning: Failed to initialize Linux automation: {}", e);
+                });
             });
-        });
+        }
 
         automation
+    }
+
+    pub fn has_display(&self) -> bool {
+        !matches!(self.display_server, DisplayServer::Unknown)
     }
 
     fn detect_display_server() -> DisplayServer {
@@ -248,5 +254,9 @@ impl SystemAutomation for LinuxAutomation {
 
     fn get_temp_path(&self) -> PathBuf {
         std::env::temp_dir()
+    }
+
+    fn has_display(&self) -> bool {
+        self.has_display()
     }
 }

--- a/crates/goose-mcp/src/computercontroller/platform/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/platform/mod.rs
@@ -19,6 +19,9 @@ pub trait SystemAutomation: Send + Sync {
     fn execute_system_script(&self, script: &str) -> std::io::Result<String>;
     fn get_shell_command(&self) -> (&'static str, &'static str); // (shell, arg)
     fn get_temp_path(&self) -> std::path::PathBuf;
+    fn has_display(&self) -> bool {
+        true
+    }
 }
 
 pub fn create_system_automation() -> Box<dyn SystemAutomation + Send + Sync> {


### PR DESCRIPTION
fixes #6797

**Problem:** On headless Linux (no `$DISPLAY` or `$WAYLAND_DISPLAY`), the `computercontroller` extension prints `Warning: Failed to initialize Linux automation: Unable to detect display server` every time goose runs, even though the user has no display and doesn't need display-dependent tools.

**Root cause:** `LinuxAutomation::new()` unconditionally calls `initialize()`, which fails when no display server is detected and prints a warning via `eprintln!`.
