### PR TITLE
chore(ui): remove stale comment in CardHeader.tsx

### DIFF
--- a/ui/desktop/src/components/settings/providers/subcomponents/CardHeader.tsx
+++ b/ui/desktop/src/components/settings/providers/subcomponents/CardHeader.tsx
@@ -21,7 +21,6 @@ interface ProviderNameAndStatusProps {
 }
 
 const ProviderNameAndStatus = memo(({ name, isConfigured }: ProviderNameAndStatusProps) => {
-  // Remove the console.log completely
   return (
     <div className="flex items-center justify-between w-full">
       <CardTitle name={name} />


### PR DESCRIPTION
## Why

A comment reading `// Remove the console.log completely` was left behind after the console.log it referenced was already removed in a previous commit.

## What

Remove the stale comment from `CardHeader.tsx` line 24.

## How to review

1 line deleted. The comment was the only change — no logic affected.

## Testing

No runtime impact — comment-only change.