### PR TITLE
fix: handle unknown tool calls gracefully instead of failing

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -1382,9 +1382,27 @@ impl ExtensionManager {
             });
         }
 
+        // Build a list of available tool names to help the model self-correct
+        let available_tool_names: Vec<String> = tools.iter().map(|t| t.name.to_string()).collect();
+        let suggestion = if !available_tool_names.is_empty() {
+            format!(
+                " Available tools: [{}]. Please use one of these tools instead.",
+                available_tool_names.join(", ")
+            )
+        } else {
+            String::new()
+        };
+
+        tracing::warn!(
+            monotonic_counter.goose.unknown_tool_calls = 1,
+            tool_name = %tool_name,
+            "Model called unknown tool '{}' that is not in the available tools list",
+            tool_name,
+        );
+
         Err(ErrorData::new(
             ErrorCode::RESOURCE_NOT_FOUND,
-            format!("Tool '{}' not found", tool_name),
+            format!("Tool '{}' not found.{}", tool_name, suggestion),
             None,
         ))
     }


### PR DESCRIPTION
## Summary

Fixes #8166

When a model emits a tool call for a non-existent tool (e.g. `read_file`, `view_file`, `run_command`), goose currently returns a generic `"Tool 'X' not found"` error. While this error is sent back to the model as a tool response, the message lacks context to help the model self-correct, often causing repeated failures and task interruption.

This PR enhances the error handling in `resolve_tool` to:

- **Include available tool names** in the error message so the model can pick a valid tool on retry
- **Add telemetry logging** (`monotonic_counter.goose.unknown_tool_calls`) to track unknown tool call rates by provider/model

### Before
```
Tool 'read_file' not found
```

### After
```
Tool 'read_file' not found. Available tools: [developer__text_editor, developer__shell, ...]. Please use one of these tools instead.
```

The existing error flow is preserved — `ErrorData` with `RESOURCE_NOT_FOUND` code is returned and serialized as a tool response to the model, allowing it to retry with a valid tool name.

## Changed files

- `crates/goose/src/agents/extension_manager.rs` — Enhanced `resolve_tool()` error path with available tool list and telemetry

## Test plan

- [ ] Existing `test_dispatch_tool_call` test continues to pass (error code unchanged)
- [ ] Verify the error message now includes available tool names when a non-existent tool is called
- [ ] Manual test with a model that tends to hallucinate tool names (e.g. local models)

🤖 Generated with [Claude Code](https://claude.com/claude-code)