### PR TITLE
fix(cli): show actual provider error in configuration failure message

### DIFF
--- a/crates/goose-cli/src/commands/configure.rs
+++ b/crates/goose-cli/src/commands/configure.rs
@@ -1,12 +1,12 @@
 use crate::recipes::github_recipe::GOOSE_RECIPE_GITHUB_REPO_CONFIG_KEY;
 use cliclack::spinner;
 use console::style;
-use goose::agents::Agent;
-use goose::agents::extension::{PLATFORM_EXTENSIONS, ToolInfo};
+use goose::agents::extension::{ToolInfo, PLATFORM_EXTENSIONS};
 use goose::agents::extension_manager::get_parameter_names;
-use goose::agents::{ExtensionConfig, extension::Envs};
+use goose::agents::Agent;
+use goose::agents::{extension::Envs, ExtensionConfig};
 use goose::config::declarative_providers::{
-    CreateCustomProviderParams, create_custom_provider, remove_custom_provider,
+    create_custom_provider, remove_custom_provider, CreateCustomProviderParams,
 };
 use goose::config::extensions::{
     get_all_extension_names, get_all_extensions, get_enabled_extensions, get_extension_by_name,
@@ -16,17 +16,17 @@ use goose::config::paths::Paths;
 use goose::config::permission::PermissionLevel;
 use goose::config::signup_tetrate::TetrateAuth;
 use goose::config::{
-    Config, ConfigError, ExperimentManager, ExtensionEntry, GooseMode, PermissionManager,
-    configure_tetrate,
+    configure_tetrate, Config, ConfigError, ExperimentManager, ExtensionEntry, GooseMode,
+    PermissionManager,
 };
 use goose::model::ModelConfig;
 #[cfg(feature = "telemetry")]
-use goose::posthog::{TELEMETRY_ENABLED_KEY, get_telemetry_choice};
+use goose::posthog::{get_telemetry_choice, TELEMETRY_ENABLED_KEY};
 use goose::providers::base::ConfigKey;
 use goose::providers::chatgpt_codex::reasoning_levels_for_model;
 use goose::providers::formats::anthropic::supports_adaptive_thinking;
 use goose::providers::provider_test::test_provider_configuration;
-use goose::providers::{RetryConfig, create, providers, retry_operation};
+use goose::providers::{create, providers, retry_operation, RetryConfig};
 use goose::session::SessionType;
 use serde_json::Value;
 use std::collections::HashMap;


### PR DESCRIPTION
## Summary
- Replace hardcoded generic error message in `goose configure` with the actual provider error
- Users can now diagnose configuration failures (wrong model name, auth issues, unsupported features) without digging into logs

Fixes #8352

## Screenshot

Top: before (generic message), Bottom: after (actual error shown)

<img width="1270" height="1353" alt="Before and after comparison" src="https://github.com/user-attachments/assets/e2212474-3f12-49a3-ae37-870a1d276e67" />

(sorry for the terminal theme readability lol)

## Test plan
- [x] Run `goose configure` with a non-existent model name — shows the actual 404 error instead of generic message
- [x] Run `goose configure` with a valid model — succeeds as before (no change to happy path)
- [x] `cargo check -p goose-cli` passes