### PR TITLE
fix: create logs dir before writing llm request log

### DIFF
--- a/crates/goose/src/providers/utils.rs
+++ b/crates/goose/src/providers/utils.rs
@@ -376,6 +376,7 @@ impl RequestLog {
         Payload: Serialize,
     {
         let logs_dir = Paths::in_state_dir("logs");
+        fs_err::create_dir_all(&logs_dir)?;
 
         let request_id = Uuid::new_v4();
         let temp_name = format!("llm_request.{request_id}.jsonl");
@@ -524,6 +525,27 @@ pub fn json_escape_control_chars_in_string(s: &str) -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn test_request_log_start_creates_logs_dir() {
+        let _guard = env_lock::lock_env([("GOOSE_PATH_ROOT", None::<&str>)]);
+        let temp_dir = tempfile::tempdir().unwrap();
+        std::env::set_var("GOOSE_PATH_ROOT", temp_dir.path());
+
+        let logs_dir = Paths::in_state_dir("logs");
+        assert!(!logs_dir.exists(), "logs dir should not exist yet");
+
+        let log = RequestLog::start(
+            &ModelConfig::new("test").unwrap(),
+            &json!({"model": "test"}),
+        )
+        .expect("RequestLog::start should create missing logs dir");
+        drop(log);
+
+        assert!(logs_dir.is_dir(), "logs dir should have been created");
+
+        std::env::remove_var("GOOSE_PATH_ROOT");
+    }
 
     #[test]
     fn test_detect_image_path() {


### PR DESCRIPTION
## Summary
`RequestLog::start` opened `<state>/logs/llm_request.<uuid>.jsonl` with `File::create`, which creates the file but not its parent directory. On fresh installs (or when the `logs/` directory was cleared), every provider streaming request failed with `ENOENT`, and the `providers::ollama::tests::test_stream_ollama_timeout_on_stall` test panicked at the `RequestLog::start(...).unwrap()` call.

This change calls `fs_err::create_dir_all` on the logs directory at the top of `RequestLog::start` so the rename in `finish()` and the file write here both have a guaranteed parent. The existing workaround in `crates/goose-acp/tests/fixtures/mod.rs` (which pre-creates the dir before tests run) is no longer load-bearing.

### Testing
- Added `providers::utils::tests::test_request_log_start_creates_logs_dir` — points `GOOSE_PATH_ROOT` at a fresh tempdir, asserts `logs/` does not exist, calls `RequestLog::start`, asserts it now exists. Uses the same `env_lock` pattern as `providers::init::tests`.
- `cargo test -p goose --lib providers::utils::tests::test_request_log_start_creates_logs_dir -- --exact` — passes.
- `cargo fmt --check -p goose` — clean.
- `cargo clippy -p goose --lib --tests -- -D warnings` — clean.

### Related Issues
Fixes #8485