### PR TITLE
only run windows compile on main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,8 +79,7 @@ jobs:
   rust-build-windows:
     name: Build Rust Project on Windows
     runs-on: windows-latest
-    needs: changes
-    if: needs.changes.outputs.code == 'true' || github.event_name != 'pull_request'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout Code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8  # v6.0.1


### PR DESCRIPTION
## Summary

### Why
currently we triggers rust compilation on windows when new changes are pushed into pr.  This step takes long time and if the step failed it does not prevent the change from merging into `main`

### What
Only run in the `main` branch and it already makes easy to trace the changes if this step fails

### Testing
build pipeline