### PR TITLE
fix: prevent invalid HTML nesting from fenced code blocks breaking layout

### DIFF
--- a/ui/desktop/src/components/MarkdownContent.test.tsx
+++ b/ui/desktop/src/components/MarkdownContent.test.tsx
@@ -161,6 +161,71 @@ console.log('Hello, World!');
       });
     });
 
+    it('does not nest block-level code block content inside a <pre> element', async () => {
+      // react-markdown wraps code blocks in <pre> by default; when CodeBlock renders
+      // a <div>, this creates invalid HTML (<pre><div>) that browsers auto-correct
+      // by moving the <div> outside <pre>, disrupting surrounding text layout.
+      // The fix: components.pre returns its children directly (no <pre> wrapper).
+      const content = `Any text
+
+\`\`\`bash
+ls -la
+\`\`\`
+
+Additional text`;
+
+      const { container } = renderWithIntl(<MarkdownContent content={content} />);
+
+      await waitFor(() => {
+        expect(container).toHaveTextContent('Any text');
+        expect(container).toHaveTextContent('ls -la');
+        expect(container).toHaveTextContent('Additional text');
+      });
+
+      // The code block content should NOT be inside a <pre> element
+      // (pre is stripped to avoid <pre><div> invalid HTML nesting)
+      const preElements = container.querySelectorAll('pre');
+      expect(preElements).toHaveLength(0);
+    });
+
+    it('renders multiple fenced code blocks without disrupting surrounding text layout', async () => {
+      const content = `Any text
+
+Another text
+
+\`\`\`bash
+ls -la
+pwd
+\`\`\`
+
+Additional text
+
+Maybe something else
+
+\`\`\`text
+And some text here
+\`\`\`
+
+Final text`;
+
+      const { container } = renderWithIntl(<MarkdownContent content={content} />);
+
+      await waitFor(() => {
+        expect(container).toHaveTextContent('Any text');
+        expect(container).toHaveTextContent('Another text');
+        expect(container).toHaveTextContent('ls -la');
+        expect(container).toHaveTextContent('pwd');
+        expect(container).toHaveTextContent('Additional text');
+        expect(container).toHaveTextContent('Maybe something else');
+        expect(container).toHaveTextContent('And some text here');
+        expect(container).toHaveTextContent('Final text');
+      });
+
+      // No <pre> elements should remain (stripped to avoid invalid nesting)
+      const preElements = container.querySelectorAll('pre');
+      expect(preElements).toHaveLength(0);
+    });
+
     it('renders inline code', async () => {
       const content = 'Use `console.log()` to debug.';
 

--- a/ui/desktop/src/components/MarkdownContent.tsx
+++ b/ui/desktop/src/components/MarkdownContent.tsx
@@ -292,6 +292,7 @@ const MarkdownContent = memo(function MarkdownContent({
                 />
               );
             },
+            pre: ({ children }) => <>{children}</>,
             code: MarkdownCode,
           }}
         >


### PR DESCRIPTION
Fixes #8290

## Problem

In react-markdown v10, fenced code blocks with a language specifier (e.g. ` ```bash `) are handled by the custom `MarkdownCode` component, which renders a `CodeBlock` — a `<div>`-based component using `SyntaxHighlighter` with `PreTag="div"`.

However, react-markdown wraps all block code elements with a default `<pre>` element when `components.pre` is not customized. This creates invalid HTML:

```html
<pre>      <!-- react-markdown default -->
  <div>  <!-- CodeBlock / SyntaxHighlighter with PreTag="div" -->
    <code>...</code>
  </div>
</pre>
```

Browsers auto-correct `<div>` inside `<pre>` by moving the `<div>` outside the `<pre>`, which disrupts the layout of surrounding text content. This explains why fenced code blocks **sometimes** break the message layout — the issue appears whenever a response contains code blocks with a language specifier.

## Solution

Add `pre: ({ children }) => <>{children}</>` to the `components` prop of `ReactMarkdown`. This strips the default `<pre>` wrapper, letting the `CodeBlock` component render its own block-level presentation (via `SyntaxHighlighter` with `PreTag="div"`) without being wrapped in an invalid `<pre>` element.

## Testing

- Added two new tests to `MarkdownContent.test.tsx`:
  1. Verifies no `<pre>` elements remain in the DOM for a single code block
  2. Verifies multiple fenced code blocks render correctly alongside surrounding text (reproducing the reporter's exact example)
- All 26 existing tests continue to pass