### PR TITLE
fix(ci): produce .tar.gz archives for Zed ACP registry compatibility

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -144,7 +144,6 @@ jobs:
           # Copy the goose binary
           cp "target/${TARGET}/release/goose" "target/${TARGET}/release/goose-package/"
 
-          # Create the tar archives (bz2 for backward compat, gz for Zed/ACP registry compat)
           cd "target/${TARGET}/release"
           tar -cjf "goose-${TARGET}.tar.bz2" -C goose-package .
           tar -czf "goose-${TARGET}.tar.gz" -C goose-package .
@@ -163,7 +162,7 @@ jobs:
 
           cd "target/${TARGET}/release"
           7z a -tzip "goose-${TARGET}.zip" goose-package/
-          echo "ARTIFACT=target/${TARGET}/release/goose-${TARGET}.zip" >> $GITHUB_ENV
+          echo "ARTIFACT_ZIP=target/${TARGET}/release/goose-${TARGET}.zip" >> $GITHUB_ENV
 
       - name: Upload CLI artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f  # v6.0.0
@@ -172,4 +171,5 @@ jobs:
           path: |
             ${{ env.ARTIFACT_BZ2 }}
             ${{ env.ARTIFACT_GZ }}
-            ${{ env.ARTIFACT }}
+            ${{ env.ARTIFACT_ZIP }}
+

--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -134,6 +134,7 @@ jobs:
         with:
           subject-path: |
             goose-*.tar.bz2
+            goose-*.tar.gz
             Goose*.zip
             *.deb
             *.rpm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,7 @@ jobs:
         with:
           subject-path: |
             goose-*.tar.bz2
+            goose-*.tar.gz
             goose-*.zip
             Goose*.zip
             *.deb


### PR DESCRIPTION
## Summary

- Adds `.tar.gz` archive output alongside the existing `.tar.bz2` for Linux/macOS CLI builds
- Updates all release workflows (release, nightly, canary) to include `goose-*.tar.gz` in published artifacts

## Problem

Zed's agent server store ([`agent_server_store.rs`](https://github.com/zed-industries/zed/blob/main/crates/project/src/agent_server_store.rs)) only supports `.tar.gz`, `.tgz`, and `.zip` when downloading agent binaries:

```rust
let asset_kind = if archive_url.ends_with(".zip") {
    AssetKind::Zip
} else if archive_url.ends_with(".tar.gz") || archive_url.ends_with(".tgz") {
    AssetKind::TarGz
} else {
    anyhow::bail!("unsupported archive type in URL: {}", archive_url);
};
```

Goose currently only publishes `.tar.bz2` for Linux/macOS, causing Zed users to get `"unsupported archive type in URL"` when installing Goose via the ACP registry.

## Solution

Produce **both** `.tar.bz2` (backward compat) and `.tar.gz` (Zed compat) in the build pipeline. This is a minimal change — one extra `tar` command in `build-cli.yml` and glob additions in the release workflows.

Once merged and released, the ACP registry entry for Goose can be updated to point to the `.tar.gz` URLs.

## Test plan

- [ ] Verify CI builds produce both `.tar.bz2` and `.tar.gz` artifacts
- [ ] Verify release assets include both archive formats
- [ ] After ACP registry update, verify Zed can install Goose via registry method

Closes #8047

🤖 Generated with [Claude Code](https://claude.com/claude-code)