### PR TITLE
fix: align hamburger menu with macOS traffic light buttons

### DIFF
--- a/ui/desktop/src/components/Layout/AppLayout.tsx
+++ b/ui/desktop/src/components/Layout/AppLayout.tsx
@@ -147,6 +147,7 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
   }, [isPushTopNav]);
 
   const headerPadding = safeIsMacOS ? 'pl-[96px]' : 'pl-4';
+  const headerTop = safeIsMacOS ? 'top-[15px]' : 'top-[11px]';
 
   // Determine flex direction based on navigation position (for push mode)
   const getLayoutClass = () => {
@@ -200,7 +201,7 @@ const AppLayoutContent: React.FC<AppLayoutContentProps> = ({ activeSessions }) =
             ? 'bottom-4 right-6'
             : cn(
                 headerPadding,
-                'top-[15px]',
+                headerTop,
                 navigationPosition === 'right' ? 'right-6 left-auto' : 'ml-1.5'
               )
         )}


### PR DESCRIPTION
## Summary
Adjusted the hamburger menu button positioning on macOS to properly align with the traffic light buttons. Increased horizontal padding (pl-21 → pl-[96px]) and corrected vertical offset (top-[11px] → top-[15px]).

### Testing
Manual testing on macOS. Verified visual alignment of the hamburger button with traffic light circles in both expanded and collapsed navigation states.

### Related Issues
Fixes #8299

### Screenshots/Demos (for UX changes)
Before:  
<img width="169" height="115" alt="image" src="https://github.com/user-attachments/assets/cd481652-3335-496e-9261-71c9302b4578" />

After:   
<img width="170" height="77" alt="image" src="https://github.com/user-attachments/assets/bf1395d6-3848-43df-afec-fefa249fc0dd" />


https://github.com/user-attachments/assets/2bfbf0ff-037a-4964-ba78-7d472e0df2dd

