### PR TITLE
docs: remove stale hackathon banner from Root.tsx

### DIFF
--- a/documentation/src/theme/Root.tsx
+++ b/documentation/src/theme/Root.tsx
@@ -5,8 +5,6 @@ interface Props {
   children: ReactNode;
 }
 
-const SHOW_BANNER = false;
-
 export default function Root({ children }: Props): JSX.Element {
   // Initialize gtag as no-op if not present (prevents errors in development)
   useEffect(() => {
@@ -15,39 +13,5 @@ export default function Root({ children }: Props): JSX.Element {
     }
   }, []);
 
-  return (
-    <>
-      {SHOW_BANNER && (
-        <div
-          style={{
-            backgroundColor: '#25c2a0',
-            color: '#000',
-            padding: '8px 16px',
-            textAlign: 'center',
-            fontSize: '14px',
-            fontWeight: '500',
-            position: 'relative',
-            zIndex: 1000,
-            lineHeight: '1.3',
-          }}
-        >
-          ✨ NO KEYBOARDS ALLOWED HACKATHON✨ : build next-gen interfaces with goose and win prizes.{' '}
-          <a
-            href="https://nokeyboardsallowed.dev"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              color: '#000',
-              textDecoration: 'underline',
-              fontWeight: '700',
-            }}
-          >
-            Deadline Nov 14
-          </a>
-          .
-        </div>
-      )}
-      {children}
-    </>
-  );
+  return <>{children}</>;
 }


### PR DESCRIPTION
## Why
The 'No Keyboards Allowed Hackathon' banner in `Root.tsx` has `SHOW_BANNER = false` and the event deadline was Nov 14, 2025. The banner component, styles, and link are dead code.

## What
Remove the banner constant, JSX block, and associated styles from `documentation/src/theme/Root.tsx`. The `Props` interface and gtag initialisation are preserved.

## How to review
Single file, ~25 lines removed. The `SHOW_BANNER` constant and entire conditional block are deleted. Nothing else changes.

## Testing
- `cd documentation && npm run build` — builds without errors
- Visual: docs site renders identically (banner was already hidden)