### PR TITLE
fix: use platform-appropriate commands in developer extension instructions

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/mod.rs
@@ -63,11 +63,9 @@ fn developer_instructions() -> &'static str {
 
 impl DeveloperClient {
     pub fn new(_context: PlatformExtensionContext) -> Result<Self> {
-        let info = InitializeResult::new(
-            ServerCapabilities::builder().enable_tools().build(),
-        )
-        .with_server_info(Implementation::new(EXTENSION_NAME, "1.0.0").with_title("Developer"))
-        .with_instructions(developer_instructions());
+        let info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new(EXTENSION_NAME, "1.0.0").with_title("Developer"))
+            .with_instructions(developer_instructions());
 
         Ok(Self {
             info,


### PR DESCRIPTION
## Summary

On Windows, the developer extension instructions reference Unix-only commands (`rg`, `cat`, `sed`) that are unavailable. This contradicts the global hint that tells the model to "use only Windows commands", causing conflicting instructions and failed tool calls.

## Changes

Extract the instructions string into a `developer_instructions()` function that returns platform-appropriate alternatives at compile time:

- **Windows:** `findstr` / `Select-String`, `type` / `Get-Content` (via shell)
- **Unix/macOS:** `rg`, `cat`, `sed` (unchanged)

Single file change: `crates/goose/src/agents/platform_extensions/developer/mod.rs`

## Why `cfg!(windows)` over `std::env::consts::OS`

The developer extension already uses `#[cfg(windows)]` / `#[cfg(not(windows))]` throughout `shell.rs` for platform-conditional compilation (shell selection, PATH resolution, etc). Using `cfg!(windows)` in the instructions function follows the same pattern and is evaluated at compile time with no runtime cost.

## Testing

- All 34 developer extension tests pass
- `cargo check -p goose` clean
- No new dependencies

Fixes #7836