### PR TITLE
set MACOSX_DEPLOYMENT_TARGET=12.0

### DIFF
--- a/.github/workflows/bundle-desktop-intel.yml
+++ b/.github/workflows/bundle-desktop-intel.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: macos-latest
     name: Bundle Desktop App on Intel macOS
     env:
-      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     permissions:
       id-token: write
       contents: read
@@ -67,7 +67,7 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
         with:
-          key: intel-macos-deployment-target-14
+          key: intel-macos-deployment-target-12
 
 
       - name: Build goose-server for Intel macOS (x86_64)

--- a/.github/workflows/bundle-desktop.yml
+++ b/.github/workflows/bundle-desktop.yml
@@ -38,7 +38,7 @@ jobs:
     runs-on: macos-latest
     name: Bundle Desktop App on macOS
     env:
-      MACOSX_DEPLOYMENT_TARGET: "14.0"
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     permissions:
       id-token: write
       contents: read
@@ -112,7 +112,7 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
-          key: macos-deployment-target-14
+          key: macos-deployment-target-12
 
       # Build the project
       - name: Build goosed


### PR DESCRIPTION
## Summary
Add MACOSX_DEPLOYMENT_TARGET (min macos version) to 12.0 so that it does not crash on macos <15 and is usable


### Type of Change
<!-- Select all that apply -->
- [ ] Feature
- [ ] Bug fix
- [ ] Refactor / Code quality
- [ ] Performance improvement
- [ ] Documentation
- [ ] Tests
- [ ] Security fix
- [X] Build / Release
- [ ] Other (specify below)

### Testing
Manual testing on https://github.com/block/goose/actions/runs/23179532634

### Related Issues
Relates to https://github.com/block/goose/issues/7674
