### PR TITLE
fix: update all block.github.io/goose URLs to new GitHub repository location

### DIFF
--- a/crates/goose-cli/src/session/builder.rs
+++ b/crates/goose-cli/src/session/builder.rs
@@ -665,7 +665,7 @@ pub async fn build_session(session_config: SessionBuilderConfig) -> CliSession {
                 "Error {}.\n\
                 Please check your system keychain and run 'goose configure' again.\n\
                 If your system is unable to use the keyring, please try setting secret key(s) via environment variables.\n\
-                For more info, see: https://block.github.io/goose/docs/troubleshooting/#keychainkeyring-errors",
+                For more info, see: https://github.com/aaif-goose/goose/docs/troubleshooting/#keychainkeyring-errors",
                 e
             ));
             process::exit(1);

--- a/crates/goose/src/agents/builtin_skills/skills/goose_doc_guide.md
+++ b/crates/goose/src/agents/builtin_skills/skills/goose_doc_guide.md
@@ -15,11 +15,11 @@ Do NOT use this skill for:
 
 ## Steps (COMPLETE ALL BEFORE RESPONDING)
 1. **Fetch official docs**
-   - Fetch the doc map from `https://block.github.io/goose/goose-docs-map.md`
+   - Fetch the doc map from `https://github.com/aaif-goose/goose/goose-docs-map.md`
    - Search the doc map for pages relevant to the user's topic and get the paths for these pages
    - Use the EXACT paths from the doc map. For example:
    - If doc map shows: `docs/guides/sessions/session-management.md`
-   - Fetch: `https://block.github.io/goose/docs/guides/sessions/session-management.md`
+   - Fetch: `https://github.com/aaif-goose/goose/docs/guides/sessions/session-management.md`
    - Do NOT modify or guess paths.
    - **ONLY fetch paths that are explicitly listed in the doc map - do not guess or infer URLs**
    - Make multiple fetch calls in parallel and save to temp files
@@ -53,4 +53,4 @@ Do NOT use this skill for:
 5. **List documentation links**
    - Only include docs actually used
    - Remove `.md` suffix from URLs
-   - Example: If you fetched `https://block.github.io/goose/docs/guides/sessions/session-management.md`, list it as `https://block.github.io/goose/docs/guides/sessions/session-management`
+   - Example: If you fetched `https://github.com/aaif-goose/goose/docs/guides/sessions/session-management.md`, list it as `https://github.com/aaif-goose/goose/docs/guides/sessions/session-management`

--- a/crates/goose/src/providers/openrouter.rs
+++ b/crates/goose/src/providers/openrouter.rs
@@ -57,7 +57,7 @@ impl OpenRouterProvider {
 
         let auth = AuthMethod::BearerToken(api_key);
         let api_client = ApiClient::new(host, auth)?
-            .with_header("HTTP-Referer", "https://block.github.io/goose")?
+            .with_header("HTTP-Referer", "https://github.com/aaif-goose/goose")?
             .with_header("X-Title", "goose")?;
 
         Ok(Self {

--- a/crates/goose/src/providers/tetrate.rs
+++ b/crates/goose/src/providers/tetrate.rs
@@ -55,7 +55,7 @@ impl TetrateProvider {
 
         let auth = AuthMethod::BearerToken(api_key);
         let api_client = ApiClient::new(host, auth)?
-            .with_header("HTTP-Referer", "https://block.github.io/goose")?
+            .with_header("HTTP-Referer", "https://github.com/aaif-goose/goose")?
             .with_header("X-Title", "goose")?;
 
         Ok(Self {

--- a/services/ask-ai-bot/utils/ai/system-prompt.ts
+++ b/services/ask-ai-bot/utils/ai/system-prompt.ts
@@ -4,7 +4,7 @@ export const MAX_STEPS = 15;
 
 export function buildSystemPrompt(serverContext?: string): string {
   let prompt = dedent`You are a helpful assistant in the goose Discord server.
-Your role is to provide assistance and answer questions about codename goose, an open-source AI agent developed by Block. codename goose's website is \`https://block.github.io/goose\`. Your answers should be short and to the point. Always assume that a user's question is related to codename goose unless they specifically state otherwise. DO NOT capitalize "goose" or "codename goose".
+Your role is to provide assistance and answer questions about codename goose, an open-source AI agent developed by Block. codename goose's website is \`https://github.com/aaif-goose/goose\`. Your answers should be short and to the point. Always assume that a user's question is related to codename goose unless they specifically state otherwise. DO NOT capitalize "goose" or "codename goose".
 
 You can perform a maximum of ${MAX_STEPS} steps (tool calls, text outputs, etc.). If you exceed this limit, no response will be provided to the user. BEFORE you reach the limit, STOP calling tools, respond to the user, and don't call any tools after your final response until the user asks another question.
 

--- a/services/ask-ai-bot/utils/ai/tools/docs-search.ts
+++ b/services/ask-ai-bot/utils/ai/tools/docs-search.ts
@@ -93,7 +93,7 @@ function initializeSearch(): MiniSearch<DocFile> {
 }
 
 function generateWebUrl(filePath: string): string {
-  const baseUrl = "https://block.github.io/goose/docs";
+  const baseUrl = "https://github.com/aaif-goose/goose/docs";
   // Remove file extension for the URL path
   const urlPath = filePath.replace(/\.[^/.]+$/, "");
   return `${baseUrl}/${urlPath}`;

--- a/services/ask-ai-bot/utils/ai/tools/docs-viewer.ts
+++ b/services/ask-ai-bot/utils/ai/tools/docs-viewer.ts
@@ -6,7 +6,7 @@ function getDocsDir(): string {
 }
 
 function generateWebUrl(filePath: string): string {
-  const baseUrl = "https://block.github.io/goose/docs";
+  const baseUrl = "https://github.com/aaif-goose/goose/docs";
   // Remove file extension for the URL path
   const urlPath = filePath.replace(/\.[^/.]+$/, "");
   return `${baseUrl}/${urlPath}`;

--- a/ui/desktop/forge.config.ts
+++ b/ui/desktop/forge.config.ts
@@ -88,7 +88,7 @@ module.exports = {
         name: 'Goose',
         bin: 'Goose',
         maintainer: 'Block, Inc.',
-        homepage: 'https://block.github.io/goose/',
+        homepage: 'https://github.com/aaif-goose/goose/',
         categories: ['Development'],
         desktopTemplate: './forge.deb.desktop',
         options: {
@@ -103,7 +103,7 @@ module.exports = {
         name: 'Goose',
         bin: 'Goose',
         maintainer: 'Block, Inc.',
-        homepage: 'https://block.github.io/goose/',
+        homepage: 'https://github.com/aaif-goose/goose/',
         categories: ['Development'],
         desktopTemplate: './forge.rpm.desktop',
         options: {
@@ -123,7 +123,7 @@ module.exports = {
             scalable: 'src/images/icon.svg',
             '512x512': 'src/images/icon-512.png',
           },
-          homepage: 'https://block.github.io/goose/',
+          homepage: 'https://github.com/aaif-goose/goose/',
           runtimeVersion: '25.08',
           baseVersion: '25.08',
           bin: 'Goose',

--- a/ui/desktop/src/components/BaseChat.tsx
+++ b/ui/desktop/src/components/BaseChat.tsx
@@ -409,7 +409,7 @@ export default function BaseChat({
           {/* Goose watermark - top right */}
           <div className="absolute top-3 right-4 z-[60] flex flex-row items-center gap-1">
             <a
-              href="https://block.github.io/goose"
+              href="https://github.com/aaif-goose/goose"
               target="_blank"
               rel="noopener noreferrer"
               className="no-drag flex flex-row items-center gap-1 hover:opacity-80 transition-opacity"

--- a/ui/desktop/src/components/extensions/ExtensionsView.tsx
+++ b/ui/desktop/src/components/extensions/ExtensionsView.tsx
@@ -156,7 +156,7 @@ export default function ExtensionsView({
                 className="flex items-center gap-2 justify-center"
                 variant="secondary"
                 onClick={() =>
-                  window.open('https://block.github.io/goose/v1/extensions/', '_blank')
+                  window.open('https://github.com/aaif-goose/goose/v1/extensions/', '_blank')
                 }
               >
                 <GPSIcon size={12} />

--- a/ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx
+++ b/ui/desktop/src/components/recipes/CreateEditRecipeModal.tsx
@@ -497,7 +497,7 @@ export default function CreateEditRecipeModal({
                   ? intl.formatMessage(i18n.createSubtitle)
                   : intl.formatMessage(i18n.editSubtitle)}{' '}
                 <a
-                  href="https://block.github.io/goose/docs/guides/recipes/"
+                  href="https://github.com/aaif-goose/goose/docs/guides/recipes/"
                   target="_blank"
                   rel="noopener noreferrer"
                   className="inline-flex items-center gap-1 text-blue-500 hover:text-blue-600 hover:underline"

--- a/ui/desktop/src/components/settings/chat/GoosehintsModal.tsx
+++ b/ui/desktop/src/components/settings/chat/GoosehintsModal.tsx
@@ -105,7 +105,7 @@ const HelpText = () => {
               className="text-blue-500 hover:text-blue-600 p-0 h-auto"
               onClick={() =>
                 window.open(
-                  'https://block.github.io/goose/docs/guides/using-goosehints/',
+                  'https://github.com/aaif-goose/goose/docs/guides/using-goosehints/',
                   '_blank'
                 )
               }

--- a/ui/desktop/src/components/settings/extensions/ExtensionsSection.tsx
+++ b/ui/desktop/src/components/settings/extensions/ExtensionsSection.tsx
@@ -228,7 +228,7 @@ export default function ExtensionsSection({
             <Button
               className="flex items-center gap-2 justify-center"
               variant="secondary"
-              onClick={() => window.open('https://block.github.io/goose/v1/extensions/', '_blank')}
+              onClick={() => window.open('https://github.com/aaif-goose/goose/v1/extensions/', '_blank')}
             >
               <GPSIcon size={12} />
               {intl.formatMessage(i18n.browseExtensions)}

--- a/ui/desktop/src/components/settings/providers/modal/constants.tsx
+++ b/ui/desktop/src/components/settings/providers/modal/constants.tsx
@@ -1,1 +1,1 @@
-export const QUICKSTART_GUIDE_URL = 'https://block.github.io/goose/docs/quickstart';
+export const QUICKSTART_GUIDE_URL = 'https://github.com/aaif-goose/goose/docs/quickstart';

--- a/ui/desktop/src/components/ui/Diagnostics.tsx
+++ b/ui/desktop/src/components/ui/Diagnostics.tsx
@@ -143,10 +143,10 @@ export const DiagnosticsModal: React.FC<DiagnosticsModalProps> = ({
       const body = `**Describe the bug**
 
 💡 Before filing, please check common issues:  
-https://block.github.io/goose/docs/troubleshooting  
+https://github.com/aaif-goose/goose/docs/troubleshooting  
 
 📦 To help us debug faster, attach your **diagnostics zip** if possible.  
-👉 How to capture it: https://block.github.io/goose/docs/troubleshooting/diagnostics-and-reporting/
+👉 How to capture it: https://github.com/aaif-goose/goose/docs/troubleshooting/diagnostics-and-reporting/
 
 A clear and concise description of what the bug is.
 


### PR DESCRIPTION
## Summary
Updates all remaining `block.github.io/goose` URLs to the new canonical location at `github.com/aaif-goose/goose` across the codebase.

This ensures users are directed to the correct docs, troubleshooting guides, quickstart, and extensions pages from the CLI, desktop UI, AI bot integrations, and provider headers.

### Changes
- **CLI**: Updated keychain error message link to new troubleshooting URL
- **Providers**: Updated `HTTP-Referer` header in OpenRouter and Tetrate providers to new repo URL
- **AI bot**: Updated ask-ai-bot system prompt to reference new project website
- **Docs helpers**: Updated docs search and viewer to generate links under the new GitHub docs path
- **Desktop app**: Updated forge config homepage and all UI links (watermark, recipes, extensions, goosehints) to new docs URLs
- **Diagnostics**: Updated quickstart guide constant and diagnostics modal links to new troubleshooting docs

### Testing
- Ran desktop app locally and verified all updated links open the correct GitHub docs/repo pages
- Smoke-tested AI bot docs search and viewer to confirm generated URLs resolve correctly

### Related Issues
Relates to the migration of goose docs and website to the `aaif-goose/goose` GitHub repository.