### PR TITLE
fix tauri-plugin-dialog version constraint to match other plugins

### DIFF
--- a/ui/goose2/src-tauri/Cargo.toml
+++ b/ui/goose2/src-tauri/Cargo.toml
@@ -20,7 +20,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = ["protocol-asset"] }
 tauri-plugin-app-test-driver = { path = "plugins/app-test-driver" }
 tauri-plugin-opener = "2"
-tauri-plugin-dialog = ">=2,<2.7"
+tauri-plugin-dialog = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-log = "2"
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Overview

**Category:** fix
**User Impact:** Resolves a build warning about mismatched Tauri package versions that could block `just dev` from starting.

**Problem:** The `tauri-plugin-dialog` Rust crate was pinned to `">=2,<2.7"` while the NPM package `@tauri-apps/plugin-dialog` resolved to 2.7.0, causing a version mismatch error on every dev build.

**Solution:** Relax the Cargo constraint to `"2"` to match every other Tauri plugin in the project. This lets Cargo resolve to the same minor version as the NPM package.

<details>
<summary>File changes</summary>

**ui/goose2/src-tauri/Cargo.toml**
Changed `tauri-plugin-dialog` version from `">=2,<2.7"` to `"2"` to align with the pattern used by all other Tauri plugins (`tauri-plugin-opener`, `tauri-plugin-window-state`, `tauri-plugin-log`).

</details>

## Reproduction Steps

1. Run `just dev` from `ui/goose2/`
2. Confirm the "Found version mismatched Tauri packages" error no longer appears