### PR TITLE
Update tar version to avoid CVE-2026-33056

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9975,9 +9975,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -48,7 +48,7 @@ shlex = "1.3.0"
 async-trait = { workspace = true }
 base64 = { workspace = true }
 regex = { workspace = true }
-tar = "0.4"
+tar = "0.4.45"
 reqwest = { workspace = true, features = ["blocking", "rustls"], default-features = false }
 zip = { version = "^8.0", default-features = false, features = ["deflate"] }
 bzip2 = "0.5"


### PR DESCRIPTION

## Summary
<!-- Describe your change -->
We received a CVE report in downstream builds for tar <= 0.4.44 and the fix is present in >= 0.4.45, and to avoid the version being stuck on an old version, this patch updates the Cargo.toml to have tar >= 0.4.45

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

