### PR TITLE
feat: allow GOOSE_CLI_SHOW_THINKING to be set in config.yaml

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -17,7 +17,6 @@ use std::cell::RefCell;
 use std::collections::HashMap;
 use std::io::{Error, IsTerminal, Write};
 use std::path::Path;
-use std::sync::LazyLock;
 use std::time::Duration;
 
 use super::streaming_buffer::MarkdownBuffer;
@@ -446,16 +445,11 @@ pub fn goose_mode_message(text: &str) {
     println!("\n{}", style(text).yellow(),);
 }
 
-static SHOW_THINKING: LazyLock<bool> = LazyLock::new(|| {
-    let from_env = std::env::var("GOOSE_CLI_SHOW_THINKING").is_ok();
-    let from_config = Config::global()
-        .get_param::<bool>("GOOSE_CLI_SHOW_THINKING")
-        .unwrap_or(false);
-    (from_env || from_config) && std::io::stdout().is_terminal()
-});
-
 fn should_show_thinking() -> bool {
-    *SHOW_THINKING
+    Config::global()
+        .get_param::<bool>("GOOSE_CLI_SHOW_THINKING")
+        .unwrap_or(false)
+        && std::io::stdout().is_terminal()
 }
 
 fn render_thinking(text: &str, theme: Theme) {


### PR DESCRIPTION
Previously `GOOSE_CLI_SHOW_THINKING` could only be set as an environment variable. Now it can also be set in config.yaml as a boolean, matching how other goose settings work.