### PR TITLE
Remove java/.ai-usage-marker directory

### DIFF
--- a/java/.ai-usage-marker
+++ b/java/.ai-usage-marker
@@ -1,1 +1,0 @@
-Goose <goose@block.xyz>


### PR DESCRIPTION
The `java/.ai-usage-marker` file was accidentally merged in via https://github.com/block/goose/pull/7852 and should have been removed. This PR deletes the file and the `java/` directory.