### PR TITLE
fix: resolve MDX compilation error in using-goosehints.md

### DIFF
--- a/documentation/docs/guides/context-engineering/using-goosehints.md
+++ b/documentation/docs/guides/context-engineering/using-goosehints.md
@@ -151,8 +151,6 @@ If you start goose in `my-project/`, the root-level hints are loaded immediately
         Use conventional commits for all changes.
         ```
    </details>
-
-After nested hints are loaded for a directory, they remain active for the rest of the session. If you update a hint file and want goose to pick up the new content reliably, restart the session.
 2. <details>
      <summary>`frontend/.goosehints`</summary>
         ```
@@ -179,7 +177,7 @@ After nested hints are loaded for a directory, they remain active for the rest o
 
         Always confirm UI changes with design team before implementation.
         ```
-   </details> 
+   </details>
 3. <details>
      <summary>`frontend/components/.goosehints` (current directory)</summary>
         ```
@@ -194,6 +192,10 @@ After nested hints are loaded for a directory, they remain active for the rest o
         - Follow naming convention: PascalCase
         ```
    </details>
+
+:::note
+After nested hints are loaded for a directory, they remain active for the rest of the session. If you update a hint file and want goose to pick up the new content reliably, restart the session.
+:::
 
 ## Common Use Cases
 Here are some ways people have used hints to provide additional context to goose:


### PR DESCRIPTION
## Problem

CI fails with:

```
MDX compilation failed for file "documentation/docs/guides/context-engineering/using-goosehints.md"
Cause: Expected a closing tag for `<details>` (156:4-156:13) before the end of `paragraph`
```

## Root Cause

The numbered list containing `<details>` tags was broken by a paragraph inserted between items 1 and 2. MDX treats the continuation as a paragraph rather than a new list item, so the `<details>` on item 2 is never properly closed from MDX's perspective.

## Fix

- Move the note about nested hint persistence **after** the numbered list and wrap it in a `:::note` admonition
- Remove trailing whitespace on a `</details>` tag