### PR TITLE
chore: remove stale TODO referencing non-existent doc in experiments.rs

### DIFF
--- a/crates/goose/src/config/experiments.rs
+++ b/crates/goose/src/config/experiments.rs
@@ -5,7 +5,6 @@ use std::collections::HashMap;
 /// It is the ground truth for init experiments. The experiment names in users' experiment list but not
 /// in the list will be remove from user list; The experiment names in the ground-truth list but not
 /// in users' experiment list will be added to user list with default value false;
-/// TODO: keep this up to date with the experimental-features.md documentation page
 const ALL_EXPERIMENTS: &[(&str, bool)] = &[];
 
 /// Experiment configuration management


### PR DESCRIPTION
## Why

Line 8 of `experiments.rs` contains a TODO:
```
TODO: keep this up to date with the experimental-features.md documentation page
```

The referenced `experimental-features.md` does not exist anywhere in the repo. The `ALL_EXPERIMENTS` array is currently empty, so there is nothing to synchronise regardless. The existing doc comment above the constant already describes the synchronisation behaviour.

## What

Remove the stale TODO comment (1 line).

## How to review

One line deleted. Confirm `experimental-features.md` doesn't exist:
```
find . -name 'experimental-features*'
```

## Testing

No runtime change — comment-only removal.