### PR TITLE
build: raise default stack reserve to 8 MB

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.x86_64-pc-windows-msvc]
-rustflags = ["-C", "link-args=/FORCE:MULTIPLE"]
+rustflags = ["-C", "link-args=/FORCE:MULTIPLE /STACK:8388608"]
 
 [target.aarch64-pc-windows-msvc]
-rustflags = ["-C", "link-args=/FORCE:MULTIPLE"]
+rustflags = ["-C", "link-args=/FORCE:MULTIPLE /STACK:8388608"]


### PR DESCRIPTION
## Summary
See #6025 - on Windows, the default stack size is only 1mb, compared to MacOS/Linux where 8mb is more typical. Rust async futures are fairly demanding stack wise, and debug builds fail at runtime with stack overflow. 

### Testing
Manual testing - the repro steps are simple (Windows only):
1. cargo build -p goose-cli
2. run 'goose acp' and send an initialize payload via stdio
3. application terminates with stack overflow

Issue repros without the stack increase, and does not repro with the stack increase.

### Related Issues
Relates to #6025

### Screenshots/Demos (for UX changes)
n/a