### PR TITLE
fix: SSE reconnect followup - reset refs, prevent duplication, sort active requests

### DIFF
--- a/ui/desktop/src/hooks/useChatStream.ts
+++ b/ui/desktop/src/hooks/useChatStream.ts
@@ -373,9 +373,11 @@ export function useChatStream({
   const reloadingConversationRef = useRef(false);
   const namePollingRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // Ref to access latest state in callbacks (avoids stale closures)
+  // Ref to access latest state/sessionId in callbacks (avoids stale closures)
   const stateRef = useRef(state);
   stateRef.current = state;
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
   const doReattachRef = useRef<((requestId: string, messages: Message[]) => void) | null>(null);
 
   useEffect(() => {
@@ -471,10 +473,17 @@ export function useChatStream({
     // Suppress reattach until the reload completes
     reloadingConversationRef.current = true;
 
+    // Capture the session ID so we can guard against session switches
+    // that happen while getSession is in flight.
+    const reloadSessionId = sessionId;
+
     getSession({
-      path: { session_id: sessionId },
+      path: { session_id: reloadSessionId },
       throwOnError: true,
     }).then((response) => {
+      // Session switched while we were reloading — discard stale result
+      if (reloadSessionId !== sessionIdRef.current) return;
+
       const session = response.data as Session;
       const messages = session?.conversation || [];
       if (messages.length > 0) {
@@ -490,6 +499,13 @@ export function useChatStream({
     }).catch((e) => {
       console.warn('Failed to reload conversation after buffer overflow:', e);
       reloadingConversationRef.current = false;
+      // Best-effort recovery: if ActiveRequests arrived during the failed
+      // reload, reattach with current messages so the reply isn't lost.
+      if (reloadSessionId !== sessionIdRef.current) return;
+      const pendingRequestId = pendingReattachRequestIdRef.current;
+      if (pendingRequestId) {
+        doReattachRef.current?.(pendingRequestId, stateRef.current.messages);
+      }
     });
   }, [sessionId]);
 


### PR DESCRIPTION
## Summary
Follow-up fixes to #7834 (SSE reconnect):

- **Reset request-tracking refs on session switch** — clear all active/pending/buffer refs in the session-load effect cleanup so switching sessions doesn't leak state from the previous session's in-flight request
- **Prevent overflow duplication** — clear active request state in `reloadConversation` so the SSE reconnect doesn't reattach and replay deltas on top of the freshly-loaded conversation after a buffer overflow
- **Sort ActiveRequests by ID** — use lexicographic sort on uuidv7 IDs to always pick the newest reply, not an arbitrary HashMap key order