### PR TITLE
fix: deliver truncation notice as separate content block

### DIFF
--- a/crates/goose/src/agents/platform_extensions/developer/shell.rs
+++ b/crates/goose/src/agents/platform_extensions/developer/shell.rs
@@ -139,7 +139,10 @@ impl ShellTool {
         let output_dir = self.output_dir.path();
         let slot = self.call_index.fetch_add(1, Ordering::Relaxed) % OUTPUT_SLOTS;
         let stdout_result = if raw_stdout.is_empty() {
-            TruncateResult { text: String::new(), truncation: None }
+            TruncateResult {
+                text: String::new(),
+                truncation: None,
+            }
         } else {
             match truncate_output(&raw_stdout, &format!("stdout-{slot}"), output_dir) {
                 Ok(r) => r,
@@ -147,7 +150,10 @@ impl ShellTool {
             }
         };
         let stderr_result = if raw_stderr.is_empty() {
-            TruncateResult { text: String::new(), truncation: None }
+            TruncateResult {
+                text: String::new(),
+                truncation: None,
+            }
         } else {
             match truncate_output(&raw_stderr, &format!("stderr-{slot}"), output_dir) {
                 Ok(r) => r,
@@ -216,9 +222,7 @@ impl ShellTool {
             }
             let mut error_blocks = vec![Content::text(rendered).with_priority(0.0)];
             if !truncation_notices.is_empty() {
-                error_blocks.push(
-                    Content::text(truncation_notices.join("\n")).with_priority(0.0),
-                );
+                error_blocks.push(Content::text(truncation_notices.join("\n")).with_priority(0.0));
             }
             let mut result = CallToolResult::error(error_blocks);
             result.structured_content = structured_content;
@@ -227,9 +231,7 @@ impl ShellTool {
 
         let mut content_blocks = vec![Content::text(rendered).with_priority(0.0)];
         if !truncation_notices.is_empty() {
-            content_blocks.push(
-                Content::text(truncation_notices.join("\n")).with_priority(0.0),
-            );
+            content_blocks.push(Content::text(truncation_notices.join("\n")).with_priority(0.0));
         }
         let mut result = CallToolResult::success(content_blocks);
         result.structured_content = structured_content;
@@ -614,7 +616,10 @@ mod tests {
         assert!(preview.starts_with("line 2450"));
         assert!(preview.contains("line 2499"));
 
-        let info = result.truncation.as_ref().expect("expected truncation info");
+        let info = result
+            .truncation
+            .as_ref()
+            .expect("expected truncation info");
         assert!(info.reason.contains("2000 line limit"));
         assert!(info.reason.contains("2500 lines total"));
 
@@ -634,7 +639,10 @@ mod tests {
         assert!(input.lines().count() <= OUTPUT_LIMIT_LINES);
 
         let result = render_output(&input, "test_bytes", dir.path()).unwrap();
-        let info = result.truncation.as_ref().expect("expected truncation info");
+        let info = result
+            .truncation
+            .as_ref()
+            .expect("expected truncation info");
         assert!(info.reason.contains("byte limit"));
         assert!(info.reason.contains("bytes total"));
 


### PR DESCRIPTION
## Problem

When shell output exceeds the 50kB / 2000-line limit, the truncation notice (`[Full output saved to /tmp/... Read it with head, tail, or sed...]`) is appended directly to the preview text. This causes two issues:

1. **Model ignores the notice.** The notice text becomes part of the `stdout` field in the structured JSON (`ShellOutput`). The model parses the JSON and treats the notice as command output data — it never "sees" it as an instruction to read the temp file.

2. **Unix-only commands on Windows.** The notice references `head`, `tail`, and `sed` which are unavailable on Windows.

## Fix

- Extract a `TruncateResult` struct so `truncate_output()` returns the preview text and truncation metadata (path + reason) separately
- Deliver the truncation notice as a **separate `Content` block** in the `CallToolResult`, keeping `structured_content` clean
- Use platform-appropriate commands in the notice (PowerShell on Windows, head/tail/sed on Unix)

The structured `ShellOutput` JSON now contains only the actual command output (truncated preview), while the instruction to read the full output arrives as a distinct message the model can see and act on.

## Changes

Single file: `crates/goose/src/agents/platform_extensions/developer/shell.rs`

- New `TruncateResult` / `TruncationInfo` structs
- New `truncation_notice()` helper with `cfg!(windows)` branching
- Updated `truncate_output()` and `render_output()` return types
- Updated `shell_with_cwd()` to collect notices and emit as separate Content block
- All 34 existing tests updated and passing

## Testing

```
cargo test -p goose -- developer
# 34 passed, 0 failed
```

No behavioural change for output under the limit (returns `TruncateResult` with `truncation: None`).

Fixes #7846