### PR TITLE
fix(test): add env_lock to is_openai_reasoning_model tests

### DIFF
--- a/crates/goose/src/model.rs
+++ b/crates/goose/src/model.rs
@@ -468,8 +468,17 @@ mod tests {
     mod is_openai_reasoning_model {
         use super::*;
 
+        const ENV_LOCK_KEYS: [(&str, Option<&str>); 5] = [
+            ("GOOSE_MAX_TOKENS", None),
+            ("GOOSE_TEMPERATURE", None),
+            ("GOOSE_CONTEXT_LIMIT", None),
+            ("GOOSE_TOOLSHIM", None),
+            ("GOOSE_TOOLSHIM_OLLAMA_MODEL", None),
+        ];
+
         #[test]
         fn bare_reasoning_models() {
+            let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
             assert!(ModelConfig::new_or_fail("o1").is_openai_reasoning_model());
             assert!(ModelConfig::new_or_fail("o1-preview").is_openai_reasoning_model());
             assert!(ModelConfig::new_or_fail("o3").is_openai_reasoning_model());
@@ -481,6 +490,7 @@ mod tests {
 
         #[test]
         fn goose_prefixed_reasoning_models() {
+            let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
             assert!(ModelConfig::new_or_fail("goose-o3-mini").is_openai_reasoning_model());
             assert!(ModelConfig::new_or_fail("goose-o4-mini").is_openai_reasoning_model());
             assert!(ModelConfig::new_or_fail("goose-gpt-5").is_openai_reasoning_model());
@@ -488,6 +498,7 @@ mod tests {
 
         #[test]
         fn databricks_prefixed_reasoning_models() {
+            let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
             assert!(ModelConfig::new_or_fail("databricks-o3-mini").is_openai_reasoning_model());
             assert!(ModelConfig::new_or_fail("databricks-o4-mini").is_openai_reasoning_model());
             assert!(ModelConfig::new_or_fail("databricks-gpt-5").is_openai_reasoning_model());
@@ -495,6 +506,7 @@ mod tests {
 
         #[test]
         fn non_reasoning_models() {
+            let _guard = env_lock::lock_env(ENV_LOCK_KEYS);
             assert!(!ModelConfig::new_or_fail("claude-sonnet-4").is_openai_reasoning_model());
             assert!(!ModelConfig::new_or_fail("gpt-4o").is_openai_reasoning_model());
             assert!(


### PR DESCRIPTION
## Summary

`is_openai_reasoning_model` tests call `ModelConfig::new_or_fail` which reads env vars (`GOOSE_MAX_TOKENS`, `GOOSE_TEMPERATURE`, etc.) without `env_lock`. Parallel test runs that set these vars to invalid values cause intermittent failures in `databricks_prefixed_reasoning_models`.

### Type of Change
- [x] Tests

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

`cargo test -p goose -- model::tests --nocapture` — 976 passed, 0 failed.

### Related Issues

Found while working on #7854.