### PR TITLE
fix: hide hidden extensions in UI

### DIFF
--- a/crates/goose-server/src/routes/config_management.rs
+++ b/crates/goose-server/src/routes/config_management.rs
@@ -252,7 +252,10 @@ pub async fn read_config(
     )
 )]
 pub async fn get_extensions() -> Result<Json<ExtensionResponse>, ErrorResponse> {
-    let extensions = goose::config::get_all_extensions();
+    let extensions = goose::config::get_all_extensions()
+        .into_iter()
+        .filter(|ext| !goose::agents::extension_manager::is_hidden_extension(&ext.config.name()))
+        .collect();
     let warnings = goose::config::get_warnings();
     Ok(Json(ExtensionResponse {
         extensions,


### PR DESCRIPTION
This seems like a needed fix in the implementation of hidden extensions. They aren't currently hidden in the UI. Could also do this in the frontend code... whatever we think is best.