### PR TITLE
Add VerifiedState MCP extension for verified agent memory

### DIFF
--- a/documentation/docs/guides/context-engineering/using-goosehints.md
+++ b/documentation/docs/guides/context-engineering/using-goosehints.md
@@ -139,61 +139,60 @@ my-project/
 ```
 
 If you start goose in `my-project/`, the root-level hints are loaded immediately. Later, when goose accesses files under `frontend/components/`, it loads the nested hints for that path and combines them in the following order:
-1. <details>
-     <summary>`my-project/.goosehints` (project root)</summary>
-        ```
-        This is a React + TypeScript project using Vite.
+1. `my-project/.goosehints` (project root)
 
-        @README.md                    # Project overview and setup instructions
-        @docs/development-setup.md    # Development environment configuration
+   ```
+   This is a React + TypeScript project using Vite.
 
-        Always run tests before committing: `npm test`
-        Use conventional commits for all changes.
-        ```
-   </details>
+   @README.md                    # Project overview and setup instructions
+   @docs/development-setup.md    # Development environment configuration
+
+   Always run tests before committing: `npm test`
+   Use conventional commits for all changes.
+   ```
+
+2. `frontend/.goosehints`
+
+   ```
+   This frontend uses React 18 with TypeScript and Tailwind CSS.
+
+   @package.json                      # Dependencies and scripts
+   @docs/frontend-architecture.md     # Frontend structure and patterns
+
+   ## Development Standards
+   - Use functional components with hooks (no class components)
+   - Implement proper TypeScript interfaces for all props
+   - Follow the component structure: /components/ComponentName/index.tsx
+   - Use Tailwind classes instead of custom CSS when possible
+
+   ## Testing Requirements
+   - Write unit tests for all components using React Testing Library
+   - Test files should be co-located: ComponentName.test.tsx
+   - Run `npm run test:frontend` before committing changes
+
+   ## State Management
+   - Use React Query for server state
+   - Use Zustand for client state management
+   - Avoid prop drilling - lift state appropriately
+
+   Always confirm UI changes with design team before implementation.
+   ```
+
+3. `frontend/components/.goosehints` (current directory)
+
+   ```
+   Components in this directory use our design system.
+
+   @docs/component-api.md    # Component interface standards and examples
+
+   All components must:
+   - Export a default component
+   - Include TypeScript props interface
+   - Have corresponding .test.tsx file
+   - Follow naming convention: PascalCase
+   ```
 
 After nested hints are loaded for a directory, they remain active for the rest of the session. If you update a hint file and want goose to pick up the new content reliably, restart the session.
-2. <details>
-     <summary>`frontend/.goosehints`</summary>
-        ```
-        This frontend uses React 18 with TypeScript and Tailwind CSS.
-
-        @package.json                      # Dependencies and scripts
-        @docs/frontend-architecture.md     # Frontend structure and patterns
-
-        ## Development Standards
-        - Use functional components with hooks (no class components)
-        - Implement proper TypeScript interfaces for all props
-        - Follow the component structure: /components/ComponentName/index.tsx
-        - Use Tailwind classes instead of custom CSS when possible
-
-        ## Testing Requirements  
-        - Write unit tests for all components using React Testing Library
-        - Test files should be co-located: ComponentName.test.tsx
-        - Run `npm run test:frontend` before committing changes
-
-        ## State Management
-        - Use React Query for server state
-        - Use Zustand for client state management
-        - Avoid prop drilling - lift state appropriately
-
-        Always confirm UI changes with design team before implementation.
-        ```
-   </details> 
-3. <details>
-     <summary>`frontend/components/.goosehints` (current directory)</summary>
-        ```
-        Components in this directory use our design system.
-
-        @docs/component-api.md    # Component interface standards and examples
-
-        All components must:
-        - Export a default component
-        - Include TypeScript props interface
-        - Have corresponding .test.tsx file
-        - Follow naming convention: PascalCase
-        ```
-   </details>
 
 ## Common Use Cases
 Here are some ways people have used hints to provide additional context to goose:

--- a/documentation/docs/mcp/verifiedstate-mcp.md
+++ b/documentation/docs/mcp/verifiedstate-mcp.md
@@ -5,27 +5,28 @@ description: Add VerifiedState MCP Server as a goose Extension for verified agen
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
 This tutorial covers how to add the [VerifiedState MCP Server](https://verifiedstate.ai) as a goose extension. VerifiedState provides decision trace infrastructure — every assertion your goose agent makes gets a cryptographic verification receipt.
 
 :::tip Quick Install
 <Tabs groupId="interface">
-  <TabItem value="cli" label="goose CLI" default>
-  Use `goose configure` to add a `Command-line Extension (stdio)` extension type with:
-
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=%40verifiedstate%2Fmcp-server&id=verifiedstate&name=VerifiedState&description=Verified%20agent%20memory%20with%20cryptographic%20receipts&env=VERIFIEDSTATE_API_KEY%3DYour%20API%20Key&env=VERIFIEDSTATE_NAMESPACE_ID%3DYour%20Namespace%20ID)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
   **Command**
-  ```
-  npx @verifiedstate/mcp-server
-  ```
-
-  **Environment Variables**
-  ```
-  VERIFIEDSTATE_API_KEY=vs_live_your_key
-  VERIFIEDSTATE_NAMESPACE_ID=your_namespace_id
+  ```sh
+  npx -y @verifiedstate/mcp-server
   ```
   </TabItem>
 </Tabs>
+  **Environment Variables**
+  ```
+  VERIFIEDSTATE_API_KEY: <YOUR_API_KEY>
+  VERIFIEDSTATE_NAMESPACE_ID: <YOUR_NAMESPACE_ID>
+  ```
 :::
 
 ## What VerifiedState adds to goose
@@ -39,21 +40,44 @@ goose is an autonomous agent making consequential decisions — architectural ch
 
 ## Configuration
 
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
+:::
+
 <Tabs groupId="interface">
-  <TabItem value="cli" label="goose CLI" default>
-
-    <CLIExtensionInstructions
-      name="VerifiedState"
-      description="Decision trace infrastructure for AI agents. Cryptographic receipts on every assertion."
-      type="stdio"
-      command="npx @verifiedstate/mcp-server"
-      envVars={[
-        { key: "VERIFIEDSTATE_API_KEY", value: "your-api-key" },
-        { key: "VERIFIEDSTATE_NAMESPACE_ID", value: "your-namespace-id" }
-      ]}
-    />
-
+  <TabItem value="ui" label="goose Desktop" default>
+  <GooseDesktopInstaller
+    extensionId="verifiedstate"
+    extensionName="VerifiedState"
+    description="Verified agent memory with cryptographic receipts"
+    command="npx"
+    args={["-y", "@verifiedstate/mcp-server"]}
+    envVars={[
+      { name: "VERIFIEDSTATE_API_KEY", label: "Your VerifiedState API Key" },
+      { name: "VERIFIEDSTATE_NAMESPACE_ID", label: "Your Namespace ID" }
+    ]}
+    apiKeyLink="https://verifiedstate.ai/keys"
+    apiKeyLinkText="VerifiedState API Key"
+  />
   </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="verifiedstate"
+      description="Verified agent memory with cryptographic receipts"
+      type="stdio"
+      command="npx -y @verifiedstate/mcp-server"
+      timeout={300}
+      envVars={[
+        { key: "VERIFIEDSTATE_API_KEY", value: "<Your VerifiedState API Key>" },
+        { key: "VERIFIEDSTATE_NAMESPACE_ID", value: "<Your Namespace ID>" }
+      ]}
+      infoNote={
+        <>
+          Get your free API key at <a href="https://verifiedstate.ai/keys" target="_blank" rel="noopener noreferrer">verifiedstate.ai/keys</a>. Free tier includes 25,000 assertions/month.
+        </>
+      }
+    />
+    </TabItem>
 </Tabs>
 
 ## Available Tools


### PR DESCRIPTION
## Summary

Adds documentation for the VerifiedState MCP extension, which provides verified agent memory with cryptographic receipts.

## What it does

VerifiedState adds a decision trace layer to Goose. Every assertion a Goose agent makes gets:
- A cryptographic verification receipt (Ed25519 signed)
- Evidence grounding (what supported the assertion)
- Point-in-time queryability (reconstruct beliefs at any moment)
- Conflict detection (contradicting assertions flagged)

## MCP Tools

| Tool | Description |
|------|-------------|
| `memory_ingest` | Store content as an artifact |
| `memory_query` | Six-channel retrieval |
| `memory_verify` | Produce signed receipt |
| `memory_health` | Namespace health metrics |

## Why this matters for Goose

Goose handles ~90% of Block's code submissions. These are consequential decisions. When something breaks months later, teams need to know what Goose believed about the codebase when it made that choice. VerifiedState provides that audit trail.

## Links

- https://verifiedstate.ai
- https://verifiedstate.ai/docs
- npm: `@verifiedstate/sdk`
- Free tier: 25k assertions/month