### PR TITLE
fix: update webmcp blog post metadata image URL

### DIFF
--- a/documentation/blog/2026-03-17-webmcp-for-beginners/index.md
+++ b/documentation/blog/2026-03-17-webmcp-for-beginners/index.md
@@ -179,10 +179,10 @@ Right now, WebMCP only works on sites that choose to implement it, which limits 
   <meta property="og:type" content="article" />
   <meta property="og:url" content="https://block.github.io/goose/blog/2026/03/17/webmcp-for-beginners" />
   <meta property="og:description" content="WebMCP lets websites expose structured actions that AI agents can call directly. This guide explains how it works, how it differs from MCP and browser automation, and how to build your own WebMCP-enabled site." />
-  <meta property="og:image" content="https://block.github.io/goose/assets/images/webmcp-for-beginners.png" />
+  <meta property="og:image" content="https://block.github.io/goose/assets/images/webmcp-for-beginners-f12da638fe0f49acf924c720a7d1243a.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta property="twitter:domain" content="block.github.io/goose" />
   <meta name="twitter:title" content="WebMCP for Beginners" />
   <meta name="twitter:description" content="WebMCP lets websites expose structured actions that AI agents can call directly. This guide explains how it works, how it differs from MCP and browser automation, and how to build your own WebMCP-enabled site." />
-  <meta name="twitter:image" content="https://block.github.io/goose/assets/images/webmcp-for-beginners.png" />
+  <meta name="twitter:image" content="https://block.github.io/goose/assets/images/webmcp-for-beginners-f12da638fe0f49acf924c720a7d1243a.png" />
 </head>


### PR DESCRIPTION
## Summary
Update the og:image and twitter:image meta tags in the WebMCP for Beginners blog post to use the correct hashed image filename.

## Changes
- Updated `og:image` URL to include the content hash
- Updated `twitter:image` URL to include the content hash

This ensures proper social media preview rendering when the blog post is shared.