### PR TITLE
fix: recursively discover nested skills under configured roots

### DIFF
--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -269,8 +269,7 @@ fn walk_files_recursively<F, G>(
     visited_dirs: &mut HashSet<PathBuf>,
     should_descend: &mut G,
     visit_file: &mut F,
-)
-where
+) where
     F: FnMut(&Path),
     G: FnMut(&Path) -> bool,
 {
@@ -2186,7 +2185,9 @@ You review code."#;
         let sources = client.discover_filesystem_sources(temp_dir.path());
 
         let root_skill = sources.iter().find(|s| s.name == "root-skill").unwrap();
-        assert!(root_skill.supporting_files.contains(&root_skill_dir.join("README.md")));
+        assert!(root_skill
+            .supporting_files
+            .contains(&root_skill_dir.join("README.md")));
         assert!(!root_skill
             .supporting_files
             .contains(&nested_skill_dir.join("SKILL.md")));


### PR DESCRIPTION
## Summary
- update summon skill discovery to recursively find `SKILL.md` files under the existing configured skill roots
- support nested skill catalogs and root-level skill manifests, not just `<root>/<skill-name>/SKILL.md`
- recursively collect supporting files within skill directories and add coverage for nested discovery cases

## Why
Goose currently expects a very strict skill directory layout, which causes it to miss valid skills stored in catalog-style trees such as `~/.claude/skills/catalog/.../SKILL.md` or at the root like `~/.claude/skills/SKILL.md`.

That makes Goose less compatible with shared skill repositories and less seamless than other agents that can understand skills from broader layouts inside the same documented skill roots.

## What Changed
- changed `scan_skills_from_dir()` in `crates/goose/src/agents/platform_extensions/summon.rs` to recursively discover `SKILL.md` files under each configured skills root
- treat each discovered file’s parent directory as the skill directory
- updated `find_supporting_files()` to recurse through the full skill directory instead of only one subdirectory level
- added tests for:
  - nested `.claude/skills/catalog/.../SKILL.md` discovery
  - root-level `.claude/skills/SKILL.md` discovery
  - nested supporting files inside a skill directory

## Scope
This does not change which top-level directories Goose searches for skills. It remains limited to the documented roots such as:
- `./.goose/skills`
- `./.claude/skills`
- `./.agents/skills`
- `~/.config/goose/skills`
- `~/.claude/skills`
- `~/.config/agents/skills`

The only behavior change is that Goose now discovers skills recursively within those roots.

## Validation
- ran `cargo test -p goose agents::platform_extensions::summon::tests`
- all summon extension tests passed

## Notes
- this change is intended to improve compatibility with real-world skill repositories and catalog layouts without changing skill precedence or the configured search roots