### PR TITLE
fix: add missing cfg guard for code-mode feature in reply_parts.rs

### DIFF
--- a/crates/goose/src/agents/reply_parts.rs
+++ b/crates/goose/src/agents/reply_parts.rs
@@ -154,6 +154,8 @@ impl Agent {
             .await;
         #[cfg(not(feature = "code-mode"))]
         let code_execution_active = false;
+
+        #[cfg(feature = "code-mode")]
         if code_execution_active {
             let disclosure_style =
                 crate::agents::platform_extensions::code_execution::get_tool_disclosure();


### PR DESCRIPTION
## Summary

The `if code_execution_active { ... }` block in `reply_parts.rs` references `code_execution::get_tool_disclosure()` and `pctx_code_mode::config::ToolDisclosure` variants without a `#[cfg(feature = "code-mode")]` guard. When `code-mode` is disabled, the `code_execution` module and `pctx_code_mode` crate are not available, causing 4 compilation errors.

The existing guards correctly set `code_execution_active = false` when the feature is off, but the compiler still needs to resolve the types inside the if-block at compile time. Adding the cfg attribute to the if-block itself ensures the entire block is excluded from compilation when code-mode is disabled.

Follows the same pattern established in #7976 (`local-inference` feature gate) and #8080 (`aws-providers` feature gate).

**Changes:**
- `crates/goose/src/agents/reply_parts.rs` — Add `#[cfg(feature = "code-mode")]` to the `if code_execution_active` block (1 line addition)

### Testing

- [x] `cargo check -p goose --no-default-features --features rustls-tls` — now succeeds (previously failed with 4 errors)
- [x] `cargo check -p goose` — compiles with all defaults (no behavior change)

### Related Issues

N/A

### Screenshots/Demos (for UX changes)

N/A (backend-only change, no UI impact)