### PR TITLE
fix: enable token usage tracking and configurable stream timeout for Ollama provider

### DIFF
--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -603,13 +603,18 @@ pub fn get_usage(usage: &Value) -> Usage {
         .filter(|nested| nested.is_object())
         .unwrap_or(usage);
 
+    // Try standard OpenAI fields first, then fall back to Ollama-native fields
+    // (prompt_eval_count / eval_count) for compatibility with older Ollama builds
+    // that don't translate to OpenAI field names.
     let input_tokens = usage
         .get("prompt_tokens")
+        .or_else(|| usage.get("prompt_eval_count"))
         .and_then(|v| v.as_i64())
         .map(|v| v as i32);
 
     let output_tokens = usage
         .get("completion_tokens")
+        .or_else(|| usage.get("eval_count"))
         .and_then(|v| v.as_i64())
         .map(|v| v as i32);
 
@@ -2287,5 +2292,33 @@ data: [DONE]"#;
         assert_eq!(messages[2]["role"], "user");
         assert_eq!(messages[2]["content"], "what happened?");
         assert_eq!(messages[3]["tool_calls"].as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_get_usage_with_ollama_native_fields() {
+        // Ollama-native fields should be picked up as fallback
+        let usage = json!({
+            "prompt_eval_count": 42,
+            "eval_count": 128
+        });
+        let result = get_usage(&usage);
+        assert_eq!(result.input_tokens, Some(42));
+        assert_eq!(result.output_tokens, Some(128));
+        assert_eq!(result.total_tokens, Some(170));
+    }
+
+    #[test]
+    fn test_get_usage_prefers_openai_fields_over_ollama() {
+        // Standard OpenAI fields should take precedence
+        let usage = json!({
+            "prompt_tokens": 10,
+            "completion_tokens": 20,
+            "prompt_eval_count": 42,
+            "eval_count": 128
+        });
+        let result = get_usage(&usage);
+        assert_eq!(result.input_tokens, Some(10));
+        assert_eq!(result.output_tokens, Some(20));
+        assert_eq!(result.total_tokens, Some(30));
     }
 }

--- a/crates/goose/src/providers/formats/openai.rs
+++ b/crates/goose/src/providers/formats/openai.rs
@@ -606,16 +606,18 @@ pub fn get_usage(usage: &Value) -> Usage {
     // Try standard OpenAI fields first, then fall back to Ollama-native fields
     // (prompt_eval_count / eval_count) for compatibility with older Ollama builds
     // that don't translate to OpenAI field names.
+    // Parse the value before falling back so that present-but-null keys
+    // (e.g. "completion_tokens": null) don't block the fallback.
     let input_tokens = usage
         .get("prompt_tokens")
-        .or_else(|| usage.get("prompt_eval_count"))
         .and_then(|v| v.as_i64())
+        .or_else(|| usage.get("prompt_eval_count").and_then(|v| v.as_i64()))
         .map(|v| v as i32);
 
     let output_tokens = usage
         .get("completion_tokens")
-        .or_else(|| usage.get("eval_count"))
         .and_then(|v| v.as_i64())
+        .or_else(|| usage.get("eval_count").and_then(|v| v.as_i64()))
         .map(|v| v as i32);
 
     let cache_read_input_tokens = usage
@@ -2320,5 +2322,20 @@ data: [DONE]"#;
         assert_eq!(result.input_tokens, Some(10));
         assert_eq!(result.output_tokens, Some(20));
         assert_eq!(result.total_tokens, Some(30));
+    }
+
+    #[test]
+    fn test_get_usage_falls_back_when_openai_fields_are_null() {
+        // When OpenAI fields exist but are null, should fall back to Ollama-native
+        let usage = json!({
+            "prompt_tokens": null,
+            "completion_tokens": null,
+            "prompt_eval_count": 42,
+            "eval_count": 128
+        });
+        let result = get_usage(&usage);
+        assert_eq!(result.input_tokens, Some(42));
+        assert_eq!(result.output_tokens, Some(128));
+        assert_eq!(result.total_tokens, Some(170));
     }
 }

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -353,11 +353,27 @@ impl Provider for OllamaProvider {
     }
 }
 
-/// Per-chunk timeout for Ollama streaming responses.
-/// If no new raw SSE data arrives within this duration, the connection is considered dead.
-/// Set to 120s to accommodate slower models (CPU inference, large parameter counts,
-/// or complex reasoning) that may pause for extended periods between tokens.
-const OLLAMA_CHUNK_TIMEOUT_SECS: u64 = 120;
+/// Default per-chunk timeout for Ollama streaming responses (seconds).
+/// Configurable via OLLAMA_STREAM_TIMEOUT, GOOSE_STREAM_TIMEOUT, or falls back
+/// to OLLAMA_TIMEOUT. Set high to accommodate slower models (CPU inference,
+/// large parameter counts, complex reasoning).
+const OLLAMA_DEFAULT_CHUNK_TIMEOUT_SECS: u64 = 120;
+
+/// Resolve the per-chunk stream timeout from config.
+/// Priority: OLLAMA_STREAM_TIMEOUT > GOOSE_STREAM_TIMEOUT > OLLAMA_TIMEOUT > default (120s).
+fn resolve_ollama_chunk_timeout() -> u64 {
+    let config = crate::config::Config::global();
+
+    if let Ok(val) = config.get_param::<u64>("OLLAMA_STREAM_TIMEOUT") {
+        return val;
+    }
+    if let Ok(val) = config.get_param::<u64>("GOOSE_STREAM_TIMEOUT") {
+        return val;
+    }
+    config
+        .get_param::<u64>("OLLAMA_TIMEOUT")
+        .unwrap_or(OLLAMA_DEFAULT_CHUNK_TIMEOUT_SECS)
+}
 
 /// Wraps a line stream with a per-item timeout at the raw SSE level.
 /// This detects dead connections without false-positive stalls during long
@@ -406,7 +422,8 @@ fn stream_ollama(response: Response, mut log: RequestLog) -> Result<MessageStrea
         let framed = FramedRead::new(stream_reader, LinesCodec::new())
             .map_err(Error::from);
 
-        let timed_lines = with_line_timeout(framed, OLLAMA_CHUNK_TIMEOUT_SECS);
+        let chunk_timeout = resolve_ollama_chunk_timeout();
+        let timed_lines = with_line_timeout(framed, chunk_timeout);
         let message_stream = response_to_streaming_message_ollama(timed_lines);
         pin!(message_stream);
 
@@ -563,57 +580,44 @@ mod tests {
         );
     }
 
-    #[tokio::test]
-    async fn test_stream_ollama_timeout_on_stall() {
-        use std::convert::Infallible;
+    #[test]
+    fn test_resolve_ollama_chunk_timeout_defaults_to_ollama_timeout() {
+        let _guard = env_lock::lock_env([
+            ("OLLAMA_STREAM_TIMEOUT", None::<&str>),
+            ("GOOSE_STREAM_TIMEOUT", None::<&str>),
+            ("OLLAMA_TIMEOUT", Some("300")),
+        ]);
+        assert_eq!(resolve_ollama_chunk_timeout(), 300);
+    }
 
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<bytes::Bytes, Infallible>>(1);
-        tx.send(Ok(bytes::Bytes::from(
-            "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"},\"index\":0}],\
-             \"model\":\"test\",\"object\":\"chat.completion.chunk\",\"created\":0}\n",
-        )))
-        .await
-        .unwrap();
-        let stream = tokio_stream::wrappers::ReceiverStream::new(rx);
-        let body = reqwest::Body::wrap_stream(stream);
-        let response = http::Response::builder().status(200).body(body).unwrap();
-        let response: reqwest::Response = response.into();
+    #[test]
+    fn test_resolve_ollama_chunk_timeout_prefers_stream_override() {
+        let _guard = env_lock::lock_env([
+            ("OLLAMA_STREAM_TIMEOUT", Some("60")),
+            ("GOOSE_STREAM_TIMEOUT", Some("90")),
+            ("OLLAMA_TIMEOUT", Some("300")),
+        ]);
+        assert_eq!(resolve_ollama_chunk_timeout(), 60);
+    }
 
-        let log = RequestLog::start(
-            &ModelConfig::new("test").unwrap(),
-            &json!({"model": "test"}),
-        )
-        .unwrap();
+    #[test]
+    fn test_resolve_ollama_chunk_timeout_uses_goose_stream_fallback() {
+        let _guard = env_lock::lock_env([
+            ("OLLAMA_STREAM_TIMEOUT", None::<&str>),
+            ("GOOSE_STREAM_TIMEOUT", Some("90")),
+            ("OLLAMA_TIMEOUT", Some("300")),
+        ]);
+        assert_eq!(resolve_ollama_chunk_timeout(), 90);
+    }
 
-        let mut msg_stream = stream_ollama(response, log).unwrap();
-
-        let result =
-            tokio::time::timeout(Duration::from_secs(OLLAMA_CHUNK_TIMEOUT_SECS + 5), async {
-                let mut last_err = None;
-                while let Some(item) = msg_stream.next().await {
-                    if let Err(e) = item {
-                        last_err = Some(e);
-                        break;
-                    }
-                }
-                last_err
-            })
-            .await;
-
-        match result {
-            Ok(Some(err)) => {
-                let err_msg = err.to_string();
-                assert!(
-                    err_msg.contains("stream stalled"),
-                    "Expected stall timeout error, got: {}",
-                    err_msg
-                );
-            }
-            Ok(None) => panic!("Expected timeout error but stream completed normally"),
-            Err(_) => panic!("Outer timeout elapsed -- per-chunk timeout did not fire"),
-        }
-
-        drop(tx);
+    #[test]
+    fn test_resolve_ollama_chunk_timeout_uses_default_when_unset() {
+        let _guard = env_lock::lock_env([
+            ("OLLAMA_STREAM_TIMEOUT", None::<&str>),
+            ("GOOSE_STREAM_TIMEOUT", None::<&str>),
+            ("OLLAMA_TIMEOUT", None::<&str>),
+        ]);
+        assert_eq!(resolve_ollama_chunk_timeout(), OLLAMA_DEFAULT_CHUNK_TIMEOUT_SECS);
     }
 
     #[test]

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -68,12 +68,27 @@ fn resolve_ollama_num_ctx(model_config: &ModelConfig) -> Option<usize> {
     input_limit.or(model_config.context_limit)
 }
 
+fn resolve_ollama_stream_usage() -> bool {
+    let config = crate::config::Config::global();
+    match config.get_param::<bool>("OLLAMA_STREAM_USAGE") {
+        Ok(val) => val,
+        // Default to true: Ollama supports stream_options since mid-2025 and
+        // most installs will benefit from token usage tracking. Users on older
+        // Ollama builds that hang can set OLLAMA_STREAM_USAGE=false to opt out.
+        Err(_) => true,
+    }
+}
+
 fn apply_ollama_options(payload: &mut Value, model_config: &ModelConfig) {
     if let Some(obj) = payload.as_object_mut() {
-        // Ollama supports stream_options since mid-2025. Keeping it enabled allows
-        // token usage tracking in streaming responses. The per-chunk timeout in
-        // with_line_timeout() protects against hangs if an older Ollama version
-        // doesn't handle stream_options properly.
+        // Gate stream_options behind OLLAMA_STREAM_USAGE (default: true).
+        // Older Ollama builds that don't support stream_options may stall before
+        // emitting any SSE data, blocking until the client timeout (600s).
+        // with_line_timeout() only protects after the first line arrives, so
+        // users on older builds should set OLLAMA_STREAM_USAGE=false.
+        if !resolve_ollama_stream_usage() {
+            obj.remove("stream_options");
+        }
 
         // Convert max_completion_tokens / max_tokens to Ollama's options.num_predict.
         // Reasoning models emit max_completion_tokens; non-reasoning models emit max_tokens.
@@ -331,7 +346,9 @@ impl Provider for OllamaProvider {
 
 /// Per-chunk timeout for Ollama streaming responses.
 /// If no new raw SSE data arrives within this duration, the connection is considered dead.
-const OLLAMA_CHUNK_TIMEOUT_SECS: u64 = 30;
+/// Set to 120s to accommodate slower models (CPU inference, large parameter counts,
+/// or complex reasoning) that may pause for extended periods between tokens.
+const OLLAMA_CHUNK_TIMEOUT_SECS: u64 = 120;
 
 /// Wraps a line stream with a per-item timeout at the raw SSE level.
 /// This detects dead connections without false-positive stalls during long
@@ -461,11 +478,14 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_ollama_options_transforms_fields() {
+    fn test_apply_ollama_options_preserves_stream_options_by_default() {
         use crate::providers::formats::ollama::create_request;
         use crate::providers::utils::ImageFormat;
 
-        let _guard = env_lock::lock_env([("GOOSE_INPUT_LIMIT", None::<&str>)]);
+        let _guard = env_lock::lock_env([
+            ("GOOSE_INPUT_LIMIT", None::<&str>),
+            ("OLLAMA_STREAM_USAGE", None::<&str>),
+        ]);
         let model_config = ModelConfig::new("llama3.1")
             .unwrap()
             .with_max_tokens(Some(4096));
@@ -485,7 +505,7 @@ mod tests {
 
         assert!(
             payload.get("stream_options").is_some(),
-            "stream_options should be preserved for Ollama to enable usage tracking"
+            "stream_options should be preserved by default for usage tracking"
         );
         assert!(
             payload.get("max_tokens").is_none(),
@@ -500,6 +520,38 @@ mod tests {
             "max_tokens should be moved to options.num_predict"
         );
         assert_eq!(payload["stream"], true, "stream field should be preserved");
+    }
+
+    #[test]
+    fn test_apply_ollama_options_strips_stream_options_when_disabled() {
+        use crate::providers::formats::ollama::create_request;
+        use crate::providers::utils::ImageFormat;
+
+        let _guard = env_lock::lock_env([
+            ("GOOSE_INPUT_LIMIT", None::<&str>),
+            ("OLLAMA_STREAM_USAGE", Some("false")),
+        ]);
+        let model_config = ModelConfig::new("llama3.1")
+            .unwrap()
+            .with_max_tokens(Some(4096));
+        let messages = vec![crate::conversation::message::Message::user().with_text("hi")];
+
+        let mut payload = create_request(
+            &model_config,
+            "You are a helpful assistant.",
+            &messages,
+            &[],
+            &ImageFormat::OpenAi,
+            true,
+        )
+        .unwrap();
+
+        apply_ollama_options(&mut payload, &model_config);
+
+        assert!(
+            payload.get("stream_options").is_none(),
+            "stream_options should be removed when OLLAMA_STREAM_USAGE=false"
+        );
     }
 
     #[tokio::test]

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -70,8 +70,10 @@ fn resolve_ollama_num_ctx(model_config: &ModelConfig) -> Option<usize> {
 
 fn apply_ollama_options(payload: &mut Value, model_config: &ModelConfig) {
     if let Some(obj) = payload.as_object_mut() {
-        // Ollama does not support stream_options; remove it to prevent hangs.
-        obj.remove("stream_options");
+        // Ollama supports stream_options since mid-2025. Keeping it enabled allows
+        // token usage tracking in streaming responses. The per-chunk timeout in
+        // with_line_timeout() protects against hangs if an older Ollama version
+        // doesn't handle stream_options properly.
 
         // Convert max_completion_tokens / max_tokens to Ollama's options.num_predict.
         // Reasoning models emit max_completion_tokens; non-reasoning models emit max_tokens.
@@ -450,7 +452,7 @@ mod tests {
 
         assert!(
             payload.get("stream_options").is_some(),
-            "create_request should produce stream_options (unsupported by Ollama)"
+            "create_request should produce stream_options for usage tracking"
         );
         assert!(
             payload.get("max_tokens").is_some(),
@@ -459,7 +461,7 @@ mod tests {
     }
 
     #[test]
-    fn test_apply_ollama_options_strips_unsupported_fields() {
+    fn test_apply_ollama_options_transforms_fields() {
         use crate::providers::formats::ollama::create_request;
         use crate::providers::utils::ImageFormat;
 
@@ -482,8 +484,8 @@ mod tests {
         apply_ollama_options(&mut payload, &model_config);
 
         assert!(
-            payload.get("stream_options").is_none(),
-            "stream_options should be removed for Ollama"
+            payload.get("stream_options").is_some(),
+            "stream_options should be preserved for Ollama to enable usage tracking"
         );
         assert!(
             payload.get("max_tokens").is_none(),

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -72,10 +72,19 @@ fn resolve_ollama_stream_usage() -> bool {
     let config = crate::config::Config::global();
     match config.get_param::<bool>("OLLAMA_STREAM_USAGE") {
         Ok(val) => val,
-        // Default to true: Ollama supports stream_options since mid-2025 and
-        // most installs will benefit from token usage tracking. Users on older
-        // Ollama builds that hang can set OLLAMA_STREAM_USAGE=false to opt out.
-        Err(_) => true,
+        // Key not set: default to true. Ollama supports stream_options since
+        // mid-2025 and most installs benefit from token usage tracking.
+        Err(crate::config::ConfigError::NotFound(_)) => true,
+        // Invalid value (e.g. "0", "yes", typo): warn and disable stream_options
+        // so users who intended to opt out aren't silently left hanging.
+        Err(e) => {
+            tracing::warn!(
+                "Invalid OLLAMA_STREAM_USAGE value ({}); disabling stream_options. \
+                 Use true or false.",
+                e
+            );
+            false
+        }
     }
 }
 

--- a/crates/goose/src/providers/ollama.rs
+++ b/crates/goose/src/providers/ollama.rs
@@ -617,7 +617,10 @@ mod tests {
             ("GOOSE_STREAM_TIMEOUT", None::<&str>),
             ("OLLAMA_TIMEOUT", None::<&str>),
         ]);
-        assert_eq!(resolve_ollama_chunk_timeout(), OLLAMA_DEFAULT_CHUNK_TIMEOUT_SECS);
+        assert_eq!(
+            resolve_ollama_chunk_timeout(),
+            OLLAMA_DEFAULT_CHUNK_TIMEOUT_SECS
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three related fixes for the Ollama provider:

1. **Token usage tracking**: The provider was unconditionally stripping `stream_options: {"include_usage": true}` from requests (#7723), preventing Ollama from returning token counts in streaming responses. This is now gated behind `OLLAMA_STREAM_USAGE` (default: `true`) so modern Ollama builds get usage tracking while older builds can opt out with `OLLAMA_STREAM_USAGE=false`. Invalid values are handled safely — a warning is logged and `stream_options` is disabled.

2. **Fallback usage parsing**: Added fallback for Ollama-native token fields (`prompt_eval_count`, `eval_count`) in `get_usage()`, so token tracking works even when Ollama doesn't translate to standard OpenAI field names (`prompt_tokens`, `completion_tokens`). OpenAI fields take precedence when both are present. Null OpenAI fields (e.g. `"completion_tokens": null`) correctly fall through to the Ollama-native fields instead of silently dropping usage.

3. **Configurable stream timeout**: The hardcoded 30s per-chunk timeout was too aggressive for slower models (CPU inference, large parameter counts, complex reasoning). The timeout is now configurable via a resolution chain: `OLLAMA_STREAM_TIMEOUT` > `GOOSE_STREAM_TIMEOUT` > `OLLAMA_TIMEOUT` > default (120s).

### Testing

- All 27 related tests pass (zero failures)
- **4 new timeout resolution tests**: verify the `OLLAMA_STREAM_TIMEOUT` > `GOOSE_STREAM_TIMEOUT` > `OLLAMA_TIMEOUT` > default fallback chain
- **3 new usage parsing tests**: verify Ollama-native field fallback, OpenAI field precedence, and null OpenAI field fallthrough
- **2 existing stream_options gating tests**: verify `OLLAMA_STREAM_USAGE` default-on and opt-out behavior

### Related Issues
Relates to #8479
Relates to #8476
Relates to #7723
