### PR TITLE
docs: add vmware-aiops MCP extension documentation

### DIFF
--- a/documentation/docs/mcp/vmware-aiops-mcp.md
+++ b/documentation/docs/mcp/vmware-aiops-mcp.md
@@ -68,8 +68,9 @@ vmware-aiops doctor
       extensionName="VMware AIops"
       description="Natural language VMware vCenter/ESXi monitoring and operations"
       type="stdio"
-      command="python"
-      args={["-m", "mcp_server"]}
+      command="uvx"
+      args={["--from", "vmware-aiops", "vmware-aiops-mcp"]}
+      timeout={300}
       envVars={[
         { name: "VMWARE_AIOPS_CONFIG", label: "Path to config.yaml (e.g. /Users/you/.vmware-aiops/config.yaml)" }
       ]}
@@ -80,7 +81,7 @@ vmware-aiops doctor
       name="vmware-aiops"
       description="Natural language VMware vCenter/ESXi monitoring and operations"
       type="stdio"
-      command="python -m mcp_server"
+      command="uvx --from vmware-aiops vmware-aiops-mcp"
       timeout={300}
       envVars={[
         { key: "VMWARE_AIOPS_CONFIG", value: "/Users/you/.vmware-aiops/config.yaml" }


### PR DESCRIPTION
## Summary

Adds documentation for [vmware-aiops](https://github.com/zw008/VMware-AIops), an MCP server that enables natural language management of VMware vCenter/ESXi infrastructure via goose.

**What it does:**
- 32 MCP tools: VM lifecycle, deployment, guest operations, health monitoring, datastore browsing
- Plan → Apply orchestration (multi-step ops with automatic rollback)
- Guest Exec with stdout/stderr capture + OS auto-detection (Linux/Windows)
- Works with local models via Ollama (qwen2.5:32b recommended)

**Install:**
```sh
uv tool install vmware-aiops
vmware-aiops mcp-config install --agent goose
```

**Checklist:**
- [x] Follows the `_template_.mdx` structure (frontmatter, Quick Install, Configuration with tabs, Example Usage)
- [x] Includes both goose Desktop and goose CLI tabs
- [x] Realistic example prompt and output
- [x] DCO sign-off included (`git commit -s`)
- [x] File named `vmware-aiops-mcp.md` following existing convention

Signed-off-by: Wei Zhou <zw008@github.com>