### PR TITLE
Lifei/not notify for forked repo

### DIFF
--- a/.github/workflows/build-notify.yml
+++ b/.github/workflows/build-notify.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   notify:
     if: >
+      github.event.workflow_run.head_repository.full_name == github.repository &&
       github.event.workflow_run.conclusion == 'failure' &&
       (
         github.event.workflow_run.name != 'CI' ||

--- a/.github/workflows/build-notify.yml
+++ b/.github/workflows/build-notify.yml
@@ -17,6 +17,7 @@ jobs:
       (
         github.event.workflow_run.name != 'CI' ||
         github.event.workflow_run.head_branch == 'main' ||
+        github.event.workflow_run.head_branch == 'lifei/not-notify-for-forked-repo' ||
         github.event.workflow_run.event == 'merge_group'
       )
     runs-on: ubuntu-latest

--- a/.github/workflows/build-notify.yml
+++ b/.github/workflows/build-notify.yml
@@ -17,7 +17,6 @@ jobs:
       (
         github.event.workflow_run.name != 'CI' ||
         github.event.workflow_run.head_branch == 'main' ||
-        github.event.workflow_run.head_branch == 'lifei/not-notify-for-forked-repo' ||
         github.event.workflow_run.event == 'merge_group'
       )
     runs-on: ubuntu-latest

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -1,3 +1,5 @@
+const    X:    i32    =    1;
+
 #[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
 compile_error!("At least one of `rustls-tls` or `native-tls` features must be enabled");
 

--- a/crates/goose/src/lib.rs
+++ b/crates/goose/src/lib.rs
@@ -1,5 +1,3 @@
-const    X:    i32    =    1;
-
 #[cfg(not(any(feature = "rustls-tls", feature = "native-tls")))]
 compile_error!("At least one of `rustls-tls` or `native-tls` features must be enabled");
 


### PR DESCRIPTION
## Summary
Only trigger discord notification for the workflow failure on this repo, not the forked repo

 

