### PR TITLE
fix: macos intel sign

### DIFF
--- a/.github/workflows/bundle-desktop-manual.yml
+++ b/.github/workflows/bundle-desktop-manual.yml
@@ -9,13 +9,20 @@ on:
         type: string
 
 jobs:
+  bundle-desktop-unsigned:
+    uses: ./.github/workflows/bundle-desktop.yml
+    permissions:
+      id-token: write
+      contents: read
+    with:
+      signing: false
+      ref: ${{ inputs.branch }}
+
   bundle-desktop-intel-unsigned:
     uses: ./.github/workflows/bundle-desktop-intel.yml
     permissions:
       id-token: write
       contents: read
     with:
-      signing: true
+      signing: false
       ref: ${{ inputs.branch }}
-    secrets:
-      OSX_CODESIGN_ROLE: ${{ secrets.OSX_CODESIGN_ROLE }}


### PR DESCRIPTION
## Summary
Fixed the bundle macos intel.  

### Root cause
Electron ships arm64 binaries ad-hoc signed but x64 binaries unsigned, and the recently out rewritten codesign lambda uses --strict which validates subcomponents before they've been signed, causing it to fail on macos x64 binaries.

### Fix
Apply ad-hoc sign on x64 binaries.  We only need to apply to this branch as in `main` branch we no longer use the codsign lambda. 


