### PR TITLE
fix: add skip_canonical_filtering to Anthropic and Ollama providers

### DIFF
--- a/crates/goose/src/providers/anthropic.rs
+++ b/crates/goose/src/providers/anthropic.rs
@@ -56,6 +56,7 @@ pub struct AnthropicProvider {
     supports_streaming: bool,
     name: String,
     custom_models: Option<Vec<String>>,
+    skip_canonical_filtering: bool,
 }
 
 impl AnthropicProvider {
@@ -82,6 +83,7 @@ impl AnthropicProvider {
             supports_streaming: true,
             name: ANTHROPIC_PROVIDER_NAME.to_string(),
             custom_models: None,
+            skip_canonical_filtering: false,
         })
     }
 
@@ -139,6 +141,7 @@ impl AnthropicProvider {
             supports_streaming,
             name: config.name.clone(),
             custom_models,
+            skip_canonical_filtering: config.skip_canonical_filtering,
         })
     }
 
@@ -238,6 +241,10 @@ impl ProviderDef for AnthropicProvider {
 impl Provider for AnthropicProvider {
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn skip_canonical_filtering(&self) -> bool {
+        self.skip_canonical_filtering
     }
 
     fn get_model_config(&self) -> ModelConfig {

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -51,6 +51,7 @@ pub struct OllamaProvider {
     model: ModelConfig,
     supports_streaming: bool,
     name: String,
+    skip_canonical_filtering: bool,
 }
 fn resolve_ollama_num_ctx(model_config: &ModelConfig) -> Option<usize> {
     let config = crate::config::Config::global();
@@ -131,6 +132,7 @@ impl OllamaProvider {
             model,
             supports_streaming: true,
             name: OLLAMA_PROVIDER_NAME.to_string(),
+            skip_canonical_filtering: false,
         })
     }
 
@@ -193,6 +195,7 @@ impl OllamaProvider {
             model,
             supports_streaming,
             name: config.name.clone(),
+            skip_canonical_filtering: config.skip_canonical_filtering,
         })
     }
 }
@@ -233,6 +236,10 @@ impl ProviderDef for OllamaProvider {
 impl Provider for OllamaProvider {
     fn get_name(&self) -> &str {
         &self.name
+    }
+
+    fn skip_canonical_filtering(&self) -> bool {
+        self.skip_canonical_filtering
     }
 
     fn get_model_config(&self) -> ModelConfig {


### PR DESCRIPTION
## Summary

My earlier PR https://github.com/aaif-goose/goose/pull/8001 superseded by PR #8052, which introduced the `skip_canonical_filtering` setting for declarative providers. However it did not actually solve my original problem.

## Details

Our company uses a custom proxy with an Anthropic-compatible API. After PR #8052 was merged, we expected `skip_canonical_filtering: true` to work for our provider config:
```json
    {
      "name": "tiktok-proxy",
      "engine": "anthropic",
      "skip_canonical_filtering": true,
      ...
    }
``` 

However, even with `"skip_canonical_filtering": true`, models like `glm-5` and `kimi-k2` were still missing from the dropdown. Investigation revealed that:

1. `OpenAiProvider` correctly implements `skip_canonical_filtering()` returning the configured value
2. `AnthropicProvider` does NOT have the field; it relies on the default which returns `false`
3. `OllamaProvider` has the same issue

Since our provider uses `engine: "anthropic"`, it creates an `AnthropicProvider` which ignores the setting entirely.

## Fix
Added `skip_canonical_filtering: bool` field to both `AnthropicProvider` and `OllamaProvider`, wired through `from_custom_config()` to respect the declarative provider config setting.

## Testing
- `cargo clippy --all-targets -- -D warnings` passes
- `cargo test -p goose` passes
- Verified `glm-5`, `kimi-k2`, and other custom models now appear in the desktop UI model dropdown

CC @DOsinga