### PR TITLE
[codex] docs: pin AGENTS.md packaging names

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,19 @@ cd ui/desktop && pnpm test   # test UI
 git commit -s                # required for DCO sign-off
 ```
 
+## Packaging
+```bash
+download_cli.sh              # POSIX installer (uses GOOSE_BIN_DIR)
+download_cli.ps1             # PowerShell installer (uses GOOSE_BIN_DIR)
+ui/goose-binary/             # native npm binary packages
+```
+
+- `@aaif/goose-binary-darwin-arm64`
+- `@aaif/goose-binary-darwin-x64`
+- `@aaif/goose-binary-linux-arm64`
+- `@aaif/goose-binary-linux-x64`
+- `@aaif/goose-binary-win32-x64`
+
 ## Structure
 ```
 crates/


### PR DESCRIPTION
## Summary
- add a packaging section to `AGENTS.md` with the current installer script locations
- document `GOOSE_BIN_DIR` as the installer env var used by both install scripts
- list the five current native npm binary packages under `ui/goose-binary/`

## Why
The issue body references stale line numbers and examples that do not exist on current `main`, but it points at a real maintenance problem: `AGENTS.md` did not include the current packaging/install names that are easy to copy incorrectly.

This change puts the repo-backed ground truth directly in `AGENTS.md` so future edits have the right installer env var and native package names in one place.

## Impact
- contributors and coding agents have the current installer/package names in the repo's main instructions file
- future docs or rename edits are less likely to drift toward stale package scopes or env vars

## Testing
- `git diff --check`

Closes #8226
