### PR TITLE
fix: models not shown in "Choose Model" modal after OAuth configuration completes

### DIFF
--- a/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
+++ b/ui/desktop/src/components/settings/providers/ProviderGrid.tsx
@@ -168,10 +168,10 @@ function ProviderCards({
   }, [refreshProviders]);
 
   const onProviderConfigured = useCallback(
-    (provider: ProviderDetails) => {
+    async (provider: ProviderDetails) => {
       setConfiguringProvider(null);
       if (refreshProviders) {
-        refreshProviders();
+        await refreshProviders();
       }
       setSwitchModelProvider(provider.name);
       setShowSwitchModelModal(true);


### PR DESCRIPTION
## Summary
After completing OAuth configuration for ChatGPT Codex, the "Choose Model" modal opened automatically but didn't show ChatGPT Codex models. The provider list hadn't been refreshed yet, so the newly configured provider wasn't included.

### Root Cause

In `ProviderGrid.tsx`, the `onProviderConfigured` callback called `refreshProviders()` but didn't await it before opening the model selector modal. The provider list fetch was still in progress when the modal rendered.

### Fix
Make `onProviderConfigured async` and `await refreshProviders()` before setting the model provider state and opening the modal.

### Testing
1. Configure ChatGPT Codex via OAuth
2. After browser authorization and returning to app
3. "Choose Model" modal now opens with ChatGPT Codex models available for selection

### Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [ ] Build / Release
- [ ] Other (specify below)

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Screenshots/Demos (for UX changes)
Before:  
<img width="1062" height="700" alt="screenshot-2026-03-14_14-26-51" src="https://github.com/user-attachments/assets/5c775eec-d33c-4602-8d4c-463ec3f4a927" />


After:   
<img width="1034" height="686" alt="screenshot-2026-03-14_14-25-38" src="https://github.com/user-attachments/assets/4d3cb3bd-fd62-46d9-9b46-e19e841e38d6" />


