### PR TITLE
fix: expand tool calls by default when Response Style is Detailed

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -811,7 +811,7 @@ function ToolCallView({
   );
   return (
     <ToolCallExpandable
-      isStartExpanded={isRenderingProgress}
+      isStartExpanded={isRenderingProgress || isExpandToolDetails}
       isForceExpand={false}
       label={
         extensionTooltip ? (
@@ -874,7 +874,7 @@ function ToolCallView({
         <>
           {toolResults.map((result, index) => (
             <div key={index} className={cn('border-t border-border-primary')}>
-              <ToolResultView toolCall={toolCall} result={result} isStartExpanded={false} />
+              <ToolResultView toolCall={toolCall} result={result} isStartExpanded={isExpandToolDetails} />
             </div>
           ))}
         </>


### PR DESCRIPTION
Fixes #8213

## Problem
When **Response Styles** is set to **Detailed** in Settings → Chat, tool calls still appear collapsed by default. The `ToolCallExpandable` wrapper only starts expanded when rendering live progress (`isRenderingProgress`), and `ToolResultView` always starts collapsed (`isStartExpanded={false}`), ignoring the `responseStyle` setting entirely.

## Solution
Two targeted changes in `ToolCallWithResponse.tsx`:

1. `ToolCallExpandable` now starts expanded when `isExpandToolDetails` is true (i.e. `responseStyle === 'detailed'`), in addition to the existing live-progress condition.
2. `ToolResultView` now receives `isStartExpanded={isExpandToolDetails}` instead of the hardcoded `false`, so tool outputs also expand automatically in Detailed mode.

The `isExpandToolDetails` value is already computed correctly in `ToolCallView` based on `responseStyle`, so no logic changes are needed — just threading the existing value through to the two components.

## Testing
- Set **Settings → Chat → Response Styles** to **Detailed**
- Run a session that produces tool calls
- Verify tool call blocks start expanded (both the tool arguments and the tool output)
- Switch to **Concise** and verify tool calls start collapsed