### PR TITLE
docs(mcp): add Rendex MCP Server extension tutorial

### DIFF
--- a/documentation/docs/mcp/rendex-mcp.md
+++ b/documentation/docs/mcp/rendex-mcp.md
@@ -1,0 +1,171 @@
+---
+title: Rendex Extension
+description: Add Rendex MCP Server as a goose Extension for Screenshots, PDFs, and HTML-to-Image Rendering
+---
+
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
+import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
+
+This tutorial covers how to add the [Rendex MCP Server](https://github.com/copperline-labs/rendex-mcp) as a goose extension to capture screenshots, generate PDFs, and render HTML to images from any webpage or raw HTML — useful for archiving UIs, generating invoices and reports, producing OG images, and giving goose a reliable "see the web" capability that doesn't require spinning up a full browser automation stack.
+
+:::tip Quick Install
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@copperline/rendex-mcp&id=rendex&name=Rendex&description=Capture%20screenshots%2C%20generate%20PDFs%2C%20and%20render%20HTML%20to%20images%20via%20AI%20agents&env=RENDEX_API_KEY%3DRendex%20API%20Key)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  **Command**
+  ```sh
+  npx -y @copperline/rendex-mcp
+  ```
+  </TabItem>
+</Tabs>
+  **Environment Variable**
+  ```
+  RENDEX_API_KEY: <YOUR_API_KEY>
+  ```
+:::
+
+## Configuration
+
+:::info
+Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
+:::
+
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  <GooseDesktopInstaller
+    extensionId="rendex"
+    extensionName="Rendex"
+    description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
+    command="npx"
+    args={["-y", "@copperline/rendex-mcp"]}
+    envVars={[
+      { name: "RENDEX_API_KEY", label: "Rendex API Key" }
+    ]}
+    apiKeyLink="https://rendex.dev/dashboard/keys"
+    apiKeyLinkText="Rendex API key"
+  />
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Rendex"
+      description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
+      command="npx -y @copperline/rendex-mcp"
+      envVars={[
+        { key: "RENDEX_API_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
+      ]}
+      infoNote={
+        <>
+          Get your API key from{" "}
+          <a href="https://rendex.dev/dashboard/keys" target="_blank" rel="noopener noreferrer">
+            rendex.dev
+          </a> and paste it in. Free tier includes 500 calls/month.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+## Available Tool
+
+Rendex exposes a single outcome-focused tool, `rendex_screenshot`, that handles screenshots, PDF generation, and HTML-to-image rendering with typed parameters for every option.
+
+| Capability | Notes |
+|---|---|
+| **Output formats** | PNG, JPEG, WebP, PDF |
+| **Full-page capture** | Scroll-and-stitch, with `bestAttempt` fallback on heavy sites |
+| **Dark mode** | Emulates `prefers-color-scheme: dark` |
+| **Element selector** | Capture a specific element (`#hero`, `.pricing-card`) instead of the whole viewport |
+| **CSS/JS injection** | Inject up to 50KB of custom CSS/JS before capture — hide cookie banners, add watermarks, override styles |
+| **Cookie/header injection** | Set up to 50 cookies and arbitrary headers for authenticated pages |
+| **PDF options** | Page size (A4/Letter/Legal/Tabloid/A3), landscape, margins, scale, print background |
+| **Geo-targeting** | ISO country code + city/state for country-specific rendering (Pro/Enterprise) |
+| **Async pipeline** | Set `async=true` to get a job ID + HMAC-signed webhook callback when the render completes |
+| **Caching** | `cacheTtl` returns a signed R2 URL for cached results |
+| **Raw HTML input** | Pass `html` instead of `url` to render arbitrary markup (invoices, social cards, email templates, OG images) |
+
+Rendex runs on Cloudflare Workers with Browser Rendering on the back end, so Node/Chromium doesn't have to spin up locally.
+
+## Example Usage
+
+Let's use the Rendex extension to generate an invoice PDF from raw HTML and archive a product page.
+
+### goose Prompt
+
+```
+1. Render this HTML as an A4 PDF with 1cm margins:
+
+   <!doctype html>
+   <html>
+     <body style="font-family: system-ui; padding: 40px;">
+       <h1>Invoice #0042</h1>
+       <p>Bill to: Acme Corp</p>
+       <table>
+         <tr><td>MCP server listing</td><td>$500.00</td></tr>
+         <tr><td>Total</td><td><b>$500.00</b></td></tr>
+       </table>
+     </body>
+   </html>
+
+2. Then take a full-page screenshot of https://news.ycombinator.com in dark mode
+
+3. Return both results so I can save them
+```
+
+### goose Output
+
+```
+I'll generate the invoice PDF first, then capture the HN page.
+
+[rendex_screenshot: format=pdf, pdfFormat=A4, pdfMargin={top: 1cm, ...}, html=<invoice markup>]
+✓ PDF captured successfully (12,344 bytes)
+  width: 1280  height: 800  capturedAt: 2026-04-15T12:34:56Z
+
+[rendex_screenshot: url=https://news.ycombinator.com, fullPage=true, darkMode=true]
+✓ Screenshot captured (PNG, 847KB)
+  width: 1280  height: 4,321  waitStrategy: networkidle2
+
+Both renders completed. You have:
+  1. Invoice PDF (A4, 12.3KB) — base64 in result 1
+  2. Dark-mode full-page screenshot of Hacker News (PNG, 847KB) — base64 in result 2
+```
+
+## Pricing
+
+Rendex is free to try — you don't need a credit card for the free tier.
+
+| Plan | Calls/Month | Rate limit |
+|---|---|---|
+| Free | 500 | 10/min |
+| Starter | 10,000 | 60/min |
+| Pro | 100,000 | 300/min |
+| Enterprise | Custom | 1,000/min |
+
+Get an API key at [rendex.dev](https://rendex.dev).
+
+## Remote (Zero-Install) Option
+
+Rendex also exposes a remote Streamable HTTP endpoint at `https://mcp.rendex.dev/mcp`. If your goose client supports the `type: http` transport, you can skip the `npx` step entirely:
+
+```yaml
+extensions:
+  rendex:
+    type: http
+    url: https://mcp.rendex.dev/mcp
+    envVars:
+      RENDEX_API_KEY: your-api-key  # sent as Authorization: Bearer <key>
+```
+
+The remote endpoint uses Bearer auth — goose will pass `RENDEX_API_KEY` as `Authorization: Bearer <key>` to every request.
+
+## Links
+
+- **Website**: [rendex.dev](https://rendex.dev)
+- **GitHub**: [copperline-labs/rendex-mcp](https://github.com/copperline-labs/rendex-mcp)
+- **npm**: [`@copperline/rendex-mcp`](https://www.npmjs.com/package/@copperline/rendex-mcp)
+- **Smithery**: [smithery.ai/server/copperline/rendex-mcp](https://smithery.ai/server/copperline/rendex-mcp)
+- **Official MCP Registry**: `io.github.copperline-labs/rendex-mcp`

--- a/documentation/docs/mcp/rendex-mcp.md
+++ b/documentation/docs/mcp/rendex-mcp.md
@@ -12,10 +12,6 @@ This tutorial covers how to add the [Rendex MCP Server](https://github.com/coppe
 
 ## Configuration
 
-<Tabs groupId="remote-or-local">
-<!-- REMOTE SETUP (default — zero install) -->
-<TabItem value="remote" label="Rendex Remote MCP" default>
-
 :::tip Quick Install
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
@@ -71,93 +67,6 @@ This tutorial covers how to add the [Rendex MCP Server](https://github.com/coppe
     />
   </TabItem>
 </Tabs>
-
-</TabItem>
-
-<!-- LOCAL SETUP -->
-<TabItem value="local" label="Rendex Local MCP">
-
-:::tip Quick Install
-<Tabs groupId="interface">
-  <TabItem value="ui" label="goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@copperline/rendex-mcp&id=rendex_local&name=Rendex%20Local%20MCP&description=Capture%20screenshots%2C%20generate%20PDFs%2C%20and%20render%20HTML%20to%20images%20via%20AI%20agents&env=RENDEX_API_KEY%3DRendex%20API%20Key)
-  </TabItem>
-  <TabItem value="cli" label="goose CLI">
-  **Command**
-  ```sh
-  npx -y @copperline/rendex-mcp
-  ```
-  </TabItem>
-</Tabs>
-
-  **Environment Variable**
-  ```
-  RENDEX_API_KEY: <YOUR_RENDEX_API_KEY>
-  ```
-:::
-
-:::info
-Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
-:::
-
-<Tabs groupId="interface">
-  <TabItem value="ui" label="goose Desktop" default>
-    <GooseDesktopInstaller
-      extensionId="rendex_local"
-      extensionName="Rendex Local MCP"
-      description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
-      type="stdio"
-      command="npx"
-      args={["-y", "@copperline/rendex-mcp"]}
-      envVars={[
-        { name: "RENDEX_API_KEY", label: "Rendex API Key" }
-      ]}
-      apiKeyLink="https://rendex.dev/dashboard/keys"
-      apiKeyLinkText="Rendex API key"
-    />
-  </TabItem>
-
-  <TabItem value="cli" label="goose CLI">
-    <CLIExtensionInstructions
-      name="Rendex Local MCP"
-      description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
-      type="stdio"
-      command="npx -y @copperline/rendex-mcp"
-      timeout={300}
-      envVars={[
-        { key: "RENDEX_API_KEY", value: "rdx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
-      ]}
-      infoNote={
-        <>
-          Obtain your <a href="https://rendex.dev/dashboard/keys" target="_blank" rel="noopener noreferrer">Rendex API key</a> and paste it in.
-        </>
-      }
-    />
-  </TabItem>
-</Tabs>
-
-</TabItem>
-</Tabs>
-
-## Available Tool
-
-Rendex exposes a single outcome-focused tool, `rendex_screenshot`, that handles screenshots, PDF generation, and HTML-to-image rendering with typed parameters for every option.
-
-| Capability | Notes |
-|---|---|
-| **Output formats** | PNG, JPEG, WebP, PDF |
-| **Full-page capture** | Scroll-and-stitch, with `bestAttempt` fallback on heavy sites |
-| **Dark mode** | Emulates `prefers-color-scheme: dark` |
-| **Element selector** | Capture a specific element (`#hero`, `.pricing-card`) instead of the whole viewport |
-| **CSS/JS injection** | Inject up to 50KB of custom CSS/JS before capture — hide cookie banners, add watermarks, override styles |
-| **Cookie/header injection** | Set up to 50 cookies and arbitrary headers for authenticated pages |
-| **PDF options** | Page size (A4/Letter/Legal/Tabloid/A3), landscape, margins, scale, print background |
-| **Geo-targeting** | ISO country code + city/state for country-specific rendering (Pro/Enterprise) |
-| **Async pipeline** | Set `async=true` to get a job ID + HMAC-signed webhook callback when the render completes |
-| **Caching** | `cacheTtl` returns a signed R2 URL for cached results |
-| **Raw HTML input** | Pass `html` instead of `url` to render arbitrary markup (invoices, social cards, email templates, OG images) |
-
-Rendex runs on Cloudflare Workers with Browser Rendering on the back end, so Node/Chromium doesn't have to spin up locally.
 
 ## Example Usage
 

--- a/documentation/docs/mcp/rendex-mcp.md
+++ b/documentation/docs/mcp/rendex-mcp.md
@@ -8,13 +8,79 @@ import TabItem from '@theme/TabItem';
 import GooseDesktopInstaller from '@site/src/components/GooseDesktopInstaller';
 import CLIExtensionInstructions from '@site/src/components/CLIExtensionInstructions';
 
-This tutorial covers how to add the [Rendex MCP Server](https://github.com/copperline-labs/rendex-mcp) as a goose extension to capture screenshots, generate PDFs, and render HTML to images from any webpage or raw HTML — useful for archiving UIs, generating invoices and reports, producing OG images, and giving goose a reliable "see the web" capability that doesn't require spinning up a full browser automation stack.
+This tutorial covers how to add the [Rendex MCP Server](https://github.com/copperline-labs/rendex-mcp) as a goose extension to capture screenshots, generate PDFs, and render HTML to images from any webpage or raw HTML — useful for archiving UIs, generating invoices and reports, producing OG images, and giving goose a reliable "see the web" capability without spinning up a full browser automation stack.
+
+## Configuration
+
+<Tabs groupId="remote-or-local">
+<!-- REMOTE SETUP (default — zero install) -->
+<TabItem value="remote" label="Rendex Remote MCP" default>
 
 :::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?type=streamable_http&url=https%3A%2F%2Fmcp.rendex.dev%2Fmcp&id=rendex&name=Rendex&description=Capture%20screenshots%2C%20generate%20PDFs%2C%20and%20render%20HTML%20to%20images%20via%20AI%20agents&header=Authorization%3DBearer%20YOUR_RENDEX_API_KEY)
+  </TabItem>
+  <TabItem value="cli" label="goose CLI">
+  Add a `Remote Extension (Streaming HTTP)` extension type with:
+
+  **Endpoint URL**
+  ```
+  https://mcp.rendex.dev/mcp
+  ```
+  </TabItem>
+</Tabs>
+
+  **Custom Request Header**
+  ```
+  Authorization: Bearer <YOUR_RENDEX_API_KEY>
+  ```
+:::
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@copperline/rendex-mcp&id=rendex&name=Rendex&description=Capture%20screenshots%2C%20generate%20PDFs%2C%20and%20render%20HTML%20to%20images%20via%20AI%20agents&env=RENDEX_API_KEY%3DRendex%20API%20Key)
+    <GooseDesktopInstaller
+      extensionId="rendex"
+      extensionName="Rendex"
+      description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
+      type="http"
+      url="https://mcp.rendex.dev/mcp"
+      envVars={[
+        { name: "Authorization", label: "Bearer YOUR_RENDEX_API_KEY" }
+      ]}
+      apiKeyLink="https://rendex.dev/dashboard/keys"
+      apiKeyLinkText="Rendex API key"
+    />
+  </TabItem>
+
+  <TabItem value="cli" label="goose CLI">
+    <CLIExtensionInstructions
+      name="Rendex"
+      description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
+      type="http"
+      url="https://mcp.rendex.dev/mcp"
+      timeout={300}
+      envVars={[
+        { key: "Authorization", value: "Bearer rdx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
+      ]}
+      infoNote={
+        <>
+          Obtain your <a href="https://rendex.dev/dashboard/keys" target="_blank" rel="noopener noreferrer">Rendex API key</a> and paste it in as the <code>Bearer</code> token. Free tier includes 500 calls/month, no credit card required.
+        </>
+      }
+    />
+  </TabItem>
+</Tabs>
+
+</TabItem>
+
+<!-- LOCAL SETUP -->
+<TabItem value="local" label="Rendex Local MCP">
+
+:::tip Quick Install
+<Tabs groupId="interface">
+  <TabItem value="ui" label="goose Desktop" default>
+  [Launch the installer](goose://extension?cmd=npx&arg=-y&arg=@copperline/rendex-mcp&id=rendex_local&name=Rendex%20Local%20MCP&description=Capture%20screenshots%2C%20generate%20PDFs%2C%20and%20render%20HTML%20to%20images%20via%20AI%20agents&env=RENDEX_API_KEY%3DRendex%20API%20Key)
   </TabItem>
   <TabItem value="cli" label="goose CLI">
   **Command**
@@ -23,13 +89,12 @@ This tutorial covers how to add the [Rendex MCP Server](https://github.com/coppe
   ```
   </TabItem>
 </Tabs>
+
   **Environment Variable**
   ```
-  RENDEX_API_KEY: <YOUR_API_KEY>
+  RENDEX_API_KEY: <YOUR_RENDEX_API_KEY>
   ```
 :::
-
-## Configuration
 
 :::info
 Note that you'll need [Node.js](https://nodejs.org/) installed on your system to run this command, as it uses `npx`.
@@ -37,37 +102,41 @@ Note that you'll need [Node.js](https://nodejs.org/) installed on your system to
 
 <Tabs groupId="interface">
   <TabItem value="ui" label="goose Desktop" default>
-  <GooseDesktopInstaller
-    extensionId="rendex"
-    extensionName="Rendex"
-    description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
-    command="npx"
-    args={["-y", "@copperline/rendex-mcp"]}
-    envVars={[
-      { name: "RENDEX_API_KEY", label: "Rendex API Key" }
-    ]}
-    apiKeyLink="https://rendex.dev/dashboard/keys"
-    apiKeyLinkText="Rendex API key"
-  />
+    <GooseDesktopInstaller
+      extensionId="rendex_local"
+      extensionName="Rendex Local MCP"
+      description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
+      type="stdio"
+      command="npx"
+      args={["-y", "@copperline/rendex-mcp"]}
+      envVars={[
+        { name: "RENDEX_API_KEY", label: "Rendex API Key" }
+      ]}
+      apiKeyLink="https://rendex.dev/dashboard/keys"
+      apiKeyLinkText="Rendex API key"
+    />
   </TabItem>
+
   <TabItem value="cli" label="goose CLI">
     <CLIExtensionInstructions
-      name="Rendex"
+      name="Rendex Local MCP"
       description="Capture screenshots, generate PDFs, and render HTML to images via AI agents"
+      type="stdio"
       command="npx -y @copperline/rendex-mcp"
+      timeout={300}
       envVars={[
-        { key: "RENDEX_API_KEY", value: "▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪▪" }
+        { key: "RENDEX_API_KEY", value: "rdx_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" }
       ]}
       infoNote={
         <>
-          Get your API key from{" "}
-          <a href="https://rendex.dev/dashboard/keys" target="_blank" rel="noopener noreferrer">
-            rendex.dev
-          </a> and paste it in. Free tier includes 500 calls/month.
+          Obtain your <a href="https://rendex.dev/dashboard/keys" target="_blank" rel="noopener noreferrer">Rendex API key</a> and paste it in.
         </>
       }
     />
   </TabItem>
+</Tabs>
+
+</TabItem>
 </Tabs>
 
 ## Available Tool
@@ -136,7 +205,7 @@ Both renders completed. You have:
 
 ## Pricing
 
-Rendex is free to try — you don't need a credit card for the free tier.
+Rendex is free to try — no credit card required for the free tier.
 
 | Plan | Calls/Month | Rate limit |
 |---|---|---|
@@ -146,21 +215,6 @@ Rendex is free to try — you don't need a credit card for the free tier.
 | Enterprise | Custom | 1,000/min |
 
 Get an API key at [rendex.dev](https://rendex.dev).
-
-## Remote (Zero-Install) Option
-
-Rendex also exposes a remote Streamable HTTP endpoint at `https://mcp.rendex.dev/mcp`. If your goose client supports the `type: http` transport, you can skip the `npx` step entirely:
-
-```yaml
-extensions:
-  rendex:
-    type: http
-    url: https://mcp.rendex.dev/mcp
-    envVars:
-      RENDEX_API_KEY: your-api-key  # sent as Authorization: Bearer <key>
-```
-
-The remote endpoint uses Bearer auth — goose will pass `RENDEX_API_KEY` as `Authorization: Bearer <key>` to every request.
 
 ## Links
 

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -650,6 +650,7 @@
         "required": true
       }
     ],
+    "show_install_command": false,
     "type": "streamable-http"
   },
   {

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -637,18 +637,20 @@
     "id": "rendex-mcp",
     "name": "Rendex",
     "description": "Capture screenshots, generate PDFs, and render HTML to images via AI agents",
-    "command": "npx -y @copperline/rendex-mcp",
+    "url": "https://mcp.rendex.dev/mcp",
     "link": "https://github.com/copperline-labs/rendex-mcp",
-    "installation_notes": "Install using npx package manager.",
+    "installation_notes": "This is a remote extension that requires a Rendex API key from https://rendex.dev/dashboard/keys as a Request Header e.g Authorization: Bearer <YOUR_RENDEX_API_KEY>. Free tier includes 500 calls/month, no credit card required.",
     "is_builtin": false,
     "endorsed": false,
-    "environmentVariables": [
+    "environmentVariables": [],
+    "headers": [
       {
-        "name": "RENDEX_API_KEY",
-        "description": "Required API key from https://rendex.dev",
+        "name": "Authorization",
+        "description": "Bearer <YOUR_RENDEX_API_KEY>",
         "required": true
       }
-    ]
+    ],
+    "type": "streamable-http"
   },
   {
     "id": "repomix-mcp",

--- a/documentation/static/servers.json
+++ b/documentation/static/servers.json
@@ -634,6 +634,23 @@
     ]
   },
   {
+    "id": "rendex-mcp",
+    "name": "Rendex",
+    "description": "Capture screenshots, generate PDFs, and render HTML to images via AI agents",
+    "command": "npx -y @copperline/rendex-mcp",
+    "link": "https://github.com/copperline-labs/rendex-mcp",
+    "installation_notes": "Install using npx package manager.",
+    "is_builtin": false,
+    "endorsed": false,
+    "environmentVariables": [
+      {
+        "name": "RENDEX_API_KEY",
+        "description": "Required API key from https://rendex.dev",
+        "required": true
+      }
+    ]
+  },
+  {
     "id": "repomix-mcp",
     "name": "Repomix",
     "description": "Repository analysis and code organization",


### PR DESCRIPTION
## What this adds

A new MCP extension tutorial page at \`documentation/docs/mcp/rendex-mcp.md\` for [Rendex](https://rendex.dev) — an MCP server that gives goose the ability to capture screenshots, generate PDFs, and render HTML to images from any webpage or raw HTML.

Single outcome-focused tool (\`rendex_screenshot\`) with a typed JSON Schema covering 30+ parameters across three rendering modes:

- **Screenshots**: PNG / JPEG / WebP, full-page, dark mode, element selector, CSS/JS injection, cookie + header injection, ad blocking
- **PDFs**: A4 / Letter / Legal / Tabloid / A3, landscape, margins, scale, print background
- **HTML rendering**: pass raw HTML instead of a URL for invoices, OG images, email template previews, social cards

Plus geo-targeting (Pro/Enterprise), an async pipeline with HMAC-signed webhook callbacks, and signed-R2-URL caching. Hosted on Cloudflare Workers with Browser Rendering on the back end, so no local Chromium needed.

## Why a small first PR

Following the guidance in CONTRIBUTING.md — starting with a narrow, single-file contribution that follows the existing \`documentation/docs/mcp/_template_.mdx\` structure and mirrors conventions from the current third-party server tutorials (\`browserbase-mcp.md\`, \`agentql-mcp.md\`, etc.).

## Install paths documented

- **stdio / Desktop installer**: \`npx -y @copperline/rendex-mcp\` with \`RENDEX_API_KEY\` env var (free tier: 500 calls/month, no credit card)
- **Remote / Streamable HTTP**: \`https://mcp.rendex.dev/mcp\` with Bearer auth for clients that support \`type: http\`

## Canonical metadata

| Field | Value |
|---|---|
| Name | Rendex |
| npm | [\`@copperline/rendex-mcp@1.0.1\`](https://www.npmjs.com/package/@copperline/rendex-mcp) |
| GitHub | [copperline-labs/rendex-mcp](https://github.com/copperline-labs/rendex-mcp) |
| Remote | \`https://mcp.rendex.dev/mcp\` |
| Official MCP Registry | \`io.github.copperline-labs/rendex-mcp\` |
| Smithery | [\`copperline/rendex-mcp\`](https://smithery.ai/server/copperline/rendex-mcp) |
| License | MIT |

## Test plan

- [x] Markdown renders cleanly (matches template imports + component props)
- [x] \`goose://extension?...\` desktop URL is correctly URL-encoded and follows existing tutorials' format
- [x] stdio install path tested — \`npx -y @copperline/rendex-mcp\` with a real API key connects and exposes \`rendex_screenshot\` (verified via Smithery scan + local Claude Desktop)
- [x] Remote endpoint \`mcp.rendex.dev/mcp\` returns \`serverInfo: {name: "rendex", version: "1.0.1"}\` on \`initialize\` (verified this morning)
- [x] DCO sign-off on commit

Happy to iterate on tone, copy, or structure if the maintainers want anything changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)