### PR TITLE
fix: use OPENAI_API_KEY secret for recipe security scanner

### DIFF
--- a/.github/workflows/recipe-security-scanner.yml
+++ b/.github/workflows/recipe-security-scanner.yml
@@ -146,7 +146,7 @@ jobs:
       - name: Scan all recipe files
         if: steps.find_recipes.outputs.has_recipes == 'true' && steps.recipe_changes.outputs.recipe_files_changed == 'true'
         env:
-          SECURITY_SCANNER_ANTHROPIC_API_KEY: ${{ secrets.SECURITY_SCANNER_ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           TRAINING_DATA_LOW: ${{ secrets.TRAINING_DATA_LOW }}
           TRAINING_DATA_MEDIUM: ${{ secrets.TRAINING_DATA_MEDIUM }}
           TRAINING_DATA_EXTREME: ${{ secrets.TRAINING_DATA_EXTREME }}
@@ -159,7 +159,7 @@ jobs:
           sudo chmod -R 777 "$OUT" || true
           
           # Verify secrets are available (without logging details)
-          if [ -z "$SECURITY_SCANNER_ANTHROPIC_API_KEY" ] || [ -z "$TRAINING_DATA_LOW" ] || [ -z "$TRAINING_DATA_MEDIUM" ] || [ -z "$TRAINING_DATA_EXTREME" ]; then
+          if [ -z "$OPENAI_API_KEY" ] || [ -z "$TRAINING_DATA_LOW" ] || [ -z "$TRAINING_DATA_MEDIUM" ] || [ -z "$TRAINING_DATA_EXTREME" ]; then
             echo "❌ One or more required secrets are missing or inaccessible"
             exit 1
           fi
@@ -183,7 +183,7 @@ jobs:
               
               # Run scanner on this recipe with training data
               if docker run --rm \
-                -e SECURITY_SCANNER_ANTHROPIC_API_KEY="$SECURITY_SCANNER_ANTHROPIC_API_KEY" \
+                -e OPENAI_API_KEY="$OPENAI_API_KEY" \
                 -e TRAINING_DATA_LOW="$TRAINING_DATA_LOW" \
                 -e TRAINING_DATA_MEDIUM="$TRAINING_DATA_MEDIUM" \
                 -e TRAINING_DATA_EXTREME="$TRAINING_DATA_EXTREME" \


### PR DESCRIPTION
The recipe security scanner uses `GOOSE_PROVIDER=openai` with `gpt-4o` but the workflow was passing `SECURITY_SCANNER_ANTHROPIC_API_KEY` which `scan-recipe.sh` doesn't recognize — it checks for `OPENAI_API_KEY` (line 192).

This has been broken since Feb 20 when PRs #7387/#7391 renamed the env var. Every recipe-touching PR since has failed the security scan.

Fix: use the existing `OPENAI_API_KEY` repo secret directly.

**Needs to merge before #8152 so the security scan can pass on that PR (workflow uses `pull_request_target`).**