### PR TITLE
fix: expand tool calls by default when Response Style is Detailed

### DIFF
--- a/ui/desktop/src/components/ToolCallWithResponse.tsx
+++ b/ui/desktop/src/components/ToolCallWithResponse.tsx
@@ -811,7 +811,7 @@ function ToolCallView({
   );
   return (
     <ToolCallExpandable
-      isStartExpanded={isRenderingProgress}
+      isStartExpanded={isRenderingProgress || isExpandToolDetails}
       isForceExpand={false}
       label={
         extensionTooltip ? (
@@ -874,7 +874,7 @@ function ToolCallView({
         <>
           {toolResults.map((result, index) => (
             <div key={index} className={cn('border-t border-border-primary')}>
-              <ToolResultView toolCall={toolCall} result={result} isStartExpanded={false} />
+              <ToolResultView toolCall={toolCall} result={result} isStartExpanded={isExpandToolDetails} />
             </div>
           ))}
         </>


### PR DESCRIPTION
Reopening #8333 — expand tool calls by default when the Response Style is set to Detailed.

Originally authored by the @octo-patch. Reopened after the original PR was auto-closed.