### PR TITLE
Set MACOSX_DEPLOYMENT_TARGET=12.0 in build-cli.yml

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -25,6 +25,8 @@ jobs:
   build-cli:
     name: Build CLI
     runs-on: ${{ matrix.build-on }}
+    env:
+      MACOSX_DEPLOYMENT_TARGET: "12.0"
     strategy:
       fail-fast: false
       matrix:
@@ -81,7 +83,7 @@ jobs:
         if: matrix.use-cross
         uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5  # v2.8.2
         with:
-          key: ${{ matrix.architecture }}-${{ matrix.target-suffix }}
+          key: ${{ matrix.architecture }}-${{ matrix.target-suffix }}-macos-deployment-target-12
 
       - name: Cache Cargo artifacts (Windows)
         if: matrix.os == 'windows'


### PR DESCRIPTION
## Summary

PR #7947 added `MACOSX_DEPLOYMENT_TARGET=12.0` to the desktop app bundle workflows (`bundle-desktop.yml`, `bundle-desktop-intel.yml`) to fix #7674. However, the standalone CLI binary built by `build-cli.yml` was not updated.

The CLI binary is still compiled without `MACOSX_DEPLOYMENT_TARGET`, causing `_OBJC_CLASS_$_MTLResidencySetDescriptor` (a macOS 15+ Metal API) to be strongly linked. This makes the binary crash with `signal: abort trap` on any macOS version below 15 (Sequoia).

Verified with `otool` and `nm` on the v1.30.0 release binary:
- `minos 11.0, sdk 15.5` -- claims macOS 11 minimum but built with SDK 15.5
- `_OBJC_CLASS_$_MTLResidencySetDescriptor` is a strong (not weak) external symbol
- Metal.framework loaded via `LC_LOAD_DYLIB` (strong), not `LC_LOAD_WEAK_DYLIB`

## Changes
- Added `MACOSX_DEPLOYMENT_TARGET: "12.0"` as a job-level env var in `build-cli.yml`
- Busted Cargo cache key for macOS to force clean rebuild

## Testing
- The fix mirrors the approach validated in #7947
- Can be verified by building the CLI on macOS with SDK 15+ and running `otool -l` / `nm` to confirm the symbol is now weak-linked

Fixes #7674