### PR TITLE
chore(ui): remove debug console.log statements from App.tsx

### DIFF
--- a/ui/desktop/src/App.tsx
+++ b/ui/desktop/src/App.tsx
@@ -412,7 +412,6 @@ export function AppInner() {
   const { addExtension } = useConfig();
 
   useEffect(() => {
-    console.log('Sending reactReady signal to Electron');
     try {
       window.electron.reactReady();
     } catch (error) {
@@ -457,7 +456,6 @@ export function AppInner() {
   }, [navigate]);
 
   useEffect(() => {
-    console.log('Setting up keyboard shortcuts');
     const handleKeyDown = (event: KeyboardEvent) => {
       const isMac = window.electron.platform === 'darwin';
       if ((isMac ? event.metaKey : event.ctrlKey) && event.key === 'n') {
@@ -536,9 +534,6 @@ export function AppInner() {
     const handleSetView = (_event: IpcRendererEvent, ...args: unknown[]) => {
       const newView = args[0] as View;
       const section = args[1] as string | undefined;
-      console.log(
-        `Received view change request to: ${newView}${section ? `, section: ${section}` : ''}`
-      );
 
       if (section && newView === 'settings') {
         navigate(`/settings?section=${section}`);
@@ -553,7 +548,6 @@ export function AppInner() {
 
   useEffect(() => {
     const handleNewChat = (_event: IpcRendererEvent, ..._args: unknown[]) => {
-      console.log('Received new-chat event from keyboard shortcut');
       window.dispatchEvent(new CustomEvent(AppEvents.TRIGGER_NEW_CHAT));
     };
 
@@ -580,16 +574,9 @@ export function AppInner() {
   useEffect(() => {
     const handleSetInitialMessage = async (_event: IpcRendererEvent, ...args: unknown[]) => {
       const initialMessage = args[0] as string;
-      console.log(
-        '[App] Received set-initial-message event:',
-        initialMessage,
-        'isProcessing:',
-        isProcessingRef.current
-      );
 
       if (initialMessage && !isProcessingRef.current) {
         isProcessingRef.current = true;
-        console.log('[App] Processing initial message from launcher:', initialMessage);
         navigate('/pair', {
           state: {
             initialMessage: { msg: initialMessage, images: [] },
@@ -598,8 +585,6 @@ export function AppInner() {
         setTimeout(() => {
           isProcessingRef.current = false;
         }, 1000);
-      } else if (initialMessage) {
-        console.log('[App] Ignoring duplicate initial message (already processing)');
       }
     };
     window.electron.on('set-initial-message', handleSetInitialMessage);


### PR DESCRIPTION
## Why

App.tsx contains 7 `console.log` statements used for development-time debugging of IPC events and lifecycle signals. These appear in DevTools in production builds and provide no value to end users.

## What

Remove all `console.log` calls from `ui/desktop/src/App.tsx`:
- reactReady signal notification
- Keyboard shortcut setup trace
- View change request logging
- New-chat event trace
- Initial message IPC event logging (received / processing / duplicate)

All `console.error` calls for actual error handling are **preserved**.

Also removes a now-empty `else if` branch that only contained a removed log statement.

## How to review

Single file, 15 lines deleted. Verify each removal was a `console.log` (not `console.error`), and that no logic was affected.

## Testing

- `npm run build` in `ui/desktop` — no compile errors
- Manual: open Goose desktop, verify IPC events (new chat, view switching, initial message) still work. The only difference is silence in DevTools console.