### PR TITLE
fix: restore npm-production-publishing environment to release job

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -196,6 +196,9 @@ jobs:
     name: Release to npm
     runs-on: ubuntu-latest
     needs: [generate-schema, build-goose-binaries]
+    environment:
+      name: npm-production-publishing
+      url: https://www.npmjs.com/org/aaif
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Problem

The npm publish workflow has been failing with `ENEEDAUTH` errors because the `NPM_PUBLISH_TOKEN` secret is not accessible during the publish step.

## Root Cause

The `environment:` configuration was accidentally removed from the `release` job in commit 5b4dd405. This environment block is required to access the `NPM_PUBLISH_TOKEN` secret from the `npm-production-publishing` GitHub environment.

## Solution

This PR restores the `environment:` block to the `release` job:

```yaml
environment:
  name: npm-production-publishing
  url: https://www.npmjs.com/org/aaif
```

## Testing

Tested in workflow run https://github.com/block/goose/actions/runs/23755181363 which correctly blocked deployment from a non-main branch, confirming the environment protection rules are working as expected.

Once merged to main, the workflow should be able to access the secret and publish successfully.

## Related

- Follows up on e3b78e8 which fixed the `.npmrc` auth token inheritance issue
- Related to #8163 and #8122