### PR TITLE
feat: add copilot-acp provider

### DIFF
--- a/crates/goose/src/providers/copilot_acp.rs
+++ b/crates/goose/src/providers/copilot_acp.rs
@@ -1,0 +1,93 @@
+use anyhow::Result;
+use futures::future::BoxFuture;
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use crate::acp::{
+    extension_configs_to_mcp_servers, AcpProvider, AcpProviderConfig, PermissionMapping,
+    ACP_CURRENT_MODEL,
+};
+use crate::config::search_path::SearchPaths;
+use crate::config::{Config, GooseMode};
+use crate::model::ModelConfig;
+use crate::providers::base::{ProviderDef, ProviderMetadata};
+
+const COPILOT_ACP_PROVIDER_NAME: &str = "copilot-acp";
+const COPILOT_ACP_DOC_URL: &str = "https://github.com/github/copilot-cli";
+const COPILOT_ACP_BINARY: &str = "copilot";
+
+const MODE_AGENT: &str = "https://agentclientprotocol.com/protocol/session-modes#agent";
+const MODE_PLAN: &str = "https://agentclientprotocol.com/protocol/session-modes#plan";
+
+pub struct CopilotAcpProvider;
+
+impl ProviderDef for CopilotAcpProvider {
+    type Provider = AcpProvider;
+
+    fn metadata() -> ProviderMetadata {
+        ProviderMetadata::new(
+            COPILOT_ACP_PROVIDER_NAME,
+            "GitHub Copilot CLI (ACP)",
+            "Use goose with your GitHub Copilot subscription via the Copilot CLI.",
+            ACP_CURRENT_MODEL,
+            vec![],
+            COPILOT_ACP_DOC_URL,
+            vec![],
+        )
+        .with_setup_steps(vec![
+            "Install the Copilot CLI: `npm install -g @github/copilot`",
+            "Run `copilot login` to authenticate with your GitHub account",
+            "Set in your goose config file (`~/.config/goose/config.yaml` on macOS/Linux):\n  GOOSE_PROVIDER: copilot-acp\n  GOOSE_MODEL: current",
+            "Restart goose for changes to take effect",
+        ])
+    }
+
+    fn from_env(
+        model: ModelConfig,
+        extensions: Vec<crate::config::ExtensionConfig>,
+    ) -> BoxFuture<'static, Result<AcpProvider>> {
+        Box::pin(async move {
+            let config = Config::global();
+            // with_npm() includes npm global bin dir (desktop app PATH may not)
+            let resolved_command = SearchPaths::builder()
+                .with_npm()
+                .resolve(COPILOT_ACP_BINARY)?;
+            let goose_mode = config.get_goose_mode().unwrap_or(GooseMode::Auto);
+
+            // Copilot uses standard ACP permission option IDs (allow_once,
+            // allow_always, reject_once) so kind-based fallback handles them.
+            let permission_mapping = PermissionMapping::default();
+
+            let mut args = vec!["--acp".to_string()];
+            if model.model_name != ACP_CURRENT_MODEL {
+                args.push("--model".to_string());
+                args.push(model.model_name.clone());
+            }
+
+            // Copilot modes are full protocol URIs.
+            // No approve-specific mode; permissions are handled separately.
+            let mode_mapping = HashMap::from([
+                (GooseMode::Auto, MODE_AGENT.to_string()),
+                (GooseMode::Approve, MODE_AGENT.to_string()),
+                (GooseMode::SmartApprove, MODE_AGENT.to_string()),
+                (GooseMode::Chat, MODE_PLAN.to_string()),
+            ]);
+
+            let provider_config = AcpProviderConfig {
+                command: resolved_command,
+                args,
+                env: vec![],
+                env_remove: vec![],
+                work_dir: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                mcp_servers: extension_configs_to_mcp_servers(&extensions),
+                session_mode_id: Some(mode_mapping[&goose_mode].clone()),
+                mode_mapping,
+                permission_mapping,
+                notification_callback: None,
+            };
+
+            let metadata = Self::metadata();
+            AcpProvider::connect(metadata.name, model, goose_mode, provider_config).await
+        })
+    }
+}

--- a/crates/goose/src/providers/init.rs
+++ b/crates/goose/src/providers/init.rs
@@ -16,6 +16,7 @@ use super::{
     claude_code::ClaudeCodeProvider,
     codex::CodexProvider,
     codex_acp::CodexAcpProvider,
+    copilot_acp::CopilotAcpProvider,
     cursor_agent::CursorAgentProvider,
     databricks::DatabricksProvider,
     gcpvertexai::GcpVertexAIProvider,
@@ -59,6 +60,7 @@ async fn init_registry() -> RwLock<ProviderRegistry> {
         registry.register::<ClaudeAcpProvider>(false);
         registry.register::<ClaudeCodeProvider>(true);
         registry.register::<CodexAcpProvider>(false);
+        registry.register::<CopilotAcpProvider>(false);
         registry.register::<CodexProvider>(true);
         registry.register::<CursorAgentProvider>(false);
         registry.register::<DatabricksProvider>(true);

--- a/crates/goose/src/providers/mod.rs
+++ b/crates/goose/src/providers/mod.rs
@@ -14,6 +14,7 @@ pub mod claude_code;
 pub(crate) mod cli_common;
 pub mod codex;
 pub mod codex_acp;
+pub mod copilot_acp;
 pub mod cursor_agent;
 pub mod databricks;
 pub mod embedding;

--- a/crates/goose/tests/providers.rs
+++ b/crates/goose/tests/providers.rs
@@ -121,6 +121,7 @@ struct ProviderTestConfig {
     test_permissions: bool,
     test_smart_approve: bool,
     test_mode_update: bool,
+    test_mcp_tools: bool,
     test_context_length_exceeded: bool,
     expect_context_length_exceeded: bool,
     context_length_exceeded: usize,
@@ -144,6 +145,7 @@ impl ProviderTestConfig {
             test_permissions: true,
             test_smart_approve: true,
             test_mode_update: true,
+            test_mcp_tools: true,
             test_context_length_exceeded: true,
             expect_context_length_exceeded: true,
             context_length_exceeded: 600_000,
@@ -172,6 +174,11 @@ impl ProviderTestConfig {
 
     fn test_smart_approve(mut self, v: bool) -> Self {
         self.test_smart_approve = v;
+        self
+    }
+
+    fn test_mcp_tools(mut self, v: bool) -> Self {
+        self.test_mcp_tools = v;
         self
     }
 
@@ -657,11 +664,13 @@ async fn test_provider(config: ProviderTestConfig) -> Result<()> {
             .await?
             .test_basic_response()
             .await?;
-        run_test(GooseMode::Auto).await?.test_tool_usage().await?;
-        run_test(GooseMode::Auto)
-            .await?
-            .test_image_content_support()
-            .await?;
+        if config.test_mcp_tools {
+            run_test(GooseMode::Auto).await?.test_tool_usage().await?;
+            run_test(GooseMode::Auto)
+                .await?
+                .test_image_content_support()
+                .await?;
+        }
         if config.model_switch_name.is_some() {
             run_test(GooseMode::Auto).await?.test_model_switch().await?;
         }
@@ -888,6 +897,18 @@ async fn test_claude_acp_provider() -> Result<()> {
 async fn test_codex_acp_provider() -> Result<()> {
     ProviderTestConfig::with_agentic_provider("codex-acp", ACP_CURRENT_MODEL, "codex-acp")
         .model_switch_name("gpt-5.4-mini")
+        .run()
+        .await
+}
+
+// Requires: npm install -g @github/copilot
+#[tokio::test]
+async fn test_copilot_acp_provider() -> Result<()> {
+    ProviderTestConfig::with_agentic_provider("copilot-acp", ACP_CURRENT_MODEL, "copilot")
+        .model_switch_name("gpt-4.1")
+        // Copilot ignores mcpServers passed via session/new
+        // https://github.com/github/copilot-cli/issues/1040
+        .test_mcp_tools(false)
         .run()
         .await
 }


### PR DESCRIPTION
## Summary

Add an ACP provider for GitHub's Copilot CLI. Copilot CLI supports ACP natively via its `--acp` flag.

### Notable limitations

- **MCP not yet supported**: copilot ignores `mcpServers` in `session/new` ([github/copilot-cli#1040](https://github.com/github/copilot-cli/issues/1040))
- **No `session/close`**
- **No terminal or fs delegation**: all execution is local

### Type of Change
- [x] Feature
- [x] Tests

### AI Assistance
- [x] This PR was created or reviewed with AI assistance

### Testing

#### Provider integration tests

```bash
$ source bin/activate-hermit
$ npm install -g @github/copilot
$ cargo test --test providers -- test_copilot_acp_provider --nocapture
running 1 test
=== copilot-acp::model_listing ===
&models = [
    "claude-sonnet-4.6", "claude-sonnet-4.5", "claude-haiku-4.5",
    "claude-opus-4.6", "claude-opus-4.5", "claude-sonnet-4",
    "gpt-5.4", "gpt-5.3-codex", "gpt-5.2-codex", "gpt-5.2",
    "gpt-5.1-codex-max", "gpt-5.1-codex", "gpt-5.1",
    "gpt-5.4-mini", "gpt-5.1-codex-mini", "gpt-5-mini", "gpt-4.1",
]
=== copilot-acp::basic_response === Hello! 👋 How can I help you today?
=== copilot-acp::model_switch (claude-sonnet-4.6 -> gpt-4.1) === Hello! 👋 How can I help you today?
=== copilot-acp::permission_allow ===
=== copilot-acp::permission_deny ===
test test_copilot_acp_provider ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 19 filtered out; finished in 36.69s

============== Providers ==============
✅ copilot-acp
=======================================
```

MCP tool tests skipped — [github/copilot-cli#1040](https://github.com/github/copilot-cli/issues/1040).

#### Goose CLI

```bash
$ GOOSE_PROVIDER=copilot-acp GOOSE_MODEL=current RUST_LOG=debug,sacp=trace target/release/goose run -t 'say hello'

    __( O)>  ● new session · copilot-acp current
   \____)    20260327_1
     L L     goose is ready
Hello! How can I help you with the goose project today?
```

```bash
$ grep -rh 'resolved ACP model' ~/.local/state/goose/logs/
{"timestamp":"2026-03-27T15:00:00.309339Z","level":"INFO","fields":{"message":"resolved ACP model","from":"current","to":"claude-sonnet-4.6"},"target":"goose::acp::provider"}
```

#### Goose CLI — permission routing (approve mode)

```bash
$ rm -rf ~/.local/state/goose/logs ~/.local/share/goose/sessions
$ GOOSE_PROVIDER=copilot-acp GOOSE_MODEL=current GOOSE_MODE=approve RUST_LOG=debug,sacp=trace target/release/goose run -t 'Write the word hello to /tmp/test-copilot-acp.txt'

    __( O)>  ● new session · copilot-acp current
   \____)    20260327_1
     L L     goose is ready
```

```bash
$ grep -rh 'request_permission' ~/.local/state/goose/logs/ | head -1
{"timestamp":"2026-03-27T15:01:36.152998Z","level":"TRACE","fields":{"message":"Received JSON-RPC message","message":"{\"jsonrpc\":\"2.0\",\"id\":0,\"method\":\"session/request_permission\",\"params\":{\"sessionId\":\"8c5ef659-503a-4e47-bfda-d19598962e12\",\"toolCall\":{\"toolCallId\":\"shell-permission\",\"title\":\"Write hello to file\",\"kind\":\"execute\",\"status\":\"pending\",\"rawInput\":{\"command\":\"echo \\\"hello\\\" > /tmp/test-copilot-acp.txt\",\"commands\":[\"echo \\\"hello\\\" > /tmp/test-copilot-acp.txt\"]}},\"options\":[{\"optionId\":\"allow_once\",\"kind\":\"allow_once\",\"name\":\"Allow once\"},{\"optionId\":\"allow_always\",\"kind\":\"allow_always\",\"name\":\"Always allow\"},{\"optionId\":\"reject_once\",\"kind\":\"reject_once\",\"name\":\"Deny\"}]}}"},"target":"sacp::jsonrpc::transport_actor"}
```

#### Copilot-side logs (`~/.copilot/logs/`)

```bash
$ cat $(ls -t ~/.copilot/logs/process-*.log | head -1)
2026-03-27T15:01:26.901Z [INFO] Starting ACP server (stdio)
2026-03-27T15:01:28.861Z [INFO] MCP config prepared for ACP mode
2026-03-27T15:01:28.861Z [INFO] ACP server started (stdio mode)
2026-03-27T15:01:28.862Z [INFO] ACP initialize request from client: unknown
2026-03-27T15:01:30.139Z [INFO] Created ACP session: bc0c6272-e52b-4683-a747-9c620a34a44c
2026-03-27T15:01:31.084Z [INFO] Created ACP session: 8c5ef659-503a-4e47-bfda-d19598962e12
2026-03-27T15:01:31.663Z [INFO] Created ACP session: 0780520e-8672-49da-8365-5959f960752c
2026-03-27T15:01:31.667Z [INFO] Using default model: claude-sonnet-4.6
```
