### PR TITLE
feat(providers): add llama-swap declarative provider

### DIFF
--- a/crates/goose/src/config/declarative_providers.rs
+++ b/crates/goose/src/config/declarative_providers.rs
@@ -531,6 +531,34 @@ mod tests {
     }
 
     #[test]
+    fn test_llama_swap_json_deserializes() {
+        let json = include_str!("../providers/declarative/llama_swap.json");
+        let config: DeclarativeProviderConfig =
+            serde_json::from_str(json).expect("llama_swap.json should parse");
+        assert_eq!(config.name, "llama_swap");
+        assert_eq!(config.display_name, "Llama Swap");
+        assert!(matches!(config.engine, ProviderEngine::OpenAI));
+        assert_eq!(config.api_key_env, "");
+        assert!(!config.requires_auth);
+        assert!(config.skip_canonical_filtering);
+        assert_eq!(config.dynamic_models, Some(true));
+        assert_eq!(config.supports_streaming, Some(true));
+        assert_eq!(config.base_url, "${LLAMA_SWAP_HOST}/v1/chat/completions");
+        assert!(config.models.is_empty());
+
+        let env_vars = config.env_vars.as_ref().expect("env_vars should be set");
+        assert_eq!(env_vars.len(), 1);
+        assert_eq!(env_vars[0].name, "LLAMA_SWAP_HOST");
+        assert!(!env_vars[0].required);
+        assert!(!env_vars[0].secret);
+        assert_eq!(env_vars[0].primary, Some(true));
+        assert_eq!(
+            env_vars[0].default,
+            Some("http://localhost:8080".to_string())
+        );
+    }
+
+    #[test]
     fn test_existing_json_files_still_deserialize_without_new_fields() {
         let json = include_str!("../providers/declarative/groq.json");
         let config: DeclarativeProviderConfig =

--- a/crates/goose/src/providers/declarative/llama_swap.json
+++ b/crates/goose/src/providers/declarative/llama_swap.json
@@ -1,0 +1,23 @@
+{
+  "name": "llama_swap",
+  "engine": "openai",
+  "display_name": "Llama Swap",
+  "description": "Local proxy that hot-swaps llama.cpp (and other) inference backends on demand via an OpenAI-compatible API.",
+  "api_key_env": "",
+  "base_url": "${LLAMA_SWAP_HOST}/v1/chat/completions",
+  "env_vars": [
+    {
+      "name": "LLAMA_SWAP_HOST",
+      "required": false,
+      "secret": false,
+      "primary": true,
+      "default": "http://localhost:8080",
+      "description": "Base URL of the llama-swap proxy (default: http://localhost:8080)"
+    }
+  ],
+  "dynamic_models": true,
+  "models": [],
+  "supports_streaming": true,
+  "requires_auth": false,
+  "skip_canonical_filtering": true
+}


### PR DESCRIPTION
## Summary
Adds a new fixed declarative provider entry for [llama-swap](https://github.com/mostlygeek/llama-swap) at `crates/goose/src/providers/declarative/llama_swap.json`. No Rust code changes are required: `register_declarative_providers` picks it up automatically via `include_dir!` and dispatches it through the existing `OpenAiProvider::from_custom_config` path.

Config choices:
* `engine: "openai"` because llama-swap exposes `/v1/chat/completions` and `/v1/models` with full OpenAI compatibility.
* `LLAMA_SWAP_HOST` env var with a default of `http://localhost:8080` (matches llama-swap's documented default) so users can point at a non-default host/port through the normal settings UI.
* `dynamic_models: true` so the user's YAML-configured model list is fetched from `/v1/models` at runtime rather than hardcoded.
* `requires_auth: false` and `skip_canonical_filtering: true` to match the `lmstudio` pattern, since llama-swap runs unauthenticated by default and model names are user-defined.

### Testing
* Added `test_llama_swap_json_deserializes` in `crates/goose/src/config/declarative_providers.rs` alongside the existing `test_tanzu_json_deserializes`, asserting all shipped defaults (name, engine, base_url template, env var default, `dynamic_models`, `skip_canonical_filtering`, etc.).
* `cargo test -p goose --lib config::declarative_providers` passes locally (9/9).
* Manual end-to-end smoke test against a local llama-swap on `:8080` is planned before merge: verify the provider shows up in the picker with `LLAMA_SWAP_HOST` pre-filled, `/v1/models` populates dynamically, and both streaming and non-streaming completions work. A second pass with a non-default `LLAMA_SWAP_HOST` will confirm the env var override path.

### Related Issues
N/A

### Screenshots/Demos (for UX changes)
N/A (no UI code changes; the new provider appears in the existing provider list using its declarative metadata).