### PR TITLE
fix: safe agent recovery on submit failure and accurate disconnect messaging

### DIFF
--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "goose-app",
   "productName": "Goose",
-  "version": "1.27.0",
+  "version": "1.27.1",
   "description": "Goose App",
   "engines": {
     "node": "^24.10.0",

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -339,7 +339,7 @@ async function streamFromResponse(
     if (!signal?.aborted) {
       toastError({
         title: 'Connection lost',
-        msg: 'The response may be incomplete. You can try sending your message again.',
+        msg: 'The response may be incomplete and the turn may have partially executed on the backend. Reload the session to check the latest state before retrying — resending may duplicate tool actions.',
       });
     }
   } catch (error) {
@@ -624,6 +624,7 @@ export function useChatStream({
           },
           throwOnError: true,
           signal: abortControllerRef.current.signal,
+          // Do not retry /reply — the endpoint is not idempotent and retrying can duplicate tool calls
           sseMaxRetryAttempts: 0,
         });
 
@@ -640,7 +641,20 @@ export function useChatStream({
         if (error instanceof Error && error.name === 'AbortError') {
           // Silently handle abort
         } else {
-          // Unexpected error during fetch setup (streamFromResponse handles its own errors)
+          // The submit failed — attempt to restore the agent (it may have been
+          // evicted from the LRU cache or the server may have restarted) so the
+          // session is in a usable state for the user's next manual attempt.
+          try {
+            await resumeAgent({
+              body: {
+                session_id: sessionId,
+                load_model_and_extensions: true,
+              },
+              throwOnError: true,
+            });
+          } catch {
+            // resumeAgent also failed — nothing more we can do automatically
+          }
           onFinish('Submit error: ' + errorMessage(error));
         }
       }
@@ -673,6 +687,7 @@ export function useChatStream({
           },
           throwOnError: true,
           signal: abortControllerRef.current.signal,
+          // Do not retry /reply — the endpoint is not idempotent and retrying can duplicate tool calls
           sseMaxRetryAttempts: 0,
         });
 
@@ -688,6 +703,18 @@ export function useChatStream({
         if (error instanceof Error && error.name === 'AbortError') {
           // Silently handle abort
         } else {
+          // Restore the agent so the session is usable for the user's next manual attempt
+          try {
+            await resumeAgent({
+              body: {
+                session_id: sessionId,
+                load_model_and_extensions: true,
+              },
+              throwOnError: true,
+            });
+          } catch {
+            // resumeAgent also failed — nothing more we can do automatically
+          }
           onFinish('Submit error: ' + errorMessage(error));
         }
       }
@@ -820,6 +847,7 @@ export function useChatStream({
                 },
                 throwOnError: true,
                 signal: abortControllerRef.current.signal,
+                // Do not retry /reply — the endpoint is not idempotent and retrying can duplicate tool calls
                 sseMaxRetryAttempts: 0,
               });
 


### PR DESCRIPTION
## Summary

When a `/reply` request fails (due to agent LRU eviction, server restart, or network loss), silently restore the agent so the session remains usable, and show accurate messaging about what happened.

## Problem

Multiple users have reported that Goose "just hangs" when sending a message after not interacting for a while, requiring a full restart to recover. The root causes:

- When the backend agent becomes unavailable (LRU eviction, server restart, macOS sleep/wake), the frontend had no recovery mechanism — `resumeAgent` was only called once on mount
- The existing connection-lost toast encouraged users to "try sending your message again" with no warning that resending could duplicate tool actions (shell commands, file edits, MCP calls)

### Why we do NOT retry `/reply`

The `/reply` endpoint is a **one-shot turn submission**, not a resumable stream. There is no protocol support for idempotent turn submission, reconnecting to an in-flight turn, or replaying buffered events. Retrying the SSE connection would re-submit the same turn and potentially **duplicate side effects**. True resumable streaming requires protocol-level changes (idempotent `reply_id`, event replay, `Last-Event-ID` support) tracked separately.

## Changes

- **Add explicit `// Do not retry /reply` comments** at all 3 SSE call sites explaining why `sseMaxRetryAttempts` must stay at `0`
- **Silent agent recovery on failure**: when a submit fails with a non-abort error, attempt `resumeAgent` to restore the session (handles LRU eviction, server restart, extension reload) so the user can manually retry. Does NOT auto-resend the message.
- **Accurate disconnect messaging**: update connection-lost toast to warn that the turn may have partially executed and resending may duplicate tool actions

## What this does NOT do

- Does not auto-retry `/reply` requests (unsafe without idempotency)
- Does not auto-resend the user's message
- Does not claim the connection was "restored" or "reconnected"

## Testing

- Verified syntax and balanced braces across all changes
- All 3 `sseMaxRetryAttempts` call sites documented
- Recovery logic added to both `handleSubmit` and `submitElicitationResponse` error handlers
- No server-side changes required

## Files Changed

- `ui/desktop/src/hooks/useChatStream.ts` — agent recovery + messaging + comments
- `ui/desktop/package.json` — patch version bump to 1.27.1