### PR TITLE
Fix ETXTBSY on Linux during update (#8468)

### DIFF
--- a/crates/goose-cli/src/commands/update.rs
+++ b/crates/goose-cli/src/commands/update.rs
@@ -428,7 +428,10 @@ fn find_binary(extract_dir: &Path, binary_name: &str) -> Option<PathBuf> {
 /// On Windows we must rename the running exe (Windows allows rename but not
 /// delete/overwrite of a locked file) then copy the new file in.
 ///
-/// On Unix we can simply copy over the existing binary.
+/// On Unix, we write to a temp file in the same directory to avoid ETXTBSY
+/// ("Text file busy") on Linux, which blocks writing to a running executable.
+/// Renaming then atomically replaces the directory entry without affecting
+/// the file currently in use by the kernel.
 fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
     #[cfg(target_os = "windows")]
     {
@@ -462,18 +465,34 @@ fn replace_binary(new_binary: &Path, current_exe: &Path) -> Result<()> {
 
     #[cfg(not(target_os = "windows"))]
     {
-        // On Unix, copy the new binary over the existing one
-        fs::copy(new_binary, current_exe)
-            .with_context(|| format!("Failed to copy new binary to {}", current_exe.display()))?;
+        // Write to a temp file and avoids ETXTBSY ("Text file busy") on Linux
+        // where the kernel refuses to open write a running executable.
+        let dest_dir = current_exe
+            .parent()
+            .context("Current executable has no parent directory")?;
+
+        let tmp_file = tempfile::Builder::new()
+            .prefix("goose-update-")
+            .tempfile_in(dest_dir)?;
+
+        let tmp_path = tmp_file.path();
+
+        fs::copy(new_binary, tmp_path)
+            .with_context(|| format!("Failed to write update to {}", tmp_path.display()))?;
 
         // Ensure the binary is executable
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
-            let mut perms = fs::metadata(current_exe)?.permissions();
+            let mut perms = fs::metadata(tmp_path)?.permissions();
             perms.set_mode(0o755);
-            fs::set_permissions(current_exe, perms)?;
+            fs::set_permissions(tmp_path, perms)?;
         }
+
+        fs::rename(tmp_path, current_exe).with_context(|| {
+            let _ = fs::remove_file(tmp_path);
+            format!("Failed to replace binary at {}", current_exe.display())
+        })?;
     }
 
     Ok(())
@@ -599,6 +618,34 @@ mod tests {
 
         let content = fs::read_to_string(&current).unwrap();
         assert_eq!(content, "new version");
+    }
+
+    // On Unix the replacement must go through a rename so that it avoids
+    // ETXTBSY on Linux.
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_replace_binary_unix_no_leftover_tmp() {
+        let tmp = tempdir().unwrap();
+        let new_bin = tmp.path().join("new_goose");
+        let current = tmp.path().join("goose");
+
+        fs::write(&new_bin, b"new version").unwrap();
+        fs::write(&current, b"old version").unwrap();
+
+        replace_binary(&new_bin, &current).unwrap();
+
+        assert_eq!(fs::read_to_string(&current).unwrap(), "new version");
+
+        // No stray goose-update-* temp files should remain.
+        let leftovers: Vec<_> = fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .filter(|e| e.file_name().to_string_lossy().starts_with("goose-update-"))
+            .collect();
+        assert!(
+            leftovers.is_empty(),
+            "stray temp files left behind: {leftovers:?}"
+        );
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Summary

On Linux, the kernel enforces ETXTBSY ("Text file busy") and refuses to open a file for writting if that file is being executed.

The original code prior to this change used "fs::copy(...)" which opens the destination file for writting and this was being blocked by the ETXTBSY error.

This patch fixes the issue by copying the new binary to a temp file in the same directory as the current executable and then uses "fs::rename" to atomically swap the directory entry (it only updates the directory mapping it doesn't open the file's content).

This basically mimics what is already implemented for Windows in the update.rs module but adapted for Unix semantics.

Fixes #8468

### Testing

Unit test (test_replace_binary_unix_no_leftover_tmp) and manual test.

### Related Issues
Relates to #8468
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

```bash
$ goose update
Downloading goose-x86_64-unknown-linux-gnu.tar.bz2 from stable release...
Downloaded 72451366 bytes.
Archive SHA-256: 47f5cbc3b55a36fa55b85b7166c606758dd2595137b1c5d246ddf32556a99087
Verifying SLSA provenance via Sigstore...
Sigstore provenance verification passed.
Error: Failed to replace current binary

Caused by:
    0: Failed to copy new binary to /home/lmartins/.local/bin/goose
    1: Text file busy (os error 26)
 ```

After:   

```bash
$ ./target/debug/goose update
Downloading goose-x86_64-unknown-linux-gnu.tar.bz2 from stable release...
Downloaded 72451366 bytes.
Archive SHA-256: 47f5cbc3b55a36fa55b85b7166c606758dd2595137b1c5d246ddf32556a99087
Verifying SLSA provenance via Sigstore...
Sigstore provenance verification passed.
goose updated successfully (verified with Sigstore SLSA provenance).
```