### PR TITLE
Fix version bump

### DIFF
--- a/.github/workflows/bundle-desktop-intel.yml
+++ b/.github/workflows/bundle-desktop-intel.yml
@@ -62,7 +62,7 @@ jobs:
           # Update version in package.json
           source ./bin/activate-hermit
           cd ui/desktop
-          pnpm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
+          npm pkg set "version=${{ inputs.version }}"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2

--- a/.github/workflows/bundle-desktop-linux.yml
+++ b/.github/workflows/bundle-desktop-linux.yml
@@ -39,7 +39,7 @@ jobs:
           # Update version in package.json
           source ./bin/activate-hermit
           cd ui/desktop
-          pnpm version ${{ inputs.version }} --no-git-tag-version --allow-same-version
+          npm pkg set "version=${{ inputs.version }}"
 
       - name: Debug workflow info
         env:

--- a/.github/workflows/bundle-desktop.yml
+++ b/.github/workflows/bundle-desktop.yml
@@ -107,7 +107,7 @@ jobs:
           source ./bin/activate-hermit
           # Update version in package.json 
           cd ui/desktop
-          pnpm version "${VERSION}" --no-git-tag-version --allow-same-version
+          npm pkg set "version=${VERSION}"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2

--- a/Justfile
+++ b/Justfile
@@ -328,7 +328,7 @@ get-prior-version version:
 bump-version version:
     @just validate {{ version }} || exit 1
     @uvx --from=toml-cli toml set --toml-path=Cargo.toml "workspace.package.version" {{ version }}
-    @cd ui/desktop && pnpm version {{ version }} --no-git-tag-version --allow-same-version
+    @cd ui/desktop && npm pkg set "version={{ version }}"
     # update Cargo.lock after bumping versions in Cargo.toml
     @cargo update --workspace
     @just set-openapi-version {{ version }}


### PR DESCRIPTION
The workspace references aren't compatible with `npm version`

(see: https://github.com/block/goose/actions/runs/23467107182/job/68281562617)