### PR TITLE
feat: filter tools by MCP Apps visibility metadata

### DIFF
--- a/crates/goose-server/src/routes/agent.rs
+++ b/crates/goose-server/src/routes/agent.rs
@@ -14,6 +14,7 @@ use goose::agents::{Container, ExtensionLoadResult};
 use goose::goose_apps::{fetch_mcp_apps, GooseApp, McpAppCache};
 
 use base64::Engine;
+use goose::agents::reply_parts::is_tool_visible_to_app;
 use goose::agents::ExtensionConfig;
 use goose::config::resolve_extensions_for_new_session;
 use goose::config::{Config, GooseMode};
@@ -1046,6 +1047,18 @@ async fn call_tool(
     let agent = state
         .get_agent_for_route(payload.session_id.clone())
         .await?;
+
+    // Check app-side visibility: reject calls to tools that exclude "app"
+    let tools = agent.list_tools(&payload.session_id, None).await;
+    if let Some(tool) = tools.iter().find(|t| *t.name == payload.name) {
+        if !is_tool_visible_to_app(tool) {
+            warn!(
+                tool = %payload.name,
+                "Rejected app call to model-only tool"
+            );
+            return Err(StatusCode::FORBIDDEN);
+        }
+    }
 
     let arguments = match payload.arguments {
         Value::Object(map) => Some(map),

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -1920,14 +1920,17 @@ impl Agent {
             .build();
 
         let recipe_prompt = prompt_manager.get_recipe_prompt().await;
-        let tools = self
+        let tools: Vec<_> = self
             .extension_manager
             .get_prefixed_tools(session_id, None)
             .await
             .map_err(|e| {
                 tracing::error!("Failed to get tools for recipe creation: {}", e);
                 e
-            })?;
+            })?
+            .into_iter()
+            .filter(super::reply_parts::is_tool_visible_to_model)
+            .collect();
 
         messages.push(Message::user().with_text(recipe_prompt));
 

--- a/crates/goose/src/agents/mod.rs
+++ b/crates/goose/src/agents/mod.rs
@@ -12,7 +12,7 @@ pub mod moim;
 pub mod platform_extensions;
 pub mod platform_tools;
 pub mod prompt_manager;
-mod reply_parts;
+pub mod reply_parts;
 pub mod retry;
 mod schedule_tool;
 pub mod subagent_execution_tool;

--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -201,6 +201,10 @@ impl Agent {
                 .collect();
         }
 
+        // Filter out tools not visible to the model per MCP Apps visibility spec.
+        // Tools with `_meta.ui.visibility` that doesn't include "model" are app-only.
+        tools.retain(is_tool_visible_to_model);
+
         // Stable tool ordering is important for multi session prompt caching.
         tools.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -470,6 +474,48 @@ impl Agent {
     }
 }
 
+/// Check whether a tool should be callable by an app based on MCP Apps visibility metadata.
+///
+/// Per the MCP Apps spec (2026-01-26), if `_meta.ui.visibility` is present and does not
+/// include `"app"`, the tool is model-only and must not be callable by app UIs.
+/// If the field is absent, the tool defaults to visible to both model and app.
+pub fn is_tool_visible_to_app(tool: &Tool) -> bool {
+    let Some(meta) = &tool.meta else {
+        return true;
+    };
+    let Some(ui) = meta.0.get("ui") else {
+        return true;
+    };
+    let Some(visibility) = ui.get("visibility") else {
+        return true;
+    };
+    let Some(arr) = visibility.as_array() else {
+        return true;
+    };
+    arr.iter().any(|v| v.as_str() == Some("app"))
+}
+
+/// Check whether a tool should be visible to the model based on MCP Apps visibility metadata.
+///
+/// Per the MCP Apps spec (2026-01-26), tools may declare `_meta.ui.visibility` as an array
+/// of `"model"` and/or `"app"`. If the field is absent, the tool defaults to visible to both.
+/// If present and does not include `"model"`, the tool is app-only and must not be sent to the LLM.
+pub fn is_tool_visible_to_model(tool: &Tool) -> bool {
+    let Some(meta) = &tool.meta else {
+        return true;
+    };
+    let Some(ui) = meta.0.get("ui") else {
+        return true;
+    };
+    let Some(visibility) = ui.get("visibility") else {
+        return true;
+    };
+    let Some(arr) = visibility.as_array() else {
+        return true;
+    };
+    arr.iter().any(|v| v.as_str() == Some("model"))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -613,5 +659,98 @@ mod tests {
             error_seen,
             "Error should have been propagated, not silently ignored"
         );
+    }
+
+    fn make_tool_with_meta(meta_json: Option<serde_json::Value>) -> Tool {
+        let mut tool = Tool::new("test_tool", "a test tool", object!({ "type": "object" }));
+        if let Some(v) = meta_json {
+            let obj = v.as_object().unwrap().clone();
+            tool = tool.with_meta(rmcp::model::Meta(obj));
+        }
+        tool
+    }
+
+    #[test]
+    fn test_tool_visible_when_no_meta() {
+        let tool = make_tool_with_meta(None);
+        assert!(is_tool_visible_to_model(&tool));
+    }
+
+    #[test]
+    fn test_tool_visible_when_meta_has_no_ui() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"other": "stuff"})));
+        assert!(is_tool_visible_to_model(&tool));
+    }
+
+    #[test]
+    fn test_tool_visible_when_ui_has_no_visibility() {
+        let tool = make_tool_with_meta(Some(
+            serde_json::json!({"ui": {"resourceUri": "ui://foo/bar"}}),
+        ));
+        assert!(is_tool_visible_to_model(&tool));
+    }
+
+    #[test]
+    fn test_tool_visible_when_visibility_includes_model() {
+        let tool = make_tool_with_meta(Some(
+            serde_json::json!({"ui": {"visibility": ["model", "app"]}}),
+        ));
+        assert!(is_tool_visible_to_model(&tool));
+    }
+
+    #[test]
+    fn test_tool_visible_when_visibility_is_model_only() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": ["model"]}})));
+        assert!(is_tool_visible_to_model(&tool));
+    }
+
+    #[test]
+    fn test_tool_hidden_when_visibility_is_app_only() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": ["app"]}})));
+        assert!(!is_tool_visible_to_model(&tool));
+    }
+
+    #[test]
+    fn test_tool_hidden_when_visibility_is_empty() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": []}})));
+        assert!(!is_tool_visible_to_model(&tool));
+    }
+
+    #[test]
+    fn test_tool_visible_when_visibility_is_not_array() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": "model"}})));
+        assert!(is_tool_visible_to_model(&tool));
+    }
+
+    #[test]
+    fn test_app_visible_when_no_meta() {
+        let tool = make_tool_with_meta(None);
+        assert!(is_tool_visible_to_app(&tool));
+    }
+
+    #[test]
+    fn test_app_visible_when_visibility_includes_app() {
+        let tool = make_tool_with_meta(Some(
+            serde_json::json!({"ui": {"visibility": ["model", "app"]}}),
+        ));
+        assert!(is_tool_visible_to_app(&tool));
+    }
+
+    #[test]
+    fn test_app_visible_when_visibility_is_app_only() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": ["app"]}})));
+        assert!(is_tool_visible_to_app(&tool));
+    }
+
+    #[test]
+    fn test_app_hidden_when_visibility_is_model_only() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": ["model"]}})));
+        assert!(!is_tool_visible_to_app(&tool));
+    }
+
+    #[test]
+    fn test_app_hidden_when_visibility_is_empty() {
+        let tool = make_tool_with_meta(Some(serde_json::json!({"ui": {"visibility": []}})));
+        assert!(!is_tool_visible_to_app(&tool));
     }
 }

--- a/crates/goose/src/agents/subagent_handler.rs
+++ b/crates/goose/src/agents/subagent_handler.rs
@@ -231,7 +231,12 @@ async fn build_subagent_prompt(
     session_id: &str,
     system_instructions: String,
 ) -> Result<String> {
-    let tools = agent.list_tools(session_id, None).await;
+    let tools: Vec<_> = agent
+        .list_tools(session_id, None)
+        .await
+        .into_iter()
+        .filter(super::reply_parts::is_tool_visible_to_model)
+        .collect();
     render_template(
         "subagent_system.md",
         &SubagentPromptContext {


### PR DESCRIPTION
## Summary

Per the [MCP Apps spec (2026-01-26)](https://github.com/modelcontextprotocol/ext-apps/blob/main/specification/2026-01-26/apps.mdx), tools may declare `_meta.ui.visibility` as an array of `"model"` and/or `"app"`. This PR enforces visibility in both directions.

### Changes

**`crates/goose/src/agents/reply_parts.rs`**

- Added `is_tool_visible_to_model(tool)` — returns `false` when `_meta.ui.visibility` is present but doesn't include `"model"`. Used to filter tools before they reach the LLM.
- Added `is_tool_visible_to_app(tool)` — returns `false` when `_meta.ui.visibility` is present but doesn't include `"app"`. Used to reject app-originated tool calls to model-only tools.
- Both default to visible when the field is absent (per spec default: `["model", "app"]`).
- Made `reply_parts` module public so the server crate can use these helpers.

**`crates/goose/src/agents/subagent_handler.rs`**

- Tool names rendered into the subagent system prompt are now filtered through `is_tool_visible_to_model`, preventing app-only tool names from leaking into subagent prompts.

**`crates/goose-server/src/routes/agent.rs`**

- The `/agent/call_tool` route now checks `is_tool_visible_to_app` before dispatching. Calls to model-only tools from app UIs return `403 Forbidden`.

### Tests (13 new)

**Model visibility (8 tests)**

| Test | Asserts |
|---|---|
| `no_meta` | Visible ✅ |
| `meta_has_no_ui` | Visible ✅ |
| `ui_has_no_visibility` | Visible ✅ |
| `visibility_includes_model` | Visible ✅ |
| `visibility_is_model_only` | Visible ✅ |
| `visibility_is_app_only` | **Hidden** 🚫 |
| `visibility_is_empty` | **Hidden** 🚫 |
| `visibility_is_not_array` (malformed) | Visible ✅ (graceful fallback) |

**App visibility (5 tests)**

| Test | Asserts |
|---|---|
| `app_visible_when_no_meta` | Callable ✅ |
| `app_visible_when_visibility_includes_app` | Callable ✅ |
| `app_visible_when_visibility_is_app_only` | Callable ✅ |
| `app_hidden_when_visibility_is_model_only` | **Rejected** 🚫 |
| `app_hidden_when_visibility_is_empty` | **Rejected** 🚫 |

---

### Manual Testing

Connect to the [MCP App Bench](https://mcp-app-bench.onrender.com) server, which includes a **Visibility Inspector** with four test tools at different visibility levels.

**Setup:** Add the bench as a Streamable HTTP extension:
```
https://mcp-app-bench.onrender.com/mcp
```

**Test model-side filtering:**

1. Ask the model: *"What tools do you have that start with `visibility-`?"*
2. The model should list these tools:

| Tool | `_meta.ui.visibility` | Model sees it? |
|---|---|---|
| `visibility-both` | `["model", "app"]` | ✅ Yes |
| `visibility-model-only` | `["model"]` | ✅ Yes |
| `visibility-default` | *(absent)* | ✅ Yes |
| `visibility-app-only` | `["app"]` | 🚫 **No** |

3. Ask the model to call `visibility-app-only` — it should not know about it.

**Test app-side filtering:**

1. Ask the model to run `inspect-visibility` to open the Visibility Inspector UI.
2. Click the **"Call visibility-app-only"** button — this calls the tool directly from the app UI and should succeed.
3. A model-only tool called from the app UI would return 403 Forbidden.

Closes #7467