### PR TITLE
fix: reduce summon agent frontmatter warning noise

### DIFF
--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -150,22 +150,52 @@ struct AgentMetadata {
 }
 
 fn parse_frontmatter<T: for<'de> Deserialize<'de>>(content: &str) -> Option<(T, String)> {
+    match try_parse_frontmatter(content) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            warn!("Failed to parse frontmatter: {}", e);
+            None
+        }
+    }
+}
+
+fn try_parse_frontmatter<T: for<'de> Deserialize<'de>>(
+    content: &str,
+) -> std::result::Result<Option<(T, String)>, serde_yaml::Error> {
     let parts: Vec<&str> = content.split("---").collect();
     if parts.len() < 3 {
-        return None;
+        return Ok(None);
     }
 
     let yaml_content = parts[1].trim();
-    let metadata: T = match serde_yaml::from_str(yaml_content) {
-        Ok(m) => m,
-        Err(e) => {
-            warn!("Failed to parse frontmatter: {}", e);
-            return None;
-        }
-    };
+    let metadata: T = serde_yaml::from_str(yaml_content)?;
 
     let body = parts[2..].join("---").trim().to_string();
-    Some((metadata, body))
+    Ok(Some((metadata, body)))
+}
+
+fn is_missing_required_field(error: &serde_yaml::Error, field: &str) -> bool {
+    error.to_string().contains(&format!("missing field `{field}`"))
+}
+
+fn build_agent_source(metadata: AgentMetadata, body: String, path: PathBuf) -> Source {
+    let description = metadata.description.unwrap_or_else(|| {
+        let model_info = metadata
+            .model
+            .as_ref()
+            .map(|m| format!(" ({})", m))
+            .unwrap_or_default();
+        format!("Agent{}", model_info)
+    });
+
+    Source {
+        name: metadata.name,
+        kind: SourceKind::Agent,
+        description,
+        path,
+        content: body,
+        supporting_files: Vec::new(),
+    }
 }
 
 fn parse_skill_content(content: &str, path: PathBuf) -> Option<Source> {
@@ -191,24 +221,7 @@ fn parse_skill_content(content: &str, path: PathBuf) -> Option<Source> {
 
 fn parse_agent_content(content: &str, path: PathBuf) -> Option<Source> {
     let (metadata, body): (AgentMetadata, String) = parse_frontmatter(content)?;
-
-    let description = metadata.description.unwrap_or_else(|| {
-        let model_info = metadata
-            .model
-            .as_ref()
-            .map(|m| format!(" ({})", m))
-            .unwrap_or_default();
-        format!("Agent{}", model_info)
-    });
-
-    Some(Source {
-        name: metadata.name,
-        kind: SourceKind::Agent,
-        description,
-        path,
-        content: body,
-        supporting_files: Vec::new(),
-    })
+    Some(build_agent_source(metadata, body, path))
 }
 
 /// Scan a directory for skill subdirectories containing SKILL.md files.
@@ -381,7 +394,22 @@ fn scan_agents_from_dir(
             }
         };
 
-        if let Some(source) = parse_agent_content(&content, path) {
+        let parsed = match try_parse_frontmatter::<AgentMetadata>(&content) {
+            Ok(parsed) => parsed,
+            Err(e) => {
+                if !is_missing_required_field(&e, "name") {
+                    warn!(
+                        "Failed to parse agent file {} frontmatter: {}",
+                        path.display(),
+                        e
+                    );
+                }
+                continue;
+            }
+        };
+
+        if let Some((metadata, body)) = parsed {
+            let source = build_agent_source(metadata, body, path);
             if !seen.contains(&source.name) {
                 seen.insert(source.name.clone());
                 sources.push(source);
@@ -2053,9 +2081,42 @@ impl McpClientTrait for SummonClient {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::io;
+    use std::sync::Mutex as StdMutex;
     use std::fs;
     use std::sync::Arc;
     use tempfile::TempDir;
+    use tracing_subscriber::fmt::MakeWriter;
+
+    #[derive(Clone, Default)]
+    struct TestWriter {
+        buf: Arc<StdMutex<Vec<u8>>>,
+    }
+
+    impl<'a> MakeWriter<'a> for TestWriter {
+        type Writer = TestWriterGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            TestWriterGuard {
+                buf: Arc::clone(&self.buf),
+            }
+        }
+    }
+
+    struct TestWriterGuard {
+        buf: Arc<StdMutex<Vec<u8>>>,
+    }
+
+    impl io::Write for TestWriterGuard {
+        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+            self.buf.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
 
     fn create_test_context() -> PlatformExtensionContext {
         PlatformExtensionContext {
@@ -2088,6 +2149,72 @@ You review code."#;
 
         assert!(parse_skill_content("no frontmatter", PathBuf::new()).is_none());
         assert!(parse_skill_content("---\nunclosed", PathBuf::new()).is_none());
+    }
+
+    #[test]
+    fn test_agent_scan_skips_markdown_without_name_warning() {
+        let temp_dir = TempDir::new().unwrap();
+        let agents_dir = temp_dir.path().join(".claude/agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        fs::write(
+            agents_dir.join("README.md"),
+            "---\ntitle: Notes\n---\nThis is not an agent.",
+        )
+        .unwrap();
+        fs::write(
+            agents_dir.join("reviewer.md"),
+            "---\nname: reviewer\nmodel: sonnet\n---\nYou review code.",
+        )
+        .unwrap();
+
+        let writer = TestWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .without_time()
+            .with_target(false)
+            .finish();
+
+        let (sources, logs) = tracing::subscriber::with_default(subscriber, || {
+            let mut sources = Vec::new();
+            let mut seen = HashSet::new();
+            scan_agents_from_dir(&agents_dir, &mut sources, &mut seen);
+            let logs = String::from_utf8(writer.buf.lock().unwrap().clone()).unwrap();
+            (sources, logs)
+        });
+
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].name, "reviewer");
+        assert!(!logs.contains("missing field `name`"));
+        assert!(!logs.contains("README.md"));
+    }
+
+    #[test]
+    fn test_agent_scan_warns_with_path_for_invalid_frontmatter() {
+        let temp_dir = TempDir::new().unwrap();
+        let agents_dir = temp_dir.path().join(".claude/agents");
+        fs::create_dir_all(&agents_dir).unwrap();
+        let invalid_path = agents_dir.join("broken.md");
+        fs::write(&invalid_path, "---\nname: [unterminated\n---\nBroken").unwrap();
+
+        let writer = TestWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .with_writer(writer.clone())
+            .with_ansi(false)
+            .without_time()
+            .with_target(false)
+            .finish();
+
+        let logs = tracing::subscriber::with_default(subscriber, || {
+            let mut sources = Vec::new();
+            let mut seen = HashSet::new();
+            scan_agents_from_dir(&agents_dir, &mut sources, &mut seen);
+            assert!(sources.is_empty());
+            String::from_utf8(writer.buf.lock().unwrap().clone()).unwrap()
+        });
+
+        assert!(logs.contains("Failed to parse agent file"));
+        assert!(logs.contains("broken.md"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #8273

## Summary
- stop warning when agent directories contain markdown files with YAML frontmatter but no name field
- keep warning for genuinely invalid agent frontmatter, and include the file path in that warning
- add focused tests covering both cases

## Validation
- static diff review only in this environment
- could not run cargo test or cargo fmt here because the Rust toolchain is not installed
