### PR TITLE
docs: add PQS Prompt Quality Score MCP extension tutorial

### DIFF
--- a/documentation/docs/mcp/pqs-mdp.md
+++ b/documentation/docs/mcp/pqs-mdp.md
@@ -1,0 +1,52 @@
+---
+title: PQS - Prompt Quality Score Extension
+description: Add PQS MCP Server as a goose Extension
+---
+
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+
+This tutorial covers how to add the [PQS MCP Server](https://github.com/OnChainAIIntel/pqs-mcp-server) as a goose extension to score, optimize, and compare LLM prompts before inference. PQS is the world's first named AI prompt quality score — grade any prompt A-F on a 40-point scale, get an optimized version, or compare Claude vs GPT-4o on the same prompt.
+
+## Configuration
+
+:::info Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`. :::
+
+<GooseDesktopInstaller
+  extensionId="pqs"
+  extensionName="PQS - Prompt Quality Score"
+  description="Score, optimize, and compare LLM prompts before inference"
+  type="stdio"
+  command="npx"
+  args={["pqs-mcp-server"]}
+  timeout={300}
+  envVars={[
+    { name: "PQS_API_KEY", label: "PQS API Key — optional, only needed for paid tools. Get one at pqs.onchainintel.net" }
+  ]}
+  apiKeyLink="https://pqs.onchainintel.net"
+  apiKeyLinkText="PQS API Key"
+/>
+
+<CLIExtensionInstructions
+  name="PQS - Prompt Quality Score"
+  description="Score, optimize, and compare LLM prompts before inference"
+  type="stdio"
+  command="npx pqs-mcp-server"
+  timeout={300}
+  envVars={[
+    { key: "PQS_API_KEY", value: "●●●●●●●●●●●●●●●●●●●●●●●●●●●●●●" }
+  ]}
+  infoNote={
+    <>
+      Get your API key from{" "}
+      <a href="https://pqs.onchainintel.net" target="_blank" rel="noopener noreferrer">
+        pqs.onchainintel.net
+      </a>.
+      The free score_prompt tool requires no API key.
+    </>
+  }
+/>
+
+## Example Usage
+
+Use PQS to check prompt quality bef


### PR DESCRIPTION
## Summary
Adds tutorial for PQS (Prompt Quality Score) MCP server — the world's first named AI prompt quality score. Enables goose users to score, optimize, and compare LLM prompts before inference.

- Free scoring via score_prompt (no API key needed)
- $0.025 USDC optimize via optimize_prompt
- $1.25 USDC Claude vs GPT-4o compare via compare_models
- Built on PEEM, RAGAS, G-Eval, MT-Bench
- npm: https://www.npmjs.com/package/pqs-mcp-server
- GitHub: https://github.com/OnChainAIIntel/pqs-mcp-server

### Testing
Verified npx pqs-mcp-server runs correctly and all three tools are functional.

### Related Issues
N/A