### PR TITLE
Fix goose update failing on Linux with ETXTBSY

### DIFF
--- a/download_cli.sh
+++ b/download_cli.sh
@@ -293,13 +293,20 @@ if [ "$OS" = "windows" ]; then
   mv "$EXTRACT_DIR/goose.exe" "$GOOSE_BIN_DIR/$OUT_FILE"
 else
   # On Linux, if the target binary is currently running, writing to it fails
-  # with ETXTBSY ("Text file busy"). Removing the file first releases the path
-  # while the running process keeps its inode reference, allowing the new
-  # binary to be placed at the same path.
+  # with ETXTBSY ("Text file busy"). Rename the old binary out of the way
+  # first, then move the new one in. If the move fails, restore the old binary
+  # so the user is never left without an executable.
   if [ -f "$GOOSE_BIN_DIR/$OUT_FILE" ]; then
-    rm -f "$GOOSE_BIN_DIR/$OUT_FILE"
+    mv "$GOOSE_BIN_DIR/$OUT_FILE" "$GOOSE_BIN_DIR/$OUT_FILE.old"
+    if ! mv "$EXTRACT_DIR/goose" "$GOOSE_BIN_DIR/$OUT_FILE"; then
+      echo "Error: failed to install new binary, restoring previous version"
+      mv "$GOOSE_BIN_DIR/$OUT_FILE.old" "$GOOSE_BIN_DIR/$OUT_FILE"
+      exit 1
+    fi
+    rm -f "$GOOSE_BIN_DIR/$OUT_FILE.old"
+  else
+    mv "$EXTRACT_DIR/goose" "$GOOSE_BIN_DIR/$OUT_FILE"
   fi
-  mv "$EXTRACT_DIR/goose" "$GOOSE_BIN_DIR/$OUT_FILE"
 fi
 
 # Copy Windows runtime DLLs if they exist


### PR DESCRIPTION
## Summary
- `goose update` fails on Linux with "Text file busy (os error 26)" when the download script tries to `mv` the new binary over the running one
- Root cause: `mv` across filesystems (e.g., `/tmp` to `~/.local/bin`) falls back to copy+unlink, which fails because Linux prohibits writing to a running executable
- Fix: remove the old binary before `mv` — the running process keeps its inode reference while the path is freed for the new binary

## Test plan
- [ ] CI passes
- [ ] On Linux, run `goose update` while goose is the running process — should succeed without ETXTBSY
- [ ] On macOS, `goose update` still works (the `rm` is harmless since macOS allows overwriting running binaries)
- [ ] Fresh install (no existing binary) still works due to the `if [ -f ... ]` guard

Fixes #8006

🤖 Generated with [Claude Code](https://claude.com/claude-code)