### PR TITLE
Suppress rmcp::service from OTLP log export

### DIFF
--- a/crates/goose/src/otel/otlp.rs
+++ b/crates/goose/src/otel/otlp.rs
@@ -335,11 +335,28 @@ fn otel_logs_level() -> Level {
         .unwrap_or(Level::INFO)
 }
 
+/// Targets suppressed from OTLP log export.
+///
+/// `rmcp::service` logs the full `InitializeResult` (including extension instructions
+/// and user memory content) as a `peer_info` attribute on every MCP handshake.
+/// This can be 400KB+ per session init and contains PII/sensitive data.
+/// These logs have no analytical value in OTLP — suppress them entirely.
+const OTLP_LOGS_SUPPRESSED_TARGETS: &[&str] = &["rmcp::service"];
+
 /// Creates a custom filter for OTLP logs.
 /// Level is resolved via RUST_LOG → OTEL_LOG_LEVEL → default INFO.
+/// Suppresses targets listed in `OTLP_LOGS_SUPPRESSED_TARGETS`.
 fn create_otlp_logs_filter() -> FilterFn<impl Fn(&Metadata<'_>) -> bool> {
     let min_level = otel_logs_level();
-    FilterFn::new(move |metadata: &Metadata<'_>| metadata.level() <= &min_level)
+    FilterFn::new(move |metadata: &Metadata<'_>| {
+        if metadata.level() > &min_level {
+            return false;
+        }
+        let target = metadata.target();
+        !OTLP_LOGS_SUPPRESSED_TARGETS
+            .iter()
+            .any(|suppressed| target.starts_with(suppressed))
+    })
 }
 
 /// Shutdown OTLP providers gracefully


### PR DESCRIPTION
## Summary
The rmcp crate logs the full InitializeResult (including extension
instructions and user memory content) as a peer_info attribute on
every MCP handshake. These entries can be 400KB+ each and contain
PII/sensitive data that cannot be effectively redacted with regex.

Filter out rmcp::service from OTLP log export via a target-based
suppression list in create_otlp_logs_filter().


