### PR TITLE
fix: reconsolidate split tool-call messages to follow OpenAI format

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -336,9 +336,11 @@ fn merge_split_tool_call_messages(messages: &mut Vec<Value>) {
                 break;
             }
             let next = &messages[peek];
-            let has_no_content = next
-                .get("content")
-                .is_none_or(|c| c.is_null() || c.as_str().is_some_and(|s| s.is_empty()));
+            let has_no_content = next.get("content").is_none_or(|c| {
+                c.is_null()
+                    || c.as_str().is_some_and(|s| s.is_empty())
+                    || c.as_array().is_some_and(|a| a.is_empty())
+            });
             let is_split = next.get("role") == Some(&json!("assistant"))
                 && next
                     .get("tool_calls")


### PR DESCRIPTION
## Summary

Adds a post-processing step in `format_messages` that merges consecutive split assistant tool-call messages back into a single message with multiple `tool_calls`, conforming to the [OpenAI chat completions spec](https://platform.openai.com/docs/guides/function-calling).

## Problem

The agent internally splits a single assistant response with N parallel tool calls into N separate assistant messages (one per tool call). This deviates from the OpenAI standard, which specifies one assistant message with a `tool_calls` array containing all parallel calls:

```
# OpenAI standard format:
{"role": "assistant", "tool_calls": [call_1, call_2, call_3], "reasoning_content": "..."}
{"role": "tool", "tool_call_id": "call_1", ...}
{"role": "tool", "tool_call_id": "call_2", ...}
{"role": "tool", "tool_call_id": "call_3", ...}

# Current Goose format (split):
{"role": "assistant", "tool_calls": [call_1], "reasoning_content": "..."}
{"role": "tool", "tool_call_id": "call_1", ...}
{"role": "assistant", "tool_calls": [call_2], "reasoning_content": "..."}
{"role": "tool", "tool_call_id": "call_2", ...}
{"role": "assistant", "tool_calls": [call_3], "reasoning_content": "..."}
{"role": "tool", "tool_call_id": "call_3", ...}
```

This causes several issues:

1. **Spec non-compliance** — providers that strictly follow the OpenAI format may not handle the split format correctly
2. **Wasted context** — fields like `reasoning_content` are cloned onto every split message, consuming N times the tokens for what should appear once
3. **Thinking model compatibility** — models like Kimi K2.5 and GLM-5 that use `reasoning_content` see the same reasoning block repeated N times per turn, which grows linearly across turns and can degrade generation quality in long agentic sessions

## Fix

`merge_split_tool_call_messages()` runs as a post-processing step at the end of `format_messages`. It detects consecutive assistant messages that each have `tool_calls` and identical `reasoning_content`, and merges them into a single message with one `reasoning_content` and a combined `tool_calls` array.

**Scope guard**: Only triggers when `reasoning_content` is present and non-empty, so non-thinking models are completely unaffected. The agent's internal splitting behavior is unchanged — this only affects the outbound API format.

## Test plan

- [x] Tested with Kimi K2.5 running on Exo across a 19-minute session with 36+ tool call turns
- [x] Verified reasoning stays stable across turns (no linear growth)
- [x] Verified parallel tool calls (3 in one response) parse and execute correctly
- [x] Verified non-thinking model behavior is unchanged (merge doesn't trigger without reasoning_content)
- [ ] Unit tests for merge_split_tool_call_messages edge cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)