### PR TITLE
fix: use build_host_url for GCP Vertex AI location fallback

### DIFF
--- a/crates/goose/src/providers/gcpvertexai.rs
+++ b/crates/goose/src/providers/gcpvertexai.rs
@@ -72,7 +72,7 @@ fn build_vertex_url(
     let host_url = if configured_location == target_location {
         host.to_string()
     } else {
-        host.replace(configured_location, target_location)
+        GcpVertexAIProvider::build_host_url(target_location)
     };
 
     let base_url =
@@ -733,6 +733,60 @@ mod tests {
             .as_str()
             .contains("europe-west1-aiplatform.googleapis.com"));
         assert!(url.as_str().contains("locations/europe-west1"));
+    }
+
+    #[test]
+    fn test_build_vertex_url_global_location_fallback() {
+        // When configured_location is "global", the host is
+        // "https://aiplatform.googleapis.com" which does not contain "global".
+        // Falling back to a regional target_location must rebuild the host
+        // via build_host_url rather than string replacement.
+        let url = build_vertex_url(
+            "https://aiplatform.googleapis.com",
+            "global",
+            "test-project",
+            "claude-haiku-4-5@20251001",
+            ModelProvider::Anthropic,
+            "us-east5",
+            true,
+        )
+        .unwrap();
+
+        assert!(
+            url.as_str()
+                .starts_with("https://us-east5-aiplatform.googleapis.com"),
+            "Expected regional host for us-east5, got: {}",
+            url
+        );
+        assert!(
+            url.as_str().contains("locations/us-east5"),
+            "Expected locations/us-east5 in path, got: {}",
+            url
+        );
+        assert!(url.as_str().contains(":streamRawPredict"));
+    }
+
+    #[test]
+    fn test_build_vertex_url_global_location_same() {
+        // When both configured and target are "global", the host should stay as-is.
+        let url = build_vertex_url(
+            "https://aiplatform.googleapis.com",
+            "global",
+            "test-project",
+            "claude-haiku-4-5@20251001",
+            ModelProvider::Anthropic,
+            "global",
+            true,
+        )
+        .unwrap();
+
+        assert!(
+            url.as_str()
+                .starts_with("https://aiplatform.googleapis.com"),
+            "Expected global host, got: {}",
+            url
+        );
+        assert!(url.as_str().contains("locations/global"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix invalid URL when `GCP_LOCATION=global` and the streaming fallback tries to switch to a regional endpoint.

## Problem

In `build_vertex_url()`, when `configured_location != target_location`, the code does `host.replace(configured_location, target_location)`. When `configured_location = "global"`, the host is `"https://aiplatform.googleapis.com"` — the string `"global"` doesn't appear in this URL, so the replace is a no-op. The result is a global host paired with a regional path (`locations/us-east5`), which GCP returns 500 for.

## Fix

Replace `host.replace(configured_location, target_location)` with `GcpVertexAIProvider::build_host_url(target_location)`, which correctly constructs both global and regional host URLs. This function already existed and is used during provider initialization.

## Tests

Two new test cases added:
- `test_build_vertex_url_global_location_fallback` — verifies global→regional produces correct regional URL
- `test_build_vertex_url_global_location_same` — verifies global→global keeps the global host

All 8 provider tests pass. `cargo fmt` and `cargo clippy` clean.

Closes #8053