### PR TITLE
Revert "fix: rename bin for the tui (#8231)"

### DIFF
--- a/ui/text/package.json
+++ b/ui/text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose",
-  "version": "0.1.1",
+  "version": "0.1.0",
   "description": "Goose - an open-source AI agent",
   "license": "Apache-2.0",
   "repository": {
@@ -16,7 +16,7 @@
   ],
   "type": "module",
   "bin": {
-    "goose-text": "dist/tui.js"
+    "goose": "dist/tui.js"
   },
   "files": [
     "dist",


### PR DESCRIPTION
This isn't actually needed - I just had a strange bin conflict earlier

```
npx @aaif/goose@0.1.0
```

works fine and will work going forward to have the main `bin` be named `goose`