### PR TITLE
docs: add GOOSE_INPUT_LIMIT to config-files.md

### DIFF
--- a/documentation/docs/guides/config-files.md
+++ b/documentation/docs/guides/config-files.md
@@ -43,6 +43,7 @@ The following settings can be configured at the root level of your config.yaml f
 | `GOOSE_PLANNER_MODEL` | Model for planning mode | Model name | Falls back to `GOOSE_MODEL` | No |
 | `GOOSE_TOOLSHIM` | Enable tool interpretation | true/false | false | No |
 | `GOOSE_TOOLSHIM_OLLAMA_MODEL` | Model for tool interpretation | Model name (e.g., "llama3.2") | System default | No |
+| `GOOSE_INPUT_LIMIT` | Override input token limit for Ollama (maps to `num_ctx`) | Positive integer | Model default | No |
 | `GOOSE_CLI_MIN_PRIORITY` | Tool output verbosity | Float between 0.0 and 1.0 | 0.0 | No |
 | `GOOSE_CLI_THEME` | [Theme](/docs/guides/goose-cli-commands#themes) for CLI response  markdown | "light", "dark", "ansi" | "dark" | No |
 | `GOOSE_CLI_LIGHT_THEME` | Custom syntax highlighting theme for light mode | [bat theme name](https://github.com/sharkdp/bat#adding-new-themes) | "GitHub" | No |


### PR DESCRIPTION
## Summary

Documents that `GOOSE_INPUT_LIMIT` can be set in `config.yaml` for Ollama users who want to override the default input token limit.

## What changed

Added `GOOSE_INPUT_LIMIT` to the Global Settings table in the configuration files documentation. This setting maps to Ollama's `num_ctx` option and allows users to specify a custom maximum input token count.

## Example usage

```yaml
GOOSE_PROVIDER: ollama
GOOSE_MODEL: qwen2.5
GOOSE_INPUT_LIMIT: 32768
```

## Related

- https://github.com/block/goose/pull/7281 - fix: allow ollama input limit override

The environment variables doc already had this documented, but the config-files doc was missing it.