### PR TITLE
fix: simplify donut chart schema for OpenAI compatibility

### DIFF
--- a/crates/goose-mcp/src/autovisualiser/mod.rs
+++ b/crates/goose-mcp/src/autovisualiser/mod.rs
@@ -989,11 +989,7 @@ Example multiple charts:
             true,
         )?;
 
-        let count = data
-            .get("data")
-            .and_then(|d| d.as_array())
-            .map(|a| a.len())
-            .unwrap_or(1);
+        let count = data.as_array().map(|a| a.len()).unwrap_or(1);
         let text_fallback = format!("donut/pie chart: {} chart(s)", count);
 
         let mut result = CallToolResult::structured(data);
@@ -1692,25 +1688,6 @@ mod donut_format_tests {
         assert!(
             result.is_ok(),
             "labeled values should parse: {:?}",
-            result.err()
-        );
-    }
-
-    #[test]
-    fn labeled_values_as_single_chart() {
-        // {"data": [{"values": [{"label": "A", "value": 10}, {"label": "B", "value": 20}]}]}
-        let input = json!({
-            "data": [{
-                "values": [
-                    {"label": "A", "value": 10},
-                    {"label": "B", "value": 20}
-                ]
-            }]
-        });
-        let result = round_trip(input);
-        assert!(
-            result.is_ok(),
-            "labeled values as single chart should parse: {:?}",
             result.err()
         );
     }


### PR DESCRIPTION
## Summary

Fixes #8173

The `autovisualiser__render_donut` tool schema was rejected by OpenAI-compatible endpoints because it used `#[serde(untagged)]` enums, which generate `anyOf`/`oneOf` constructs in JSON Schema that OpenAI's function calling validation does not support.

This PR replaces the two problematic untagged enums with simpler, flat types:

- **`DonutDataItem`**: Changed from an untagged enum (`Number(f64)` | `LabeledValue { label, value }`) to a plain struct with required `label` and `value` fields. This produces a single object schema instead of `anyOf`.
- **`DonutChartData`**: Removed the untagged enum (`Single(SingleDonutChart)` | `Multiple(Vec<SingleDonutChart>)`). `RenderDonutParams.data` now takes `Vec<SingleDonutChart>` directly — a single chart is represented as a one-element array.
- Removed the `labels` field from `SingleDonutChart` since labels are now always embedded in each `DonutDataItem`.
- Updated tool description examples to reflect the new schema.
- Updated tests accordingly.

The HTML template (`donut_template.html`) already handles both object-style values and arrays, so no template changes are needed.

## Test plan

- [ ] Existing `test_render_donut` and `donut_rejects_empty_values` tests pass
- [ ] Verify the generated JSON Schema no longer contains `anyOf`/`oneOf` for the donut tool
- [ ] Test with OpenAI-compatible endpoint: `goose run --provider openai --model gpt-4o-mini --with-builtin autovisualiser --text "Reply with exactly OK"` should not return schema validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)