### PR TITLE
fix: propagate token usage from ACP provider responses

### DIFF
--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1,3 +1,4 @@
+use agent_client_protocol_schema::Usage as AcpUsage;
 use agent_client_protocol_schema::AGENT_METHOD_NAMES;
 use anyhow::{Context, Result};
 use async_stream::try_stream;
@@ -30,7 +31,7 @@ use crate::conversation::message::{Message, MessageContent};
 use crate::model::ModelConfig;
 use crate::permission::permission_confirmation::PrincipalType;
 use crate::permission::{Permission, PermissionConfirmation};
-use crate::providers::base::{MessageStream, PermissionRouting, Provider};
+use crate::providers::base::{MessageStream, PermissionRouting, Provider, ProviderUsage, Usage};
 use crate::providers::errors::ProviderError;
 use crate::subprocess::configure_subprocess;
 
@@ -115,7 +116,7 @@ enum AcpUpdate {
         request: Box<RequestPermissionRequest>,
         response_tx: oneshot::Sender<RequestPermissionResponse>,
     },
-    Complete(StopReason),
+    Complete(StopReason, Option<AcpUsage>),
     Error(String),
 }
 
@@ -635,6 +636,7 @@ impl Provider for AcpProvider {
             .map_err(|_| ProviderError::RequestFailed("goose_mode lock poisoned".into()))?;
 
         let reject_all_tools = goose_mode == GooseMode::Chat;
+        let model_name = model_config.model_name.clone();
 
         Ok(Box::pin(try_stream! {
             // ACP agents execute tools internally. Goose never dispatches tool calls;
@@ -708,7 +710,19 @@ impl Provider for AcpProvider {
                         let response = map_permission_response(&permission_mapping, &request, decision);
                         let _ = response_tx.send(response);
                     }
-                    AcpUpdate::Complete(_reason) => {
+                    AcpUpdate::Complete(_reason, acp_usage) => {
+                        if let Some(u) = acp_usage {
+                            let provider_usage = ProviderUsage::new(
+                                model_name.clone(),
+                                Usage {
+                                    input_tokens: Some(u.input_tokens as i32),
+                                    output_tokens: Some(u.output_tokens as i32),
+                                    total_tokens: Some(u.total_tokens as i32),
+                                    ..Default::default()
+                                },
+                            );
+                            yield (None, Some(provider_usage));
+                        }
                         break;
                     }
                     AcpUpdate::Error(e) => {
@@ -1109,7 +1123,7 @@ async fn handle_requests(
                 match response {
                     Ok(r) => {
                         log_undelivered(
-                            response_tx.try_send(AcpUpdate::Complete(r.stop_reason)),
+                            response_tx.try_send(AcpUpdate::Complete(r.stop_reason, r.usage)),
                             AGENT_METHOD_NAMES.session_prompt,
                         );
                     }


### PR DESCRIPTION
## Summary

Fixes #8132 — ACP client provider discards token usage data from `PromptResponse`, causing all-zero token counts for ACP-based providers (claude-acp, codex-acp). This breaks cost reporting and context window monitoring.

## Changes

Three targeted changes in `crates/goose/src/acp/provider.rs`:

1. **Extend `AcpUpdate::Complete`** to carry `Option<AcpUsage>` alongside `StopReason`
2. **Forward `r.usage`** when sending the complete signal from the prompt response handler
3. **Map ACP `Usage` to `ProviderUsage`** and yield it as the final stream item before breaking

## Graceful degradation

For ACP agents that don't yet populate `PromptResponse.usage` (e.g. codex-acp, goose-acp server), `r.usage` is `None`, no `ProviderUsage` is yielded, and the existing `"unknown"` fallback in `collect_stream()` applies unchanged. As those adapters add usage reporting, it starts working automatically.

## Notes

- `AcpUsage` fields are `u64`, Goose's `Usage` uses `Option<i32>` — the `as i32` cast is safe for practical token counts
- `AcpUsage` also has optional `thought_tokens`, `cached_read_tokens`, `cached_write_tokens` which Goose's `Usage` doesn't model yet — these could be surfaced in a follow-up

Credit to the issue reporter for the thorough root cause analysis and proposed fix.

Generated with [Claude Code](https://claude.com/claude-code)