### PR TITLE
chore: remove redundant husky prepare script

### DIFF
--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -38,7 +38,6 @@
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:integration:watch": "vitest --config vitest.integration.config.ts",
     "test:integration:debug": "DEBUG=1 vitest run --config vitest.integration.config.ts",
-    "prepare": "husky",
     "start-alpha-gui": "ALPHA=true pnpm run start-gui"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
The pre-commit hook is manually configured at the git root (`.husky/pre-commit`) and correctly runs lint-staged for ui/desktop. The prepare script in the subdirectory can't work (no .git folder there) and causes warnings.

### Testing
Tested manually


