### PR TITLE
fix: rename bin for the tui

### DIFF
--- a/ui/text/package.json
+++ b/ui/text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Goose - an open-source AI agent",
   "license": "Apache-2.0",
   "repository": {
@@ -16,7 +16,7 @@
   ],
   "type": "module",
   "bin": {
-    "goose": "dist/tui.js"
+    "goose-text": "dist/tui.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
Changed the bin entry from `"goose"` to `"goose-text"` to avoid creating a conflicting `goose` command in `node_modules/.bin/` that would shadow the globally installed Rust binary. Users can still run `npx @aaif/goose` as before, but local installs now create a non-conflicting `goose-text` command instead.