### PR TITLE
fix: use `overflow: clip` to not disrupt sticky ToC

### DIFF
--- a/documentation/src/css/custom.css
+++ b/documentation/src/css/custom.css
@@ -244,7 +244,7 @@ html {
 .hero--logo {
   display: 'flex';
   justify-content: 'center';
-  margin-bottom: '1rem' 
+  margin-bottom: '1rem'
 }
 
 .pill-button {
@@ -450,7 +450,7 @@ html, body {
 /* Ensure all containers respect viewport width */
 .container {
   max-width: 100%;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* Prevent navbar from causing horizontal overflow */
@@ -461,7 +461,7 @@ html, body {
 /* Ensure main content doesn't overflow */
 main {
   max-width: 100%;
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* Custom scrollbar for filter sections */


### PR DESCRIPTION
Fixes a regression in #6082 that caused the Table of Contents for pages to not be sticky.

## Before

Pay attention to the ToC sidebar on the right.

https://github.com/user-attachments/assets/d412092e-2bc9-4fd5-897b-245a00f73b74

## After

https://github.com/user-attachments/assets/5a3f4071-7d5a-4411-ad47-8a40a390892d
