### PR TITLE
fix: reduce summon frontmatter warning noise

### DIFF
--- a/crates/goose/src/agents/platform_extensions/mod.rs
+++ b/crates/goose/src/agents/platform_extensions/mod.rs
@@ -19,7 +19,6 @@ use crate::agents::mcp_client::McpClientTrait;
 use crate::session::Session;
 use once_cell::sync::Lazy;
 use serde::Deserialize;
-use tracing::warn;
 
 #[derive(Debug, Clone)]
 pub struct Source {
@@ -61,23 +60,19 @@ impl Source {
     }
 }
 
-pub fn parse_frontmatter<T: for<'de> Deserialize<'de>>(content: &str) -> Option<(T, String)> {
+pub fn parse_frontmatter<T: for<'de> Deserialize<'de>>(
+    content: &str,
+) -> Result<Option<(T, String)>, serde_yaml::Error> {
     let parts: Vec<&str> = content.split("---").collect();
     if parts.len() < 3 {
-        return None;
+        return Ok(None);
     }
 
     let yaml_content = parts[1].trim();
-    let metadata: T = match serde_yaml::from_str(yaml_content) {
-        Ok(m) => m,
-        Err(e) => {
-            warn!("Failed to parse frontmatter: {}", e);
-            return None;
-        }
-    };
+    let metadata: T = serde_yaml::from_str(yaml_content)?;
 
     let body = parts[2..].join("---").trim().to_string();
-    Some((metadata, body))
+    Ok(Some((metadata, body)))
 }
 
 pub use ext_manager::MANAGE_EXTENSIONS_TOOL_NAME_COMPLETE;

--- a/crates/goose/src/agents/platform_extensions/skills.rs
+++ b/crates/goose/src/agents/platform_extensions/skills.rs
@@ -25,7 +25,14 @@ struct SkillMetadata {
 }
 
 fn parse_skill_content(content: &str, path: PathBuf) -> Option<Source> {
-    let (metadata, body): (SkillMetadata, String) = parse_frontmatter(content)?;
+    let (metadata, body): (SkillMetadata, String) = match parse_frontmatter(content) {
+        Ok(Some(parsed)) => parsed,
+        Ok(None) => return None,
+        Err(e) => {
+            warn!("Failed to parse skill frontmatter: {}", e);
+            return None;
+        }
+    };
 
     if metadata.name.contains('/') {
         warn!("Skill name '{}' contains '/', skipping", metadata.name);

--- a/crates/goose/src/agents/platform_extensions/summon.rs
+++ b/crates/goose/src/agents/platform_extensions/summon.rs
@@ -95,69 +95,21 @@ struct AgentMetadata {
     model: Option<String>,
 }
 
-fn try_parse_frontmatter<T: for<'de> Deserialize<'de>>(
-    content: &str,
-) -> std::result::Result<Option<(T, String)>, serde_yaml::Error> {
-    let parts: Vec<&str> = content.split("---").collect();
-    if parts.len() < 3 {
-        return Ok(None);
-    }
-
-    let yaml_content = parts[1].trim();
-    let metadata: T = serde_yaml::from_str(yaml_content)?;
-
-    let body = parts[2..].join("---").trim().to_string();
-    Ok(Some((metadata, body)))
-}
-
-fn is_missing_required_field(error: &serde_yaml::Error, field: &str) -> bool {
-    error
-        .to_string()
-        .contains(&format!("missing field `{field}`"))
-}
-
-fn frontmatter_looks_like_non_agent_markdown(path: &Path, content: &str) -> bool {
-    if path
-        .file_name()
-        .and_then(|name| name.to_str())
-        .is_some_and(|name| name.eq_ignore_ascii_case("README.md"))
-    {
-        return true;
-    }
-
-    let parts: Vec<&str> = content.split("---").collect();
-    if parts.len() < 3 {
-        return false;
-    }
-
-    let metadata: serde_yaml::Mapping = match serde_yaml::from_str(parts[1].trim()) {
-        Ok(metadata) => metadata,
-        Err(_) => return false,
+fn parse_agent_content(content: &str, path: &Path) -> Option<Source> {
+    let (metadata, body): (AgentMetadata, String) = match parse_frontmatter(content) {
+        Ok(Some(parsed)) => parsed,
+        Ok(None) => return None,
+        Err(e) => {
+            // Missing fields means this file has valid YAML but isn't an agent — skip silently.
+            // Only warn on actual YAML syntax errors.
+            if e.to_string().contains("missing field") {
+                return None;
+            }
+            warn!("Failed to parse agent file {}: {}", path.display(), e);
+            return None;
+        }
     };
 
-    const COMMON_DOC_KEYS: &[&str] = &[
-        "aliases",
-        "author",
-        "authors",
-        "category",
-        "categories",
-        "date",
-        "description",
-        "draft",
-        "sidebar_position",
-        "slug",
-        "summary",
-        "tags",
-        "title",
-    ];
-
-    metadata.keys().all(|key| {
-        key.as_str()
-            .is_some_and(|key| COMMON_DOC_KEYS.contains(&key))
-    })
-}
-
-fn build_agent_source(metadata: AgentMetadata, body: String, path: PathBuf) -> Source {
     let description = metadata.description.unwrap_or_else(|| {
         let model_info = metadata
             .model
@@ -167,20 +119,14 @@ fn build_agent_source(metadata: AgentMetadata, body: String, path: PathBuf) -> S
         format!("Agent{}", model_info)
     });
 
-    Source {
+    Some(Source {
         name: metadata.name,
         kind: SourceKind::Agent,
         description,
-        path,
+        path: path.to_path_buf(),
         content: body,
         supporting_files: Vec::new(),
-    }
-}
-
-#[cfg(test)]
-fn parse_agent_content(content: &str, path: PathBuf) -> Option<Source> {
-    let (metadata, body): (AgentMetadata, String) = parse_frontmatter(content)?;
-    Some(build_agent_source(metadata, body, path))
+    })
 }
 
 fn scan_recipes_from_dir(
@@ -263,26 +209,7 @@ fn scan_agents_from_dir(
             }
         };
 
-        let parsed = match try_parse_frontmatter::<AgentMetadata>(&content) {
-            Ok(parsed) => parsed,
-            Err(e) => {
-                if is_missing_required_field(&e, "name")
-                    && frontmatter_looks_like_non_agent_markdown(&path, &content)
-                {
-                    continue;
-                }
-
-                warn!(
-                    "Failed to parse agent file {} frontmatter: {}",
-                    path.display(),
-                    e
-                );
-                continue;
-            }
-        };
-
-        if let Some((metadata, body)) = parsed {
-            let source = build_agent_source(metadata, body, path);
+        if let Some(source) = parse_agent_content(&content, &path) {
             if !seen.contains(&source.name) {
                 seen.insert(source.name.clone());
                 sources.push(source);
@@ -1267,8 +1194,9 @@ impl SummonClient {
                 .map_err(|e| format!("Failed to read agent file: {}", e))?
         };
 
-        let (metadata, _): (AgentMetadata, String) =
-            parse_frontmatter(&agent_content).ok_or("Failed to parse agent frontmatter")?;
+        let (metadata, _): (AgentMetadata, String) = parse_frontmatter(&agent_content)
+            .map_err(|e| format!("Failed to parse agent frontmatter: {}", e))?
+            .ok_or("No frontmatter found in agent file")?;
 
         let model = metadata.model;
 
@@ -1734,41 +1662,8 @@ mod tests {
     use serial_test::serial;
     use std::collections::HashSet;
     use std::fs;
-    use std::io;
     use std::sync::Arc;
-    use std::sync::Mutex as StdMutex;
     use tempfile::TempDir;
-    use tracing_subscriber::fmt::MakeWriter;
-
-    #[derive(Clone, Default)]
-    struct TestWriter {
-        buf: Arc<StdMutex<Vec<u8>>>,
-    }
-
-    impl<'a> MakeWriter<'a> for TestWriter {
-        type Writer = TestWriterGuard;
-
-        fn make_writer(&'a self) -> Self::Writer {
-            TestWriterGuard {
-                buf: Arc::clone(&self.buf),
-            }
-        }
-    }
-
-    struct TestWriterGuard {
-        buf: Arc<StdMutex<Vec<u8>>>,
-    }
-
-    impl io::Write for TestWriterGuard {
-        fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
-            self.buf.lock().unwrap().extend_from_slice(bytes);
-            Ok(bytes.len())
-        }
-
-        fn flush(&mut self) -> io::Result<()> {
-            Ok(())
-        }
-    }
 
     fn create_test_context() -> PlatformExtensionContext {
         PlatformExtensionContext {
@@ -1785,15 +1680,15 @@ name: reviewer
 model: sonnet
 ---
 You review code."#;
-        let source = parse_agent_content(agent, PathBuf::new()).unwrap();
+        let source = parse_agent_content(agent, Path::new("")).unwrap();
         assert_eq!(source.name, "reviewer");
         assert!(source.description.contains("sonnet"));
     }
 
     #[test]
-    fn test_agent_scan_skips_markdown_without_name_warning() {
+    fn test_agent_scan_skips_non_agent_markdown() {
         let temp_dir = TempDir::new().unwrap();
-        let agents_dir = temp_dir.path().join(".claude/agents");
+        let agents_dir = temp_dir.path().join("agents");
         fs::create_dir_all(&agents_dir).unwrap();
         fs::write(
             agents_dir.join("README.md"),
@@ -1801,92 +1696,28 @@ You review code."#;
         )
         .unwrap();
         fs::write(
+            agents_dir.join("notes.md"),
+            "---\nauthor: someone\ntags: [docs]\n---\nJust documentation.",
+        )
+        .unwrap();
+        fs::write(
             agents_dir.join("reviewer.md"),
             "---\nname: reviewer\nmodel: sonnet\n---\nYou review code.",
         )
         .unwrap();
-
-        let writer = TestWriter::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(writer.clone())
-            .with_ansi(false)
-            .without_time()
-            .with_target(false)
-            .finish();
-
-        let (sources, logs) = tracing::subscriber::with_default(subscriber, || {
-            let mut sources = Vec::new();
-            let mut seen = HashSet::new();
-            scan_agents_from_dir(&agents_dir, &mut sources, &mut seen);
-            let logs = String::from_utf8(writer.buf.lock().unwrap().clone()).unwrap();
-            (sources, logs)
-        });
-
-        assert_eq!(sources.len(), 1);
-        assert_eq!(sources[0].name, "reviewer");
-        assert!(!logs.contains("missing field `name`"));
-        assert!(!logs.contains("README.md"));
-    }
-
-    #[test]
-    fn test_agent_scan_warns_with_path_for_missing_name_in_agent_like_file() {
-        let temp_dir = TempDir::new().unwrap();
-        let agents_dir = temp_dir.path().join(".claude/agents");
-        fs::create_dir_all(&agents_dir).unwrap();
-        let invalid_path = agents_dir.join("reviewer.md");
+        fs::write(agents_dir.join("plain.md"), "No frontmatter at all.").unwrap();
         fs::write(
-            &invalid_path,
-            "---\nnam: reviewer\nmodel: sonnet\n---\nYou review code.",
+            agents_dir.join("broken.md"),
+            "---\nname: [unterminated\n---\nBroken YAML.",
         )
         .unwrap();
 
-        let writer = TestWriter::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(writer.clone())
-            .with_ansi(false)
-            .without_time()
-            .with_target(false)
-            .finish();
+        let mut sources = Vec::new();
+        let mut seen = HashSet::new();
+        scan_agents_from_dir(&agents_dir, &mut sources, &mut seen);
 
-        let logs = tracing::subscriber::with_default(subscriber, || {
-            let mut sources = Vec::new();
-            let mut seen = HashSet::new();
-            scan_agents_from_dir(&agents_dir, &mut sources, &mut seen);
-            assert!(sources.is_empty());
-            String::from_utf8(writer.buf.lock().unwrap().clone()).unwrap()
-        });
-
-        assert!(logs.contains("Failed to parse agent file"));
-        assert!(logs.contains("reviewer.md"));
-        assert!(logs.contains("missing field `name`"));
-    }
-
-    #[test]
-    fn test_agent_scan_warns_with_path_for_invalid_frontmatter() {
-        let temp_dir = TempDir::new().unwrap();
-        let agents_dir = temp_dir.path().join(".claude/agents");
-        fs::create_dir_all(&agents_dir).unwrap();
-        let invalid_path = agents_dir.join("broken.md");
-        fs::write(&invalid_path, "---\nname: [unterminated\n---\nBroken").unwrap();
-
-        let writer = TestWriter::default();
-        let subscriber = tracing_subscriber::fmt()
-            .with_writer(writer.clone())
-            .with_ansi(false)
-            .without_time()
-            .with_target(false)
-            .finish();
-
-        let logs = tracing::subscriber::with_default(subscriber, || {
-            let mut sources = Vec::new();
-            let mut seen = HashSet::new();
-            scan_agents_from_dir(&agents_dir, &mut sources, &mut seen);
-            assert!(sources.is_empty());
-            String::from_utf8(writer.buf.lock().unwrap().clone()).unwrap()
-        });
-
-        assert!(logs.contains("Failed to parse agent file"));
-        assert!(logs.contains("broken.md"));
+        assert_eq!(sources.len(), 1);
+        assert_eq!(sources[0].name, "reviewer");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- skip obvious non-agent markdown like README docs when the `name` field is missing
- keep warning for agent-like files that are missing `name`, and include the file path in the warning
- add summon regression coverage for both the quiet and warning paths

Closes #8273

## Validation
- `cargo fmt --all`
- `cargo test -p goose summon --lib --no-default-features --features "code-mode aws-providers telemetry otel rustls-tls"`
- `cargo check -p goose --no-default-features --features "code-mode aws-providers telemetry otel rustls-tls"`