### PR TITLE
fix(ollama): wire worker model and fix thinking leak in summaries

### DIFF
--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__all_platform_extensions.snap
@@ -128,3 +128,30 @@ Template:
 # Response Guidelines
 
 Use Markdown formatting for all responses.
+
+## Efficiency
+
+- Act, don't plan repeatedly. State your intent once, then execute.
+- Never re-derive your full plan from scratch each turn. Reference your earlier reasoning instead.
+- Use the minimum number of tool calls needed. Batch related operations when possible.
+- When a tool call succeeds, move to the next step immediately without restating the plan.
+
+## Error Recovery
+
+- When a tool call fails, read the error message carefully before retrying.
+- Never retry the exact same command that just failed without changing something. Diagnose the root cause first.
+- After 2 consecutive failures on the same task, stop and explain the blocker to the user rather than continuing to retry.
+- For git operations: verify branch state and remote state before creating PRs or pushing.
+
+## Working Memory
+
+- Keep a mental model of your current directory, git branch, and files you have created or modified.
+- Do not run `pwd`, `git status`, or `ls` repeatedly if nothing has changed since your last check.
+- When resuming after tool output, continue from where you left off. Do not restart your reasoning from the beginning.
+
+## Tool Usage
+
+- Prefer reading files before editing them.
+- Prefer a single comprehensive shell command over many small sequential ones.
+- When creating multiple files, plan the dependency order to avoid broken imports.
+- Always verify that imports reference files that exist or that you will create in the current plan.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__basic.snap
@@ -16,3 +16,30 @@ No extensions are defined. You should let the user know that they should add ext
 # Response Guidelines
 
 Use Markdown formatting for all responses.
+
+## Efficiency
+
+- Act, don't plan repeatedly. State your intent once, then execute.
+- Never re-derive your full plan from scratch each turn. Reference your earlier reasoning instead.
+- Use the minimum number of tool calls needed. Batch related operations when possible.
+- When a tool call succeeds, move to the next step immediately without restating the plan.
+
+## Error Recovery
+
+- When a tool call fails, read the error message carefully before retrying.
+- Never retry the exact same command that just failed without changing something. Diagnose the root cause first.
+- After 2 consecutive failures on the same task, stop and explain the blocker to the user rather than continuing to retry.
+- For git operations: verify branch state and remote state before creating PRs or pushing.
+
+## Working Memory
+
+- Keep a mental model of your current directory, git branch, and files you have created or modified.
+- Do not run `pwd`, `git status`, or `ls` repeatedly if nothing has changed since your last check.
+- When resuming after tool output, continue from where you left off. Do not restart your reasoning from the beginning.
+
+## Tool Usage
+
+- Prefer reading files before editing them.
+- Prefer a single comprehensive shell command over many small sequential ones.
+- When creating multiple files, plan the dependency order to avoid broken imports.
+- Always verify that imports reference files that exist or that you will create in the current plan.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__one_extension.snap
@@ -26,3 +26,30 @@ how to use this extension
 # Response Guidelines
 
 Use Markdown formatting for all responses.
+
+## Efficiency
+
+- Act, don't plan repeatedly. State your intent once, then execute.
+- Never re-derive your full plan from scratch each turn. Reference your earlier reasoning instead.
+- Use the minimum number of tool calls needed. Batch related operations when possible.
+- When a tool call succeeds, move to the next step immediately without restating the plan.
+
+## Error Recovery
+
+- When a tool call fails, read the error message carefully before retrying.
+- Never retry the exact same command that just failed without changing something. Diagnose the root cause first.
+- After 2 consecutive failures on the same task, stop and explain the blocker to the user rather than continuing to retry.
+- For git operations: verify branch state and remote state before creating PRs or pushing.
+
+## Working Memory
+
+- Keep a mental model of your current directory, git branch, and files you have created or modified.
+- Do not run `pwd`, `git status`, or `ls` repeatedly if nothing has changed since your last check.
+- When resuming after tool output, continue from where you left off. Do not restart your reasoning from the beginning.
+
+## Tool Usage
+
+- Prefer reading files before editing them.
+- Prefer a single comprehensive shell command over many small sequential ones.
+- When creating multiple files, plan the dependency order to avoid broken imports.
+- Always verify that imports reference files that exist or that you will create in the current plan.

--- a/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
+++ b/crates/goose/src/agents/snapshots/goose__agents__prompt_manager__tests__typical_setup.snap
@@ -34,3 +34,30 @@ Consider asking if they'd like to disable some extensions to improve tool select
 # Response Guidelines
 
 Use Markdown formatting for all responses.
+
+## Efficiency
+
+- Act, don't plan repeatedly. State your intent once, then execute.
+- Never re-derive your full plan from scratch each turn. Reference your earlier reasoning instead.
+- Use the minimum number of tool calls needed. Batch related operations when possible.
+- When a tool call succeeds, move to the next step immediately without restating the plan.
+
+## Error Recovery
+
+- When a tool call fails, read the error message carefully before retrying.
+- Never retry the exact same command that just failed without changing something. Diagnose the root cause first.
+- After 2 consecutive failures on the same task, stop and explain the blocker to the user rather than continuing to retry.
+- For git operations: verify branch state and remote state before creating PRs or pushing.
+
+## Working Memory
+
+- Keep a mental model of your current directory, git branch, and files you have created or modified.
+- Do not run `pwd`, `git status`, or `ls` repeatedly if nothing has changed since your last check.
+- When resuming after tool output, continue from where you left off. Do not restart your reasoning from the beginning.
+
+## Tool Usage
+
+- Prefer reading files before editing them.
+- Prefer a single comprehensive shell command over many small sequential ones.
+- When creating multiple files, plan the dependency order to avoid broken imports.
+- Always verify that imports reference files that exist or that you will create in the current plan.

--- a/crates/goose/src/context_mgmt/mod.rs
+++ b/crates/goose/src/context_mgmt/mod.rs
@@ -516,6 +516,14 @@ pub async fn summarize_tool_call(
         .complete_fast(session_id, system_prompt, &summarization_request, &[])
         .await?;
 
+    // Strip thinking/reasoning content from summaries. When the fast model is a
+    // thinking model (e.g. Nemotron, Qwen3), its reasoning tokens leak into the
+    // summary and get injected as user-role thinking — polluting the conversation
+    // context and confusing the main model.
+    response.content.retain(|c| {
+        matches!(c, MessageContent::Text(_))
+    });
+
     response.role = Role::User;
     response.created = matching_messages.last().unwrap().created;
     response.metadata = MessageMetadata::agent_only();

--- a/crates/goose/src/prompts/compaction.md
+++ b/crates/goose/src/prompts/compaction.md
@@ -4,6 +4,8 @@
 - Include user requests, your responses, all technical content, and as much of the original context as possible
 - This will be used to let the user continue the working session
 - Use framing and tone knowing the content will be read an agent (you) on a next exchange to allow for continuation of the session
+- Do NOT include any thinking or reasoning blocks (e.g. `<think>`, `reasoning_content`) — only include the actionable content and decisions
+- Preserve the current working state: current directory path, current git branch, list of files created or modified during the session
 
 **Conversation History:**
 {{ messages }}

--- a/crates/goose/src/prompts/subagent_system.md
+++ b/crates/goose/src/prompts/subagent_system.md
@@ -27,6 +27,8 @@ You have access to {{tool_count}} tools: {{available_tools}}
 - Avoid exploratory tool usage unless explicitly required
 - Stop using tools once you have sufficient information
 - Provide clear, concise responses without excessive tool calls
+- Never retry a failed tool call with identical arguments. Diagnose the error first
+- If a tool fails twice in a row on the same task, report the blocker and move on
 
 # Communication Guidelines
 - **Progress Updates**: Report progress clearly and concisely
@@ -36,3 +38,5 @@ You have access to {{tool_count}} tools: {{available_tools}}
 - **Summarization**: If asked for a summary or report of your work, that should be the last message you generate
 
 Remember: You are part of a larger system. Your specialized focus helps the main agent handle multiple concerns efficiently. Complete your task efficiently with less tool usage.
+
+**Anti-Looping**: If you find yourself repeating similar reasoning or actions, stop immediately. Summarize what you have accomplished so far and what is blocking you. Do not continue retrying.

--- a/crates/goose/src/prompts/system.md
+++ b/crates/goose/src/prompts/system.md
@@ -41,3 +41,30 @@ Consider asking if they'd like to disable some extensions to improve tool select
 # Response Guidelines
 
 Use Markdown formatting for all responses.
+
+## Efficiency
+
+- Act, don't plan repeatedly. State your intent once, then execute.
+- Never re-derive your full plan from scratch each turn. Reference your earlier reasoning instead.
+- Use the minimum number of tool calls needed. Batch related operations when possible.
+- When a tool call succeeds, move to the next step immediately without restating the plan.
+
+## Error Recovery
+
+- When a tool call fails, read the error message carefully before retrying.
+- Never retry the exact same command that just failed without changing something. Diagnose the root cause first.
+- After 2 consecutive failures on the same task, stop and explain the blocker to the user rather than continuing to retry.
+- For git operations: verify branch state and remote state before creating PRs or pushing.
+
+## Working Memory
+
+- Keep a mental model of your current directory, git branch, and files you have created or modified.
+- Do not run `pwd`, `git status`, or `ls` repeatedly if nothing has changed since your last check.
+- When resuming after tool output, continue from where you left off. Do not restart your reasoning from the beginning.
+
+## Tool Usage
+
+- Prefer reading files before editing them.
+- Prefer a single comprehensive shell command over many small sequential ones.
+- When creating multiple files, plan the dependency order to avoid broken imports.
+- Always verify that imports reference files that exist or that you will create in the current plan.

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -97,6 +97,27 @@ fn apply_ollama_options(payload: &mut Value, model_config: &ModelConfig) {
 impl OllamaProvider {
     pub async fn from_env(model: ModelConfig) -> Result<Self> {
         let config = crate::config::Config::global();
+
+        // Wire the worker/fast model if configured. Unlike cloud providers that have
+        // a hardcoded default fast model, Ollama relies on the user's config since
+        // models are locally managed. This enables tool-pair summarization and
+        // compaction to use a smaller, faster model instead of the main model.
+        let model = match config.get_param::<String>("GOOSE_WORKER_MODEL") {
+            Ok(worker_model) if worker_model != model.model_name => {
+                let fallback = model.clone();
+                model
+                    .with_fast(&worker_model, OLLAMA_PROVIDER_NAME)
+                    .unwrap_or_else(|e| {
+                        tracing::warn!(
+                            "Failed to configure worker model '{}': {}. Using main model for fast operations.",
+                            worker_model, e
+                        );
+                        fallback
+                    })
+            }
+            _ => model,
+        };
+
         let host: String = config
             .get_param("OLLAMA_HOST")
             .unwrap_or_else(|_| OLLAMA_HOST.to_string());


### PR DESCRIPTION
## Summary

Three fixes for Ollama-based agentic sessions that cause context pollution, wasted compute, and model looping:

- **Wire `GOOSE_WORKER_MODEL` as the fast model for Ollama provider** — Unlike cloud providers (Anthropic -> claude-haiku, OpenAI -> gpt-4o-mini, etc.), the Ollama provider never called `model.with_fast()`. This meant `complete_fast()` always fell back to the expensive main model for tool-pair summarization and compaction, wasting compute on a 120B+ model for simple summaries.

- **Strip thinking/reasoning content from tool-pair summaries** — When the summarization model is a thinking model (Nemotron 3 Super, Qwen3, etc.), its reasoning tokens leaked into summary messages stored as `Role::User` content. This injected ghost "user thinking" messages (e.g., "We need to summarize: a tool call to shell command...") into the conversation, confusing the main model and polluting context.

- **Improve system, compaction, and subagent prompts** — Added efficiency guidelines (do not re-derive plans), error recovery patterns (do not retry identical failed commands), working memory instructions (do not re-run pwd/git status), and anti-looping directives. These changes are especially impactful for local/open-weight models that are more susceptible to looping.

## Motivation

Observed during an 8-hour Goose session using Nemotron 3 Super (120B) via Ollama:
- 505 messages in the session, ~70% were duplicates or ghost thinking
- The model repeated "We are in the..." re-orientation **108 times**
- 70 user-role thinking messages injected by the summarization system
- The worker model (devstral-small-2) was configured but **never called** (0 requests in logs)
- The model retried the same failed `gh pr create` command 8 times without diagnosing the root cause

## Test plan

- [x] `cargo test -p goose --lib` — 1098 passed, 0 failed
- [x] Snapshot tests updated for new system prompt content
- [x] `cargo check -p goose` — clean compilation
- [ ] Manual test: configure GOOSE_WORKER_MODEL with Ollama and verify complete_fast() uses the worker model
- [ ] Manual test: run a thinking model session and verify tool-pair summaries contain no thinking blocks

## Files changed

| File | Change |
|------|--------|
| `crates/goose/src/providers/ollama.rs` | Read GOOSE_WORKER_MODEL from config and wire as fast model |
| `crates/goose/src/context_mgmt/mod.rs` | Strip Thinking/RedactedThinking content from summaries |
| `crates/goose/src/prompts/system.md` | Add efficiency, error recovery, working memory, and tool usage guidelines |
| `crates/goose/src/prompts/compaction.md` | Exclude thinking blocks, preserve working state |
| `crates/goose/src/prompts/subagent_system.md` | Add anti-looping and error recovery rules |
| `crates/goose/src/agents/snapshots/*.snap` | Updated snapshot tests for new system prompt |

Generated with [Claude Code](https://claude.com/claude-code)
