### PR TITLE
chore: ignore unmaintained warning for proc-macro-error

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -5,3 +5,9 @@ yanked = "deny"
 # Emulate cargo-audit which only checks vulnerabilities and yanked crates, not unmaintained/unsound.
 unmaintained = "none"
 unsound = "none"
+
+# Ignore proc-macro-error unmaintained warning
+# See: https://github.com/block/goose/issues/7008
+ignore = [
+    "RUSTSEC-2024-0370",  # proc-macro-error is unmaintained
+]


### PR DESCRIPTION
Ignores #7008 which seems reasonable as it's "unmaintained" and not actually a vuln