### PR TITLE
fix(ui): auto-focus chat input on Hub mount

### DIFF
--- a/ui/desktop/src/components/Hub.tsx
+++ b/ui/desktop/src/components/Hub.tsx
@@ -41,12 +41,8 @@ export default function Hub({
   const [isCreatingSession, setIsCreatingSession] = useState(false);
   const inputRef = useRef<HTMLTextAreaElement>(null);
 
-  // Focus the chat input immediately after mount so users can start typing
-  // without tabbing through navigation and session elements first.
+  // rAF is more reliable than autoFocus across async render boundaries (Suspense, OnboardingGuard, etc.)
   useEffect(() => {
-    // Use requestAnimationFrame to ensure the DOM has fully painted
-    // before focusing — more reliable than autoFocus across async
-    // render boundaries (Suspense, OnboardingGuard, etc.).
     const frameId = requestAnimationFrame(() => {
       inputRef.current?.focus();
     });


### PR DESCRIPTION
## Problem

Opening a new Goose window requires **~12 Tab presses** to reach the chat input. The textarea has `autoFocus` but it's unreliable across the async render chain:

```
renderer.tsx (lazy App) → Suspense → OnboardingGuard (async provider check) → AppLayout → Hub → ChatInput → textarea
```

By the time the textarea mounts and `autoFocus` fires, focus can be lost to re-renders or stolen by earlier elements in the tab order (7 nav buttons + session insight cards).

Related: #5039 — the original input-disabled bug was fixed, but the render chain change that fixed it introduced this focus regression. Different root cause (focus timing vs disabled state), same UX priority: the input must be ready to type on window open.

## Fix

Pass an `inputRef` from Hub to ChatInput and imperatively focus it via `useEffect` + `requestAnimationFrame` after mount. This fires after the DOM has fully painted, making it reliable regardless of the async render chain.

**1 file changed, +15 −1 lines.**

## Testing

- Open a new Goose window → cursor is in the chat input, ready to type
- Navigate away and back to Hub → input re-focuses
- Typecheck: `tsc --noEmit` ✅
- Lint: `eslint src/components/Hub.tsx` ✅