### PR TITLE
fix(authentication): Allow connecting to Oauth servers that use protected-resource fallback instead of the WWW-authenticate header

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use axum::http::{HeaderMap, HeaderName};
 use chrono::{DateTime, Utc};
 use futures::stream::{FuturesUnordered, StreamExt};
-use futures::{FutureExt, future};
+use futures::{future, FutureExt};
 use once_cell::sync::Lazy;
 use rmcp::service::{ClientInitializeError, ServiceError};
 use rmcp::transport::streamable_http_client::{
@@ -14,10 +14,10 @@ use rmcp::transport::{
 use std::collections::HashMap;
 use std::path::PathBuf;
 use std::process::Stdio;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
-use tempfile::{TempDir, tempdir};
+use tempfile::{tempdir, TempDir};
 use tokio::io::AsyncReadExt;
 use tokio::process::Command;
 use tokio::sync::Mutex;
@@ -27,8 +27,8 @@ use tracing::{error, warn};
 
 use super::container::Container;
 use super::extension::{
-    ExtensionConfig, ExtensionError, ExtensionInfo, ExtensionResult, PLATFORM_EXTENSIONS,
-    PlatformExtensionContext, ToolInfo,
+    ExtensionConfig, ExtensionError, ExtensionInfo, ExtensionResult, PlatformExtensionContext,
+    ToolInfo, PLATFORM_EXTENSIONS,
 };
 use super::tool_execution::{ToolCallContext, ToolCallResult};
 use super::types::SharedProvider;
@@ -38,7 +38,7 @@ use crate::agents::mcp_client::{GooseMcpClientCapabilities, McpClient, McpClient
 use crate::builtin_extension::get_builtin_extension;
 use crate::config::extensions::name_to_key;
 use crate::config::search_path::SearchPaths;
-use crate::config::{Config, get_all_extensions};
+use crate::config::{get_all_extensions, Config};
 use crate::oauth::oauth_flow;
 use crate::prompt_template;
 use crate::subprocess::configure_subprocess;
@@ -1710,7 +1710,7 @@ mod tests {
     use super::*;
     use rmcp::model::CallToolResult;
     use rmcp::model::{InitializeResult, JsonObject};
-    use rmcp::{ServiceError as Error, object};
+    use rmcp::{object, ServiceError as Error};
 
     use rmcp::model::ListPromptsResult;
     use rmcp::model::ListResourcesResult;
@@ -1956,16 +1956,12 @@ mod tests {
 
         let tool_names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
         assert!(!tool_names.iter().any(|name| name == "test_extension__tool")); // Default unavailable
-        assert!(
-            tool_names
-                .iter()
-                .any(|name| name == "test_extension__available_tool")
-        );
-        assert!(
-            !tool_names
-                .iter()
-                .any(|name| name == "test_extension__hidden_tool")
-        );
+        assert!(tool_names
+            .iter()
+            .any(|name| name == "test_extension__available_tool"));
+        assert!(!tool_names
+            .iter()
+            .any(|name| name == "test_extension__hidden_tool"));
         assert!(tool_names.len() == 1);
     }
 
@@ -1990,16 +1986,12 @@ mod tests {
 
         let tool_names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
         assert!(tool_names.iter().any(|name| name == "test_extension__tool"));
-        assert!(
-            tool_names
-                .iter()
-                .any(|name| name == "test_extension__available_tool")
-        );
-        assert!(
-            tool_names
-                .iter()
-                .any(|name| name == "test_extension__hidden_tool")
-        );
+        assert!(tool_names
+            .iter()
+            .any(|name| name == "test_extension__available_tool"));
+        assert!(tool_names
+            .iter()
+            .any(|name| name == "test_extension__hidden_tool"));
         assert!(tool_names.len() == 3);
     }
 


### PR DESCRIPTION
## Motivation

Some MCP servers (Datadog) return a bare `HTTP 401` without a `WWW-Authenticate` header, which rmcp surfaces as `UnexpectedServerResponse` rather than a typed `AuthRequired` error. 

The MCP draft [authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization) says clients must support discovery through 

1. `WWW-Authenticate` (what Linear does) OR
2. the protected-resource well-known fallback (what Datadog does)

The draft does not require the header to be present if the well-known metadata is available, but the Goose code seems to always require the header. Previous code only checked for the typed error, so these servers silently failed instead of triggering the OAuth flow.

**Changes:**

- Rename `extract_auth_error` → `should_attempt_oauth_fallback` (returns `bool`; the `Option<&AuthRequiredError>` return value was never used beyond `.is_some()`)
- Add detection for `UnexpectedServerResponse` whose body starts with `"HTTP 401"`
- Add string fallback (`error.to_string().contains("unexpected server response: HTTP 401")`) for servers whose transport wraps the error in a type that fails the `downcast_ref::<StreamableHttpError<reqwest::Error>>()`



### Testing

Added unit tests to `extension_manager.rs` for these branches

| Test | Branch covered |
|---|---|
| `test_oauth_fallback_on_typed_auth_required` | `AuthRequired` (regression guard for original path) |
| `test_oauth_fallback_on_unexpected_response_http_401_prefix` | `UnexpectedServerResponse` starting with `"HTTP 401"` |
| `test_oauth_fallback_via_string_when_downcast_fails` | string fallback when downcast returns `None` |
| `test_no_oauth_fallback_on_http_403` | 403 must not trigger OAuth |
| `test_no_oauth_fallback_when_401_not_at_body_start` | pins `starts_with` vs `contains` (is a mutation guard) |
| `test_no_oauth_fallback_on_unrelated_transport_error` | inner `_ => false` arm |
| `test_no_oauth_fallback_on_non_transport_client_error` | outer `_ => false` arm |

### Related Issues

Relates to https://github.com/block/goose/issues/5107#issuecomment-4131132500


### Screenshots/Demos (for UX changes)


| Before (can't connect) | After (connects and lists Datadog MCP server tools) |
|--------|--------|
| <img width="566" height="177" alt="image" src="https://github.com/user-attachments/assets/86f17bdc-2680-4a71-979b-8df7b7e917fe" /> | <img width="660" height="398" alt="image" src="https://github.com/user-attachments/assets/6ecb7eb0-3645-4f36-be74-bcf306f74092" /> | 
