### PR TITLE
fix: fixes re-posting bug

### DIFF
--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -593,6 +593,7 @@ export function useChatStream({
           },
           throwOnError: true,
           signal: abortControllerRef.current.signal,
+          sseMaxRetryAttempts: 1,
         });
 
         await streamFromResponse(stream, currentMessages, dispatch, onFinish, sessionId);
@@ -634,6 +635,7 @@ export function useChatStream({
           },
           throwOnError: true,
           signal: abortControllerRef.current.signal,
+          sseMaxRetryAttempts: 1,
         });
 
         await streamFromResponse(stream, currentMessages, dispatch, onFinish, sessionId);
@@ -773,6 +775,7 @@ export function useChatStream({
                 },
                 throwOnError: true,
                 signal: abortControllerRef.current.signal,
+                sseMaxRetryAttempts: 1,
               });
 
               await streamFromResponse(stream, messagesForUI, dispatch, onFinish, targetSessionId);


### PR DESCRIPTION
urgent patch to stop the destlop client reposting to the agent anytime there is a blip with TLS/connection to electron. 
Seems to be an issue since TLS.

This was causing unusable retries for me, and gets session into a really never ending stuck state. 