### PR TITLE
fix(cli): display platform-correct secrets path in keyring config dialog

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1478,7 +1478,11 @@ pub fn configure_keyring_dialog() -> anyhow::Result<()> {
     };
 
     let _ = cliclack::log::info(format!("Current secret storage: {}", current_status));
-    let _ = cliclack::log::warning("Note: Disabling the keyring stores secrets in a plain text file (~/.config/goose/secrets.yaml)");
+    let secrets_path = Paths::config_dir().join("secrets.yaml");
+    let _ = cliclack::log::warning(format!(
+        "Note: Disabling the keyring stores secrets in a plain text file ({})",
+        secrets_path.display()
+    ));
 
     let storage_option = cliclack::select("How would you like to store secrets?")
         .item(
@@ -1504,9 +1508,10 @@ pub fn configure_keyring_dialog() -> anyhow::Result<()> {
         "file" => {
             // Set the disable flag to use file storage
             config.set_param("GOOSE_DISABLE_KEYRING", Value::String("true".to_string()))?;
-            cliclack::outro(
-                "Secret storage set to file (~/.config/goose/secrets.yaml). Keep this file secure!",
-            )?;
+            cliclack::outro(format!(
+                "Secret storage set to file ({}). Keep this file secure!",
+                secrets_path.display(),
+            ))?;
             let _ =
                 cliclack::log::info("You may need to restart goose for this change to take effect");
         }


### PR DESCRIPTION
## Summary

- The keyring configuration dialog in `goose configure` hardcoded `~/.config/goose/secrets.yaml` in warning and confirmation messages
- This path is only correct on Linux — on Windows the actual path is `C:\Users\<user>\AppData\Roaming\Block\goose\config\secrets.yaml`, on macOS it's `~/Library/Application Support/Block/goose/`
- Replaced hardcoded string with `Paths::config_dir().join("secrets.yaml")`, which is already imported and used elsewhere in the same file

Fixes #8326

## Before / After

**Before** (hardcoded Unix path on Windows):
<img width="1269" height="554" alt="old" src="https://github.com/user-attachments/assets/d9248077-f683-4a90-96bc-96f402c1dbab" />


**After** (correct platform path):
<img width="1260" height="598" alt="new" src="https://github.com/user-attachments/assets/509d436e-87d8-48fb-a257-148ca762e901" />

## Test plan

- [x] Built and tested on Windows 11 — path now shows correct platform path
- [x] Compilation verified on Linux (WSL) via `cargo check`