### PR TITLE
chore(ui): remove debug console.log from renderer.tsx

### DIFF
--- a/ui/desktop/src/renderer.tsx
+++ b/ui/desktop/src/renderer.tsx
@@ -20,13 +20,11 @@ const TELEMETRY_CONFIG_KEY = 'GOOSE_TELEMETRY_ENABLED';
   const isLauncher = window.location.hash === '#/launcher';
 
   if (!isLauncher) {
-    console.log('window created, getting goosed connection info');
     const gooseApiHost = await window.electron.getGoosedHostPort();
     if (gooseApiHost === null) {
       window.alert('failed to start goose backend process');
       return;
     }
-    console.log('connecting at', gooseApiHost);
     client.setConfig({
       baseUrl: gooseApiHost,
       headers: {


### PR DESCRIPTION
## Why

`renderer.tsx` contains two startup debug logs that leak connection details (`goosed` host/port) to the browser DevTools console in production builds.

## What

Remove 2 `console.log` statements from `ui/desktop/src/renderer.tsx`:
- `'window created, getting goosed connection info'`
- `'connecting at', gooseApiHost`

## How to review

Single file, 2 lines deleted. No logic changes.

## Testing

- `npm run build` in `ui/desktop` — no compile errors
- Manual: open Goose desktop, verify the app still connects to goosed. The only difference is silence in DevTools console.