### PR TITLE
feat: bump versions (already published)

### DIFF
--- a/ui/acp/package.json
+++ b/ui/acp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-acp",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Agent Client Protocol (ACP) SDK for Goose AI agent",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-darwin-arm64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-darwin-arm64",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Goose binary for macOS ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-darwin-x64/package.json
+++ b/ui/goose-binary/goose-binary-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-darwin-x64",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Goose binary for macOS x64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-linux-arm64/package.json
+++ b/ui/goose-binary/goose-binary-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-linux-arm64",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Goose binary for Linux ARM64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/goose-binary/goose-binary-linux-x64/package.json
+++ b/ui/goose-binary/goose-binary-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose-binary-linux-x64",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Goose binary for Linux x64",
   "license": "Apache-2.0",
   "repository": {

--- a/ui/text/package.json
+++ b/ui/text/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aaif/goose",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Goose - an open-source AI agent",
   "license": "Apache-2.0",
   "repository": {
@@ -47,7 +47,7 @@
     "@aaif/goose-binary-win32-x64": "workspace:*"
   },
   "overrides": {
-    "react": "19.2.4"
+    "react": "^19.2.4"
   },
   "devDependencies": {
     "@types/marked-terminal": "^6.1.1",


### PR DESCRIPTION
I published these already from a local publishing flow. Still working out issues in the github actions based publishing but I wanted to get a clean slate of all of them out on npm. This just updates the versions in git to be in sync.