### PR TITLE
fix: emit user-facing message on compaction failure

### DIFF
--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1540,6 +1540,11 @@ impl Agent {
                                 Err(e) => {
                                     crate::posthog::emit_error("compaction_failed", &e.to_string());
                                     error!("Compaction failed: {}", e);
+                                    yield AgentEvent::Message(
+                                        Message::assistant().with_text(
+                                            format!("Ran into this error trying to compact: {e}.\n\nPlease try again or create a new session")
+                                        )
+                                    );
                                     break;
                                 }
                             }


### PR DESCRIPTION
## Summary
When compaction fails, the user sees "Compacting to continue conversation..." with a thinking indicator, then the stream ends with no follow-up. The user is left with a stalled thinking spinner and no indication that compaction failed.

Emit a message explaining the failure and suggesting they retry or start a new session.
