### PR TITLE
fix: resolve user login PATH for MCP extension subprocesses

### DIFF
--- a/crates/goose-mcp/src/computercontroller/mod.rs
+++ b/crates/goose-mcp/src/computercontroller/mod.rs
@@ -1,5 +1,5 @@
 #[cfg(not(windows))]
-use crate::subprocess::user_login_path;
+use crate::subprocess::merged_path;
 use crate::subprocess::SubprocessExt;
 #[cfg(target_os = "macos")]
 use base64::Engine;
@@ -872,7 +872,7 @@ impl ComputerControllerServer {
                     .env("GOOSE_TERMINAL", "1")
                     .env("AGENT", "goose");
                 #[cfg(not(windows))]
-                if let Some(path) = user_login_path() {
+                if let Some(path) = merged_path() {
                     cmd.env("PATH", path);
                 }
                 cmd.set_no_window().output().await.map_err(|e| {
@@ -1072,7 +1072,7 @@ impl ComputerControllerServer {
     fn run_peekaboo_cmd(&self, args: &[&str]) -> Result<String, ErrorData> {
         let mut cmd = std::process::Command::new("peekaboo");
         cmd.args(args);
-        if let Some(path) = user_login_path() {
+        if let Some(path) = merged_path() {
             cmd.env("PATH", path);
         }
         let output = cmd.output().map_err(|e| {

--- a/crates/goose-mcp/src/subprocess.rs
+++ b/crates/goose-mcp/src/subprocess.rs
@@ -44,11 +44,18 @@ fn resolve_login_shell_path() -> Option<String> {
     use std::path::PathBuf;
     use std::process::Stdio;
 
-    let shell = if PathBuf::from("/bin/bash").is_file() {
-        "/bin/bash".to_string()
-    } else {
-        std::env::var("SHELL").unwrap_or_else(|_| "sh".to_string())
-    };
+    // Prefer the user's configured shell so we source the right profile files.
+    // Fall back to /bin/bash (common default) then sh as last resort.
+    let shell = std::env::var("SHELL")
+        .ok()
+        .filter(|s| PathBuf::from(s).is_file())
+        .unwrap_or_else(|| {
+            if PathBuf::from("/bin/bash").is_file() {
+                "/bin/bash".to_string()
+            } else {
+                "sh".to_string()
+            }
+        });
 
     std::process::Command::new(&shell)
         .args(["-l", "-i", "-c", "echo $PATH"])
@@ -80,4 +87,28 @@ fn resolve_login_shell_path() -> Option<String> {
 pub fn user_login_path() -> Option<&'static str> {
     static CACHED: OnceLock<Option<String>> = OnceLock::new();
     CACHED.get_or_init(resolve_login_shell_path).as_deref()
+}
+
+/// Merge the login shell PATH with the current process PATH.
+///
+/// Prepends login shell entries so user tools are found first, while
+/// preserving any runtime PATH additions (e.g. from direnv, nix, or
+/// auto-install helpers like ensure_peekaboo).
+#[cfg(not(windows))]
+pub fn merged_path() -> Option<String> {
+    let login = user_login_path()?;
+    let current = std::env::var("PATH").unwrap_or_default();
+    if current.is_empty() {
+        return Some(login.to_string());
+    }
+    // Deduplicate: login shell entries first, then any current entries not already present.
+    let login_entries: Vec<&str> = login.split(':').collect();
+    let mut seen: std::collections::HashSet<&str> = login_entries.iter().copied().collect();
+    let mut merged = login_entries;
+    for entry in current.split(':') {
+        if seen.insert(entry) {
+            merged.push(entry);
+        }
+    }
+    Some(merged.join(":"))
 }


### PR DESCRIPTION
## Summary

When Goose Desktop launches from Dock or Spotlight on macOS, `goosed` inherits a minimal PATH:

```
/Applications/Goose.app/Contents/Resources/bin:/usr/bin:/bin:/usr/sbin:/sbin
```

This means MCP extensions cannot find user-installed tools (`gh`, `brew`, `claude`, `cargo`, etc.) unless the user provides absolute paths.

The developer extension fixed this in #5774 by resolving the user's login shell PATH once and injecting it into subprocesses. But that fix lives in the `goose` crate — the MCP extensions in `goose-mcp` never got the same treatment.

## Changes

**`crates/goose-mcp/src/subprocess.rs`**
- Adds `resolve_login_shell_path()` — spawns a login shell once to recover the full PATH
- Adds `user_login_path()` — caches the result in a `OnceLock` for the process lifetime
- Ported directly from `crates/goose/src/agents/platform_extensions/developer/shell.rs`

**`crates/goose-mcp/src/computercontroller/mod.rs`**
- Injects the resolved PATH at both subprocess spawn points:
  - Shell script execution (`automation_script`)
  - Peekaboo commands (macOS UI automation)

## Why duplicate instead of shared crate?

`goose-mcp` does not depend on `goose` — they are sibling crates. Both already duplicate `SubprocessExt` in their respective `subprocess.rs` files. This follows the existing pattern. A shared utility crate could consolidate both in a follow-up.

## Testing

- `cargo check -p goose-mcp` — clean
- `cargo test -p goose-mcp` — 46/46 passed
- Manually verified: `gh`, `brew`, `git`, `jq`, `cargo` all resolve correctly from computercontroller shell after the change

Fixes #5915