### PR TITLE
fix(openai): use safely_parse_json for streaming tool arguments

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -750,7 +750,7 @@ where
                         let parsed = if arguments.is_empty() {
                             Ok(json!({}))
                         } else {
-                            serde_json::from_str::<Value>(arguments)
+                            safely_parse_json(arguments)
                         };
 
                         let metadata = if let Some(sig) = &last_signature {


### PR DESCRIPTION
The streaming path used `serde_json::from_str` directly while the non-streaming path already used `safely_parse_json` (which handles control character escaping). This made streaming tool calls fail on payloads containing unescaped control characters.

One-line fix: replace `serde_json::from_str::<Value>(arguments)` with `safely_parse_json(arguments)` on the streaming tool call accumulation path, matching the non-streaming path.

Fixes #8167