### PR TITLE
fix: clarify that sandbox functions are only callable via execute_typescript

### DIFF
--- a/crates/goose/src/agents/platform_extensions/code_execution.rs
+++ b/crates/goose/src/agents/platform_extensions/code_execution.rs
@@ -478,15 +478,21 @@ impl McpClientTrait for CodeExecutionClient {
 
         let disclosure_style_moim = match self.disclosure {
             ToolDisclosure::Catalog => {
-                let available_fns: Vec<_> = code_mode
-                    .list_functions()
-                    .functions
+                let functions = code_mode.list_functions().functions;
+                let sandbox_only: Vec<_> = functions
                     .iter()
+                    .filter(|f| !crate::agents::extension_manager::is_first_class_extension(&f.namespace))
                     .map(|f| format!("{}.{}", &f.namespace, &f.name))
                     .collect();
-                format!("Available functions: {}
-
-                Use the list_functions & get_function_details tools to see tool signatures and input/output types before calling execute_typescript.", available_fns.join(", "))
+                let mut msg = String::new();
+                if !sandbox_only.is_empty() {
+                    msg.push_str(&format!(
+                        "Additional functions available ONLY via execute_typescript (do NOT call these as direct tool calls): {}",
+                        sandbox_only.join(", ")
+                    ));
+                }
+                msg.push_str("\n\n                Use the list_functions & get_function_details tools to see tool signatures and input/output types before calling execute_typescript.");
+                msg
             }
             ToolDisclosure::Filesystem => {
                 let available_filepaths: Vec<_> = code_mode


### PR DESCRIPTION
The MOIM info-msg lists sandbox functions (Todo.todoWrite, Autovisualiser.renderMermaid, etc.) as "Available functions" with no indication they can't be called directly. Models attempt direct tool calls, which fail with `-32002: Tool not found`.

Uses `is_first_class_extension()` to filter the function list. Extensions with `unprefixed_tools=true` (Developer, Analyze) have their tools registered as direct top-level tools and are excluded from the sandbox-only label. Only functions from non-first-class extensions are labeled as execute_typescript-only.