### PR TITLE
chore(ui): remove debug console.log from SessionSharingSection

### DIFF
--- a/ui/desktop/src/components/settings/sessions/SessionSharingSection.tsx
+++ b/ui/desktop/src/components/settings/sessions/SessionSharingSection.tsx
@@ -8,7 +8,6 @@ import { trackSettingToggled } from '../../../utils/analytics';
 
 export default function SessionSharingSection() {
   const envBaseUrlShare = window.appConfig.get('GOOSE_BASE_URL_SHARE');
-  console.log('envBaseUrlShare', envBaseUrlShare);
 
   // If env is set, force sharing enabled and set the baseUrl accordingly.
   const [sessionSharingConfig, setSessionSharingConfig] = useState({


### PR DESCRIPTION
## Why

`SessionSharingSection.tsx` logs the `GOOSE_BASE_URL_SHARE` environment variable value to the browser DevTools console on every render. This leaks configuration to anyone with DevTools open.

## What

Remove 1 `console.log` statement from `ui/desktop/src/components/settings/sessions/SessionSharingSection.tsx`.

## How to review

Single file, 1 line deleted. The `envBaseUrlShare` variable is still read and used — only the debug log is removed.

## Testing

No runtime impact. Session sharing settings continue to work as before.