### PR TITLE
fix: handle reasoning content blocks in OpenAI-compat streaming parser

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -58,7 +58,8 @@ enum DeltaContent {
 #[derive(Serialize, Deserialize, Debug)]
 struct ContentPart {
     r#type: String,
-    text: String,
+    #[serde(default)]
+    text: Option<String>,
     #[serde(rename = "thoughtSignature")]
     thought_signature: Option<String>,
 }
@@ -100,7 +101,7 @@ fn extract_content_and_signature(
 
             let text = text_parts
                 .iter()
-                .map(|p| p.text.as_str())
+                .filter_map(|p| p.text.as_deref())
                 .collect::<String>();
 
             let signature = text_parts


### PR DESCRIPTION
## Summary
Adaptive thinking (#7944) sends `thinking.type = "adaptive"` to Databricks for Claude 4.6 models, but the OpenAI-compat streaming parser can't deserialize the resulting reasoning chunks. This causes **all streaming responses to fail** for Claude Opus 4.6 and Sonnet 4.6 via Databricks.

## Root Cause
Databricks returns content blocks like `{"type":"reasoning","summary":[...]}` which lack a `text` field. `ContentPart` in `openai.rs` requires `text: String`, so serde deserialization fails with `data did not match any variant of untagged enum DeltaContent`.

## Fix
- Make `ContentPart.text` optional (`String` → `Option<String>` with `#[serde(default)]`)
- Update `extract_content_and_signature` to use `filter_map` + `as_deref()` for the now-optional text

Reasoning content parts are already filtered out by the existing `filter(|p| p.r#type == "text")`, so they don't affect text extraction. Reasoning is captured separately via `Delta.reasoning_content` / `Delta.reasoning_details`.

Fixes #8077