### PR TITLE
feat(skills): add MiniMax-AI/cli as external skill source

### DIFF
--- a/documentation/static/external-skills.json
+++ b/documentation/static/external-skills.json
@@ -1,0 +1,13 @@
+{
+  "skills": [
+    {
+      "id": "mmx-cli",
+      "name": "mmx-cli",
+      "description": "Generate text, images, video, speech, and music via MiniMax AI platform",
+      "author": "MiniMax-AI",
+      "version": "latest",
+      "tags": ["text", "image", "video", "speech", "music", "web-search"],
+      "sourceUrl": "https://github.com/MiniMax-AI/cli"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `documentation/static/external-skills.json` so the mmx-cli skill is discoverable out of the box
- Users can install via `npx skills add MiniMax-AI/cli` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**1 new file, 13 lines added, 0 files modified.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- Running `generate-skills-manifest.js` lists the mmx-cli skill alongside official skills
- `npx skills add MiniMax-AI/cli` installs successfully
- Ask goose "generate a jazz instrumental" — goose invokes `mmx music generate` via terminal