### PR TITLE
fix: reduce log noise from MOIM injection and summon frontmatter parsing

### DIFF
--- a/crates/goose/src/agents/moim.rs
+++ b/crates/goose/src/agents/moim.rs
@@ -36,6 +36,9 @@ pub async fn inject_moim(
             !issue.contains("Merged consecutive user messages")
                 && !issue.contains("Merged consecutive assistant messages")
                 && !issue.contains("Added placeholder to empty tool result")
+                && !issue.contains("Merged text content")
+                && !issue.contains("Removed trailing assistant message")
+                && !issue.contains("Trimmed trailing whitespace from assistant message")
         });
 
         if has_unexpected_issues {

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -35,7 +35,7 @@ use tokio::sync::{mpsc, Mutex};
 
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
-use tracing::{info, warn};
+use tracing::{debug, info, warn};
 
 pub static EXTENSION_NAME: &str = "summon";
 
@@ -159,7 +159,7 @@ fn parse_frontmatter<T: for<'de> Deserialize<'de>>(content: &str) -> Option<(T, 
     let metadata: T = match serde_yaml::from_str(yaml_content) {
         Ok(m) => m,
         Err(e) => {
-            warn!("Failed to parse frontmatter: {}", e);
+            debug!("Failed to parse frontmatter: {}", e);
             return None;
         }
     };


### PR DESCRIPTION
Fixes #8273
Fixes #8274

## Problem

Two sources of excessive WARN-level log noise that pollute sessions:

1. **MOIM log spam (#8274)**: `inject_moim()` inserts a user message then calls `fix_conversation()`, which auto-corrects invalid sequences and returns a list of issues it fixed. The code correctly treats most auto-corrections as expected, but three additional patterns — `"Merged text content"`, `"Removed trailing assistant message"`, and `"Trimmed trailing whitespace from assistant message"` — were not in the expected list, causing a WARN on every LLM call (142+ per long session).

2. **Summon frontmatter warnings (#8273)**: The summon extension scans markdown files to find skills and agents. `parse_frontmatter()` emits a WARN when a file's YAML front matter can't be deserialized into the expected struct (e.g., a plain markdown file missing the `name` field). Non-extension markdown files are expected to fail this check and be skipped silently, so the WARN is misleading and noisy (fires 2x on startup plus once per subagent invocation).

## Solution

- **moim.rs**: Add the three missing patterns to the `has_unexpected_issues` filter so they are treated as normal auto-corrections rather than triggering a WARN.
- **summon.rs**: Downgrade the `parse_frontmatter` failure log from `warn!` to `debug!` since skipping non-extension files is the intended behavior.

## Testing

- Existing unit tests for `moim` and `summon` pass unchanged
- No behavioral change — only log level affected; errors that are genuinely unexpected still trigger WARN