### PR TITLE
fix "View as Markdown" feature not working

### DIFF
--- a/documentation/src/theme/DocItem/Layout/index.tsx
+++ b/documentation/src/theme/DocItem/Layout/index.tsx
@@ -359,6 +359,7 @@ function CopyPageButton(): ReactNode {
 
 // New wrapper component that adds dropdown menu to copy button
 function PageActionsMenu(): ReactNode {
+  const {metadata} = useDoc();
   const [dropdownOpen, setDropdownOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
   
@@ -391,11 +392,8 @@ function PageActionsMenu(): ReactNode {
   }, [dropdownOpen]);
   
   const handleViewMarkdown = () => {
-    const currentPath = window.location.pathname;
-    const mdPath = currentPath.endsWith('/') 
-      ? `${currentPath.slice(0, -1)}.md` 
-      : `${currentPath}.md`;
-    window.open(mdPath, '_blank');
+    const source = metadata?.source?.replace('@site/', '') || '';
+    window.open(`https://raw.githubusercontent.com/block/goose/refs/heads/main/documentation/${source}`, '_blank');
     setDropdownOpen(false);
   };
   


### PR DESCRIPTION
## Before

Go to https://block.github.io/goose/docs/guides/recipes/, click the dropdown next to "Copy Page" and choose "View as Markdown". 404 error.

<img width="327" height="158" alt="image" src="https://github.com/user-attachments/assets/e1433040-f1db-4c83-b935-08d3126e9d90" />
<img width="789" height="317" alt="image" src="https://github.com/user-attachments/assets/3b5cce79-eeef-462a-8640-c0a47b13277b" />

## After

Same behavior opens https://raw.githubusercontent.com/block/goose/refs/heads/main/documentation/docs/guides/recipes/index.mdx rather than a non-existant link.