### PR TITLE
fix: enable Discord notifications for release announcements

### DIFF
--- a/.github/workflows/goose-release-notes.yml
+++ b/.github/workflows/goose-release-notes.yml
@@ -214,7 +214,7 @@ jobs:
             response=$(curl -s -X POST "https://discord.com/api/v10/channels/${channel}/messages" \
               -H "Authorization: Bot ${DISCORD_BOT_TOKEN}" \
               -H "Content-Type: application/json" \
-              -d "{\"content\": $content, \"flags\": 4}")
+              -d "{\"content\": $content, \"flags\": 4, \"allowed_mentions\": {\"parse\": [\"everyone\"]}}")
 
             # Debug: show response if there's an error
             if echo "$response" | jq -e '.code' > /dev/null 2>&1; then


### PR DESCRIPTION
Remove `SUPPRESS_NOTIFICATIONS` flag (`flags: 4`) so `@everyone` mentions actually ping users when new releases are posted.

This flag was likely added during development/testing to avoid spamming during debugging, but was left in accidentally.