### PR TITLE
fix: hard-coded tool call id in code mode callback

### DIFF
--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -253,11 +253,7 @@ fn create_tool_callback(
                 }
                 params
             };
-            let ctx = crate::agents::ToolCallContext::new(
-                session_id,
-                None,
-                Some("tool-request-id".to_string()),
-            );
+            let ctx = crate::agents::ToolCallContext::new(session_id, None, None);
             match manager
                 .dispatch_tool_call(&ctx, tool_call, CancellationToken::new())
                 .await


### PR DESCRIPTION
Another change slipped this in. We don't have a tool call ID here, but we can set None, not a hardcoded value.