### PR TITLE
fix: prioritize predefined model context_limit over canonical registry

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -111,8 +111,6 @@ impl ModelConfig {
     }
 
     pub fn with_canonical_limits(mut self, provider_name: &str) -> Self {
-        // Check predefined models first — these are explicitly configured by the
-        // operator/deployment and should take priority over generic canonical defaults.
         if let Some(pm) = find_predefined_model(&self.model_name) {
             if self.context_limit.is_none() {
                 self.context_limit = pm.context_limit;


### PR DESCRIPTION
When a model is configured via `GOOSE_PREDEFINED_MODELS` with a custom `context_limit` (e.g., 1M for extended context), the value is ignored if the same model exists in the canonical registry. The canonical lookup runs first in `with_canonical_limits()` and sets `context_limit` to its default (200k for most models), so the predefined check never fires since `context_limit` is already `Some(...)`.

This causes auto-compaction to trigger at ~160k tokens instead of the configured 1M, destroying conversation history mid-session.

The fix moves the predefined models check before the canonical registry lookup. Since predefined models represent explicit operator configuration, they should take priority over generic defaults. The env var (`GOOSE_CONTEXT_LIMIT`) still has the highest priority since it is resolved in `new_base()` before `with_canonical_limits()` runs.

Resolution chain after this fix:

| Priority | Source | Behavior |
|----------|--------|----------|
| 1 | `GOOSE_CONTEXT_LIMIT` env var | Set in `new_base()`, never overwritten |
| 2 | `GOOSE_PREDEFINED_MODELS` | Checked first in `with_canonical_limits()` |
| 3 | Canonical model registry | Fallback if neither above sets the value |

Fixes #7839