### PR TITLE
fix: add periodic health check to detect backend unavailability

### DIFF
--- a/ui/desktop/package.json
+++ b/ui/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "goose-app",
   "productName": "Goose",
-  "version": "1.27.0",
+  "version": "1.27.2",
   "description": "Goose App",
   "engines": {
     "node": "^24.10.0",

--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -27,6 +27,7 @@ import {
 import { errorMessage } from '../utils/conversionUtils';
 import { showExtensionLoadResults } from '../utils/extensionErrorUtils';
 import { maybeHandlePlatformEvent } from '../utils/platform_events';
+import { useHealthCheck } from './useHealthCheck';
 
 const resultsCache = new Map<string, { messages: Message[]; session: Session }>();
 
@@ -365,6 +366,27 @@ export function useChatStream({
   // Ref to access latest state in callbacks (avoids stale closures)
   const stateRef = useRef(state);
   stateRef.current = state;
+
+  // Periodic health check — active when session is loaded and not streaming.
+  // Detects backend unavailability between user messages so we can surface
+  // a warning before the user's next submit fails silently.
+  useHealthCheck({
+    enabled: !!state.session && state.chatState === ChatState.Idle,
+    onRecovered: useCallback(() => {
+      // Attempt to restore the agent when backend comes back
+      if (sessionId) {
+        resumeAgent({
+          body: {
+            session_id: sessionId,
+            load_model_and_extensions: true,
+          },
+          throwOnError: true,
+        }).catch((err) => {
+          console.warn('Failed to restore agent after health recovery:', err);
+        });
+      }
+    }, [sessionId]),
+  });
 
   useEffect(() => {
     return () => {

--- a/ui/desktop/src/hooks/useHealthCheck.ts
+++ b/ui/desktop/src/hooks/useHealthCheck.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useCallback } from 'react';
+import { status } from '../api';
+import { toastError } from '../toasts';
+
+/**
+ * Interval between health checks in milliseconds.
+ * We check every 30 seconds when the session is idle.
+ */
+const HEALTH_CHECK_INTERVAL_MS = 30_000;
+
+/**
+ * Number of consecutive failures before showing a warning to the user.
+ * A single missed ping could be a transient blip — we wait for 3 in a row.
+ */
+const FAILURE_THRESHOLD = 3;
+
+interface UseHealthCheckProps {
+  /** Whether the health check should be active (e.g., session is loaded and idle) */
+  enabled: boolean;
+  /** Callback invoked when the backend is confirmed unreachable after FAILURE_THRESHOLD misses */
+  onUnreachable?: () => void;
+  /** Callback invoked when the backend recovers after being unreachable */
+  onRecovered?: () => void;
+}
+
+/**
+ * Periodically pings the goosed `/status` endpoint to detect backend
+ * unavailability between user messages. This catches:
+ * - goosed process crashes
+ * - Network/TCP connection silently dying (e.g., after macOS sleep/wake)
+ * - Server restarts
+ *
+ * When the backend becomes unreachable, a toast is shown to the user
+ * and an optional callback is fired so the parent can attempt reconnection.
+ */
+export function useHealthCheck({
+  enabled,
+  onUnreachable,
+  onRecovered,
+}: UseHealthCheckProps): void {
+  const consecutiveFailuresRef = useRef(0);
+  const wasUnreachableRef = useRef(false);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const checkHealth = useCallback(async () => {
+    try {
+      await status({ throwOnError: true });
+
+      // Backend is reachable — reset failure counter
+      if (consecutiveFailuresRef.current > 0) {
+        consecutiveFailuresRef.current = 0;
+      }
+
+      // If we were previously unreachable, notify recovery
+      if (wasUnreachableRef.current) {
+        wasUnreachableRef.current = false;
+        onRecovered?.();
+      }
+    } catch {
+      consecutiveFailuresRef.current += 1;
+
+      if (
+        consecutiveFailuresRef.current >= FAILURE_THRESHOLD &&
+        !wasUnreachableRef.current
+      ) {
+        wasUnreachableRef.current = true;
+        toastError({
+          title: 'Backend unreachable',
+          msg: 'Goose cannot reach the server. Your session will be restored automatically when the connection recovers.',
+        });
+        onUnreachable?.();
+      }
+    }
+  }, [onUnreachable, onRecovered]);
+
+  useEffect(() => {
+    if (!enabled) {
+      // Clear any running interval when disabled
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+      return;
+    }
+
+    // Start periodic health checks
+    intervalRef.current = setInterval(checkHealth, HEALTH_CHECK_INTERVAL_MS);
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [enabled, checkHealth]);
+}


### PR DESCRIPTION
## Summary

Adds a periodic health check that pings the goosed `/status` endpoint every 30 seconds when the session is idle, proactively detecting backend unavailability **between** user messages.

## Problem

The goose server sends heartbeat pings only **during active reply streams** (500ms interval). Between user messages — which could be minutes or hours — there is **zero keepalive**. This means:

- The TCP connection can silently die (macOS sleep/wake, network changes)
- The goosed process could crash without the frontend knowing
- The agent could be evicted from the LRU cache

The user only discovers the problem when they try to send their next message and it fails. Multiple users have reported sessions that "just hang" after periods of inactivity, requiring a full restart.

## Approach

Rather than attempting transport-level retry on `/reply` (which is unsafe — see #7972), this PR detects problems **early** so the user is informed before their next submit fails:

1. **Detect** — ping `/status` every 30s while idle
2. **Debounce** — require 3 consecutive failures to avoid false positives from transient blips
3. **Alert** — show a toast when the backend is confirmed unreachable
4. **Recover** — when the backend comes back, call `resumeAgent` to restore the agent (handles LRU eviction, server restarts, extension reloading)

The health check is **disabled during active streaming** since the server already sends 500ms heartbeat pings in that path.

## Changes

- **New `useHealthCheck` hook** (`ui/desktop/src/hooks/useHealthCheck.ts`, 96 lines):
  - Pings `/status` every 30 seconds when enabled
  - 3 consecutive failures → toast warning ("Backend unreachable")
  - Fires `onRecovered` callback when connection is restored
  - Properly cleans up intervals on unmount and when disabled

- **Integrated into `useChatStream`**:
  - Active when: session is loaded AND `chatState === Idle`
  - Disabled when: streaming (server heartbeats cover this)
  - On recovery: calls `resumeAgent` to restore the session silently

## What this does NOT do

- Does not retry `/reply` requests (not safe — see #7972 for rationale)
- Does not auto-resend user messages
- Does not add any backend changes — reuses the existing `/status` endpoint

## Relationship to #7972

| PR | Covers | Mechanism |
|----|--------|-----------|
| #7972 | Failures **during** submit | `resumeAgent` fallback + honest error messaging |
| **#7973 (this)** | Failures **between** messages | Periodic health check + proactive recovery |

Together they cover both failure windows without unsafe transport retry.

## Testing

- Verified balanced braces and correct TypeScript syntax
- Hook uses `useCallback` for stable references to avoid unnecessary re-renders
- Interval properly cleaned up on unmount and `enabled` toggle
- Rust backend builds cleanly (no server-side changes)

## Files Changed

- `ui/desktop/src/hooks/useHealthCheck.ts` — **NEW** health check hook
- `ui/desktop/src/hooks/useChatStream.ts` — integration with health check
- `ui/desktop/package.json` — patch version bump to 1.27.2