### PR TITLE
fix: remove configured marker when deleting oauth provider configuration

### DIFF
--- a/ui/desktop/src/components/settings/providers/modal/ProviderConfiguationModal.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/ProviderConfiguationModal.tsx
@@ -164,6 +164,12 @@ export default function ProviderConfigurationModal({
       for (const param of params) {
         await remove(param.name, param.secret);
       }
+
+      const hasOAuthKey = params.some((key) => key.oauth_flow);
+      if (hasOAuthKey) {
+        const configuredMarker = `${provider.name}_configured`;
+        await remove(configuredMarker, false);
+      }
     }
 
     onClose();


### PR DESCRIPTION
## Summary
This PR ensures that when you delete ChatGPT Codex or GitHub Copilot configuration, both the token AND the configured marker are removed, so the provider correctly shows as not configured.

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing
Tested Manually

### Related Issues
Fixes #7886 

