### PR TITLE
docs: add Remote Access section with Telegram Gateway documentation

### DIFF
--- a/documentation/blog/2025-12-19-goose-mobile-terminal/index.md
+++ b/documentation/blog/2025-12-19-goose-mobile-terminal/index.md
@@ -24,7 +24,7 @@ goose is now available on the App Store! The iOS app connects to your desktop go
 3. **Scan the QR code** - Use the iOS app to scan the QR code displayed in your desktop app
 4. **Start working** - You're connected! Your mobile app now tunnels to your goose desktop instance
 
-See the [Mobile Access guide](/docs/experimental/mobile-access) for detailed steps.
+See the [Mobile Access guide](/docs/experimental/remote-access/mobile-access) for detailed steps.
 
 This means you get the full power of your desktop goose setup—all your extensions and configurations—accessible from your phone. Whether you're on the train, grabbing coffee, or just away from your desk, you can still ask goose to help with tasks or check on long-running things. Throw an idea out there for it to go to work on and pick it up later.
 

--- a/documentation/docs/experimental/goose-mobile.md
+++ b/documentation/docs/experimental/goose-mobile.md
@@ -6,7 +6,7 @@ unlisted: true
 ---
 
 :::info Archived
-goose Mobile has been archived. Mobile access to goose is now supported for [iOS devices via tunneling](/docs/experimental/mobile-access).
+goose Mobile has been archived. Mobile access to goose is now supported for [iOS devices via tunneling](/docs/experimental/remote-access/mobile-access).
 :::
 
 goose Mobile is an experimental Android project inspired by the goose application. It acts as an open agent on your phone, automating multistep tasks, responding to notifications, and even replacing your home screen for maximum efficiency.

--- a/documentation/docs/experimental/index.md
+++ b/documentation/docs/experimental/index.md
@@ -25,9 +25,9 @@ The list of experimental features may change as goose development progresses. So
       link="/docs/experimental/ollama"
     />
     <Card 
-      title="Mobile Access via Secure Tunneling"
-      description="Enable remote access to goose Desktop from the goose AI mobile app via secure tunneling."
-      link="/docs/experimental/mobile-access"
+      title="Remote Access"
+      description="Access goose remotely via the goose AI mobile app or messaging platforms like Telegram."
+      link="/docs/experimental/remote-access"
     />
     <Card 
       title="goose for VS Code Extension"

--- a/documentation/docs/experimental/mobile-access.md
+++ b/documentation/docs/experimental/mobile-access.md
@@ -3,78 +3,10 @@ title: Mobile Access via Secure Tunneling
 sidebar_position: 3
 sidebar_label: Mobile Access
 description: Enable remote access to goose from mobile devices using secure tunneling.
+slug: /experimental/mobile-access-redirect
+unlisted: true
 ---
 
-import { PanelLeft } from 'lucide-react';
+import {Redirect} from '@docusaurus/router';
 
-Mobile access lets you connect to goose remotely from an iOS mobile device using secure tunneling.
-
-:::warning Experimental Feature
-Mobile access is a preview feature in active development. Behavior and configuration may change in future releases.
-:::
-
-## How Mobile Access Works
-
-Mobile access connects your iOS device to goose Desktop through a secure tunnel. After you install and configure the **goose AI** app, you can access goose from anywhere.
-
-**Key details:**
-- Uses [Lapstone](https://github.com/michaelneale/lapstone-tunnel), a public HTTPS tunnel service provided by Mic Neale
-- Easy setup using a QR code with a unique secret key to secure the connection
-- Your tunnel URL remains the same across sessions, so you only need to configure your mobile app once
-- The connection requires your computer to be awake with goose Desktop running
-- Automatically reconnects if interrupted and restarts when you launch goose Desktop
-
-## Setup
-
-### Install the App
-1. Install the **goose AI** app on your iOS mobile device from the [App Store](https://apps.apple.com/app/goose-ai/id6752889295)
-
-:::tip App Store QR Code
-Follow the steps below to open the `Remote Access` section, then click "scan QR code" in the info box for quick access to the App Store.
-:::
-
-### Start the Tunnel
-1. Open goose Desktop
-2. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
-3. Click `Settings` in the sidebar
-4. Click `App`
-5. Scroll down to the `Remote Access` section and click `Start Tunnel`
-
-Once the tunnel starts, you'll see a `Remote Access Connection` QR code for configuring the app.
-
-:::info 
-Click `Stop Tunnel` at any time to close the connection.
-:::
-
-### Connect the App
-1. Open the **goose AI** app on your iOS mobile device
-2. Scan the `Remote Access Connection` QR code displayed in goose Desktop
-3. The app will automatically configure the connection
-
-You can now access goose Desktop from your mobile device.
-
-## What You Can Do
-
-The mobile app gives you full access to goose:
-- Start new conversations or continue existing sessions
-- Use all your goose extensions and configurations
-- Work from anywhere while your computer handles the processing
-
-## Additional Resources
-
-import ContentCardCarousel from '@site/src/components/ContentCardCarousel';
-import mobileShots from '@site/blog/2025-12-19-goose-mobile-terminal/mobile_shots.png';
-
-<ContentCardCarousel
-  items={[
-    {
-      type: 'blog',
-      title: 'goose Mobile Access and Native Terminal Support',
-      description: 'Learn about two new ways to use goose: iOS app for mobile access and native terminal support with seamless session continuity.',
-      thumbnailUrl: mobileShots,
-      linkUrl: '/goose/blog/2025/12/19/goose-mobile-terminal',
-      date: '2025-12-19',
-      duration: '4 min read'
-    }
-  ]}
-/>
+<Redirect to="/docs/experimental/remote-access/mobile-access" />

--- a/documentation/docs/experimental/remote-access/index.md
+++ b/documentation/docs/experimental/remote-access/index.md
@@ -1,0 +1,25 @@
+---
+title: Remote Access
+sidebar_position: 2
+description: Access goose remotely from mobile devices and messaging platforms.
+---
+
+import Card from '@site/src/components/Card';
+import styles from '@site/src/components/Card/styles.module.css';
+
+# Remote Access
+
+Access goose from anywhere using mobile apps or messaging platforms. These features let you interact with goose when you're away from your computer.
+
+<div className={styles.cardGrid}>
+  <Card 
+    title="Mobile Access via Secure Tunneling"
+    description="Connect to goose Desktop from the goose AI iOS app using secure tunneling."
+    link="/docs/experimental/remote-access/mobile-access"
+  />
+  <Card 
+    title="Telegram Gateway"
+    description="Chat with goose through Telegram from any device."
+    link="/docs/experimental/remote-access/telegram-gateway"
+  />
+</div>

--- a/documentation/docs/experimental/remote-access/mobile-access.md
+++ b/documentation/docs/experimental/remote-access/mobile-access.md
@@ -1,0 +1,80 @@
+---
+title: Mobile Access via Secure Tunneling
+sidebar_position: 1
+sidebar_label: Mobile Access
+description: Enable remote access to goose from mobile devices using secure tunneling.
+---
+
+import { PanelLeft } from 'lucide-react';
+
+Mobile access lets you connect to goose remotely from an iOS mobile device using secure tunneling.
+
+:::warning Experimental Feature
+Mobile access is a preview feature in active development. Behavior and configuration may change in future releases.
+:::
+
+## How Mobile Access Works
+
+Mobile access connects your iOS device to goose Desktop through a secure tunnel. After you install and configure the **goose AI** app, you can access goose from anywhere.
+
+**Key details:**
+- Uses [Lapstone](https://github.com/michaelneale/lapstone-tunnel), a public HTTPS tunnel service provided by Mic Neale
+- Easy setup using a QR code with a unique secret key to secure the connection
+- Your tunnel URL remains the same across sessions, so you only need to configure your mobile app once
+- The connection requires your computer to be awake with goose Desktop running
+- Automatically reconnects if interrupted and restarts when you launch goose Desktop
+
+## Setup
+
+### Install the App
+1. Install the **goose AI** app on your iOS mobile device from the [App Store](https://apps.apple.com/app/goose-ai/id6752889295)
+
+:::tip App Store QR Code
+Follow the steps below to open the `Remote Access` section, then click "scan QR code" in the info box for quick access to the App Store.
+:::
+
+### Start the Tunnel
+1. Open goose Desktop
+2. Click the <PanelLeft className="inline" size={16} /> button in the top-left to open the sidebar
+3. Click `Settings` in the sidebar
+4. Click `App`
+5. Scroll down to the `Remote Access` section and click `Start Tunnel`
+
+Once the tunnel starts, you'll see a `Remote Access Connection` QR code for configuring the app.
+
+:::info 
+Click `Stop Tunnel` at any time to close the connection.
+:::
+
+### Connect the App
+1. Open the **goose AI** app on your iOS mobile device
+2. Scan the `Remote Access Connection` QR code displayed in goose Desktop
+3. The app will automatically configure the connection
+
+You can now access goose Desktop from your mobile device.
+
+## What You Can Do
+
+The mobile app gives you full access to goose:
+- Start new conversations or continue existing sessions
+- Use all your goose extensions and configurations
+- Work from anywhere while your computer handles the processing
+
+## Additional Resources
+
+import ContentCardCarousel from '@site/src/components/ContentCardCarousel';
+import mobileShots from '@site/blog/2025-12-19-goose-mobile-terminal/mobile_shots.png';
+
+<ContentCardCarousel
+  items={[
+    {
+      type: 'blog',
+      title: 'goose Mobile Access and Native Terminal Support',
+      description: 'Learn about two new ways to use goose: iOS app for mobile access and native terminal support with seamless session continuity.',
+      thumbnailUrl: mobileShots,
+      linkUrl: '/goose/blog/2025/12/19/goose-mobile-terminal',
+      date: '2025-12-19',
+      duration: '4 min read'
+    }
+  ]}
+/>

--- a/documentation/docs/experimental/remote-access/telegram-gateway.md
+++ b/documentation/docs/experimental/remote-access/telegram-gateway.md
@@ -1,0 +1,106 @@
+---
+title: Telegram Gateway
+sidebar_position: 2
+sidebar_label: Telegram Gateway
+description: Chat with goose through Telegram from any device.
+---
+
+The Telegram Gateway lets you interact with goose through Telegram, enabling remote access from any device where Telegram is available.
+
+:::warning Experimental Feature
+The Gateway feature is experimental and in active development. Behavior and configuration may change in future releases.
+:::
+
+## How It Works
+
+The Gateway connects your Telegram account to goose through a secure pairing process. Once paired, you can send messages to a Telegram bot that forwards them to goose, and receive formatted responses back in Telegram.
+
+**Key details:**
+- Uses a Telegram bot that you create and configure
+- Secure pairing with a one-time code
+- Supports formatted responses with code blocks and markdown
+- Maintains a persistent session that auto-compacts for long conversations
+- Works from any device with Telegram installed
+
+## Prerequisites
+
+Before setting up the Telegram Gateway, you need to create a Telegram bot:
+
+1. Open Telegram and search for [@BotFather](https://t.me/BotFather)
+2. Send `/newbot` and follow the prompts to create your bot
+3. Copy the **bot token** that BotFather provides (looks like `123456789:ABCdefGHIjklMNOpqrsTUVwxyz`)
+
+:::tip
+Keep your bot token secure. Anyone with the token can control your bot.
+:::
+
+## Setup
+
+### Desktop App
+
+1. Open goose Desktop
+2. Go to **Settings** > **Gateways**
+3. In the Telegram section, enter your bot token
+4. Click **Start** to activate the gateway
+5. Click **Generate Pairing Code** to get a one-time pairing code
+
+### Pair Your Telegram Account
+
+1. Open Telegram and find your bot (search for the username you gave it)
+2. Send the pairing code to the bot
+3. The bot will confirm the pairing is complete
+
+You can now chat with goose through Telegram!
+
+### CLI Usage
+
+You can also manage the gateway from the command line:
+
+```bash
+# Check gateway status
+goose gateway status
+
+# Start the Telegram gateway
+goose gateway start telegram --bot-token YOUR_BOT_TOKEN
+
+# Generate a pairing code
+goose gateway pair telegram
+
+# Stop the gateway
+goose gateway stop telegram
+```
+
+## What You Can Do
+
+Once paired, you can:
+- Send messages to goose and receive responses
+- Get formatted code blocks with syntax highlighting
+- Continue conversations across multiple sessions
+- Access all your configured goose extensions
+
+## Managing Paired Users
+
+From the Desktop app's Gateway settings, you can:
+- View all paired Telegram users
+- See which session each user is connected to
+- Unpair users to revoke their access
+
+## Troubleshooting
+
+### Bot not responding
+- Verify the bot token is correct
+- Check that the gateway is running in goose Desktop
+- Ensure your computer is awake and goose Desktop is open
+
+### Pairing code not working
+- Pairing codes expire after a few minutes—generate a new one
+- Make sure you're sending the code to the correct bot
+
+### Messages not formatting correctly
+- The gateway converts goose's markdown to Telegram-compatible formatting
+- Some complex formatting may be simplified for Telegram compatibility
+
+## Additional Resources
+
+- [Telegram Bot API Documentation](https://core.telegram.org/bots)
+- [Gateway PR #7199](https://github.com/block/goose/pull/7199)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Gateway feature introduced in #7199, organized under a new **Remote Access** section in the experimental docs.

## Changes

### New Documentation Structure

```
docs/experimental/
├── remote-access/
│   ├── index.md           # Remote Access landing page with cards
│   ├── mobile-access.md   # iOS app tunneling (moved here)
│   └── telegram-gateway.md # NEW: Telegram Gateway docs
```

### New: Telegram Gateway Documentation

Covers:
- How the gateway works (pairing process, persistent sessions)
- Prerequisites (creating a Telegram bot via BotFather)
- Desktop app setup walkthrough
- CLI usage (`goose gateway status/start/pair/stop`)
- Features and capabilities
- Managing paired users
- Troubleshooting tips

### Updates

- **experimental/index.md** - Changed "Mobile Access" card to "Remote Access" card linking to the new section
- **experimental/mobile-access.md** - Now redirects to new location
- **experimental/goose-mobile.md** - Updated archived notice link
- **blog/2025-12-19-goose-mobile-terminal/index.md** - Fixed broken link

## Related

- Gateway feature PR: #7199

## Testing

- Documentation builds successfully with `npm run build`
