### PR TITLE
fix(openai): use Responses API for gpt-5.4

### DIFF
--- a/crates/goose/src/providers/openai.rs
+++ b/crates/goose/src/providers/openai.rs
@@ -233,6 +233,7 @@ impl OpenAiProvider {
         let normalized_model = model_name.to_ascii_lowercase();
         (normalized_model.starts_with("gpt-5") && normalized_model.contains("codex"))
             || normalized_model.starts_with("gpt-5.2-pro")
+            || normalized_model.starts_with("gpt-5.4")
     }
 
     fn should_use_responses_api(model_name: &str, base_path: &str) -> bool {
@@ -725,6 +726,22 @@ mod tests {
         assert!(!OpenAiProvider::should_use_responses_api(
             "gpt-5.2-codex",
             "openai/v1/chat/completions"
+        ));
+    }
+
+    #[test]
+    fn gpt_5_4_uses_responses_when_base_path_is_default() {
+        assert!(OpenAiProvider::should_use_responses_api(
+            "gpt-5.4",
+            "v1/chat/completions"
+        ));
+    }
+
+    #[test]
+    fn gpt_5_4_with_date_uses_responses() {
+        assert!(OpenAiProvider::should_use_responses_api(
+            "gpt-5.4-2026-03-01",
+            "v1/chat/completions"
         ));
     }
 


### PR DESCRIPTION
## Summary
- route `gpt-5.4*` models through OpenAI `/v1/responses` by default
- keep existing base-path override behavior intact
- add tests covering `gpt-5.4` and date-suffixed variants

## Why
OpenAI rejects function tools + `reasoning_effort` for `gpt-5.4` on `/v1/chat/completions` and requires `/v1/responses`.

## Changes
- `OpenAiProvider::is_responses_model` now treats `gpt-5.4*` as Responses models
- Added unit tests:
  - `gpt_5_4_uses_responses_when_base_path_is_default`
  - `gpt_5_4_with_date_uses_responses`

## Validation
- `cargo fmt` ✅
- `cargo test -p goose openai::tests` ⚠️ blocked in this environment due toolchain/dependency mismatch:
  - rustc `1.90.0`
  - `aws-smithy-async@1.2.14` and `aws-smithy-xml@0.60.15` require rustc `1.91.1`
- `cargo clippy --all-targets -- -D warnings` ⚠️ same blocker

## Notes
I only patched `gpt-5.4*` as requested. There may be other future GPT-5 chat variants that also require `/v1/responses`, but this PR intentionally keeps scope narrow.
