### PR TITLE
fix: expand tool calls by default when Response Style is set to Detailed

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -811,7 +811,7 @@ function ToolCallView({
   );
   return (
     <ToolCallExpandable
-      isStartExpanded={isRenderingProgress}
+      isStartExpanded={isRenderingProgress || isExpandToolDetails}
       isForceExpand={false}
       label={
         extensionTooltip ? (
@@ -874,7 +874,7 @@ function ToolCallView({
         <>
           {toolResults.map((result, index) => (
             <div key={index} className={cn('border-t border-border-primary')}>
-              <ToolResultView toolCall={toolCall} result={result} isStartExpanded={false} />
+              <ToolResultView toolCall={toolCall} result={result} isStartExpanded={isExpandToolDetails} />
             </div>
           ))}
         </>


### PR DESCRIPTION
Fixes #8213

## Problem

When **Response Styles** is set to **Detailed** in Settings → Chat, tool calls still appear collapsed by default in the desktop GUI. Restarting the app does not change the behavior, even though `responseStyle` is confirmed as `detailed` in settings.

## Solution

Two changes to `ui/desktop/src/components/ToolCallWithResponse.tsx`:

1. The outer `ToolCallExpandable` was using `isStartExpanded={isRenderingProgress}`, which only expands when progress is actively rendering. Changed to `isStartExpanded={isRenderingProgress || isExpandToolDetails}` so tool calls start expanded when `responseStyle === 'detailed'`.

2. `ToolResultView` was always rendered with `isStartExpanded={false}` regardless of response style. Changed to `isStartExpanded={isExpandToolDetails}` so tool output is also expanded in Detailed mode.

The `isExpandToolDetails` variable was already correctly computing `true` for `'detailed'` style and `false` for `'concise'` — it just wasn't being used for the outer expandable and tool result views.

## Testing

- Set Response Styles to **Detailed** in Settings → Chat
- Send a message that triggers tool calls
- Tool calls and their results should now start expanded
- Switch to **Concise** — tool calls should start collapsed