### PR TITLE
feat: add GOOSE_SHOW_FULL_OUTPUT config to disable tool output truncation

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -77,11 +77,7 @@ thread_local! {
             )
     );
     static SHOW_FULL_TOOL_OUTPUT: RefCell<bool> = RefCell::new(
-        std::env::var("GOOSE_SHOW_FULL_OUTPUT").ok()
-            .map(|val| val == "1" || val.eq_ignore_ascii_case("true"))
-            .unwrap_or_else(||
-                Config::global().get_param::<bool>("GOOSE_SHOW_FULL_OUTPUT").unwrap_or(false)
-            )
+        Config::global().get_param::<bool>("GOOSE_SHOW_FULL_OUTPUT").unwrap_or(false)
     );
 }
 


### PR DESCRIPTION
## Summary

- Wires up the existing `SHOW_FULL_TOOL_OUTPUT` flag to be user-configurable
- The flag existed but was hardcoded to `false` with no way to enable it (`toggle_full_tool_output()` was dead code)

## Configuration

Enable via either:
- **Environment variable**: `GOOSE_SHOW_FULL_OUTPUT=true` (or `1`)
- **Config parameter**: `GOOSE_SHOW_FULL_OUTPUT` (boolean)

## Use case

When using the `execute` tool or other tools with large arguments (e.g. multi-line code blocks), the CLI truncates the display, making it hard to see what code was actually sent. With this config enabled, tool call arguments and results are shown in full.

## Test plan

- [ ] `GOOSE_SHOW_FULL_OUTPUT=true goose session` shows full tool arguments
- [ ] Without the env var, behavior is unchanged (truncated as before)
- [ ] Config-based setting works via `goose configure`

🤖 Generated with [Claude Code](https://claude.com/claude-code)