### PR TITLE
perf(acp): parallelize extension loading in ACP server

### DIFF
--- a/crates/goose-acp/src/server.rs
+++ b/crates/goose-acp/src/server.rs
@@ -479,12 +479,10 @@ impl GooseAcpAgent {
         let skip_developer = acp_developer.is_some();
         let sid_str = session_id.map(|s| s.0.to_string());
 
-        // Filter out the developer extension (handled separately via ACP client)
         if skip_developer {
             extensions.retain(|ext| ext.name() != "developer");
         }
 
-        // Load all extensions in parallel
         let ext_manager = &agent.extension_manager;
         let extension_futures = extensions
             .into_iter()
@@ -947,7 +945,6 @@ impl GooseAcpAgent {
         mcp_servers: Vec<McpServer>,
         session_id: &str,
     ) -> Result<(), sacp::Error> {
-        // Phase 1: Convert all configs sequentially (fast, pure computation, fail-fast)
         let mut configs = Vec::with_capacity(mcp_servers.len());
         for mcp_server in mcp_servers {
             let config = match mcp_server_to_extension_config(mcp_server) {
@@ -963,8 +960,10 @@ impl GooseAcpAgent {
             return Ok(());
         }
 
-        // Phase 2: Load all extensions in parallel, persist state once
-        let results = agent.add_extensions_bulk(configs, session_id).await;
+        let results = agent
+            .add_extensions_bulk(configs, session_id)
+            .await
+            .map_err(|e| sacp::Error::internal_error().data(e.to_string()))?;
         for result in &results {
             if !result.success {
                 let error_msg = result.error.as_deref().unwrap_or("unknown error");

--- a/crates/goose/src/agents/agent.rs
+++ b/crates/goose/src/agents/agent.rs
@@ -767,9 +767,7 @@ impl Agent {
         self: &Arc<Self>,
         extensions: Vec<ExtensionConfig>,
         session_id: &str,
-    ) -> Vec<ExtensionLoadResult> {
-        // Resolve session working_dir and container once, before spawning futures,
-        // so each future doesn't re-acquire the container lock.
+    ) -> anyhow::Result<Vec<ExtensionLoadResult>> {
         let working_dir = match self
             .config
             .session_manager
@@ -819,14 +817,11 @@ impl Agent {
 
         let results = futures::future::join_all(extension_futures).await;
 
-        // Persist once after all extensions are loaded
         if results.iter().any(|r| r.success) {
-            if let Err(e) = self.persist_extension_state(session_id).await {
-                warn!("Failed to persist extension state after bulk load: {}", e);
-            }
+            self.persist_extension_state(session_id).await?;
         }
 
-        results
+        Ok(results)
     }
 
     async fn add_extension_inner(


### PR DESCRIPTION
## Summary

The ACP server loaded extensions sequentially in `create_agent_for_session` and `add_mcp_extensions`, making total startup time the sum of all extension init times. 
The CLI session builder (`builder.rs`) and session reload path (`load_extensions_from_session`) already parallelize extension loading, this PR brings the ACP server in line

Parallelize both paths using `futures::future::join_all`:

- **`create_agent_for_session`**: Load all platform extensions concurrently via
`ExtensionManager::add_extension`, keeping the developer extension sequential (it uses a special ACP-wrapped
 client)
- **`add_mcp_extensions`**: Split into sequential config conversion (fail-fast on bad config) and parallel
loading via a new `Agent::add_extensions_bulk()` method that resolves `working_dir` and `container` once
upfront to avoid lock contention, then persists extension state in a single transaction


### Testing
- `cargo check -p goose -p goose-acp` — compiles cleanly with no warnings
- Existing ACP server tests are unaffected


### Related Issues
N/A 


### Screenshots/Demos (for UX changes)
N/A