### PR TITLE
chore: remove debug console.log statements from main.ts

### DIFF
--- a/ui/desktop/src/main.ts
+++ b/ui/desktop/src/main.ts
@@ -1591,9 +1591,7 @@ ipcMain.handle('check-ollama', async () => {
           return resolve(false);
         }
 
-        console.log('Raw stdout from ps|grep command:', output);
         const trimmedOutput = output.trim();
-        console.log('Trimmed stdout:', trimmedOutput);
 
         const isRunning = trimmedOutput.length > 0;
         resolve(isRunning);
@@ -2186,7 +2184,6 @@ async function appMain() {
       // Remove any HTML tags for security
       const sanitizeText = (text: string) => text.replace(/<[^>]*>/g, '');
 
-      console.log('NOTIFY', data);
       const notification = new Notification({
         title: sanitizeText(data.title),
         body: sanitizeText(data.body),


### PR DESCRIPTION
## Why
`main.ts` contains debug console.log statements that log raw process output and notification data. These are development artifacts that add noise to the console in production.

## What
Remove 3 debug-artifact console.log statements from `ui/desktop/src/main.ts`:
- Raw stdout logging from process detection
- Trimmed stdout logging  
- Unstructured notification logging (`NOTIFY`)

Intentional logging (e.g., Playwright debug port message) is preserved. 15 console.log statements remain.

## How to review
Single file, 3 lines removed. Each removal is a standalone debug artifact — no logic changes.

## Testing
- `npm run build` in ui/desktop — compiles without errors
- Runtime: notification handling and process detection work identically (only console output changes)