### PR TITLE
feat: add GOOSE_SHOW_FULL_OUTPUT config to disable tool output truncation

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -77,11 +77,7 @@ thread_local! {
             )
     );
     static SHOW_FULL_TOOL_OUTPUT: RefCell<bool> = RefCell::new(
-        std::env::var("GOOSE_SHOW_FULL_OUTPUT").ok()
-            .map(|val| val == "1" || val.eq_ignore_ascii_case("true"))
-            .unwrap_or_else(||
-                Config::global().get_param::<bool>("GOOSE_SHOW_FULL_OUTPUT").unwrap_or(false)
-            )
+        Config::global().get_param::<bool>("GOOSE_SHOW_FULL_OUTPUT").unwrap_or(false)
     );
 }
 


### PR DESCRIPTION
Closes #7919

Wires up the existing `SHOW_FULL_TOOL_OUTPUT` thread-local (previously hardcoded to `false`) to read from config/env at initialization.

When `GOOSE_SHOW_FULL_OUTPUT=true` is set (via environment variable or config file), tool call arguments are displayed in full instead of being truncated to terminal width. Useful for debugging tool calls with large arguments.

Co-authored-by: Dale Lakes <6843636+spitfire55@users.noreply.github.com>