### PR TITLE
fix(recipe): correct Maverick recipe tool names, remove CLI-only card call, fix brand casing

### DIFF
--- a/documentation/src/pages/recipes/data/recipes/maverick-behavioral-adaptation.yaml
+++ b/documentation/src/pages/recipes/data/recipes/maverick-behavioral-adaptation.yaml
@@ -1,10 +1,10 @@
 version: 1.0.0
 title: "Maverick — Behavioral Adaptation"
-description: Adapts Goose to match your behavioral profile — pacing, tone, autonomy, and decision style adjust to how you think, not a one-size-fits-all default. Same model, different teammate.
+description: Adapts goose to match your behavioral profile — pacing, tone, autonomy, and decision style adjust to how you think, not a one-size-fits-all default. Same model, different teammate.
 instructions: |
-  Maverick adds behavioral intelligence to Goose. On first use, it runs a quick
+  Maverick adds behavioral intelligence to goose. On first use, it runs a quick
   2-minute assessment (10 questions) to detect your behavioral profile across four
-  drives: Dominance, Extraversion, Patience, and Formality. Then it adapts Goose's
+  drives: Dominance, Extraversion, Patience, and Formality. Then it adapts goose's
   communication style to match.
 
   Fast movers get short, decisive responses. Methodical thinkers get thorough
@@ -14,8 +14,9 @@ instructions: |
   Your profile is saved locally at ~/.maverick/profile.yaml. No cloud, no telemetry,
   no accounts. Your data stays on your machine.
 
-  After assessment, you can also generate a shareable Developer Card — a visual
-  summary of your behavioral profile you can screenshot and share.
+  After assessment, you can also generate a shareable Developer Card via the CLI
+  (`maverick card`) — a visual summary of your behavioral profile you can screenshot
+  and share.
 extensions:
 - type: stdio
   name: maverick
@@ -29,31 +30,27 @@ extensions:
 activities:
 - Detect developer behavioral profile via 10-question assessment
 - Adapt agent communication style, pacing, and autonomy to match profile
-- Generate shareable Developer Card visualization
 - Refine profile over time from interaction feedback
 prompt: |
   You are now enhanced with behavioral intelligence via the Maverick extension.
 
   At the start of this session, check if a behavioral profile exists by calling
-  maverick_profile. If no profile exists, offer to run a quick 2-minute assessment
-  by calling maverick_assess (no arguments to get the questions, then call again
-  with the answers to score).
+  maverick__maverick_profile. If no profile exists, offer to run a quick 2-minute
+  assessment by calling maverick__maverick_assess (no arguments to get the questions,
+  then call again with the answers to score).
 
-  Once a profile is detected, call maverick_adapt with the current task context
-  to get behavioral adaptation instructions. Follow those instructions for:
+  Once a profile is detected, call maverick__maverick_adapt with the current task
+  context to get behavioral adaptation instructions. Follow those instructions for:
   - Response length and detail level
   - Autonomy level (how much to do vs ask permission)
   - Communication tone and pacing
   - Decision-making style (decisive vs consultative vs evidence-based)
   - Checkpoint frequency (how often to check in)
 
-  After assessment, offer to generate a Developer Card by calling maverick_card.
-  This creates a shareable HTML visualization at ~/.maverick/card.html.
-
   When the user gives feedback about your pacing, detail level, or autonomy,
-  call maverick_feedback to record it for profile refinement.
+  call maverick__maverick_feedback to record it for profile refinement.
 
   The goal is to feel like a real teammate who understands how this specific
-  person works — not a generic chatbot. Every Goose needs its Maverick.
+  person works — not a generic chatbot. Every goose needs its Maverick.
 author:
   contact: get-airlock


### PR DESCRIPTION
Fixes for #8058 (authored by @smartrickpicks) — pushing here because the fork's maintainer-edits flag is set but the credential doesn't have access to that fork.

Closes #8058

## Changes

- **Prefix all MCP tool calls with `maverick__`** — goose exposes stdio extension tools as `<extension>__<tool>`; the original used bare names like `maverick_profile` which would fail at runtime with "Tool not found"
- **Remove `maverick_card` from the prompt** — that is a CLI command (`maverick card`), not an MCP tool; instructions now note it as a CLI command instead
- **Remove the Developer Card activity bullet** that implied it could be triggered via the agent
- **Replace `Goose` → `goose`** throughout (brand guideline for the documentation directory)