### PR TITLE
fix: read GOOSE_CONTEXT_LIMIT from config.yaml, not just env vars

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -76,16 +76,37 @@ impl ModelConfig {
     }
 
     fn new_base(model_name: String, context_env_var: Option<&str>) -> Result<Self, ConfigError> {
+        // Check a provider-specific env var first (e.g. DATABRICKS_CONTEXT_LIMIT),
+        // then fall back to GOOSE_CONTEXT_LIMIT.  Using Config::global().get_param()
+        // reads from both environment variables and config.yaml, so users can set
+        // `GOOSE_CONTEXT_LIMIT: 1000000` in config.yaml instead of exporting an
+        // env var.  See #7839.
         let context_limit = if let Some(env_var) = context_env_var {
             if let Ok(val) = std::env::var(env_var) {
                 Some(Self::validate_context_limit(&val, env_var)?)
             } else {
                 None
             }
-        } else if let Ok(val) = std::env::var("GOOSE_CONTEXT_LIMIT") {
-            Some(Self::validate_context_limit(&val, "GOOSE_CONTEXT_LIMIT")?)
         } else {
-            None
+            match crate::config::Config::global().get_param::<usize>("GOOSE_CONTEXT_LIMIT") {
+                Ok(limit) => {
+                    if limit == 0 {
+                        return Err(ConfigError::InvalidRange(
+                            "GOOSE_CONTEXT_LIMIT".to_string(),
+                            "must be greater than 0".to_string(),
+                        ));
+                    }
+                    Some(limit)
+                }
+                Err(crate::config::ConfigError::NotFound(_)) => None,
+                Err(e) => {
+                    return Err(ConfigError::InvalidValue(
+                        "GOOSE_CONTEXT_LIMIT".to_string(),
+                        String::new(),
+                        e.to_string(),
+                    ))
+                }
+            }
         };
 
         let max_tokens = Self::parse_max_tokens()?;


### PR DESCRIPTION
## Problem

ModelConfig::new_base() reads GOOSE_CONTEXT_LIMIT via std::env::var(), which only checks environment variables. Users who set the value in config.yaml have it silently ignored for the lead model, even though the same key works for the worker model (which uses Config::global().get_param() in init.rs).

## Fix

Switch to Config::global().get_param() which checks environment variables first (preserving existing behaviour) then falls back to config.yaml. This matches how GOOSE_MAX_TOKENS is already read in the same file and how GOOSE_CONTEXT_LIMIT is read for the worker model in init.rs.

## Testing

All 16 model::tests pass.

Partially addresses #7839. Complements #7888.