### PR TITLE
fix: prevent SSE connection drops from silently truncating responses

### DIFF
--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -207,7 +207,8 @@ async function streamFromResponse(
   initialMessages: Message[],
   dispatch: React.Dispatch<StreamAction>,
   onFinish: (error?: string) => void,
-  sessionId: string
+  sessionId: string,
+  signal?: AbortController['signal']
 ): Promise<void> {
   let currentMessages = initialMessages;
   const reduceMotion = prefersReducedMotion();
@@ -316,12 +317,16 @@ async function streamFromResponse(
     // onFinish() without an error to keep the conversation visible (passing
     // an error would trigger a full-page error screen via sessionLoadError),
     // then show a toast so the user knows the response may be incomplete.
+    // If the signal was aborted, the user intentionally stopped streaming,
+    // so we skip the toast.
     flushBatchedUpdates();
     onFinish();
-    toastError({
-      title: 'Connection lost',
-      msg: 'The response may be incomplete. You can try sending your message again.',
-    });
+    if (!signal?.aborted) {
+      toastError({
+        title: 'Connection lost',
+        msg: 'The response may be incomplete. You can try sending your message again.',
+      });
+    }
   } catch (error) {
     flushBatchedUpdates();
     if (error instanceof Error && error.name !== 'AbortError') {
@@ -607,7 +612,7 @@ export function useChatStream({
           sseMaxRetryAttempts: 0,
         });
 
-        await streamFromResponse(stream, currentMessages, dispatch, onFinish, sessionId);
+        await streamFromResponse(stream, currentMessages, dispatch, onFinish, sessionId, abortControllerRef.current.signal);
       } catch (error) {
         // AbortError is expected when user stops streaming
         if (error instanceof Error && error.name === 'AbortError') {
@@ -649,7 +654,7 @@ export function useChatStream({
           sseMaxRetryAttempts: 0,
         });
 
-        await streamFromResponse(stream, currentMessages, dispatch, onFinish, sessionId);
+        await streamFromResponse(stream, currentMessages, dispatch, onFinish, sessionId, abortControllerRef.current.signal);
       } catch (error) {
         if (error instanceof Error && error.name === 'AbortError') {
           // Silently handle abort
@@ -789,7 +794,7 @@ export function useChatStream({
                 sseMaxRetryAttempts: 0,
               });
 
-              await streamFromResponse(stream, messagesForUI, dispatch, onFinish, targetSessionId);
+              await streamFromResponse(stream, messagesForUI, dispatch, onFinish, targetSessionId, abortControllerRef.current.signal);
             } catch (error) {
               if (error instanceof Error && error.name === 'AbortError') {
                 dispatch({ type: 'SET_CHAT_STATE', payload: ChatState.Idle });


### PR DESCRIPTION
## Summary

When the SSE stream connection drops mid-response, the client was retrying the POST request indefinitely, causing duplicate agent tasks on the backend. PR #7830 capped retries at 1, but created a worse problem: the stream would end without a terminal `Finish` or `Error` event, making truncated responses appear successful.

This fix disables SSE retries entirely (`sseMaxRetryAttempts: 0`) on all three `/reply` call sites, since POST requests should never retry (they create work). When a connection drops, we now detect the premature stream end and show a toast notification instead of a full-page error, keeping the conversation visible while alerting the user the response may be incomplete.

### Type of Change
- [x] Bug fix

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Manual testing needed to verify:
- Toast appears when connection drops mid-stream
- Conversation remains visible with partial response
- User can retry by sending message again

### Related Issues
Related to #7830

🤖 Generated with [Claude Code](https://claude.com/claude-code)