### PR TITLE
fix: Unable to Run `goose update` on Linux

### DIFF
--- a/crates/goose-cli/src/commands/update.rs
+++ b/crates/goose-cli/src/commands/update.rs
@@ -462,9 +462,23 @@ fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
 
     #[cfg(not(target_os = "windows"))]
     {
-        // On Unix, copy the new binary over the existing one
-        fs::copy(new_binary, current_exe)
-            .with_context(|| format!("Failed to copy new binary to {}", current_exe.display()))?;
+      let old_exe = current_exe.with_extension("old");
+
+      // Rename current binary to avoid ETXTBSY on Linux
+      if current_exe.exists() {
+        fs::rename(current_exe, &old_exe).with_context(|| {
+          format!("Failed to rename {} before update", current_exe.display())
+        })?;
+      }
+
+      if let Err(e) = fs::copy(new_binary, current_exe) {
+        // Restore old binary if copy fails
+        let _ = fs::rename(&old_exe, current_exe);
+        return Err(e).with_context(|| format!("Failed to copy new binary to {}", current_exe.display()));
+      }
+
+      // Delete the old backup binary
+      let _ = fs::remove_file(&old_exe);
 
         // Ensure the binary is executable
         #[cfg(unix)]

--- a/crates/goose-cli/src/commands/update.rs
+++ b/crates/goose-cli/src/commands/update.rs
@@ -462,23 +462,25 @@ fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
 
     #[cfg(not(target_os = "windows"))]
     {
-      let old_exe = current_exe.with_extension("old");
+        let old_exe = current_exe.with_extension("old");
 
-      // Rename current binary to avoid ETXTBSY on Linux
-      if current_exe.exists() {
-        fs::rename(current_exe, &old_exe).with_context(|| {
-          format!("Failed to rename {} before update", current_exe.display())
-        })?;
-      }
+        // Rename current binary to avoid ETXTBSY on Linux
+        if current_exe.exists() {
+            fs::rename(current_exe, &old_exe).with_context(|| {
+                format!("Failed to rename {} before update", current_exe.display())
+            })?;
+        }
 
-      if let Err(e) = fs::copy(new_binary, current_exe) {
-        // Restore old binary if copy fails
-        let _ = fs::rename(&old_exe, current_exe);
-        return Err(e).with_context(|| format!("Failed to copy new binary to {}", current_exe.display()));
-      }
+        if let Err(e) = fs::copy(new_binary, current_exe) {
+            // Restore old binary if copy fails
+            let _ = fs::rename(&old_exe, current_exe);
+            return Err(e).with_context(|| {
+                format!("Failed to copy new binary to {}", current_exe.display())
+            });
+        }
 
-      // Delete the old backup binary
-      let _ = fs::remove_file(&old_exe);
+        // Delete the old backup binary
+        let _ = fs::remove_file(&old_exe);
 
         // Ensure the binary is executable
         #[cfg(unix)]


### PR DESCRIPTION
## Summary
<!-- Describe your change -->
Currently, when running `goose update` in Linux, you will get an error:

> Error: Failed to replace current binary
Caused by:
0: Failed to copy new binary to /home/thoa/.local/bin/goose
1: Text file busy (os error 26

This is because Linux prevents overwriting an executable file that is currently running.

The solution is to rename the current executable file to `executable.old`, copy the newly downed executable over, then delete the old backup.

### Testing
Manual testing

### Related Issues
fixes #8468 


### Screenshots/Demos (for UX changes)
N/A

