### PR TITLE
fix(github_copilot): use GITHUB_COPILOT_HOST for enterprise token endpoint

### DIFF
--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -325,7 +325,13 @@ impl GithubCopilotProvider {
             .send()
             .await?
             .error_for_status()
-            .map_err(|e| anyhow!("failed to fetch copilot token from {}: {}", self.urls.copilot_token_url, e))?
+            .map_err(|e| {
+                anyhow!(
+                    "failed to fetch copilot token from {}: {}",
+                    self.urls.copilot_token_url,
+                    e
+                )
+            })?
             .text()
             .await?;
         tracing::trace!("copilot token response: {}", resp);

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -317,13 +317,6 @@ impl GithubCopilotProvider {
                 _ => return Err(err.into()),
             },
         };
-        let api_key_url = match config.get_param::<String>("GITHUB_COPILOT_HOST") {
-            Ok(host) => {
-                let host = host.trim_end_matches('/');
-                format!("{}/api/copilot_internal/v2/token", host)
-            }
-            Err(_) => GITHUB_COPILOT_API_KEY_URL.to_string(),
-        };
         let resp = self
             .client
             .get(&self.urls.copilot_token_url)
@@ -332,7 +325,7 @@ impl GithubCopilotProvider {
             .send()
             .await?
             .error_for_status()
-            .map_err(|e| anyhow!("failed to fetch copilot token from {}: {}", api_key_url, e))?
+            .map_err(|e| anyhow!("failed to fetch copilot token from {}: {}", self.urls.copilot_token_url, e))?
             .text()
             .await?;
         tracing::trace!("copilot token response: {}", resp);

--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -317,6 +317,13 @@ impl GithubCopilotProvider {
                 _ => return Err(err.into()),
             },
         };
+        let api_key_url = match config.get_param::<String>("GITHUB_COPILOT_HOST") {
+            Ok(host) => {
+                let host = host.trim_end_matches('/');
+                format!("{}/api/copilot_internal/v2/token", host)
+            }
+            Err(_) => GITHUB_COPILOT_API_KEY_URL.to_string(),
+        };
         let resp = self
             .client
             .get(&self.urls.copilot_token_url)
@@ -324,7 +331,8 @@ impl GithubCopilotProvider {
             .header(http::header::AUTHORIZATION, format!("bearer {}", &token))
             .send()
             .await?
-            .error_for_status()?
+            .error_for_status()
+            .map_err(|e| anyhow!("failed to fetch copilot token from {}: {}", api_key_url, e))?
             .text()
             .await?;
         tracing::trace!("copilot token response: {}", resp);


### PR DESCRIPTION
Fixes #8435

## Problem

When using GitHub Enterprise Cloud (GHEC), the copilot internal token endpoint is at:

```
https://<company>.ghe.com/api/copilot_internal/v2/token
```

But the provider has this URL hardcoded to `https://api.github.com/copilot_internal/v2/token`. The enterprise host returns HTTP 406 for that URL, and all three retry attempts fail with the misleading error: `failed to get api info after 3 attempts` — no mention of the actual HTTP status or URL.

## Fix

- In `refresh_api_info`, check for `GITHUB_COPILOT_HOST` via `Config::get_param`. If set, build the token URL as `<host>/api/copilot_internal/v2/token`; otherwise fall back to the existing constant.
- Wrap `error_for_status` with an error message that includes the URL so failures are diagnosable.
- Register `GITHUB_COPILOT_HOST` as an optional, non-secret `ConfigKey` in provider metadata so `goose configure` surfaces it.

## Usage

Set `GITHUB_COPILOT_HOST` to your GHE instance URL:

```bash
export GITHUB_COPILOT_HOST=https://<company>.ghe.com
```

or in `config.yaml`:

```yaml
GITHUB_COPILOT_HOST: https://<company>.ghe.com
```