### PR TITLE
docs: add MnemoPay extension tutorial

### DIFF
--- a/documentation/docs/tutorials/mnemopay-extension.md
+++ b/documentation/docs/tutorials/mnemopay-extension.md
@@ -1,18 +1,18 @@
 ---
 title: MnemoPay Extension
-description: Add MnemoPay MCP Server as a Goose Extension for persistent memory, micropayments, and fraud-aware trust scoring
+description: Add MnemoPay MCP Server as a goose extension for persistent memory, micropayments, and fraud-aware trust scoring
 ---
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-This tutorial covers how to add the [MnemoPay MCP Server](https://github.com/mnemopay/mnemopay-sdk) as a Goose extension for persistent agent memory, micropayments with escrow, and Bayesian trust scoring.
+This tutorial covers how to add the [MnemoPay MCP Server](https://github.com/mnemopay/mnemopay-sdk) as a goose extension for persistent agent memory, micropayments with escrow, and Bayesian trust scoring.
 
-With MnemoPay, Goose agents can remember findings across sessions, charge for value delivered, build reputation over time, and detect fraud — all through a single MCP extension. The core innovation is the **payment-memory feedback loop**: successful settlements reinforce the memories that led to the decision.
+With MnemoPay, goose agents can remember findings across sessions, charge for value delivered, build reputation over time, and detect fraud — all through a single MCP extension. The core innovation is the **payment-memory feedback loop**: successful settlements reinforce the memories that led to the decision.
 
 ## Supported Tools
 
-MnemoPay exposes 13 MCP tools:
+MnemoPay exposes 15 MCP tools:
 
 ### Memory
 
@@ -44,19 +44,20 @@ MnemoPay exposes 13 MCP tools:
 
 :::info
 MnemoPay runs in "quick mode" by default — zero infrastructure, in-memory with file persistence. No database setup needed.
+
 :::
 
 ## Setup
 
 <Tabs groupId="interface">
-  <TabItem value="cli" label="Goose CLI" default>
+  <TabItem value="cli" label="goose CLI" default>
 
 ```sh
-goose configure extensions --add mnemopay -- npx -y @mnemopay/sdk
+goose session --with-extension "npx -y @mnemopay/sdk"
 ```
 
   </TabItem>
-  <TabItem value="ui" label="Goose Desktop">
+  <TabItem value="ui" label="goose Desktop">
 
 1. Open **Settings** > **Extensions**
 2. Click **Add custom extension**
@@ -66,6 +67,7 @@ goose configure extensions --add mnemopay -- npx -y @mnemopay/sdk
    - **Args:** `-y @mnemopay/sdk`
    - **Type:** stdio
 4. Optionally set environment variable `MNEMOPAY_AGENT_ID` to a unique name
+
 
   </TabItem>
   <TabItem value="config" label="Config File">
@@ -94,14 +96,14 @@ extensions:
 ```
 You: Research the best practices for rate limiting in Express.js
 
-Goose: [uses remember to store findings]
+goose: [uses remember to store findings]
        [stores: "Express rate limiting: use express-rate-limit middleware, 
         set windowMs to 15min, max 100 requests per IP. For APIs, 
         consider sliding window with Redis store."]
 
 You: What did you find about rate limiting last time?
 
-Goose: [uses recall with query "rate limiting"]
+goose: [uses recall with query "rate limiting"]
        [retrieves previous research, ranked by relevance]
 ```
 
@@ -110,16 +112,16 @@ Goose: [uses recall with query "rate limiting"]
 ```
 You: Analyze this codebase and charge me for the work.
 
-Goose: [uses recall to check for prior context about this codebase]
+goose: [uses recall to check for prior context about this codebase]
        [performs analysis]
        [uses charge to create $5 escrow for "codebase analysis"]
 
 You: Great analysis, approve the payment.
 
-Goose: [uses settle to finalize]
+goose: [uses settle to finalize]
        → reputation increases by 0.01
        → memories from last hour get +0.05 importance boost
-       → next time, Goose recalls this analysis faster and more accurately
+       → next time, goose recalls this analysis faster and more accurately
 ```
 
 ## Using the Recipe
@@ -127,12 +129,12 @@ Goose: [uses settle to finalize]
 MnemoPay includes a pre-configured recipe:
 
 ```sh
-goose session --recipe https://raw.githubusercontent.com/mnemopay/mnemopay-sdk/master/integrations/goose/recipe.yaml
+goose run --recipe https://raw.githubusercontent.com/mnemopay/mnemopay-sdk/master/integrations/goose/recipe.yaml
 ```
 
-The recipe instructs Goose to automatically recall memories at session start, store important findings, and use the payment feedback loop.
+The recipe instructs goose to automatically recall memories at session start, store important findings, and use the payment feedback loop.
 
-## Pairing with Lightning
+## Pairing with lightning
 
 MnemoPay pairs with [Lightning Agent Tools](https://github.com/lightninglabs/lightning-agent-tools) for Bitcoin payments with trust:
 
@@ -148,7 +150,7 @@ extensions:
     args: ["-y", "@lightninglabs/lightning-mcp-server"]
 ```
 
-Lightning handles L402 payments. MnemoPay remembers which endpoints delivered value and scores trust.
+lightning handles L402 payments. MnemoPay remembers which endpoints delivered value and scores trust.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary

Adds a tutorial for [MnemoPay](https://github.com/mnemopay/mnemopay-sdk) — the first MCP extension that combines persistent memory, micropayments, and fraud-aware trust scoring for Goose agents.

- 13 MCP tools: 5 memory, 4 payment, 4 observability
- Payment-memory feedback loop: settlements reinforce memories that led to good decisions
- Bayesian trust scoring with reputation-gated transaction limits
- 10-signal fraud detection pipeline
- Published on npm: `@mnemopay/sdk` v0.5.0
- 143 tests passing, MIT licensed

## Setup

One line:
```sh
goose configure extensions --add mnemopay -- npx -y @mnemopay/sdk
```

## Tutorial includes

- Tool reference table (all 13 tools)
- Setup instructions (CLI, Desktop, config file)
- Usage examples (memory recall, payment feedback loop)
- Recipe integration
- Lightning Network pairing guide
- Environment variable reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)