### PR TITLE
fix: upgrade extensions config save failure log from debug to warn

### DIFF
--- a/crates/goose/src/config/extensions.rs
+++ b/crates/goose/src/config/extensions.rs
@@ -81,8 +81,7 @@ fn get_extensions_map() -> IndexMap<String, ExtensionEntry> {
 fn save_extensions_map(extensions: IndexMap<String, ExtensionEntry>) {
     let config = Config::global();
     if let Err(e) = config.set_param(EXTENSIONS_CONFIG_KEY, &extensions) {
-        // TODO(jack) why is this just a debug statement?
-        tracing::debug!("Failed to save extensions config: {}", e);
+        tracing::warn!("Failed to save extensions config: {}", e);
     }
 }
 


### PR DESCRIPTION
## Why

`save_extensions_map()` in `extensions.rs` catches config save failures but logs them at `debug` level — effectively swallowing them in production. There's even a TODO from a maintainer asking why:

```rust
// TODO(jack) why is this just a debug statement?
tracing::debug!("Failed to save extensions config: {}", e);
```

Failing to persist extension configuration is a meaningful error that users and developers should see in logs.

## What

- Upgrade `tracing::debug!` → `tracing::warn!` for the config save failure
- Remove the stale TODO comment

`tracing::warn` is already imported and used elsewhere in this file.

## How to review

2 lines changed in 1 file. Confirm `warn` is the right level (not `error`) — the app can continue functioning even if config save fails, but users should know their changes may not have persisted.

## Testing

- `cargo check -p goose` — compiles cleanly
- Trigger: temporarily make the config file read-only and toggle an extension. The warning should now appear in logs instead of being hidden behind debug verbosity.