### PR TITLE
Add elicitation integration coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4588,6 +4588,8 @@ version = "1.27.0"
 dependencies = [
  "axum 0.7.9",
  "rmcp 1.1.0",
+ "schemars 1.2.1",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/crates/goose-cli/src/session/elicitation.rs
+++ b/crates/goose-cli/src/session/elicitation.rs
@@ -162,3 +162,38 @@ fn parse_value(input: &str, field_type: &str, enum_values: Option<&Vec<Value>>) 
         _ => Value::String(input.to_string()),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_value_accepts_enum_by_name() {
+        let enum_values = vec![json!("approve"), json!("reject")];
+        assert_eq!(
+            parse_value("reject", "string", Some(&enum_values)),
+            Value::String("reject".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_value_accepts_enum_by_index() {
+        let enum_values = vec![json!("approve"), json!("reject")];
+        assert_eq!(
+            parse_value("2", "string", Some(&enum_values)),
+            Value::String("reject".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_value_handles_boolean_aliases() {
+        assert_eq!(parse_value("yes", "boolean", None), Value::Bool(true));
+        assert_eq!(parse_value("0", "boolean", None), Value::Bool(false));
+    }
+
+    #[test]
+    fn parse_value_returns_null_for_invalid_integer() {
+        assert_eq!(parse_value("abc", "integer", None), Value::Null);
+    }
+}

--- a/crates/goose-test-support/Cargo.toml
+++ b/crates/goose-test-support/Cargo.toml
@@ -9,7 +9,9 @@ description.workspace = true
 
 [dependencies]
 axum = "0.7"
-rmcp = { workspace = true, features = ["server", "macros", "transport-streamable-http-server"] }
+rmcp = { workspace = true, features = ["server", "macros", "transport-streamable-http-server", "elicitation", "schemars"] }
+schemars = { workspace = true, features = ["derive"] }
+serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 

--- a/crates/goose-test-support/src/mcp.rs
+++ b/crates/goose-test-support/src/mcp.rs
@@ -8,14 +8,29 @@ use rmcp::transport::streamable_http_server::{
     session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
 };
 use rmcp::{
-    handler::server::router::tool::ToolRouter, tool, tool_handler, tool_router,
+    elicit_safe, handler::server::router::tool::ToolRouter, tool, tool_handler, tool_router,
     ErrorData as McpError, RoleServer, ServerHandler, Service,
 };
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
 use tokio::task::JoinHandle;
 
 pub const FAKE_CODE: &str = "test-uuid-12345-67890";
 
 pub const TEST_IMAGE_B64: &str = include_str!("test_assets/test_image.b64").trim_ascii_end();
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct ConfirmationRequest {
+    prompt: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+struct ConfirmationResponse {
+    approved: bool,
+    reason: Option<String>,
+}
+
+elicit_safe!(ConfirmationResponse);
 
 pub trait HasMeta {
     fn meta(&self) -> &Meta;
@@ -117,6 +132,35 @@ impl McpFixtureServer {
             "image/png",
         )]))
     }
+
+    #[tool(description = "Trigger an elicitation request and wait for the client response")]
+    async fn request_confirmation(
+        &self,
+        request: rmcp::handler::server::wrapper::Parameters<ConfirmationRequest>,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let response = context
+            .peer
+            .elicit_with_timeout::<ConfirmationResponse>(request.0.prompt.clone(), None)
+            .await
+            .map_err(|error| {
+                McpError::new(
+                    ErrorCode::INTERNAL_ERROR,
+                    format!("elicitation failed: {error}"),
+                    None,
+                )
+            })?;
+
+        let text = match response {
+            Some(ConfirmationResponse { approved, reason }) => {
+                let reason = reason.unwrap_or_default();
+                format!("approved={approved}; reason={reason}")
+            }
+            None => "approved=false; reason=".to_string(),
+        };
+
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
 }
 
 #[tool_handler]
@@ -125,7 +169,9 @@ impl ServerHandler for McpFixtureServer {
         InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_protocol_version(ProtocolVersion::V_2025_03_26)
             .with_server_info(Implementation::new("mcp-fixture", "1.0.0"))
-            .with_instructions("Test server with get_code and get_image tools.")
+            .with_instructions(
+                "Test server with get_code, get_image, and request_confirmation tools.",
+            )
     }
 }
 

--- a/crates/goose/tests/elicitation_integration_test.rs
+++ b/crates/goose/tests/elicitation_integration_test.rs
@@ -1,0 +1,141 @@
+use goose::action_required_manager::ActionRequiredManager;
+use goose::agents::extension_manager::{ExtensionManager, ExtensionManagerCapabilities};
+use goose::agents::types::SharedProvider;
+use goose::config::{ExtensionConfig, DEFAULT_EXTENSION_DESCRIPTION, DEFAULT_EXTENSION_TIMEOUT};
+use goose::conversation::message::{ActionRequiredData, Message, MessageContent};
+use goose::session::SessionManager;
+use goose_test_support::McpFixture;
+use rmcp::model::{CallToolRequestParams, RawContent};
+use rmcp::object;
+use serde_json::json;
+use std::sync::Arc;
+use tokio::time::{timeout, Duration};
+use tokio_util::sync::CancellationToken;
+
+fn first_text(result: &rmcp::model::CallToolResult) -> &str {
+    match &result.content[0].raw {
+        RawContent::Text(text) => &text.text,
+        _ => panic!("expected text content"),
+    }
+}
+
+async fn next_elicitation_message() -> Message {
+    timeout(Duration::from_secs(5), async {
+        ActionRequiredManager::global()
+            .request_rx
+            .lock()
+            .await
+            .recv()
+            .await
+    })
+    .await
+    .expect("timed out waiting for elicitation request")
+    .expect("expected elicitation request")
+}
+
+async fn drain_action_required_queue() {
+    let mut rx = ActionRequiredManager::global().request_rx.lock().await;
+    while rx.try_recv().is_ok() {}
+}
+
+#[tokio::test]
+async fn streamable_http_extension_round_trips_elicitation_response() {
+    drain_action_required_queue().await;
+
+    let fixture = McpFixture::new(None).await;
+    let temp_dir = tempfile::tempdir().expect("tempdir");
+    let provider: SharedProvider = Arc::new(tokio::sync::Mutex::new(None));
+    let session_manager = Arc::new(SessionManager::new(temp_dir.path().to_path_buf()));
+    let extension_manager = Arc::new(ExtensionManager::new(
+        provider,
+        session_manager,
+        "goose-cli".to_string(),
+        ExtensionManagerCapabilities { mcpui: false },
+    ));
+
+    extension_manager
+        .add_extension(
+            ExtensionConfig::StreamableHttp {
+                name: "fixture".to_string(),
+                description: DEFAULT_EXTENSION_DESCRIPTION.to_string(),
+                uri: fixture.url.clone(),
+                envs: Default::default(),
+                env_keys: vec![],
+                headers: Default::default(),
+                timeout: Some(DEFAULT_EXTENSION_TIMEOUT),
+                bundled: None,
+                available_tools: vec![],
+            },
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect("add streamable http fixture");
+
+    let tools = extension_manager
+        .get_prefixed_tools("test-session-id", None)
+        .await
+        .expect("list tools");
+    assert!(
+        tools
+            .iter()
+            .any(|tool| tool.name == "fixture__request_confirmation"),
+        "fixture extension should expose the request_confirmation tool"
+    );
+
+    let tool_call = CallToolRequestParams::new("fixture__request_confirmation")
+        .with_arguments(object!({ "prompt": "Should goose continue with this release?" }));
+    let tool_result = extension_manager
+        .dispatch_tool_call("test-session-id", tool_call, None, CancellationToken::new())
+        .await
+        .expect("dispatch elicitation tool");
+
+    let result_handle = tokio::spawn(tool_result.result);
+
+    let elicitation_message = next_elicitation_message().await;
+    let MessageContent::ActionRequired(action_required) = &elicitation_message.content[0] else {
+        panic!("expected an action required message");
+    };
+
+    let ActionRequiredData::Elicitation {
+        id,
+        message,
+        requested_schema,
+    } = &action_required.data
+    else {
+        panic!("expected an elicitation request");
+    };
+
+    assert!(message.contains("Should goose continue with this release?"));
+    assert_eq!(
+        requested_schema
+            .get("properties")
+            .and_then(|value| value.get("approved"))
+            .and_then(|value| value.get("type"))
+            .and_then(|value| value.as_str()),
+        Some("boolean")
+    );
+
+    ActionRequiredManager::global()
+        .submit_response(
+            id.clone(),
+            json!({
+                "approved": true,
+                "reason": "release checks look good"
+            }),
+        )
+        .await
+        .expect("submit elicitation response");
+
+    let tool_output = timeout(Duration::from_secs(5), result_handle)
+        .await
+        .expect("timed out waiting for tool result")
+        .expect("task join should succeed")
+        .expect("tool result should succeed");
+
+    assert_eq!(
+        first_text(&tool_output),
+        "approved=true; reason=release checks look good"
+    );
+}


### PR DESCRIPTION
## Summary
Adds focused coverage for Goose's existing MCP elicitation flow.

This PR includes:
- an end-to-end integration test covering an MCP server that triggers elicitation and resumes after Goose submits the response
- an elicitation-capable MCP fixture in `goose-test-support`
- small CLI tests for elicitation input parsing

The goal is to harden existing elicitation behavior and add regression protection for the request/response flow, rather than introduce a new approval-specific product surface.

### Type of Change
- [x] Refactor / Code quality
- [x] Tests


### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
```bash
cargo fmt --all
cargo test -p goose --test elicitation_integration_test
cargo test -p goose-cli parse_value --lib
cargo clippy -p goose-test-support -p goose -p goose-cli --all-targets -- -D warnings

### Related Issues
Relates to #7841

###Discussion: hardens Goose's existing MCP elicitation support with end-to-end coverage

###Screenshots/Demos (for UX changes)
Before: No end-to-end test coverage for MCP elicitation round-tripping through Goose.

After: Added integration coverage for elicitation request/response handling plus CLI parsing tests.