### PR TITLE
fix: keep provider-returned models visible

### DIFF
--- a/crates/goose/src/providers/base.rs
+++ b/crates/goose/src/providers/base.rs
@@ -615,8 +615,13 @@ pub trait Provider: Send + Sync {
                 .enumerate()
                 .map(|(index, model)| {
                     let canonical_model = map_to_canonical_model(provider_name, &model, registry)
-                        .and_then(|canonical_id| canonical_id.split_once('/'))
-                        .and_then(|(provider, model_name)| registry.get(provider, model_name));
+                        .and_then(|canonical_id| {
+                            canonical_id
+                                .split_once('/')
+                                .and_then(|(provider, model_name)| {
+                                    registry.get(provider, model_name)
+                                })
+                        });
 
                     let (tier, release_date) = match canonical_model {
                         Some(canonical_model)


### PR DESCRIPTION
Addressing https://github.com/block/goose/issues/8321

## Summary
- stop treating the canonical registry as an allowlist in `fetch_recommended_models`
- keep every provider-returned model visible while still ranking canonically-known text/tool-capable models first
- add regression coverage for unknown models and custom proxy model lists

## Testing
- cargo fmt

## Context
This addresses the provider model list behavior where Goose silently hid models that were returned by the provider but were missing from the bundled canonical registry. The registry is now advisory for ranking instead of gating visibility.