### PR TITLE
fix(config): honour GOOSE_DISABLE_KEYRING from config.yaml at startup

### DIFF
--- a/crates/goose/src/config/base.rs
+++ b/crates/goose/src/config/base.rs
@@ -152,16 +152,17 @@ impl Default for Config {
             }
         });
 
-        let secrets =
-            if env::var("GOOSE_DISABLE_KEYRING").is_ok() || keyring_disabled_in_config(&config_path) {
-                SecretStorage::File {
-                    path: config_dir.join("secrets.yaml"),
-                }
-            } else {
-                SecretStorage::Keyring {
-                    service: KEYRING_SERVICE.to_string(),
-                }
-            };
+        let secrets = if env::var("GOOSE_DISABLE_KEYRING").is_ok()
+            || keyring_disabled_in_config(&config_path)
+        {
+            SecretStorage::File {
+                path: config_dir.join("secrets.yaml"),
+            }
+        } else {
+            SecretStorage::Keyring {
+                service: KEYRING_SERVICE.to_string(),
+            }
+        };
         Config {
             config_path,
             defaults_path,
@@ -262,8 +263,7 @@ fn keyring_disabled_in_config(config_path: &Path) -> bool {
         .and_then(|s| parse_yaml_content(&s).ok())
         .and_then(|m| {
             m.get("GOOSE_DISABLE_KEYRING")
-                .and_then(|v| v.as_str())
-                .map(|v| v == "true")
+                .map(|v| v.as_bool().unwrap_or(false) || v.as_str().is_some_and(|s| s == "true"))
         })
         .unwrap_or(false)
 }


### PR DESCRIPTION
The setting was written to config.yaml by the configure dialog but only the env var was checked at init time, so the file value was silently ignored after a restart.

Add keyring_disabled_in_config() — a small helper that does a minimal raw read of config.yaml (reusing the existing parse_yaml_content) — and OR it with the env var check in Config::default().  All errors (missing file, bad YAML) return false so the keyring stays enabled by default.

A cleaner solution would require to split the config loading and be much larger, but being hopefully the only configuration entry that is that special probably it is acceptable.
