### PR TITLE
docs: add Zcash MCP extension

### DIFF
--- a/documentation/docs/mcp/zcash-mcp.md
+++ b/documentation/docs/mcp/zcash-mcp.md
@@ -1,0 +1,77 @@
+---
+title: Zcash
+description: Shielded transactions, memo decoding, and on-chain attestation for AI agents
+---
+
+# Zcash MCP Server
+
+Zcash tools for AI agents. Shielded operations, structured memo decoding, lifecycle attestation via ZAP1, and chain queries. Privacy by default.
+
+## Quick Install
+
+```
+npx -y @frontiercompute/zcash-mcp
+```
+
+Or configure in `~/.config/goose/config.yaml`:
+
+```yaml
+extensions:
+  zcash-mcp:
+    name: Zcash
+    type: stdio
+    cmd: npx
+    args: ["-y", "@frontiercompute/zcash-mcp"]
+    enabled: true
+    envs:
+      ZAP1_API_URL: https://pay.frontiercompute.io
+```
+
+## Tools
+
+| Tool | Description |
+|------|-------------|
+| get_block_height | Current Zcash chain height |
+| lookup_transaction | Transaction details by txid |
+| get_balance | Wallet lifecycle and attestation status |
+| send_shielded | Generate shielded payment URI (ZIP 321) |
+| decode_memo | Decode ZAP1, ZIP 302, or plain text memos |
+| attest_event | Create a ZAP1 lifecycle attestation on Zcash |
+| verify_proof | Verify a ZAP1 Merkle proof |
+| get_stats | Protocol stats (leaves, anchors, event types) |
+| get_anchors | Anchor history with txids and block heights |
+| get_events | Recent attestation events |
+| get_agent_status | Agent attestation summary |
+| get_agent_bond | Agent bond and policy compliance status |
+
+## Example Usage
+
+Decode a Zcash shielded memo:
+```
+decode this memo: ZAP1:09:024e36515ea30efc15a0a7962dd8f677455938079430b9eab174f46a4328a07a
+```
+
+Verify an attestation proof:
+```
+verify this proof: ddbe05cc63697e1ce83c210ab4500cf1d2d4921eb863dbb40f10ec3e42c7b28c
+```
+
+Check protocol stats:
+```
+what are the current ZAP1 stats?
+```
+
+## Configuration
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| ZEBRA_RPC_URL | Zcash Zebra node endpoint | No (defaults to public endpoint) |
+| ZAP1_API_URL | ZAP1 attestation API | No (defaults to pay.frontiercompute.io) |
+| ZAP1_API_KEY | API key for write operations (attest_event) | No (read tools work without it) |
+
+## Links
+
+- [Source](https://github.com/Frontier-Compute/zcash-mcp)
+- [npm](https://www.npmjs.com/package/@frontiercompute/zcash-mcp)
+- [ZAP1 Protocol](https://frontiercompute.io/protocol.html)
+- [ZIP 1243 Draft](https://github.com/zcash/zips/pull/1243)

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -36,7 +36,7 @@
   {
     "id": "apify",
     "name": "Apify",
-    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store ⚡",
+    "description": "Extract data from any website with thousands of scrapers, crawlers, and automations on Apify Store \u26a1",
     "command": "npx -y @apify/actors-mcp-server",
     "link": "https://github.com/apify/apify-mcp-server",
     "installation_notes": "Install using npx. Requires an Apify API token.",
@@ -807,5 +807,32 @@
     "is_builtin": false,
     "endorsed": true,
     "environmentVariables": []
+  },
+  {
+    "id": "zcash-mcp",
+    "name": "Zcash",
+    "description": "Shielded transactions, memo decoding, and on-chain attestation for AI agents via ZAP1",
+    "command": "npx -y @frontiercompute/zcash-mcp",
+    "link": "https://github.com/Frontier-Compute/zcash-mcp",
+    "installation_notes": "Optional: set ZEBRA_RPC_URL for direct node access, ZAP1_API_URL and ZAP1_API_KEY for attestation features.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "ZEBRA_RPC_URL",
+        "description": "Zcash Zebra node RPC endpoint",
+        "required": false
+      },
+      {
+        "name": "ZAP1_API_URL",
+        "description": "ZAP1 attestation API",
+        "required": false
+      },
+      {
+        "name": "ZAP1_API_KEY",
+        "description": "ZAP1 API key for write operations",
+        "required": false
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Adds Zcash shielded operations to the Goose MCP directory.

**Package:** `npx -y @frontiercompute/zcash-mcp` (published on npm)

**12 tools:** chain queries, shielded payment URIs, memo decoding (ZAP1/ZIP 302/text), lifecycle attestation, proof verification, agent bond status.

**Why Zcash:** Privacy-preserving agent operations. Shielded memos carry structured attestation data without exposing transaction details. Agents can prove what they did without revealing who they transacted with.

**Source:** https://github.com/Frontier-Compute/zcash-mcp
**Protocol:** https://frontiercompute.io/protocol.html