### PR TITLE
feat: show $0.00 cost for local Ollama provider sessions

### DIFF
--- a/crates/goose-cli/src/session/output.rs
+++ b/crates/goose-cli/src/session/output.rs
@@ -1414,12 +1414,21 @@ pub fn display_context_usage(total_tokens: usize, context_limit: usize) {
     );
 }
 
+/// Returns true for providers that run models locally at zero cost.
+fn is_zero_cost_provider(provider: &str) -> bool {
+    provider == "ollama"
+}
+
 fn estimate_cost_usd(
     provider: &str,
     model: &str,
     input_tokens: usize,
     output_tokens: usize,
 ) -> Option<f64> {
+    if is_zero_cost_provider(provider) {
+        return Some(0.0);
+    }
+
     let canonical_model = maybe_get_canonical_model(provider, model)?;
 
     let input_cost_per_token = canonical_model.cost.input? / 1_000_000.0;
@@ -1601,5 +1610,18 @@ mod tests {
             json!({"top_up_url": "https://router.tetrate.ai/billing"}),
         );
         assert_eq!(get_credits_top_up_url(&message), None);
+    }
+
+    #[test]
+    fn test_ollama_provider_returns_zero_cost() {
+        let cost = estimate_cost_usd("ollama", "mistral-nemo", 4096, 11);
+        assert_eq!(cost, Some(0.0));
+    }
+
+    #[test]
+    fn test_non_ollama_provider_returns_nonzero_cost() {
+        let cost = estimate_cost_usd("openai", "gpt-4o", 1000, 500);
+        assert!(cost.is_some());
+        assert!(cost.unwrap() > 0.0);
     }
 }

--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -467,6 +467,11 @@ pub struct ModelInfoQuery {
     pub model: String,
 }
 
+/// Returns true for providers that run models locally at zero cost.
+fn is_zero_cost_provider(provider: &str) -> bool {
+    provider == "ollama"
+}
+
 #[utoipa::path(
     post,
     path = "/config/canonical-model-info",
@@ -479,17 +484,33 @@ pub async fn get_canonical_model_info(
     Json(query): Json<ModelInfoQuery>,
 ) -> Json<ModelInfoResponse> {
     let canonical_model = maybe_get_canonical_model(&query.provider, &query.model);
+    let zero_cost = is_zero_cost_provider(&query.provider);
 
     let model_info = canonical_model.map(|canonical_model| ModelInfoData {
         provider: query.provider.clone(),
         model: query.model.clone(),
         context_limit: canonical_model.limit.context,
         max_output_tokens: canonical_model.limit.output,
-        // Costs are per million tokens - client handles division for display
-        input_token_cost: canonical_model.cost.input,
-        output_token_cost: canonical_model.cost.output,
-        cache_read_token_cost: canonical_model.cost.cache_read,
-        cache_write_token_cost: canonical_model.cost.cache_write,
+        input_token_cost: if zero_cost {
+            Some(0.0)
+        } else {
+            canonical_model.cost.input
+        },
+        output_token_cost: if zero_cost {
+            Some(0.0)
+        } else {
+            canonical_model.cost.output
+        },
+        cache_read_token_cost: if zero_cost {
+            Some(0.0)
+        } else {
+            canonical_model.cost.cache_read
+        },
+        cache_write_token_cost: if zero_cost {
+            Some(0.0)
+        } else {
+            canonical_model.cost.cache_write
+        },
         currency: "$".to_string(),
     });
 


### PR DESCRIPTION
## Summary

When using the `ollama` provider, goose displays cloud pricing (e.g. `Cost: $0.0006 USD`) even though Ollama inference is free. This PR adds a per-provider zero-cost check so that Ollama sessions correctly show `$0.0000` while preserving token counts.

## Changes

- **CLI** (`crates/goose-cli/src/session/output.rs`): Added `is_zero_cost_provider()` helper; `estimate_cost_usd()` returns `Some(0.0)` for Ollama, so the cost line reads `$0.0000 USD` with token counts intact.
- **Server** (`crates/goose-server/src/routes/config_management.rs`): Added matching `is_zero_cost_provider()` helper; `get_canonical_model_info` zeroes out all cost fields for Ollama so the desktop UI also displays zero cost.
- **Tests**: Two new unit tests validating Ollama returns zero cost and OpenAI returns nonzero cost.

## How to test

1. Configure goose with `GOOSE_PROVIDER=ollama`, `GOOSE_MODEL=mistral-nemo`, `GOOSE_CLI_SHOW_COST=true`
2. Send a message
3. Verify cost line shows `$0.0000 USD` with token counts

Closes #8192