### PR TITLE
Remove include from Cargo.toml in goose-mcp

### DIFF
--- a/crates/goose-mcp/Cargo.toml
+++ b/crates/goose-mcp/Cargo.toml
@@ -7,16 +7,6 @@ license.workspace = true
 repository.workspace = true
 description.workspace = true
 
-# Include 3rd-party licenses for JavaScript/CSS minified files
-include = [
-    "licenses/chart-js.license",
-    "licenses/d3-js.license",
-    "licenses/d3-sankey.license",
-    "licenses/leaflet.license",
-    "licenses/leaflet-markercluster.license",
-    "licenses/mermaid.license"
-]
-
 [lints]
 workspace = true
 


### PR DESCRIPTION
## Summary

I learned that this was wrongly done by me the other day. The includes is only necessary if goose was being published in crates.io, and the format is incorrect as well. Currently, it would ignore all code and other files, and would include only the licenses.

Having the copies in upstream is enough for now.

### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [x] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
<!-- great that you got assistance 🔥, just check out the HOWTOAI guidance: https://github.com/block/goose/blob/main/HOWTOAI.md-->
- [ ] This PR was created or reviewed with AI assistance

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

