### PR TITLE
recipe: Maverick — behavioral adaptation for Goose

### DIFF
--- a/documentation/src/pages/recipes/data/recipes/maverick-behavioral-adaptation.yaml
+++ b/documentation/src/pages/recipes/data/recipes/maverick-behavioral-adaptation.yaml
@@ -1,0 +1,59 @@
+version: 1.0.0
+title: "Maverick — Behavioral Adaptation"
+description: Adapts Goose to match your behavioral profile — pacing, tone, autonomy, and decision style adjust to how you think, not a one-size-fits-all default. Same model, different teammate.
+instructions: |
+  Maverick adds behavioral intelligence to Goose. On first use, it runs a quick
+  2-minute assessment (10 questions) to detect your behavioral profile across four
+  drives: Dominance, Extraversion, Patience, and Formality. Then it adapts Goose's
+  communication style to match.
+
+  Fast movers get short, decisive responses. Methodical thinkers get thorough
+  explanations with evidence. Team players get collaborative framing. Detail-oriented
+  builders get precise, data-backed responses.
+
+  Your profile is saved locally at ~/.maverick/profile.yaml. No cloud, no telemetry,
+  no accounts. Your data stays on your machine.
+
+  After assessment, you can also generate a shareable Developer Card — a visual
+  summary of your behavioral profile you can screenshot and share.
+extensions:
+- type: stdio
+  name: maverick
+  cmd: uvx
+  args:
+  - maverick-mcp
+  - serve
+  timeout: 300
+  description: Behavioral intelligence MCP server — detects developer profile and adapts agent behavior
+  bundled: false
+activities:
+- Detect developer behavioral profile via 10-question assessment
+- Adapt agent communication style, pacing, and autonomy to match profile
+- Generate shareable Developer Card visualization
+- Refine profile over time from interaction feedback
+prompt: |
+  You are now enhanced with behavioral intelligence via the Maverick extension.
+
+  At the start of this session, check if a behavioral profile exists by calling
+  maverick_profile. If no profile exists, offer to run a quick 2-minute assessment
+  by calling maverick_assess (no arguments to get the questions, then call again
+  with the answers to score).
+
+  Once a profile is detected, call maverick_adapt with the current task context
+  to get behavioral adaptation instructions. Follow those instructions for:
+  - Response length and detail level
+  - Autonomy level (how much to do vs ask permission)
+  - Communication tone and pacing
+  - Decision-making style (decisive vs consultative vs evidence-based)
+  - Checkpoint frequency (how often to check in)
+
+  After assessment, offer to generate a Developer Card by calling maverick_card.
+  This creates a shareable HTML visualization at ~/.maverick/card.html.
+
+  When the user gives feedback about your pacing, detail level, or autonomy,
+  call maverick_feedback to record it for profile refinement.
+
+  The goal is to feel like a real teammate who understands how this specific
+  person works — not a generic chatbot. Every Goose needs its Maverick.
+author:
+  contact: get-airlock


### PR DESCRIPTION
## Summary

Adds a recipe for [Maverick](https://github.com/get-airlock/maverick-mcp) — an MCP server that adapts Goose's communication style to match each developer's behavioral profile.

- **10-question assessment** detects working style across four drives (Dominance, Extraversion, Patience, Formality)
- **17 behavioral profiles** — from fast-moving Mavericks to methodical Guardians
- **Adaptive communication** — pacing, tone, autonomy, detail level, and decision style all adjust
- **Developer Card** — shareable HTML visualization of your profile
- **Local-only** — profile saved at `~/.maverick/`, zero telemetry, no accounts

Published on PyPI: `uvx maverick-mcp serve`

## How it works

\`\`\`
uvx maverick-mcp serve          # starts MCP server (stdio)
maverick assess                 # CLI: interactive assessment
maverick card                   # CLI: generate Developer Card
\`\`\`

The recipe uses \`uvx\` to run the server — no manual install needed.

## Test plan

- [x] Installed via \`uvx maverick-mcp serve\` and verified MCP tools respond
- [x] Assessment flow works end-to-end (questions → scoring → profile save)
- [x] Developer Card generates valid HTML at \`~/.maverick/card.html\`
- [x] 64 tests passing in upstream repo
- [x] Recipe YAML follows existing format conventions (modeled after \`search-datahub.yaml\`)

Every Goose needs its Maverick.