### PR TITLE
feat: add GraphQL MCP extension to the Extensions Library

### DIFF
--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -797,6 +797,17 @@
     "environmentVariables": []
   },
   {
+    "id": "graphql",
+    "name": "GraphQL",
+    "description": "Query Block's internal GraphQL supergraph for merchant data, payments, locations, customers, and more through pre-built operations and schema introspection.",
+    "command": "npx -y @block/mcp_graphql",
+    "link": "https://github.com/squareup/mcp/tree/main/mcp_graphql",
+    "installation_notes": "Connects to Block's internal GraphQL gateway using your Registry credentials. Default client is 'regulator' for internal admin data. Add --client universal for ad-hoc schema exploration, --client square-dashboard for merchant dashboard operations, or --client compliance for compliance workflows. Add --env production to query production data (default is staging). Requires membership in the graphql-gateway--users Registry group.",
+    "is_builtin": false,
+    "endorsed": true,
+    "environmentVariables": []
+  },
+  {
     "id": "neighborhood",
     "name": "Neighborhood",
     "description": "Discover nearby restaurants, browse menus, and place takeout orders through natural conversation. Sellers are US-based.",


### PR DESCRIPTION
## Summary

Adds the `@block/mcp_graphql` extension to `servers.json` so users can discover and install it from https://block.github.io/goose/extensions/.

This MCP server connects to Block's internal GraphQL supergraph and provides tools for:
- **Executing pre-built GraphQL operations** (merchant details, payments, locations, customers, etc.)
- **Validating GraphQL operations** against the schema
- **Introspecting the schema** to discover available types and fields
- **Listing available operations** for the configured client

### Supported clients

| Client | Use Case | Auth |
|--------|----------|------|
| `regulator` (default) | Internal admin / customer data | Registry (automatic) |
| `square-dashboard` | Square merchant dashboard operations | Bearer token |
| `compliance` | Compliance investigation workflows | Registry (automatic) |
| `universal` | Ad-hoc schema exploration with full introspection | Registry (automatic) |

### Install command

```
npx -y @block/mcp_graphql
```

With options: `--client <name>`, `--env staging|production`

### Context

There has been growing interest from non-eng users in querying merchant data via GraphQL through Goose (see [#graphql](https://square.slack.com/archives/C2XTBJWGN/p1750265875573409), [#graphql-team](https://square.slack.com/archives/C06TY64LW2X/p1774545705168409)). The MCP server has been available via `npx` for months, but was not listed in the extensions directory — making it hard to discover. This PR fixes that.

Related resources:
- Source: [squareup/mcp/mcp_graphql](https://github.com/squareup/mcp/tree/main/mcp_graphql)
- GraphQL Skills bundle: `sq agents skills add --bundle=graphql`
- Dev guide: [go/graphql](https://dev-guides.sqprod.co/docs/platform/graphql)

## Test plan

- [x] `documentation/static/servers.json` is valid JSON (verified with `python3 -m json.tool`)
- [ ] Build the docs site (`cd documentation && npm run build`) — no errors
- [ ] Visit the extensions page — "GraphQL" appears in the grid
- [ ] Click into the detail page — description, install notes, and command render correctly
- [ ] Click "Install" — generates a working `goose://extension` deep link

cc @jwondrusch