### PR TITLE
fix: use api. subdomain for enterprise GitHub Copilot token URL

### DIFF
--- a/crates/goose/src/providers/githubcopilot.rs
+++ b/crates/goose/src/providers/githubcopilot.rs
@@ -82,7 +82,7 @@ impl GithubCopilotUrls {
             let base = format!("https://{}", host);
             let copilot_token_url = copilot_token_url
                 .map(|u| u.trim_end_matches('/').to_string())
-                .unwrap_or_else(|| format!("{}/api/copilot_internal/v2/token", base));
+                .unwrap_or_else(|| format!("https://api.{}/copilot_internal/v2/token", host));
             Self {
                 device_code_url: format!("{}/login/device/code", base),
                 access_token_url: format!("{}/login/oauth/access_token", base),
@@ -777,7 +777,7 @@ mod tests {
         );
         assert_eq!(
             urls.copilot_token_url,
-            "https://my-enterprise.ghe.com/api/copilot_internal/v2/token"
+            "https://api.my-enterprise.ghe.com/copilot_internal/v2/token"
         );
     }
 


### PR DESCRIPTION
The enterprise copilot token URL was incorrectly using a path prefix (/api/copilot_internal/v2/token) which returns a 404. The correct pattern, consistent with how api.github.com works for github.com, is to use the api. subdomain:

  https://api.<host>/copilot_internal/v2/token

Also restores correct use of the computed copilot_token_url variable so that the GITHUB_COPILOT_TOKEN_URL override still works.

Fixes #7716

## Summary
Removed "api" from the url-path and added it as subdomain to the Github Enterprise Host.

### Testing
Tested the implementation against our real our-company.ghe.com, instance within the provided dev-container. I can provide further information which company that is in a private conversation and I'm happy to help with any further testing.

### Related Issues
Relates to #7716  

