### PR TITLE
call goose serve from tauri frontend via goose-acp client

### DIFF
--- a/ui/goose2/acp-plus-migration-plan/00-overview.md
+++ b/ui/goose2/acp-plus-migration-plan/00-overview.md
@@ -1,0 +1,104 @@
+# ACP-Plus Migration Plan: Overview
+
+## Goal
+
+Move all ACP protocol handling from the Rust Tauri backend into the TypeScript/WebView layer, so the frontend communicates directly with `goose serve` over HTTP+SSE. The Rust layer shrinks to a thin native shell responsible only for:
+
+1. Spawning and managing the `goose serve` child process
+2. Providing the server URL to the frontend
+3. Window management / OS integration
+
+Long-term, config, personas, skills, projects, git, doctor, and all other native operations will also move behind `goose serve` ACP extension methods — eliminating the Rust middleware entirely.
+
+## Current Architecture
+
+```
+Frontend (TS)
+  → invoke("acp_send_message")          [Tauri IPC]
+    → GooseAcpManager                   [Rust singleton, dedicated thread]
+      → ClientSideConnection            [Rust ACP client over WebSocket]
+        → goose serve ws://127.0.0.1:<port>/acp   [child process]
+      ← SessionNotification             [ACP callback in Rust]
+    ← TauriMessageWriter                [emits Tauri events]
+  ← listen("acp:text", ...)             [Tauri event bus]
+    → Zustand store updates
+```
+
+## Target Architecture (Phase A)
+
+```
+Frontend (TS)
+  → GooseClient (HTTP+SSE)
+    → goose serve http://127.0.0.1:<port>/acp   [child process]
+  ← Client callbacks → direct Zustand store updates
+
+Tauri Rust shell:
+  - Spawn goose serve, expose URL
+  - Config/personas/skills/projects/git/doctor (temporary — Phase B removes these)
+  - Window management
+```
+
+## Target Architecture (Phase B — Long-Term)
+
+```
+Frontend (TS)
+  → GooseClient (HTTP+SSE)
+    → goose serve http://127.0.0.1:<port>/acp
+  ← Client callbacks → direct Zustand store updates
+
+Tauri Rust shell (~200 lines):
+  - Spawn goose serve, expose URL
+  - Window management
+  - (nothing else)
+```
+
+## Steps
+
+| Step | File | Summary |
+|------|------|---------|
+| 01 | `01-expose-goose-serve-url.md` | Add Tauri command to expose the `goose serve` HTTP URL to the frontend |
+| 02 | `02-add-acp-npm-dependencies.md` | Add `@aaif/goose-acp` and `@agentclientprotocol/sdk` to goose2 |
+| 03 | `03-create-ts-acp-connection.md` | Create the singleton TypeScript ACP connection manager |
+| 04 | `04-create-ts-notification-handler.md` | Port the Rust `SessionEventDispatcher` to TypeScript |
+| 05 | `05-create-ts-session-manager.md` | Port session state management and ACP operations to TypeScript |
+| 06 | `06-port-session-search.md` | Port session content search from Rust to TypeScript |
+| 07 | `07-rewire-shared-api-acp.md` | Replace `invoke()` wrappers in `src/shared/api/acp.ts` with direct TS ACP calls |
+| 08 | `08-rewire-hooks.md` | Remove `useAcpStream`, update `useChat`, `useAppStartup`, `AppShell` |
+| 09 | `09-delete-rust-acp-code.md` | Delete the Rust ACP middleware and unused dependencies |
+| 10 | `10-phase-b-future-native-migration.md` | Plan for moving config/personas/skills/projects/git/doctor to `goose serve` |
+
+## Ordering & Dependencies
+
+```
+01 ──┐
+     ├──→ 03 ──→ 04 ──→ 05 ──→ 07 ──→ 08 ──→ 09
+02 ──┘                    │
+                          └──→ 06 ──→ 07
+```
+
+Steps 01 and 02 are independent and can be done in parallel.
+Steps 03–06 build on each other but 06 can be done in parallel with 04/05.
+Step 07 wires everything together.
+Step 08 removes the old Tauri event listeners.
+Step 09 is cleanup — only after everything works.
+Step 10 is the Phase B roadmap.
+
+## Key Decisions
+
+1. **HTTP+SSE over WebSocket**: `goose serve` supports both. HTTP+SSE is already battle-tested by `ui/acp`'s `createHttpStream`. Visible in browser DevTools. Can switch to WS later if needed.
+
+2. **Direct store updates over event bus**: The notification handler calls Zustand store methods directly instead of emitting Tauri events. Eliminates a layer of indirection and the `useAcpStream` hook.
+
+3. **Reuse `@aaif/goose-acp`**: Already used by `ui/desktop` (Electron) and `ui/text` (Ink TUI). Provides `GooseClient`, `createHttpStream`, generated types, and Zod validators.
+
+4. **Auto-approve permissions**: Same as the current Rust implementation — accept the first option on all `request_permission` callbacks.
+
+## Risks & Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Tauri CSP blocks localhost fetch | CSP is already `null` (disabled) in `tauri.conf.json` |
+| `goose serve` not ready when frontend initializes | Rust still does readiness check; URL command only resolves after server is confirmed ready |
+| HTTP+SSE performance vs WebSocket | Both transports are supported; can switch later. SSE has keep-alive. |
+| Replay timing (notifications arriving after `loadSession` resolves) | Port the drain/stabilization logic from Rust, or rely on the `replay_complete` signal from the backend |
+| Session state consistency during migration | Can keep old Rust path behind a flag initially; remove after validation |

--- a/ui/goose2/acp-plus-migration-plan/00-overview.md
+++ b/ui/goose2/acp-plus-migration-plan/00-overview.md
@@ -49,7 +49,6 @@ Frontend (TS)
 Tauri Rust shell (~200 lines):
   - Spawn goose serve, expose URL
   - Window management
-  - (nothing else)
 ```
 
 ## Steps
@@ -76,29 +75,29 @@ Tauri Rust shell (~200 lines):
                           └──→ 06 ──→ 07
 ```
 
-Steps 01 and 02 are independent and can be done in parallel.
-Steps 03–06 build on each other but 06 can be done in parallel with 04/05.
-Step 07 wires everything together.
-Step 08 removes the old Tauri event listeners.
-Step 09 is cleanup — only after everything works.
-Step 10 is the Phase B roadmap.
+- Steps 01 and 02 are independent and can be done in parallel.
+- Steps 03–06 build on each other, though 06 can proceed in parallel with 04/05.
+- Step 07 wires everything together.
+- Step 08 removes the old Tauri event listeners.
+- Step 09 is cleanup — only after everything works.
+- Step 10 is the Phase B roadmap.
 
 ## Key Decisions
 
-1. **WebSocket transport**: `goose serve` exposes a WebSocket endpoint at `/acp`. Each WS text frame is a single JSON-RPC message. This is the same transport the Rust layer already uses — we're just moving the WebSocket client from Rust to TypeScript. WebSocket provides true bidirectional streaming with lower overhead than HTTP+SSE.
+1. **WebSocket transport.** `goose serve` exposes a WebSocket endpoint at `/acp`. Each WS text frame is a single JSON-RPC message. This is the same transport the Rust layer already uses — we are moving the WebSocket client from Rust to TypeScript. WebSocket provides true bidirectional streaming with lower overhead than HTTP+SSE.
 
-2. **Direct store updates over event bus**: The notification handler calls Zustand store methods directly instead of emitting Tauri events. Eliminates a layer of indirection and the `useAcpStream` hook.
+2. **Direct store updates over event bus.** The notification handler calls Zustand store methods directly instead of emitting Tauri events. This eliminates a layer of indirection and the `useAcpStream` hook.
 
-3. **Reuse `@aaif/goose-acp`**: Already used by `ui/desktop` (Electron) and `ui/text` (Ink TUI). Provides `GooseClient`, generated types, and Zod validators. We'll add a `createWebSocketStream` helper (either in `@aaif/goose-acp` or locally in goose2) since the package currently only ships `createHttpStream`.
+3. **Reuse `@aaif/goose-acp`.** Already used by `ui/desktop` (Electron) and `ui/text` (Ink TUI). Provides `GooseClient`, generated types, and Zod validators. A `createWebSocketStream` helper will be added (either in `@aaif/goose-acp` or locally in goose2) since the package currently only ships `createHttpStream`.
 
-4. **Auto-approve permissions**: Same as the current Rust implementation — accept the first option on all `request_permission` callbacks.
+4. **Auto-approve permissions.** Same as the current Rust implementation — accept the first option on all `request_permission` callbacks.
 
 ## Risks & Mitigations
 
 | Risk | Mitigation |
 |------|------------|
 | Tauri CSP blocks localhost WebSocket | CSP is already `null` (disabled) in `tauri.conf.json` |
-| `goose serve` not ready when frontend initializes | Rust still does readiness check; URL command only resolves after server is confirmed ready |
-| WebSocket disconnection / reconnection | Implement reconnection logic in the connection manager; the `GooseClient.closed` promise signals when the connection drops |
+| `goose serve` not ready when frontend initializes | Rust still does a readiness check; the URL command only resolves after the server is confirmed ready |
+| WebSocket disconnection / reconnection | Implement reconnection logic in the connection manager; `GooseClient.closed` signals when the connection drops |
 | Replay timing (notifications arriving after `loadSession` resolves) | Port the drain/stabilization logic from Rust, or rely on the `replay_complete` signal from the backend |
-| Session state consistency during migration | Can keep old Rust path behind a flag initially; remove after validation |
+| Session state consistency during migration | Keep the old Rust path behind a flag initially; remove after validation |

--- a/ui/goose2/acp-plus-migration-plan/00-overview.md
+++ b/ui/goose2/acp-plus-migration-plan/00-overview.md
@@ -2,7 +2,7 @@
 
 ## Goal
 
-Move all ACP protocol handling from the Rust Tauri backend into the TypeScript/WebView layer, so the frontend communicates directly with `goose serve` over HTTP+SSE. The Rust layer shrinks to a thin native shell responsible only for:
+Move all ACP protocol handling from the Rust Tauri backend into the TypeScript/WebView layer, so the frontend communicates directly with `goose serve` over WebSocket. The Rust layer shrinks to a thin native shell responsible only for:
 
 1. Spawning and managing the `goose serve` child process
 2. Providing the server URL to the frontend
@@ -28,8 +28,8 @@ Frontend (TS)
 
 ```
 Frontend (TS)
-  → GooseClient (HTTP+SSE)
-    → goose serve http://127.0.0.1:<port>/acp   [child process]
+  → GooseClient (WebSocket)
+    → goose serve ws://127.0.0.1:<port>/acp   [child process]
   ← Client callbacks → direct Zustand store updates
 
 Tauri Rust shell:
@@ -42,8 +42,8 @@ Tauri Rust shell:
 
 ```
 Frontend (TS)
-  → GooseClient (HTTP+SSE)
-    → goose serve http://127.0.0.1:<port>/acp
+  → GooseClient (WebSocket)
+    → goose serve ws://127.0.0.1:<port>/acp
   ← Client callbacks → direct Zustand store updates
 
 Tauri Rust shell (~200 lines):
@@ -56,9 +56,9 @@ Tauri Rust shell (~200 lines):
 
 | Step | File | Summary |
 |------|------|---------|
-| 01 | `01-expose-goose-serve-url.md` | Add Tauri command to expose the `goose serve` HTTP URL to the frontend |
+| 01 | `01-expose-goose-serve-url.md` | Add Tauri command to expose the `goose serve` WebSocket URL to the frontend |
 | 02 | `02-add-acp-npm-dependencies.md` | Add `@aaif/goose-acp` and `@agentclientprotocol/sdk` to goose2 |
-| 03 | `03-create-ts-acp-connection.md` | Create the singleton TypeScript ACP connection manager |
+| 03 | `03-create-ts-acp-connection.md` | Create the singleton TypeScript ACP connection manager (WebSocket transport) |
 | 04 | `04-create-ts-notification-handler.md` | Port the Rust `SessionEventDispatcher` to TypeScript |
 | 05 | `05-create-ts-session-manager.md` | Port session state management and ACP operations to TypeScript |
 | 06 | `06-port-session-search.md` | Port session content search from Rust to TypeScript |
@@ -85,11 +85,11 @@ Step 10 is the Phase B roadmap.
 
 ## Key Decisions
 
-1. **HTTP+SSE over WebSocket**: `goose serve` supports both. HTTP+SSE is already battle-tested by `ui/acp`'s `createHttpStream`. Visible in browser DevTools. Can switch to WS later if needed.
+1. **WebSocket transport**: `goose serve` exposes a WebSocket endpoint at `/acp`. Each WS text frame is a single JSON-RPC message. This is the same transport the Rust layer already uses — we're just moving the WebSocket client from Rust to TypeScript. WebSocket provides true bidirectional streaming with lower overhead than HTTP+SSE.
 
 2. **Direct store updates over event bus**: The notification handler calls Zustand store methods directly instead of emitting Tauri events. Eliminates a layer of indirection and the `useAcpStream` hook.
 
-3. **Reuse `@aaif/goose-acp`**: Already used by `ui/desktop` (Electron) and `ui/text` (Ink TUI). Provides `GooseClient`, `createHttpStream`, generated types, and Zod validators.
+3. **Reuse `@aaif/goose-acp`**: Already used by `ui/desktop` (Electron) and `ui/text` (Ink TUI). Provides `GooseClient`, generated types, and Zod validators. We'll add a `createWebSocketStream` helper (either in `@aaif/goose-acp` or locally in goose2) since the package currently only ships `createHttpStream`.
 
 4. **Auto-approve permissions**: Same as the current Rust implementation — accept the first option on all `request_permission` callbacks.
 
@@ -97,8 +97,8 @@ Step 10 is the Phase B roadmap.
 
 | Risk | Mitigation |
 |------|------------|
-| Tauri CSP blocks localhost fetch | CSP is already `null` (disabled) in `tauri.conf.json` |
+| Tauri CSP blocks localhost WebSocket | CSP is already `null` (disabled) in `tauri.conf.json` |
 | `goose serve` not ready when frontend initializes | Rust still does readiness check; URL command only resolves after server is confirmed ready |
-| HTTP+SSE performance vs WebSocket | Both transports are supported; can switch later. SSE has keep-alive. |
+| WebSocket disconnection / reconnection | Implement reconnection logic in the connection manager; the `GooseClient.closed` promise signals when the connection drops |
 | Replay timing (notifications arriving after `loadSession` resolves) | Port the drain/stabilization logic from Rust, or rely on the `replay_complete` signal from the backend |
 | Session state consistency during migration | Can keep old Rust path behind a flag initially; remove after validation |

--- a/ui/goose2/acp-plus-migration-plan/00-overview.md
+++ b/ui/goose2/acp-plus-migration-plan/00-overview.md
@@ -57,7 +57,7 @@ Tauri Rust shell (~200 lines):
 |------|------|---------|
 | 01 | `01-expose-goose-serve-url.md` | Add Tauri command to expose the `goose serve` WebSocket URL to the frontend |
 | 02 | `02-add-acp-npm-dependencies.md` | Add `@aaif/goose-acp` and `@agentclientprotocol/sdk` to goose2 |
-| 03 | `03-create-ts-acp-connection.md` | Create the singleton TypeScript ACP connection manager (WebSocket transport) |
+| 03 | `03-create-ts-acp-connection.md` | Create the singleton TypeScript ACP connection manager (WebSocket transport), reconnection logic, and feature flag |
 | 04 | `04-create-ts-notification-handler.md` | Port the Rust `SessionEventDispatcher` to TypeScript |
 | 05 | `05-create-ts-session-manager.md` | Port session state management and ACP operations to TypeScript |
 | 06 | `06-port-session-search.md` | Port session content search from Rust to TypeScript |
@@ -100,4 +100,4 @@ Tauri Rust shell (~200 lines):
 | `goose serve` not ready when frontend initializes | Rust still does a readiness check; the URL command only resolves after the server is confirmed ready |
 | WebSocket disconnection / reconnection | Implement reconnection logic in the connection manager; `GooseClient.closed` signals when the connection drops |
 | Replay timing (notifications arriving after `loadSession` resolves) | Port the drain/stabilization logic from Rust, or rely on the `replay_complete` signal from the backend |
-| Session state consistency during migration | Keep the old Rust path behind a flag initially; remove after validation |
+| Session state consistency during migration | Feature flag (`useDirectAcp` in `acpFeatureFlag.ts`) routes between old Tauri IPC and new WebSocket path. Default off, flip per-user to test, flip default to on after validation, remove in Step 09 |

--- a/ui/goose2/acp-plus-migration-plan/01-expose-goose-serve-url.md
+++ b/ui/goose2/acp-plus-migration-plan/01-expose-goose-serve-url.md
@@ -1,0 +1,117 @@
+# Step 01: Expose the `goose serve` URL to the Frontend
+
+## Objective
+
+Add a single new Tauri command that returns the HTTP base URL of the running `goose serve` process. The frontend will use this URL to connect directly via HTTP+SSE.
+
+## Why
+
+Currently the Rust layer connects to `goose serve` over WebSocket internally and proxies everything. The frontend never knows the server URL. We need to expose it so the TypeScript ACP client can connect directly.
+
+## Changes
+
+### 1. Make `port` accessible on `GooseServeProcess`
+
+**File:** `src-tauri/src/services/acp/goose_serve.rs`
+
+Add a public getter for the port:
+
+```rust
+impl GooseServeProcess {
+    /// Return the HTTP base URL for this server (used by the frontend).
+    pub fn http_url(&self) -> String {
+        format!("http://{LOCALHOST}:{}", self.port)
+    }
+
+    // ... existing methods unchanged ...
+}
+```
+
+The `port` field is already stored on the struct but is only used internally via `ws_url()`. The new `http_url()` method provides the HTTP variant.
+
+### 2. Add the Tauri command
+
+**File:** `src-tauri/src/commands/acp.rs`
+
+Add this command alongside the existing ones (it will coexist during migration):
+
+```rust
+/// Return the HTTP base URL of the running goose serve process.
+///
+/// This command blocks until the server is confirmed ready. The frontend
+/// uses this URL to establish a direct HTTP+SSE ACP connection.
+#[tauri::command]
+pub async fn get_goose_serve_url() -> Result<String, String> {
+    // GooseServeProcess::start() is idempotent — it returns immediately
+    // if the process is already running.
+    GooseServeProcess::start().await?;
+    let process = GooseServeProcess::get()?;
+    Ok(process.http_url())
+}
+```
+
+Add the necessary import at the top of the file if not already present:
+
+```rust
+use crate::services::acp::goose_serve::GooseServeProcess;
+```
+
+Note: `GooseServeProcess` is currently re-exported from `services::acp` as `resolve_goose_binary` but the struct itself is used via `goose_serve::GooseServeProcess` internally. You may need to add a `pub use` in `services/acp/mod.rs`:
+
+```rust
+pub(crate) use goose_serve::GooseServeProcess;
+```
+
+### 3. Register the command
+
+**File:** `src-tauri/src/lib.rs`
+
+Add the new command to the `invoke_handler` macro:
+
+```rust
+commands::acp::get_goose_serve_url,
+```
+
+Place it near the other `commands::acp::*` entries.
+
+### 4. Verify CSP allows localhost fetch
+
+**File:** `src-tauri/tauri.conf.json`
+
+Check the `security.csp` field. Currently it is:
+
+```json
+"security": {
+  "csp": null,
+  ...
+}
+```
+
+`null` means CSP is disabled — **no changes needed**. The frontend can freely fetch from `http://127.0.0.1:*`.
+
+If CSP were ever re-enabled, you'd need to add:
+```
+connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*
+```
+
+## Verification
+
+1. Run `just tauri-check` (or `cargo check` in `src-tauri/`) to confirm the Rust compiles.
+2. Run `cargo clippy --all-targets -- -D warnings` in `src-tauri/`.
+3. Run `cargo fmt` in `src-tauri/`.
+4. Manually test by adding a temporary `console.log(await invoke("get_goose_serve_url"))` in the frontend startup — it should print something like `http://127.0.0.1:54321`.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src-tauri/src/services/acp/goose_serve.rs` | Add `http_url()` method |
+| `src-tauri/src/services/acp/mod.rs` | Add `pub(crate) use goose_serve::GooseServeProcess` if needed |
+| `src-tauri/src/commands/acp.rs` | Add `get_goose_serve_url` command |
+| `src-tauri/src/lib.rs` | Register `get_goose_serve_url` in invoke_handler |
+
+## Notes
+
+- The existing ACP commands remain functional during migration. They will be removed in Step 09.
+- `GooseServeProcess::start()` is idempotent — calling it multiple times is safe. The first call spawns the process; subsequent calls return immediately.
+- The readiness check (WebSocket probe loop) ensures the URL is only returned after the server is accepting connections.

--- a/ui/goose2/acp-plus-migration-plan/01-expose-goose-serve-url.md
+++ b/ui/goose2/acp-plus-migration-plan/01-expose-goose-serve-url.md
@@ -2,119 +2,86 @@
 
 ## Objective
 
-Add a single new Tauri command that returns the WebSocket URL of the running `goose serve` process. The frontend will use this URL to connect directly via WebSocket.
+Add a Tauri command that returns the WebSocket URL of the running `goose serve` process so the frontend can connect directly via WebSocket.
 
 ## Why
 
-Currently the Rust layer connects to `goose serve` over WebSocket internally and proxies everything. The frontend never knows the server URL. We need to expose it so the TypeScript ACP client can connect directly.
+The Rust layer currently connects to `goose serve` over WebSocket internally and proxies everything. The frontend never knows the server URL. Exposing it lets the TypeScript ACP client connect directly.
 
 ## Changes
 
-### 1. Add a public URL getter on `GooseServeProcess`
+### 1. Re-export `GooseServeProcess`
 
-**File:** `src-tauri/src/services/acp/goose_serve.rs`
+**File:** `src-tauri/src/services/acp/mod.rs`
 
-The struct already has a `ws_url()` method that returns `ws://127.0.0.1:<port>/acp`. We just need to make sure it (or an equivalent) is accessible from the command layer. Currently `ws_url()` is `pub` on the struct, so it's already usable. No change needed to the struct itself.
-
-If you prefer a separate method name to distinguish from the internal usage:
+Add a re-export so the command layer can reference the struct:
 
 ```rust
-impl GooseServeProcess {
-    /// Return the WebSocket URL for the frontend to connect to directly.
-    pub fn frontend_ws_url(&self) -> String {
-        format!("ws://{LOCALHOST}:{}/acp", self.port)
-    }
-
-    // ... existing ws_url() method is identical, kept for backward compat ...
-}
+pub(crate) use goose_serve::GooseServeProcess;
 ```
 
-Or simply reuse `ws_url()` — it returns the same thing.
+No changes to `GooseServeProcess` itself — the existing `ws_url()` method already returns `ws://127.0.0.1:<port>/acp`.
 
 ### 2. Add the Tauri command
 
 **File:** `src-tauri/src/commands/acp.rs`
 
-Add this command alongside the existing ones (it will coexist during migration):
+Add this command alongside the existing ones:
 
 ```rust
+use crate::services::acp::goose_serve::GooseServeProcess;
+
 /// Return the WebSocket URL of the running goose serve process.
 ///
 /// This command blocks until the server is confirmed ready. The frontend
 /// uses this URL to establish a direct WebSocket ACP connection.
 #[tauri::command]
 pub async fn get_goose_serve_url() -> Result<String, String> {
-    // GooseServeProcess::start() is idempotent — it returns immediately
-    // if the process is already running.
     GooseServeProcess::start().await?;
     let process = GooseServeProcess::get()?;
     Ok(process.ws_url())
 }
 ```
 
-Add the necessary import at the top of the file if not already present:
-
-```rust
-use crate::services::acp::goose_serve::GooseServeProcess;
-```
-
-Note: `GooseServeProcess` is currently re-exported from `services::acp` as `resolve_goose_binary` but the struct itself is used via `goose_serve::GooseServeProcess` internally. You may need to add a `pub use` in `services/acp/mod.rs`:
-
-```rust
-pub(crate) use goose_serve::GooseServeProcess;
-```
-
 ### 3. Register the command
 
 **File:** `src-tauri/src/lib.rs`
 
-Add the new command to the `invoke_handler` macro:
+Add the new command to the `invoke_handler` macro near the other `commands::acp::*` entries:
 
 ```rust
 commands::acp::get_goose_serve_url,
 ```
 
-Place it near the other `commands::acp::*` entries.
-
-### 4. Verify CSP allows localhost WebSocket
+### 4. CSP — no changes needed
 
 **File:** `src-tauri/tauri.conf.json`
 
-Check the `security.csp` field. Currently it is:
+CSP is currently disabled (`"csp": null`), so the frontend can open WebSocket connections to `ws://127.0.0.1:*` without restriction.
 
-```json
-"security": {
-  "csp": null,
-  ...
-}
-```
-
-`null` means CSP is disabled — **no changes needed**. The frontend can freely open WebSocket connections to `ws://127.0.0.1:*`.
-
-If CSP were ever re-enabled, you'd need to add:
+If CSP is ever re-enabled, add:
 ```
 connect-src 'self' ws://127.0.0.1:*
 ```
 
 ## Verification
 
-1. Run `just tauri-check` (or `cargo check` in `src-tauri/`) to confirm the Rust compiles.
-2. Run `cargo clippy --all-targets -- -D warnings` in `src-tauri/`.
-3. Run `cargo fmt` in `src-tauri/`.
-4. Manually test by adding a temporary `console.log(await invoke("get_goose_serve_url"))` in the frontend startup — it should print something like `ws://127.0.0.1:54321/acp`.
+1. `cargo check` in `src-tauri/` — confirms compilation.
+2. `cargo clippy --all-targets -- -D warnings` in `src-tauri/`.
+3. `cargo fmt` in `src-tauri/`.
+4. Add a temporary `console.log(await invoke("get_goose_serve_url"))` in the frontend startup — it should print something like `ws://127.0.0.1:54321/acp`.
 
 ## Files Modified
 
 | File | Change |
 |------|--------|
-| `src-tauri/src/services/acp/goose_serve.rs` | Optionally add `frontend_ws_url()`, or reuse existing `ws_url()` |
-| `src-tauri/src/services/acp/mod.rs` | Add `pub(crate) use goose_serve::GooseServeProcess` if needed |
+| `src-tauri/src/services/acp/mod.rs` | Add `pub(crate) use goose_serve::GooseServeProcess` |
 | `src-tauri/src/commands/acp.rs` | Add `get_goose_serve_url` command |
 | `src-tauri/src/lib.rs` | Register `get_goose_serve_url` in invoke_handler |
 
 ## Notes
 
-- The existing ACP commands remain functional during migration. They will be removed in Step 09.
-- `GooseServeProcess::start()` is idempotent — calling it multiple times is safe. The first call spawns the process; subsequent calls return immediately.
-- The readiness check (WebSocket probe loop in `wait_for_server_ready`) ensures the URL is only returned after the server is accepting connections.
-- The URL includes the `/acp` path because that's the WebSocket endpoint on `goose serve`. The frontend connects to this directly — same endpoint the Rust layer currently uses in `thread.rs`.
+- The existing ACP commands remain functional during migration. They are removed in Step 09.
+- `GooseServeProcess::start()` is idempotent — the first call spawns the process; subsequent calls return immediately.
+- The readiness check (`wait_for_server_ready`) ensures the URL is only returned after the server is accepting connections.
+- The URL includes the `/acp` path — the same WebSocket endpoint the Rust layer currently uses in `thread.rs`.

--- a/ui/goose2/acp-plus-migration-plan/01-expose-goose-serve-url.md
+++ b/ui/goose2/acp-plus-migration-plan/01-expose-goose-serve-url.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Add a single new Tauri command that returns the HTTP base URL of the running `goose serve` process. The frontend will use this URL to connect directly via HTTP+SSE.
+Add a single new Tauri command that returns the WebSocket URL of the running `goose serve` process. The frontend will use this URL to connect directly via WebSocket.
 
 ## Why
 
@@ -10,24 +10,26 @@ Currently the Rust layer connects to `goose serve` over WebSocket internally and
 
 ## Changes
 
-### 1. Make `port` accessible on `GooseServeProcess`
+### 1. Add a public URL getter on `GooseServeProcess`
 
 **File:** `src-tauri/src/services/acp/goose_serve.rs`
 
-Add a public getter for the port:
+The struct already has a `ws_url()` method that returns `ws://127.0.0.1:<port>/acp`. We just need to make sure it (or an equivalent) is accessible from the command layer. Currently `ws_url()` is `pub` on the struct, so it's already usable. No change needed to the struct itself.
+
+If you prefer a separate method name to distinguish from the internal usage:
 
 ```rust
 impl GooseServeProcess {
-    /// Return the HTTP base URL for this server (used by the frontend).
-    pub fn http_url(&self) -> String {
-        format!("http://{LOCALHOST}:{}", self.port)
+    /// Return the WebSocket URL for the frontend to connect to directly.
+    pub fn frontend_ws_url(&self) -> String {
+        format!("ws://{LOCALHOST}:{}/acp", self.port)
     }
 
-    // ... existing methods unchanged ...
+    // ... existing ws_url() method is identical, kept for backward compat ...
 }
 ```
 
-The `port` field is already stored on the struct but is only used internally via `ws_url()`. The new `http_url()` method provides the HTTP variant.
+Or simply reuse `ws_url()` — it returns the same thing.
 
 ### 2. Add the Tauri command
 
@@ -36,17 +38,17 @@ The `port` field is already stored on the struct but is only used internally via
 Add this command alongside the existing ones (it will coexist during migration):
 
 ```rust
-/// Return the HTTP base URL of the running goose serve process.
+/// Return the WebSocket URL of the running goose serve process.
 ///
 /// This command blocks until the server is confirmed ready. The frontend
-/// uses this URL to establish a direct HTTP+SSE ACP connection.
+/// uses this URL to establish a direct WebSocket ACP connection.
 #[tauri::command]
 pub async fn get_goose_serve_url() -> Result<String, String> {
     // GooseServeProcess::start() is idempotent — it returns immediately
     // if the process is already running.
     GooseServeProcess::start().await?;
     let process = GooseServeProcess::get()?;
-    Ok(process.http_url())
+    Ok(process.ws_url())
 }
 ```
 
@@ -74,7 +76,7 @@ commands::acp::get_goose_serve_url,
 
 Place it near the other `commands::acp::*` entries.
 
-### 4. Verify CSP allows localhost fetch
+### 4. Verify CSP allows localhost WebSocket
 
 **File:** `src-tauri/tauri.conf.json`
 
@@ -87,11 +89,11 @@ Check the `security.csp` field. Currently it is:
 }
 ```
 
-`null` means CSP is disabled — **no changes needed**. The frontend can freely fetch from `http://127.0.0.1:*`.
+`null` means CSP is disabled — **no changes needed**. The frontend can freely open WebSocket connections to `ws://127.0.0.1:*`.
 
 If CSP were ever re-enabled, you'd need to add:
 ```
-connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*
+connect-src 'self' ws://127.0.0.1:*
 ```
 
 ## Verification
@@ -99,13 +101,13 @@ connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*
 1. Run `just tauri-check` (or `cargo check` in `src-tauri/`) to confirm the Rust compiles.
 2. Run `cargo clippy --all-targets -- -D warnings` in `src-tauri/`.
 3. Run `cargo fmt` in `src-tauri/`.
-4. Manually test by adding a temporary `console.log(await invoke("get_goose_serve_url"))` in the frontend startup — it should print something like `http://127.0.0.1:54321`.
+4. Manually test by adding a temporary `console.log(await invoke("get_goose_serve_url"))` in the frontend startup — it should print something like `ws://127.0.0.1:54321/acp`.
 
 ## Files Modified
 
 | File | Change |
 |------|--------|
-| `src-tauri/src/services/acp/goose_serve.rs` | Add `http_url()` method |
+| `src-tauri/src/services/acp/goose_serve.rs` | Optionally add `frontend_ws_url()`, or reuse existing `ws_url()` |
 | `src-tauri/src/services/acp/mod.rs` | Add `pub(crate) use goose_serve::GooseServeProcess` if needed |
 | `src-tauri/src/commands/acp.rs` | Add `get_goose_serve_url` command |
 | `src-tauri/src/lib.rs` | Register `get_goose_serve_url` in invoke_handler |
@@ -114,4 +116,5 @@ connect-src 'self' http://127.0.0.1:* ws://127.0.0.1:*
 
 - The existing ACP commands remain functional during migration. They will be removed in Step 09.
 - `GooseServeProcess::start()` is idempotent — calling it multiple times is safe. The first call spawns the process; subsequent calls return immediately.
-- The readiness check (WebSocket probe loop) ensures the URL is only returned after the server is accepting connections.
+- The readiness check (WebSocket probe loop in `wait_for_server_ready`) ensures the URL is only returned after the server is accepting connections.
+- The URL includes the `/acp` path because that's the WebSocket endpoint on `goose serve`. The frontend connects to this directly — same endpoint the Rust layer currently uses in `thread.rs`.

--- a/ui/goose2/acp-plus-migration-plan/02-add-acp-npm-dependencies.md
+++ b/ui/goose2/acp-plus-migration-plan/02-add-acp-npm-dependencies.md
@@ -1,0 +1,150 @@
+# Step 02: Add ACP NPM Dependencies to goose2
+
+## Objective
+
+Add `@aaif/goose-acp` and `@agentclientprotocol/sdk` as dependencies of the goose2 frontend so we can use the TypeScript ACP client.
+
+## Why
+
+The `@aaif/goose-acp` package (located at `ui/acp/` in the monorepo) already provides:
+
+- **`GooseClient`** — a full TypeScript ACP client wrapping `ClientSideConnection`
+- **`createHttpStream`** — an HTTP+SSE transport that speaks the same protocol as `goose serve`
+- **`GooseExtClient`** — generated typed client for Goose extension methods (`goose/providers/list`, `goose/session/export`, etc.)
+- **Generated types + Zod validators** for all Goose ACP extension method request/response shapes
+
+This package is already used by `ui/desktop` (Electron) and `ui/text` (Ink TUI). goose2 currently does NOT depend on it.
+
+## Changes
+
+### 1. Add dependencies
+
+**File:** `ui/goose2/package.json`
+
+Run from the `ui/goose2/` directory:
+
+```bash
+source ./bin/activate-hermit
+pnpm add @aaif/goose-acp @agentclientprotocol/sdk
+```
+
+If the packages are not published to npm yet or you want to use the local workspace version, use the workspace protocol instead. Check `ui/pnpm-workspace.yaml` to see if `ui/acp` is included in the workspace. If it is:
+
+```bash
+pnpm add @aaif/goose-acp@workspace:* @agentclientprotocol/sdk
+```
+
+If `ui/acp` is NOT in the pnpm workspace (goose2 has its own `pnpm-lock.yaml`), you have two options:
+
+**Option A — Link locally during development:**
+```bash
+cd ui/acp
+npm run build
+npm link
+
+cd ui/goose2
+pnpm link @aaif/goose-acp
+pnpm add @agentclientprotocol/sdk
+```
+
+**Option B — Use the published npm package:**
+```bash
+cd ui/goose2
+pnpm add @aaif/goose-acp @agentclientprotocol/sdk
+```
+
+### 2. Verify the dependency resolves
+
+After installation, verify the imports work:
+
+```bash
+cd ui/goose2
+# Quick typecheck
+pnpm typecheck
+```
+
+Create a temporary test file to confirm imports resolve:
+
+```typescript
+// src/shared/api/_test_acp_import.ts (DELETE AFTER VERIFICATION)
+import { GooseClient, createHttpStream } from "@aaif/goose-acp";
+import type { Client, SessionNotification } from "@agentclientprotocol/sdk";
+
+console.log("GooseClient:", GooseClient);
+console.log("createHttpStream:", createHttpStream);
+```
+
+Run `pnpm typecheck` to confirm no type errors. Then delete the test file.
+
+### 3. Verify key exports are available
+
+The following imports must resolve — these are what Steps 03–06 will use:
+
+From `@aaif/goose-acp`:
+```typescript
+import { GooseClient, createHttpStream } from "@aaif/goose-acp";
+```
+
+From `@agentclientprotocol/sdk`:
+```typescript
+import type {
+  Client,
+  SessionNotification,
+  SessionUpdate,
+  ContentBlock,
+  ToolCallContent,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+  NewSessionRequest,
+  NewSessionResponse,
+  LoadSessionRequest,
+  LoadSessionResponse,
+  PromptRequest,
+  PromptResponse,
+  CancelNotification,
+  SetSessionConfigOptionRequest,
+  SetSessionConfigOptionResponse,
+  ForkSessionRequest,
+  ForkSessionResponse,
+  ListSessionsRequest,
+  ListSessionsResponse,
+  InitializeRequest,
+  ProtocolVersion,
+  Implementation,
+  SessionModelState,
+  SessionInfoUpdate,
+  SessionConfigOption,
+  SessionConfigKind,
+  SessionConfigSelectOptions,
+  SessionConfigOptionCategory,
+} from "@agentclientprotocol/sdk";
+```
+
+### 4. Check `@agentclientprotocol/sdk` version compatibility
+
+The `@aaif/goose-acp` package declares `@agentclientprotocol/sdk` as a **peer dependency** (`"*"`). The Rust backend currently uses `agent-client-protocol = "0.10.4"`. The TypeScript SDK should be at a compatible version.
+
+Check `ui/acp/package.json` for the devDependency version — it currently shows `"@agentclientprotocol/sdk": "^0.14.1"`. Install the same or newer version:
+
+```bash
+pnpm add @agentclientprotocol/sdk@^0.14.1
+```
+
+## Verification
+
+1. `pnpm typecheck` passes with no errors related to the new dependencies.
+2. `pnpm check` (Biome lint + file sizes) passes.
+3. `pnpm test` still passes (no existing tests should break).
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `package.json` | Add `@aaif/goose-acp` and `@agentclientprotocol/sdk` to dependencies |
+| `pnpm-lock.yaml` | Auto-updated by pnpm |
+
+## Notes
+
+- The `@aaif/goose-acp` package exports `GooseClient` which wraps `ClientSideConnection` from `@agentclientprotocol/sdk`. It adds Goose-specific extension methods via `GooseExtClient`.
+- The `createHttpStream` function creates a `Stream` (a `{ readable, writable }` pair of `ReadableStream<AnyMessage>` and `WritableStream<AnyMessage>`) that communicates with `goose serve` over HTTP POST + SSE.
+- The HTTP+SSE transport works by: (1) POSTing JSON-RPC messages to `/acp`, (2) receiving responses and notifications via Server-Sent Events on the same connection. The first POST (initialize) establishes the SSE stream; subsequent POSTs use the `Acp-Session-Id` header.

--- a/ui/goose2/acp-plus-migration-plan/02-add-acp-npm-dependencies.md
+++ b/ui/goose2/acp-plus-migration-plan/02-add-acp-npm-dependencies.md
@@ -21,37 +21,14 @@ This package is already used by `ui/desktop` (Electron) and `ui/text` (Ink TUI).
 
 **File:** `ui/goose2/package.json`
 
-Run from the `ui/goose2/` directory:
+goose2 has its own `pnpm-lock.yaml` and is not part of the `ui/pnpm-workspace.yaml` workspace. Use the published npm packages:
 
-```bash
-source ./bin/activate-hermit
-pnpm add @aaif/goose-acp @agentclientprotocol/sdk
-```
-
-If the packages are not published to npm yet or you want to use the local workspace version, use the workspace protocol instead. Check `ui/pnpm-workspace.yaml` to see if `ui/acp` is included in the workspace. If it is:
-
-```bash
-pnpm add @aaif/goose-acp@workspace:* @agentclientprotocol/sdk
-```
-
-If `ui/acp` is NOT in the pnpm workspace (goose2 has its own `pnpm-lock.yaml`), you have two options:
-
-**Option A — Link locally during development:**
-```bash
-cd ui/acp
-npm run build
-npm link
-
-cd ui/goose2
-pnpm link @aaif/goose-acp
-pnpm add @agentclientprotocol/sdk
-```
-
-**Option B — Use the published npm package:**
 ```bash
 cd ui/goose2
-pnpm add @aaif/goose-acp @agentclientprotocol/sdk
+pnpm add @aaif/goose-acp @agentclientprotocol/sdk@^0.14.1
 ```
+
+The `@aaif/goose-acp` package declares `@agentclientprotocol/sdk` as a peer dependency (`"*"`). Pin to `^0.14.1` to match the version used by `ui/acp/package.json`.
 
 ### 2. Verify the dependency resolves
 
@@ -59,7 +36,6 @@ After installation, verify the imports work:
 
 ```bash
 cd ui/goose2
-# Quick typecheck
 pnpm typecheck
 ```
 
@@ -119,16 +95,6 @@ import type {
 } from "@agentclientprotocol/sdk";
 ```
 
-### 4. Check `@agentclientprotocol/sdk` version compatibility
-
-The `@aaif/goose-acp` package declares `@agentclientprotocol/sdk` as a **peer dependency** (`"*"`). The Rust backend currently uses `agent-client-protocol = "0.10.4"`. The TypeScript SDK should be at a compatible version.
-
-Check `ui/acp/package.json` for the devDependency version — it currently shows `"@agentclientprotocol/sdk": "^0.14.1"`. Install the same or newer version:
-
-```bash
-pnpm add @agentclientprotocol/sdk@^0.14.1
-```
-
 ## Verification
 
 1. `pnpm typecheck` passes with no errors related to the new dependencies.
@@ -144,7 +110,6 @@ pnpm add @agentclientprotocol/sdk@^0.14.1
 
 ## Notes
 
-- The `@aaif/goose-acp` package exports `GooseClient` which wraps `ClientSideConnection` from `@agentclientprotocol/sdk`. It adds Goose-specific extension methods via `GooseExtClient`.
-- The package currently ships `createHttpStream` (HTTP+SSE transport). We will use **WebSocket** transport instead. The `GooseClient` constructor accepts any `Stream` (a `{ readable, writable }` pair of `ReadableStream<AnyMessage>` and `WritableStream<AnyMessage>`). In Step 03 we'll create a `createWebSocketStream` helper — either locally in goose2 or contributed to `@aaif/goose-acp`.
+- `GooseClient` wraps `ClientSideConnection` from `@agentclientprotocol/sdk` and adds Goose-specific extension methods via `GooseExtClient`.
+- The package ships `createHttpStream` (HTTP+SSE transport), but we will use **WebSocket** transport instead. `GooseClient` accepts any `Stream` (a `{ readable, writable }` pair of `ReadableStream<AnyMessage>` and `WritableStream<AnyMessage>`). In Step 03 we'll create a `createWebSocketStream` helper.
 - The `goose serve` WebSocket endpoint at `/acp` uses simple framing: each WS text frame is a single JSON-RPC message (no newline delimiters needed). This is the same transport the Rust Tauri backend already uses in `thread.rs`.
-- If we decide to add `createWebSocketStream` to `@aaif/goose-acp` itself (we control the package), it would be exported alongside `createHttpStream` and available to all consumers.

--- a/ui/goose2/acp-plus-migration-plan/02-add-acp-npm-dependencies.md
+++ b/ui/goose2/acp-plus-migration-plan/02-add-acp-npm-dependencies.md
@@ -9,8 +9,8 @@ Add `@aaif/goose-acp` and `@agentclientprotocol/sdk` as dependencies of the goos
 The `@aaif/goose-acp` package (located at `ui/acp/` in the monorepo) already provides:
 
 - **`GooseClient`** — a full TypeScript ACP client wrapping `ClientSideConnection`
-- **`createHttpStream`** — an HTTP+SSE transport that speaks the same protocol as `goose serve`
 - **`GooseExtClient`** — generated typed client for Goose extension methods (`goose/providers/list`, `goose/session/export`, etc.)
+- **`createHttpStream`** — an HTTP+SSE transport (we won't use this — we'll use WebSocket instead, see Step 03)
 - **Generated types + Zod validators** for all Goose ACP extension method request/response shapes
 
 This package is already used by `ui/desktop` (Electron) and `ui/text` (Ink TUI). goose2 currently does NOT depend on it.
@@ -67,11 +67,10 @@ Create a temporary test file to confirm imports resolve:
 
 ```typescript
 // src/shared/api/_test_acp_import.ts (DELETE AFTER VERIFICATION)
-import { GooseClient, createHttpStream } from "@aaif/goose-acp";
+import { GooseClient } from "@aaif/goose-acp";
 import type { Client, SessionNotification } from "@agentclientprotocol/sdk";
 
 console.log("GooseClient:", GooseClient);
-console.log("createHttpStream:", createHttpStream);
 ```
 
 Run `pnpm typecheck` to confirm no type errors. Then delete the test file.
@@ -82,7 +81,7 @@ The following imports must resolve — these are what Steps 03–06 will use:
 
 From `@aaif/goose-acp`:
 ```typescript
-import { GooseClient, createHttpStream } from "@aaif/goose-acp";
+import { GooseClient } from "@aaif/goose-acp";
 ```
 
 From `@agentclientprotocol/sdk`:
@@ -146,5 +145,6 @@ pnpm add @agentclientprotocol/sdk@^0.14.1
 ## Notes
 
 - The `@aaif/goose-acp` package exports `GooseClient` which wraps `ClientSideConnection` from `@agentclientprotocol/sdk`. It adds Goose-specific extension methods via `GooseExtClient`.
-- The `createHttpStream` function creates a `Stream` (a `{ readable, writable }` pair of `ReadableStream<AnyMessage>` and `WritableStream<AnyMessage>`) that communicates with `goose serve` over HTTP POST + SSE.
-- The HTTP+SSE transport works by: (1) POSTing JSON-RPC messages to `/acp`, (2) receiving responses and notifications via Server-Sent Events on the same connection. The first POST (initialize) establishes the SSE stream; subsequent POSTs use the `Acp-Session-Id` header.
+- The package currently ships `createHttpStream` (HTTP+SSE transport). We will use **WebSocket** transport instead. The `GooseClient` constructor accepts any `Stream` (a `{ readable, writable }` pair of `ReadableStream<AnyMessage>` and `WritableStream<AnyMessage>`). In Step 03 we'll create a `createWebSocketStream` helper — either locally in goose2 or contributed to `@aaif/goose-acp`.
+- The `goose serve` WebSocket endpoint at `/acp` uses simple framing: each WS text frame is a single JSON-RPC message (no newline delimiters needed). This is the same transport the Rust Tauri backend already uses in `thread.rs`.
+- If we decide to add `createWebSocketStream` to `@aaif/goose-acp` itself (we control the package), it would be exported alongside `createHttpStream` and available to all consumers.

--- a/ui/goose2/acp-plus-migration-plan/03-create-ts-acp-connection.md
+++ b/ui/goose2/acp-plus-migration-plan/03-create-ts-acp-connection.md
@@ -1,0 +1,213 @@
+# Step 03: Create the TypeScript ACP Connection Manager
+
+## Objective
+
+Create a singleton module that manages the lifecycle of the `GooseClient` connection to `goose serve`. This is the TypeScript equivalent of the Rust `GooseAcpManager::start()` singleton.
+
+## Why
+
+All ACP operations (send prompt, list sessions, export, etc.) need a shared, initialized `GooseClient` instance. This module:
+
+1. Fetches the `goose serve` URL from the Rust backend (Step 01's command)
+2. Creates a `GooseClient` with `createHttpStream`
+3. Calls `client.initialize()` to complete the ACP handshake
+4. Provides the initialized client to all other modules
+
+## New File
+
+### `src/shared/api/acpConnection.ts`
+
+```typescript
+/**
+ * Singleton ACP connection manager.
+ *
+ * Manages the lifecycle of the GooseClient connection to goose serve.
+ * All ACP operations go through the client returned by getClient().
+ */
+import { invoke } from "@tauri-apps/api/core";
+import { GooseClient, createHttpStream } from "@aaif/goose-acp";
+import type { Client, SessionNotification, RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
+
+// Will be set by Step 04 — the notification handler
+let notificationHandler: AcpNotificationHandler | null = null;
+
+/**
+ * Interface for the notification handler that processes ACP session events.
+ * Implemented in Step 04 (acpNotificationHandler.ts).
+ */
+export interface AcpNotificationHandler {
+  handleSessionNotification(notification: SessionNotification): Promise<void>;
+}
+
+/**
+ * Register the notification handler. Called once during app initialization
+ * after the handler is created in Step 04.
+ */
+export function setNotificationHandler(handler: AcpNotificationHandler): void {
+  notificationHandler = handler;
+}
+
+// Singleton state
+let clientPromise: Promise<GooseClient> | null = null;
+let resolvedClient: GooseClient | null = null;
+
+/**
+ * Build the Client implementation that the ACP SDK calls back into.
+ *
+ * This handles two callback types:
+ * - request_permission: auto-approve with the first option (same as Rust impl)
+ * - session_notification: delegate to the registered notification handler
+ */
+function createClientCallbacks(): () => Client {
+  return () => ({
+    requestPermission: async (
+      args: RequestPermissionRequest,
+    ): Promise<RequestPermissionResponse> => {
+      // Auto-approve with the first available option, matching the Rust behavior.
+      const optionId = args.options?.[0]?.optionId ?? "approve";
+      return {
+        outcome: {
+          type: "selected",
+          optionId,
+        },
+      };
+    },
+
+    sessionNotification: async (
+      notification: SessionNotification,
+    ): Promise<void> => {
+      if (notificationHandler) {
+        await notificationHandler.handleSessionNotification(notification);
+      }
+    },
+  });
+}
+
+/**
+ * Initialize the ACP connection.
+ *
+ * 1. Calls the Rust backend to get the goose serve URL
+ * 2. Creates a GooseClient with HTTP+SSE transport
+ * 3. Sends the ACP initialize handshake
+ *
+ * This is idempotent — calling it multiple times returns the same client.
+ */
+async function initializeConnection(): Promise<GooseClient> {
+  // Get the goose serve URL from the Rust backend.
+  // This blocks until the server is confirmed ready.
+  const serverUrl: string = await invoke("get_goose_serve_url");
+
+  const client = new GooseClient(
+    createClientCallbacks(),
+    createHttpStream(serverUrl),
+  );
+
+  // Perform the ACP initialize handshake
+  await client.initialize({
+    protocolVersion: "2025-03-26",
+    capabilities: {},
+    clientInfo: {
+      name: "goose2",
+      version: "0.1.0",
+    },
+  });
+
+  return client;
+}
+
+/**
+ * Get the initialized GooseClient singleton.
+ *
+ * The first call triggers initialization (fetching the URL, creating the
+ * connection, running the ACP handshake). Subsequent calls return the
+ * same client immediately.
+ *
+ * Throws if initialization fails (e.g., goose serve is not running).
+ */
+export async function getClient(): Promise<GooseClient> {
+  if (resolvedClient) {
+    return resolvedClient;
+  }
+
+  if (!clientPromise) {
+    clientPromise = initializeConnection().then((client) => {
+      resolvedClient = client;
+      return client;
+    }).catch((error) => {
+      // Reset so the next call retries
+      clientPromise = null;
+      throw error;
+    });
+  }
+
+  return clientPromise;
+}
+
+/**
+ * Check if the client has been initialized.
+ * Useful for guards that need to know if ACP is ready without triggering init.
+ */
+export function isClientReady(): boolean {
+  return resolvedClient !== null;
+}
+
+/**
+ * Get the client synchronously, or null if not yet initialized.
+ * Use getClient() for the async version that triggers initialization.
+ */
+export function getClientSync(): GooseClient | null {
+  return resolvedClient;
+}
+```
+
+## Architecture Notes
+
+### Singleton Pattern
+
+The module uses a promise-based singleton pattern:
+- `clientPromise` ensures only one initialization runs at a time
+- `resolvedClient` caches the result for synchronous access
+- If initialization fails, `clientPromise` is reset so the next call retries
+
+This mirrors the Rust `OnceCell<Arc<GooseAcpManager>>` pattern in `manager.rs`.
+
+### Notification Handler Registration
+
+The notification handler is registered separately (in Step 04) rather than being passed to `createClientCallbacks` at construction time. This avoids a circular dependency:
+- `acpConnection.ts` creates the client
+- `acpNotificationHandler.ts` needs the client (to know about sessions)
+- `acpNotificationHandler.ts` needs to be registered with the connection
+
+The `setNotificationHandler()` function breaks this cycle.
+
+### Protocol Version
+
+The `protocolVersion` in the initialize request should match what `goose serve` expects. The Rust code uses `ProtocolVersion::LATEST` from the `agent-client-protocol` crate. Check the `@agentclientprotocol/sdk` package for the equivalent constant — it may be exported as `LATEST_PROTOCOL_VERSION` or similar. If not, use the string `"2025-03-26"` (or whatever the current latest is).
+
+### Error Handling
+
+If `invoke("get_goose_serve_url")` fails (e.g., goose binary not found), the error propagates to the caller. The app startup code (Step 08) should handle this gracefully — showing an error state rather than crashing.
+
+## Verification
+
+1. `pnpm typecheck` passes.
+2. `pnpm check` passes (Biome lint).
+3. The module can be imported without side effects — initialization only happens when `getClient()` is called.
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `src/shared/api/acpConnection.ts` | Singleton ACP connection manager |
+
+## Dependencies
+
+- Step 01 (the `get_goose_serve_url` Tauri command must exist)
+- Step 02 (`@aaif/goose-acp` and `@agentclientprotocol/sdk` must be installed)
+
+## Notes
+
+- The `createHttpStream` transport from `@aaif/goose-acp` handles the HTTP+SSE protocol details: POSTing JSON-RPC to `/acp`, reading SSE responses, managing the `Acp-Session-Id` header.
+- The `GooseClient` constructor takes `() => Client` (a factory function that returns the callback object) and a `Stream` (the transport). It wraps `ClientSideConnection` from the SDK.
+- The `requestPermission` callback shape may differ slightly between SDK versions. Check the `@agentclientprotocol/sdk` types for the exact interface. The Rust code returns `RequestPermissionResponse::new(RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id)))` — the TS equivalent should match.
+- The `initialize` request params shape may also vary. Check `InitializeRequest` in the SDK. The Rust code sends `InitializeRequest::new(ProtocolVersion::LATEST).client_info(Implementation::new("goose2", env!("CARGO_PKG_VERSION")))`.

--- a/ui/goose2/acp-plus-migration-plan/03-create-ts-acp-connection.md
+++ b/ui/goose2/acp-plus-migration-plan/03-create-ts-acp-connection.md
@@ -20,9 +20,7 @@ All ACP operations (send prompt, list sessions, export, etc.) need a shared, ini
 
 The `@agentclientprotocol/sdk` defines a `Stream` as `{ readable: ReadableStream<AnyMessage>, writable: WritableStream<AnyMessage> }`. The SDK ships `ndJsonStream` for stdio. The `@aaif/goose-acp` package ships `createHttpStream` for HTTP+SSE. Neither provides a WebSocket transport.
 
-We need a `createWebSocketStream` that bridges a browser `WebSocket` to the ACP `Stream` interface. The `goose serve` WebSocket protocol is simple: each WS text frame is a single JSON-RPC message (no newline delimiters).
-
-> **Alternative**: This helper could be contributed to `@aaif/goose-acp` so all consumers benefit. Since we control that package, we can do this at any time. For now, creating it locally in goose2 is the fastest path.
+We need a `createWebSocketStream` that bridges a browser `WebSocket` to the ACP `Stream` interface. The `goose serve` WebSocket protocol sends each WS text frame as a single JSON-RPC message (no newline delimiters).
 
 ```typescript
 /**
@@ -76,7 +74,6 @@ export function createWebSocketStream(wsUrl: string): Stream {
 
   ws.addEventListener("close", () => {
     closed = true;
-    // Wake any pending reader so it can see the stream is done.
     for (const waiter of waiters) waiter();
     waiters.length = 0;
   });
@@ -117,6 +114,10 @@ export function createWebSocketStream(wsUrl: string): Stream {
 ```
 
 ### 2. `src/shared/api/acpConnection.ts` — Singleton connection manager
+
+The module uses a promise-based singleton pattern: `clientPromise` ensures only one initialization runs at a time, `resolvedClient` caches the result for synchronous access, and if initialization fails, `clientPromise` resets so the next call retries. This mirrors the Rust `OnceCell<Arc<GooseAcpManager>>` pattern in `manager.rs`.
+
+The notification handler is registered separately (via `setNotificationHandler()` in Step 04) rather than passed at construction time. This avoids a circular dependency: `acpConnection.ts` creates the client, but `acpNotificationHandler.ts` both needs the client and must be registered with the connection.
 
 ```typescript
 /**
@@ -171,10 +172,6 @@ function createClientCallbacks(): () => Client {
     requestPermission: async (
       args: RequestPermissionRequest,
     ): Promise<RequestPermissionResponse> => {
-      // Auto-approve with the first available option, matching the Rust behavior
-      // in dispatcher.rs: RequestPermissionResponse::new(
-      //   RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id))
-      // )
       const optionId = args.options?.[0]?.optionId ?? "approve";
       return {
         outcome: {
@@ -204,8 +201,6 @@ function createClientCallbacks(): () => Client {
  * This is idempotent — calling it multiple times returns the same client.
  */
 async function initializeConnection(): Promise<GooseClient> {
-  // Get the goose serve WebSocket URL from the Rust backend.
-  // This blocks until the server is confirmed ready.
   // Returns something like "ws://127.0.0.1:54321/acp"
   const wsUrl: string = await invoke("get_goose_serve_url");
 
@@ -213,10 +208,6 @@ async function initializeConnection(): Promise<GooseClient> {
 
   const client = new GooseClient(createClientCallbacks(), stream);
 
-  // Perform the ACP initialize handshake.
-  // The protocol version should match what goose serve expects.
-  // The Rust code uses ProtocolVersion::LATEST from agent-client-protocol.
-  // Check @agentclientprotocol/sdk for the equivalent constant.
   await client.initialize({
     protocolVersion: "2025-03-26",
     capabilities: {},
@@ -250,7 +241,6 @@ export async function getClient(): Promise<GooseClient> {
         return client;
       })
       .catch((error) => {
-        // Reset so the next call retries
         clientPromise = null;
         throw error;
       });
@@ -276,66 +266,6 @@ export function getClientSync(): GooseClient | null {
 }
 ```
 
-## Architecture Notes
-
-### WebSocket Transport
-
-The `goose serve` WebSocket endpoint at `/acp` uses simple framing:
-- **Client → Server**: Send a WS text frame containing a single JSON-RPC message (no trailing newline needed)
-- **Server → Client**: Each WS text frame contains a single JSON-RPC message
-
-This is exactly what the Rust Tauri backend does in `thread.rs` — it bridges between the `ClientSideConnection`'s newline-delimited JSON and the WebSocket's frame-per-message protocol. Our `createWebSocketStream` does the same bridging but directly in the browser.
-
-### Why WebSocket over HTTP+SSE
-
-- **Same transport the Rust layer already uses** — proven to work with `goose serve`
-- **True bidirectional** — no need for separate POST requests for each message
-- **Lower overhead** — no HTTP headers per message, no SSE framing
-- **Simpler connection model** — single persistent connection vs. SSE reconnection
-- The `@aaif/goose-acp` package ships `createHttpStream` for HTTP+SSE, but that transport has quirks (fire-and-forget POSTs for non-initialize requests, session header management). WebSocket is cleaner.
-
-### Singleton Pattern
-
-The module uses a promise-based singleton pattern:
-- `clientPromise` ensures only one initialization runs at a time
-- `resolvedClient` caches the result for synchronous access
-- If initialization fails, `clientPromise` is reset so the next call retries
-
-This mirrors the Rust `OnceCell<Arc<GooseAcpManager>>` pattern in `manager.rs`.
-
-### Notification Handler Registration
-
-The notification handler is registered separately (in Step 04) rather than being passed to `createClientCallbacks` at construction time. This avoids a circular dependency:
-- `acpConnection.ts` creates the client
-- `acpNotificationHandler.ts` needs the client (to know about sessions)
-- `acpNotificationHandler.ts` needs to be registered with the connection
-
-The `setNotificationHandler()` function breaks this cycle.
-
-### Client Callback Shape
-
-The `Client` interface from `@agentclientprotocol/sdk` defines `sessionUpdate` (not `sessionNotification`) as the callback method name. The Rust code's `Client` trait has `session_notification` — this is the same callback, just different naming conventions. Verify the exact method name in the SDK's `Client` interface:
-
-```typescript
-export interface Client {
-  requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse>;
-  sessionUpdate(params: SessionNotification): Promise<void>;
-  // ... optional methods: writeTextFile, readTextFile, createTerminal, etc.
-}
-```
-
-### Protocol Version
-
-The `protocolVersion` in the initialize request should match what `goose serve` expects. The Rust code uses `ProtocolVersion::LATEST` from the `agent-client-protocol` crate (currently `"2025-03-26"`). Check the `@agentclientprotocol/sdk` package for an exported constant — it may be available as `LATEST_PROTOCOL_VERSION` or similar. If not, hardcode the string.
-
-### Error Handling
-
-If `invoke("get_goose_serve_url")` fails (e.g., goose binary not found), the error propagates to the caller. The app startup code (Step 08) should handle this gracefully — showing an error state rather than crashing.
-
-### Reconnection
-
-The initial implementation does not handle WebSocket reconnection. If the connection drops (e.g., `goose serve` crashes), `getClient()` will return the stale client. Future enhancement: monitor `client.closed` / `client.signal` and reset the singleton so the next `getClient()` call reconnects.
-
 ## Verification
 
 1. `pnpm typecheck` passes.
@@ -355,14 +285,11 @@ The initial implementation does not handle WebSocket reconnection. If the connec
 - Step 01 (the `get_goose_serve_url` Tauri command must exist)
 - Step 02 (`@aaif/goose-acp` and `@agentclientprotocol/sdk` must be installed)
 
-## Future: Contribute `createWebSocketStream` to `@aaif/goose-acp`
+## Notes
 
-Since we control the `@aaif/goose-acp` package, we should eventually move `createWebSocketStream` there so it's available to all consumers (Electron app, TUI, etc.). The function would be exported alongside `createHttpStream`:
-
-```typescript
-// In @aaif/goose-acp
-export { createHttpStream } from "./http-stream.js";
-export { createWebSocketStream } from "./ws-stream.js";
-```
-
-For now, keeping it local in goose2 is the fastest path.
+- The `goose serve` WebSocket endpoint at `/acp` sends one JSON-RPC message per WS text frame (no trailing newline). This is the same framing the Rust Tauri backend uses in `thread.rs`. `createWebSocketStream` performs the same bridging directly in the browser.
+- WebSocket is used over HTTP+SSE because it is the same transport the Rust layer already uses with `goose serve`, provides true bidirectional communication on a single persistent connection, and avoids the quirks of `createHttpStream` (fire-and-forget POSTs, session header management).
+- The `Client` interface from `@agentclientprotocol/sdk` uses `sessionUpdate` as the callback method name. The Rust `Client` trait calls it `session_notification` — same callback, different naming convention.
+- The `protocolVersion` `"2025-03-26"` matches `ProtocolVersion::LATEST` from the Rust `agent-client-protocol` crate. Use `LATEST_PROTOCOL_VERSION` from `@agentclientprotocol/sdk` if exported; otherwise hardcode the string.
+- If `invoke("get_goose_serve_url")` fails, the error propagates to the caller. The app startup code (Step 08) handles this by showing an error state rather than crashing.
+- The initial implementation does not handle WebSocket reconnection. If the connection drops, `getClient()` returns the stale client. A future step can monitor `client.closed` / `client.signal` and reset the singleton to trigger reconnection.

--- a/ui/goose2/acp-plus-migration-plan/03-create-ts-acp-connection.md
+++ b/ui/goose2/acp-plus-migration-plan/03-create-ts-acp-connection.md
@@ -2,31 +2,139 @@
 
 ## Objective
 
-Create a singleton module that manages the lifecycle of the `GooseClient` connection to `goose serve`. This is the TypeScript equivalent of the Rust `GooseAcpManager::start()` singleton.
+Create a singleton module that manages the lifecycle of the `GooseClient` connection to `goose serve` over WebSocket. This is the TypeScript equivalent of the Rust `GooseAcpManager::start()` singleton.
 
 ## Why
 
 All ACP operations (send prompt, list sessions, export, etc.) need a shared, initialized `GooseClient` instance. This module:
 
-1. Fetches the `goose serve` URL from the Rust backend (Step 01's command)
-2. Creates a `GooseClient` with `createHttpStream`
-3. Calls `client.initialize()` to complete the ACP handshake
-4. Provides the initialized client to all other modules
+1. Fetches the `goose serve` WebSocket URL from the Rust backend (Step 01's command)
+2. Creates a WebSocket `Stream` for the ACP SDK
+3. Creates a `GooseClient` with that stream
+4. Calls `client.initialize()` to complete the ACP handshake
+5. Provides the initialized client to all other modules
 
-## New File
+## New Files
 
-### `src/shared/api/acpConnection.ts`
+### 1. `src/shared/api/createWebSocketStream.ts` — WebSocket transport for ACP
+
+The `@agentclientprotocol/sdk` defines a `Stream` as `{ readable: ReadableStream<AnyMessage>, writable: WritableStream<AnyMessage> }`. The SDK ships `ndJsonStream` for stdio. The `@aaif/goose-acp` package ships `createHttpStream` for HTTP+SSE. Neither provides a WebSocket transport.
+
+We need a `createWebSocketStream` that bridges a browser `WebSocket` to the ACP `Stream` interface. The `goose serve` WebSocket protocol is simple: each WS text frame is a single JSON-RPC message (no newline delimiters).
+
+> **Alternative**: This helper could be contributed to `@aaif/goose-acp` so all consumers benefit. Since we control that package, we can do this at any time. For now, creating it locally in goose2 is the fastest path.
+
+```typescript
+/**
+ * WebSocket transport for ACP connections.
+ *
+ * Creates a Stream (readable + writable pair of AnyMessage) backed by a
+ * browser WebSocket connection. Each WS text frame is a single JSON-RPC
+ * message — no newline delimiters needed.
+ *
+ * This matches the framing used by goose serve's /acp WebSocket endpoint
+ * (see crates/goose-acp/src/transport/websocket.rs).
+ */
+import type { AnyMessage, Stream } from "@agentclientprotocol/sdk";
+
+export function createWebSocketStream(wsUrl: string): Stream {
+  const ws = new WebSocket(wsUrl);
+
+  // Queue of messages received from the server, consumed by the readable stream.
+  const incoming: AnyMessage[] = [];
+  const waiters: Array<() => void> = [];
+  let closed = false;
+
+  function pushMessage(msg: AnyMessage): void {
+    incoming.push(msg);
+    const waiter = waiters.shift();
+    if (waiter) waiter();
+  }
+
+  function waitForMessage(): Promise<void> {
+    if (incoming.length > 0 || closed) return Promise.resolve();
+    return new Promise<void>((resolve) => waiters.push(resolve));
+  }
+
+  // Wait for the WebSocket to open before allowing writes.
+  const openPromise = new Promise<void>((resolve, reject) => {
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", (event) => {
+      reject(new Error(`WebSocket connection failed: ${event}`));
+    }, { once: true });
+  });
+
+  ws.addEventListener("message", (event) => {
+    if (typeof event.data !== "string") return;
+    try {
+      const msg = JSON.parse(event.data) as AnyMessage;
+      pushMessage(msg);
+    } catch {
+      // Ignore malformed JSON
+    }
+  });
+
+  ws.addEventListener("close", () => {
+    closed = true;
+    // Wake any pending reader so it can see the stream is done.
+    for (const waiter of waiters) waiter();
+    waiters.length = 0;
+  });
+
+  ws.addEventListener("error", () => {
+    closed = true;
+    for (const waiter of waiters) waiter();
+    waiters.length = 0;
+  });
+
+  const readable = new ReadableStream<AnyMessage>({
+    async pull(controller) {
+      await waitForMessage();
+      while (incoming.length > 0) {
+        controller.enqueue(incoming.shift()!);
+      }
+      if (closed && incoming.length === 0) {
+        controller.close();
+      }
+    },
+  });
+
+  const writable = new WritableStream<AnyMessage>({
+    async write(msg) {
+      await openPromise;
+      ws.send(JSON.stringify(msg));
+    },
+    close() {
+      ws.close();
+    },
+    abort() {
+      ws.close();
+    },
+  });
+
+  return { readable, writable };
+}
+```
+
+### 2. `src/shared/api/acpConnection.ts` — Singleton connection manager
 
 ```typescript
 /**
  * Singleton ACP connection manager.
  *
- * Manages the lifecycle of the GooseClient connection to goose serve.
- * All ACP operations go through the client returned by getClient().
+ * Manages the lifecycle of the GooseClient connection to goose serve
+ * over WebSocket. All ACP operations go through the client returned
+ * by getClient().
  */
 import { invoke } from "@tauri-apps/api/core";
-import { GooseClient, createHttpStream } from "@aaif/goose-acp";
-import type { Client, SessionNotification, RequestPermissionRequest, RequestPermissionResponse } from "@agentclientprotocol/sdk";
+import { GooseClient } from "@aaif/goose-acp";
+import type {
+  Client,
+  SessionNotification,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from "@agentclientprotocol/sdk";
+import { createWebSocketStream } from "./createWebSocketStream";
 
 // Will be set by Step 04 — the notification handler
 let notificationHandler: AcpNotificationHandler | null = null;
@@ -55,15 +163,18 @@ let resolvedClient: GooseClient | null = null;
  * Build the Client implementation that the ACP SDK calls back into.
  *
  * This handles two callback types:
- * - request_permission: auto-approve with the first option (same as Rust impl)
- * - session_notification: delegate to the registered notification handler
+ * - requestPermission: auto-approve with the first option (same as Rust impl)
+ * - sessionUpdate: delegate to the registered notification handler
  */
 function createClientCallbacks(): () => Client {
   return () => ({
     requestPermission: async (
       args: RequestPermissionRequest,
     ): Promise<RequestPermissionResponse> => {
-      // Auto-approve with the first available option, matching the Rust behavior.
+      // Auto-approve with the first available option, matching the Rust behavior
+      // in dispatcher.rs: RequestPermissionResponse::new(
+      //   RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id))
+      // )
       const optionId = args.options?.[0]?.optionId ?? "approve";
       return {
         outcome: {
@@ -73,7 +184,7 @@ function createClientCallbacks(): () => Client {
       };
     },
 
-    sessionNotification: async (
+    sessionUpdate: async (
       notification: SessionNotification,
     ): Promise<void> => {
       if (notificationHandler) {
@@ -86,23 +197,26 @@ function createClientCallbacks(): () => Client {
 /**
  * Initialize the ACP connection.
  *
- * 1. Calls the Rust backend to get the goose serve URL
- * 2. Creates a GooseClient with HTTP+SSE transport
+ * 1. Calls the Rust backend to get the goose serve WebSocket URL
+ * 2. Creates a GooseClient with WebSocket transport
  * 3. Sends the ACP initialize handshake
  *
  * This is idempotent — calling it multiple times returns the same client.
  */
 async function initializeConnection(): Promise<GooseClient> {
-  // Get the goose serve URL from the Rust backend.
+  // Get the goose serve WebSocket URL from the Rust backend.
   // This blocks until the server is confirmed ready.
-  const serverUrl: string = await invoke("get_goose_serve_url");
+  // Returns something like "ws://127.0.0.1:54321/acp"
+  const wsUrl: string = await invoke("get_goose_serve_url");
 
-  const client = new GooseClient(
-    createClientCallbacks(),
-    createHttpStream(serverUrl),
-  );
+  const stream = createWebSocketStream(wsUrl);
 
-  // Perform the ACP initialize handshake
+  const client = new GooseClient(createClientCallbacks(), stream);
+
+  // Perform the ACP initialize handshake.
+  // The protocol version should match what goose serve expects.
+  // The Rust code uses ProtocolVersion::LATEST from agent-client-protocol.
+  // Check @agentclientprotocol/sdk for the equivalent constant.
   await client.initialize({
     protocolVersion: "2025-03-26",
     capabilities: {},
@@ -119,8 +233,8 @@ async function initializeConnection(): Promise<GooseClient> {
  * Get the initialized GooseClient singleton.
  *
  * The first call triggers initialization (fetching the URL, creating the
- * connection, running the ACP handshake). Subsequent calls return the
- * same client immediately.
+ * WebSocket connection, running the ACP handshake). Subsequent calls return
+ * the same client immediately.
  *
  * Throws if initialization fails (e.g., goose serve is not running).
  */
@@ -130,14 +244,16 @@ export async function getClient(): Promise<GooseClient> {
   }
 
   if (!clientPromise) {
-    clientPromise = initializeConnection().then((client) => {
-      resolvedClient = client;
-      return client;
-    }).catch((error) => {
-      // Reset so the next call retries
-      clientPromise = null;
-      throw error;
-    });
+    clientPromise = initializeConnection()
+      .then((client) => {
+        resolvedClient = client;
+        return client;
+      })
+      .catch((error) => {
+        // Reset so the next call retries
+        clientPromise = null;
+        throw error;
+      });
   }
 
   return clientPromise;
@@ -162,6 +278,22 @@ export function getClientSync(): GooseClient | null {
 
 ## Architecture Notes
 
+### WebSocket Transport
+
+The `goose serve` WebSocket endpoint at `/acp` uses simple framing:
+- **Client → Server**: Send a WS text frame containing a single JSON-RPC message (no trailing newline needed)
+- **Server → Client**: Each WS text frame contains a single JSON-RPC message
+
+This is exactly what the Rust Tauri backend does in `thread.rs` — it bridges between the `ClientSideConnection`'s newline-delimited JSON and the WebSocket's frame-per-message protocol. Our `createWebSocketStream` does the same bridging but directly in the browser.
+
+### Why WebSocket over HTTP+SSE
+
+- **Same transport the Rust layer already uses** — proven to work with `goose serve`
+- **True bidirectional** — no need for separate POST requests for each message
+- **Lower overhead** — no HTTP headers per message, no SSE framing
+- **Simpler connection model** — single persistent connection vs. SSE reconnection
+- The `@aaif/goose-acp` package ships `createHttpStream` for HTTP+SSE, but that transport has quirks (fire-and-forget POSTs for non-initialize requests, session header management). WebSocket is cleaner.
+
 ### Singleton Pattern
 
 The module uses a promise-based singleton pattern:
@@ -180,24 +312,42 @@ The notification handler is registered separately (in Step 04) rather than being
 
 The `setNotificationHandler()` function breaks this cycle.
 
+### Client Callback Shape
+
+The `Client` interface from `@agentclientprotocol/sdk` defines `sessionUpdate` (not `sessionNotification`) as the callback method name. The Rust code's `Client` trait has `session_notification` — this is the same callback, just different naming conventions. Verify the exact method name in the SDK's `Client` interface:
+
+```typescript
+export interface Client {
+  requestPermission(params: RequestPermissionRequest): Promise<RequestPermissionResponse>;
+  sessionUpdate(params: SessionNotification): Promise<void>;
+  // ... optional methods: writeTextFile, readTextFile, createTerminal, etc.
+}
+```
+
 ### Protocol Version
 
-The `protocolVersion` in the initialize request should match what `goose serve` expects. The Rust code uses `ProtocolVersion::LATEST` from the `agent-client-protocol` crate. Check the `@agentclientprotocol/sdk` package for the equivalent constant — it may be exported as `LATEST_PROTOCOL_VERSION` or similar. If not, use the string `"2025-03-26"` (or whatever the current latest is).
+The `protocolVersion` in the initialize request should match what `goose serve` expects. The Rust code uses `ProtocolVersion::LATEST` from the `agent-client-protocol` crate (currently `"2025-03-26"`). Check the `@agentclientprotocol/sdk` package for an exported constant — it may be available as `LATEST_PROTOCOL_VERSION` or similar. If not, hardcode the string.
 
 ### Error Handling
 
 If `invoke("get_goose_serve_url")` fails (e.g., goose binary not found), the error propagates to the caller. The app startup code (Step 08) should handle this gracefully — showing an error state rather than crashing.
 
+### Reconnection
+
+The initial implementation does not handle WebSocket reconnection. If the connection drops (e.g., `goose serve` crashes), `getClient()` will return the stale client. Future enhancement: monitor `client.closed` / `client.signal` and reset the singleton so the next `getClient()` call reconnects.
+
 ## Verification
 
 1. `pnpm typecheck` passes.
 2. `pnpm check` passes (Biome lint).
-3. The module can be imported without side effects — initialization only happens when `getClient()` is called.
+3. The modules can be imported without side effects — initialization only happens when `getClient()` is called.
+4. Unit test for `createWebSocketStream`: mock `WebSocket`, verify messages flow bidirectionally.
 
 ## Files Created
 
 | File | Purpose |
 |------|---------|
+| `src/shared/api/createWebSocketStream.ts` | WebSocket → ACP Stream adapter |
 | `src/shared/api/acpConnection.ts` | Singleton ACP connection manager |
 
 ## Dependencies
@@ -205,9 +355,14 @@ If `invoke("get_goose_serve_url")` fails (e.g., goose binary not found), the err
 - Step 01 (the `get_goose_serve_url` Tauri command must exist)
 - Step 02 (`@aaif/goose-acp` and `@agentclientprotocol/sdk` must be installed)
 
-## Notes
+## Future: Contribute `createWebSocketStream` to `@aaif/goose-acp`
 
-- The `createHttpStream` transport from `@aaif/goose-acp` handles the HTTP+SSE protocol details: POSTing JSON-RPC to `/acp`, reading SSE responses, managing the `Acp-Session-Id` header.
-- The `GooseClient` constructor takes `() => Client` (a factory function that returns the callback object) and a `Stream` (the transport). It wraps `ClientSideConnection` from the SDK.
-- The `requestPermission` callback shape may differ slightly between SDK versions. Check the `@agentclientprotocol/sdk` types for the exact interface. The Rust code returns `RequestPermissionResponse::new(RequestPermissionOutcome::Selected(SelectedPermissionOutcome::new(option_id)))` — the TS equivalent should match.
-- The `initialize` request params shape may also vary. Check `InitializeRequest` in the SDK. The Rust code sends `InitializeRequest::new(ProtocolVersion::LATEST).client_info(Implementation::new("goose2", env!("CARGO_PKG_VERSION")))`.
+Since we control the `@aaif/goose-acp` package, we should eventually move `createWebSocketStream` there so it's available to all consumers (Electron app, TUI, etc.). The function would be exported alongside `createHttpStream`:
+
+```typescript
+// In @aaif/goose-acp
+export { createHttpStream } from "./http-stream.js";
+export { createWebSocketStream } from "./ws-stream.js";
+```
+
+For now, keeping it local in goose2 is the fastest path.

--- a/ui/goose2/acp-plus-migration-plan/03-create-ts-acp-connection.md
+++ b/ui/goose2/acp-plus-migration-plan/03-create-ts-acp-connection.md
@@ -266,19 +266,120 @@ export function getClientSync(): GooseClient | null {
 }
 ```
 
+### 3. Reconnection Logic in `acpConnection.ts`
+
+The WebSocket can drop (laptop sleep, network blip, goose serve restart). The connection manager must detect this and recover.
+
+**Strategy: reset singleton on close, reconnect on next `getClient()` call.**
+
+Add to `acpConnection.ts`:
+
+```typescript
+/**
+ * Monitor the WebSocket connection and reset the singleton when it closes.
+ * Called once after successful initialization.
+ */
+function monitorConnection(client: GooseClient): void {
+  // GooseClient exposes a `closed` promise that resolves when the
+  // underlying connection terminates.
+  client.closed
+    .then(() => {
+      console.warn("[acp] Connection closed. Will reconnect on next getClient().");
+      resolvedClient = null;
+      clientPromise = null;
+    })
+    .catch(() => {
+      console.warn("[acp] Connection error. Will reconnect on next getClient().");
+      resolvedClient = null;
+      clientPromise = null;
+    });
+}
+```
+
+Call `monitorConnection(client)` at the end of `initializeConnection()`, after the handshake succeeds.
+
+**In-flight cleanup:** When the connection drops mid-stream, any running prompt will reject (the `client.prompt()` promise rejects when the connection closes). The session manager (Step 05) catches this in `sendPrompt()` and calls `clearWriter()` + sets chat state to idle. The notification handler does NOT need special reconnect awareness — it simply stops receiving events because the connection is gone.
+
+**What this does NOT do:**
+- Auto-reconnect in the background (no polling/retry loop)
+- Resume an in-flight prompt after reconnect
+- Retry failed operations automatically
+
+It simply ensures the next `getClient()` call creates a fresh connection. The caller (UI layer) decides whether to retry the operation.
+
+### 4. Feature Flag: `useDirectAcp`
+
+To enable safe rollback, add a feature flag that controls whether the frontend uses the new direct WebSocket path or the old Tauri IPC path.
+
+**File:** `src/shared/api/acpFeatureFlag.ts`
+
+```typescript
+/**
+ * Feature flag for direct ACP WebSocket connection.
+ *
+ * When true:  frontend talks to goose serve directly via WebSocket
+ * When false: frontend uses the old Tauri invoke() → Rust → WebSocket path
+ *
+ * This flag is used in Step 07 (rewire-shared-api-acp) to route calls.
+ * Remove this file after the migration is validated and Step 09 (cleanup) is done.
+ */
+
+const STORAGE_KEY = "goose2_use_direct_acp";
+
+export function useDirectAcp(): boolean {
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored !== null) return stored === "true";
+  } catch {
+    // localStorage not available
+  }
+  // Default: off during migration, flip to true when ready
+  return false;
+}
+
+export function setUseDirectAcp(enabled: boolean): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, String(enabled));
+  } catch {
+    // localStorage not available
+  }
+}
+```
+
+This lets us:
+- Ship Steps 01–06 without affecting any users
+- Flip the flag per-user or per-session to test the new path
+- Instantly roll back if something breaks (flip flag, refresh)
+- Remove the flag in Step 09 when the old Rust code is deleted
+
+Step 07 will use this flag to route each function:
+
+```typescript
+// Example pattern in src/shared/api/acp.ts (Step 07)
+export async function acpSendMessage(...) {
+  if (useDirectAcp()) {
+    return sendPrompt(...);         // new: TS → WebSocket → goose serve
+  }
+  return invoke("acp_send_message", ...);  // old: TS → Rust → WebSocket → goose serve
+}
+```
+
 ## Verification
 
 1. `pnpm typecheck` passes.
 2. `pnpm check` passes (Biome lint).
 3. The modules can be imported without side effects — initialization only happens when `getClient()` is called.
 4. Unit test for `createWebSocketStream`: mock `WebSocket`, verify messages flow bidirectionally.
+5. Reconnection test: close the WebSocket, verify `resolvedClient` resets to null, verify next `getClient()` creates a fresh connection.
+6. Feature flag test: verify `useDirectAcp()` reads from localStorage, defaults to false.
 
 ## Files Created
 
 | File | Purpose |
 |------|---------|
 | `src/shared/api/createWebSocketStream.ts` | WebSocket → ACP Stream adapter |
-| `src/shared/api/acpConnection.ts` | Singleton ACP connection manager |
+| `src/shared/api/acpConnection.ts` | Singleton ACP connection manager with reconnection |
+| `src/shared/api/acpFeatureFlag.ts` | Feature flag for old/new path routing |
 
 ## Dependencies
 
@@ -292,4 +393,5 @@ export function getClientSync(): GooseClient | null {
 - The `Client` interface from `@agentclientprotocol/sdk` uses `sessionUpdate` as the callback method name. The Rust `Client` trait calls it `session_notification` — same callback, different naming convention.
 - The `protocolVersion` `"2025-03-26"` matches `ProtocolVersion::LATEST` from the Rust `agent-client-protocol` crate. Use `LATEST_PROTOCOL_VERSION` from `@agentclientprotocol/sdk` if exported; otherwise hardcode the string.
 - If `invoke("get_goose_serve_url")` fails, the error propagates to the caller. The app startup code (Step 08) handles this by showing an error state rather than crashing.
-- The initial implementation does not handle WebSocket reconnection. If the connection drops, `getClient()` returns the stale client. A future step can monitor `client.closed` / `client.signal` and reset the singleton to trigger reconnection.
+- Reconnection is passive (reset-on-close), not active (no polling/retry loop). This keeps the implementation simple while ensuring the app recovers from transient disconnections. The connection is local (same machine), so reconnection typically succeeds immediately.
+- The feature flag defaults to `false` (old path). During development, enable it via browser console: `localStorage.setItem("goose2_use_direct_acp", "true")`. In production, flip the default to `true` after validation, then remove the flag entirely in Step 09.

--- a/ui/goose2/acp-plus-migration-plan/04-create-ts-notification-handler.md
+++ b/ui/goose2/acp-plus-migration-plan/04-create-ts-notification-handler.md
@@ -1,0 +1,340 @@
+# Step 04: Create the TypeScript Notification Handler
+
+## Objective
+
+Port the Rust `SessionEventDispatcher` (in `src-tauri/src/services/acp/manager/dispatcher.rs`) to TypeScript. This module receives ACP `SessionNotification` events and updates Zustand stores directly — replacing the current Tauri event bus (`acp:text`, `acp:tool_call`, etc.) and the `useAcpStream` hook.
+
+## Why
+
+Currently, ACP notifications flow through three layers:
+1. Rust `SessionEventDispatcher` receives the ACP callback
+2. Rust emits Tauri events (`acp:text`, `acp:done`, etc.)
+3. TypeScript `useAcpStream` hook listens to those events and updates stores
+
+By handling notifications directly in TypeScript, we eliminate the Tauri event bus intermediary and the `useAcpStream` hook entirely.
+
+## New File
+
+### `src/shared/api/acpNotificationHandler.ts`
+
+This file implements the `AcpNotificationHandler` interface from Step 03 and contains all the logic currently split between `dispatcher.rs`, `writer.rs`, and `useAcpStream.ts`.
+
+```typescript
+/**
+ * ACP notification handler — processes SessionNotification events from the
+ * GooseClient and updates Zustand stores directly.
+ *
+ * This replaces:
+ * - Rust: dispatcher.rs (SessionEventDispatcher, Client trait impl)
+ * - Rust: writer.rs (TauriMessageWriter)
+ * - TS: useAcpStream.ts (Tauri event listeners)
+ * - TS: replayBuffer.ts (replay buffering)
+ */
+```
+
+## Key Data Structures to Port
+
+### Session Route Map
+
+The Rust `dispatcher.rs` maintains a `HashMap<String, SessionRoute>` that maps goose session IDs to local session IDs. Port this as:
+
+```typescript
+interface SessionRoute {
+  localSessionId: string;
+  providerId: string | null;
+  /** When non-null, this session is actively streaming (live path). */
+  activeMessageId: string | null;
+  /** When true, the session was cancelled mid-stream. */
+  canceled: boolean;
+  /** Persona info for the active stream. */
+  personaId: string | null;
+  personaName: string | null;
+}
+
+// Module-level state
+const routes = new Map<string, SessionRoute>();
+```
+
+### Replay Buffer
+
+Port the replay buffer from `replayBuffer.ts` into this module (or keep it as a separate import). The key insight: during `loadSession`, notifications arrive for historical messages. These are buffered and flushed as a single `store.setMessages()` call when `replay_complete` is signaled.
+
+```typescript
+import type { Message, MessageContent, ToolRequestContent } from "@/shared/types/messages";
+
+const replayBuffers = new Map<string, Message[]>();
+```
+
+## Notification Dispatch Logic
+
+Port the `session_notification` method from `dispatcher.rs`. The Rust code handles these `SessionUpdate` variants:
+
+### 1. `SessionInfoUpdate`
+
+```typescript
+// Rust: self.emit_session_info(...)
+// TS equivalent:
+function handleSessionInfoUpdate(localSessionId: string, info: SessionInfoUpdate): void {
+  const session = useChatSessionStore.getState().getSession(localSessionId);
+  if (info.title && !session?.userSetName) {
+    useChatSessionStore.getState().updateSession(localSessionId, {
+      title: info.title,
+    }, { persistOverlay: false });
+  }
+}
+```
+
+### 2. `ConfigOptionUpdate` (model state)
+
+Port the `emit_model_state_from_options` logic. The Rust code extracts model options from `SessionConfigSelectOptions` (ungrouped or grouped) and emits them. In TS:
+
+```typescript
+import type { ModelOption } from "@/features/chat/types";
+
+function extractModelOptionsFromConfigOptions(
+  options: SessionConfigOption[],
+): { currentModelId: string; currentModelName: string | null; availableModels: ModelOption[] } | null {
+  const modelOption = options.find(
+    (opt) => opt.category === "model"  // SessionConfigOptionCategory::Model
+  );
+  if (!modelOption || modelOption.kind.type !== "select") return null;
+
+  const select = modelOption.kind;
+  const currentModelId = select.currentValue;
+  const availableModels: ModelOption[] = [];
+
+  if (select.options.type === "ungrouped") {
+    for (const value of select.options.values) {
+      availableModels.push({ id: value.value, name: value.name });
+    }
+  } else if (select.options.type === "grouped") {
+    for (const group of select.options.groups) {
+      for (const value of group.options) {
+        availableModels.push({ id: value.value, name: value.name });
+      }
+    }
+  }
+
+  const currentModelName = availableModels.find(m => m.id === currentModelId)?.name ?? null;
+  return { currentModelId, currentModelName, availableModels };
+}
+
+function handleModelState(
+  localSessionId: string,
+  providerId: string | null,
+  modelState: { currentModelId: string; currentModelName: string | null; availableModels: ModelOption[] },
+): void {
+  const sessionStore = useChatSessionStore.getState();
+  if (providerId) {
+    sessionStore.cacheModelsForProvider(providerId, modelState.availableModels);
+  }
+  const session = sessionStore.getSession(localSessionId);
+  const sessionProvider = session?.providerId;
+  if (providerId && sessionProvider && providerId !== sessionProvider) {
+    return; // provider mismatch — ignore
+  }
+  const modelName = modelState.currentModelName ?? modelState.currentModelId;
+  sessionStore.setSessionModels(localSessionId, modelState.availableModels);
+  if (!providerId && session?.modelId) {
+    return;
+  }
+  sessionStore.updateSession(localSessionId, {
+    modelId: modelState.currentModelId,
+    modelName,
+  }, { persistOverlay: false });
+}
+```
+
+### 3. `AgentMessageChunk` (live streaming — text)
+
+When a route has an `activeMessageId` (live streaming path):
+
+```typescript
+function handleLiveText(localSessionId: string, text: string): void {
+  const store = useChatStore.getState();
+  store.updateStreamingText(localSessionId, text);
+}
+```
+
+When in replay mode (no `activeMessageId`, session is loading):
+
+```typescript
+function handleReplayText(localSessionId: string, gooseSessionId: string, text: string): void {
+  const buffer = replayBuffers.get(localSessionId);
+  if (!buffer) return;
+  const route = routes.get(gooseSessionId);
+  // Find or create the current assistant message in the buffer
+  // (same logic as useAcpStream's acp:text handler for loading sessions)
+  // ...
+}
+```
+
+### 4. `ToolCall` and `ToolCallUpdate`
+
+Port the tool call handling from both the live and replay paths. The live path calls:
+```typescript
+store.appendToStreamingMessage(sessionId, toolRequest);
+```
+
+The replay path appends to the buffer message.
+
+### 5. `UserMessageChunk` (replay only)
+
+During replay, user messages arrive as `UserMessageChunk`. Port the `extract_user_message` helper:
+
+```typescript
+function extractUserMessage(raw: string): string {
+  const openTag = "<user-message>\n";
+  const closeTag = "\n</user-message>";
+  const startIdx = raw.indexOf(openTag);
+  if (startIdx >= 0) {
+    const innerStart = startIdx + openTag.length;
+    if (raw.substring(innerStart).endsWith(closeTag)) {
+      return raw.substring(innerStart, raw.length - closeTag.length);
+    }
+  }
+  return raw;
+}
+```
+
+### 6. Done / Finalize
+
+When a streaming message completes (the `prompt()` call resolves), the session manager (Step 05) calls a finalize method:
+
+```typescript
+export function finalizeMessage(localSessionId: string, messageId: string): void {
+  const store = useChatStore.getState();
+  store.updateMessage(localSessionId, messageId, (message) => {
+    const content = message.content.map((block) =>
+      block.type === "toolRequest" && block.status === "executing"
+        ? { ...block, status: "completed" as const }
+        : block,
+    );
+    return {
+      ...message,
+      content,
+      metadata: { ...message.metadata, completionStatus: "completed" },
+    };
+  });
+  store.setStreamingMessageId(localSessionId, null);
+  store.setChatState(localSessionId, "idle");
+  // ... title update logic from useAcpStream's acp:done handler
+}
+```
+
+## Public API
+
+The module should export:
+
+```typescript
+/** Register a goose session ID → local session ID binding. */
+export function bindSession(gooseSessionId: string, localSessionId: string, providerId?: string): void;
+
+/** Attach a "writer" for live streaming — sets the active message ID. */
+export function attachWriter(gooseSessionId: string, localSessionId: string, providerId: string | null, messageId: string, personaId?: string, personaName?: string): void;
+
+/** Clear the active writer after streaming completes. */
+export function clearWriter(gooseSessionId: string): void;
+
+/** Mark a session as cancelled. */
+export function markCanceled(gooseSessionId: string): boolean;
+
+/** Start replay buffering for a session. */
+export function startReplayBuffer(localSessionId: string): void;
+
+/** Finalize replay — flush buffer to store. */
+export function finalizeReplay(gooseSessionId: string): void;
+
+/** Flush the replay buffer for a session (called when loading completes). */
+export function flushReplayBuffer(localSessionId: string): void;
+
+/** Finalize a completed streaming message. */
+export function finalizeMessage(localSessionId: string, messageId: string): void;
+
+/** The main notification handler — implements AcpNotificationHandler from Step 03. */
+export function handleSessionNotification(notification: SessionNotification): Promise<void>;
+```
+
+## Porting Checklist
+
+Port each piece from the Rust source, mapping to the TS equivalent:
+
+| Rust Source | Rust Function/Method | TS Equivalent |
+|-------------|---------------------|---------------|
+| `dispatcher.rs` | `SessionEventDispatcher::session_notification` | `handleSessionNotification()` |
+| `dispatcher.rs` | `SessionEventDispatcher::bind_session` | `bindSession()` |
+| `dispatcher.rs` | `SessionEventDispatcher::attach_writer` | `attachWriter()` |
+| `dispatcher.rs` | `SessionEventDispatcher::clear_writer` | `clearWriter()` |
+| `dispatcher.rs` | `SessionEventDispatcher::mark_canceled` | `markCanceled()` |
+| `dispatcher.rs` | `SessionEventDispatcher::finalize_replay` | `finalizeReplay()` |
+| `dispatcher.rs` | `SessionEventDispatcher::emit_session_info` | `handleSessionInfoUpdate()` |
+| `dispatcher.rs` | `SessionEventDispatcher::emit_model_state` | `handleModelState()` |
+| `dispatcher.rs` | `SessionEventDispatcher::emit_model_state_from_options` | `handleModelState()` via `extractModelOptionsFromConfigOptions()` |
+| `dispatcher.rs` | `SessionEventDispatcher::emit_replay_complete` | `flushReplayBuffer()` + `store.setSessionLoading(false)` |
+| `dispatcher.rs` | `extract_user_message` | `extractUserMessage()` |
+| `dispatcher.rs` | `extract_content_preview` | `extractContentPreview()` |
+| `writer.rs` | `TauriMessageWriter::append_text` | Handled inline in `handleSessionNotification` |
+| `writer.rs` | `TauriMessageWriter::record_tool_call` | Handled inline in `handleSessionNotification` |
+| `writer.rs` | `TauriMessageWriter::record_tool_result` | Handled inline in `handleSessionNotification` |
+| `writer.rs` | `TauriMessageWriter::finalize` | `finalizeMessage()` |
+| `useAcpStream.ts` | All event listeners | Replaced by `handleSessionNotification()` |
+| `replayBuffer.ts` | Buffer management | Inlined or imported |
+
+## Store Methods Used
+
+The notification handler calls these existing Zustand store methods (no changes needed to the stores):
+
+**`useChatStore`:**
+- `addMessage(sessionId, message)`
+- `updateMessage(sessionId, messageId, updater)`
+- `setMessages(sessionId, messages)` — for replay buffer flush
+- `updateStreamingText(sessionId, text)`
+- `appendToStreamingMessage(sessionId, content)`
+- `setStreamingMessageId(sessionId, id)`
+- `setChatState(sessionId, state)`
+- `setPendingAssistantProvider(sessionId, null)`
+- `setSessionLoading(sessionId, loading)`
+- `markSessionUnread(sessionId)`
+- `setError(sessionId, error)`
+
+**`useChatSessionStore`:**
+- `updateSession(sessionId, patch, opts)`
+- `setSessionAcpId(sessionId, acpSessionId)`
+- `setSessionModels(sessionId, models)`
+- `cacheModelsForProvider(providerId, models)`
+- `getSession(sessionId)`
+
+## Registration
+
+During app initialization (Step 08), after creating the notification handler, register it with the connection manager:
+
+```typescript
+import { setNotificationHandler } from "@/shared/api/acpConnection";
+import * as notificationHandler from "@/shared/api/acpNotificationHandler";
+
+setNotificationHandler(notificationHandler);
+```
+
+## Verification
+
+1. `pnpm typecheck` passes.
+2. `pnpm check` passes.
+3. Unit tests for `extractUserMessage` and `extractContentPreview` (port the Rust tests from `dispatcher_tests.rs`).
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `src/shared/api/acpNotificationHandler.ts` | ACP notification handler — replaces dispatcher.rs + writer.rs + useAcpStream.ts |
+
+## Dependencies
+
+- Step 03 (`acpConnection.ts` must exist for the `AcpNotificationHandler` interface)
+- Zustand stores (`useChatStore`, `useChatSessionStore`) — no changes needed
+
+## Notes
+
+- The Rust dispatcher uses `Arc<Mutex<HashMap>>` for thread safety. In single-threaded JS, a plain `Map` suffices.
+- The Rust dispatcher has a `replay_events` counter and `wait_for_replay_drain` for timing. In TS, we rely on the `replay_complete` signal from the backend (which the Rust code also emits after draining). The `loadSession` RPC resolves, then the backend sends remaining notifications, then sends `replay_complete`. We just need to handle the `replay_complete` notification to flush the buffer.
+- The `SessionNotification` type from `@agentclientprotocol/sdk` has a `sessionId` field (the goose session ID) and an `update` field with the variant. Check the SDK types for the exact shape — it may differ slightly from the Rust `agent_client_protocol::SessionNotification`.
+- The `shouldTrackStreamingEvent` guard from `useAcpStream.ts` should be ported — it prevents stale events from updating already-completed messages.

--- a/ui/goose2/acp-plus-migration-plan/04-create-ts-notification-handler.md
+++ b/ui/goose2/acp-plus-migration-plan/04-create-ts-notification-handler.md
@@ -19,19 +19,6 @@ By handling notifications directly in TypeScript, we eliminate the Tauri event b
 
 This file implements the `AcpNotificationHandler` interface from Step 03 and contains all the logic currently split between `dispatcher.rs`, `writer.rs`, and `useAcpStream.ts`.
 
-```typescript
-/**
- * ACP notification handler — processes SessionNotification events from the
- * GooseClient and updates Zustand stores directly.
- *
- * This replaces:
- * - Rust: dispatcher.rs (SessionEventDispatcher, Client trait impl)
- * - Rust: writer.rs (TauriMessageWriter)
- * - TS: useAcpStream.ts (Tauri event listeners)
- * - TS: replayBuffer.ts (replay buffering)
- */
-```
-
 ## Key Data Structures to Port
 
 ### Session Route Map
@@ -42,22 +29,18 @@ The Rust `dispatcher.rs` maintains a `HashMap<String, SessionRoute>` that maps g
 interface SessionRoute {
   localSessionId: string;
   providerId: string | null;
-  /** When non-null, this session is actively streaming (live path). */
   activeMessageId: string | null;
-  /** When true, the session was cancelled mid-stream. */
   canceled: boolean;
-  /** Persona info for the active stream. */
   personaId: string | null;
   personaName: string | null;
 }
 
-// Module-level state
 const routes = new Map<string, SessionRoute>();
 ```
 
 ### Replay Buffer
 
-Port the replay buffer from `replayBuffer.ts` into this module (or keep it as a separate import). The key insight: during `loadSession`, notifications arrive for historical messages. These are buffered and flushed as a single `store.setMessages()` call when `replay_complete` is signaled.
+During `loadSession`, notifications arrive for historical messages. These are buffered and flushed as a single `store.setMessages()` call when `replay_complete` is signaled.
 
 ```typescript
 import type { Message, MessageContent, ToolRequestContent } from "@/shared/types/messages";
@@ -72,8 +55,6 @@ Port the `session_notification` method from `dispatcher.rs`. The Rust code handl
 ### 1. `SessionInfoUpdate`
 
 ```typescript
-// Rust: self.emit_session_info(...)
-// TS equivalent:
 function handleSessionInfoUpdate(localSessionId: string, info: SessionInfoUpdate): void {
   const session = useChatSessionStore.getState().getSession(localSessionId);
   if (info.title && !session?.userSetName) {
@@ -86,7 +67,7 @@ function handleSessionInfoUpdate(localSessionId: string, info: SessionInfoUpdate
 
 ### 2. `ConfigOptionUpdate` (model state)
 
-Port the `emit_model_state_from_options` logic. The Rust code extracts model options from `SessionConfigSelectOptions` (ungrouped or grouped) and emits them. In TS:
+Extract model options from `SessionConfigSelectOptions` (ungrouped or grouped) and update the session store:
 
 ```typescript
 import type { ModelOption } from "@/features/chat/types";
@@ -95,7 +76,7 @@ function extractModelOptionsFromConfigOptions(
   options: SessionConfigOption[],
 ): { currentModelId: string; currentModelName: string | null; availableModels: ModelOption[] } | null {
   const modelOption = options.find(
-    (opt) => opt.category === "model"  // SessionConfigOptionCategory::Model
+    (opt) => opt.category === "model"
   );
   if (!modelOption || modelOption.kind.type !== "select") return null;
 
@@ -131,7 +112,7 @@ function handleModelState(
   const session = sessionStore.getSession(localSessionId);
   const sessionProvider = session?.providerId;
   if (providerId && sessionProvider && providerId !== sessionProvider) {
-    return; // provider mismatch — ignore
+    return;
   }
   const modelName = modelState.currentModelName ?? modelState.currentModelId;
   sessionStore.setSessionModels(localSessionId, modelState.availableModels);
@@ -164,14 +145,13 @@ function handleReplayText(localSessionId: string, gooseSessionId: string, text: 
   if (!buffer) return;
   const route = routes.get(gooseSessionId);
   // Find or create the current assistant message in the buffer
-  // (same logic as useAcpStream's acp:text handler for loading sessions)
-  // ...
+  // and append the text chunk to it.
 }
 ```
 
 ### 4. `ToolCall` and `ToolCallUpdate`
 
-Port the tool call handling from both the live and replay paths. The live path calls:
+The live path calls:
 ```typescript
 store.appendToStreamingMessage(sessionId, toolRequest);
 ```
@@ -180,7 +160,7 @@ The replay path appends to the buffer message.
 
 ### 5. `UserMessageChunk` (replay only)
 
-During replay, user messages arrive as `UserMessageChunk`. Port the `extract_user_message` helper:
+During replay, user messages arrive as `UserMessageChunk`. Extract the inner content:
 
 ```typescript
 function extractUserMessage(raw: string): string {
@@ -218,13 +198,10 @@ export function finalizeMessage(localSessionId: string, messageId: string): void
   });
   store.setStreamingMessageId(localSessionId, null);
   store.setChatState(localSessionId, "idle");
-  // ... title update logic from useAcpStream's acp:done handler
 }
 ```
 
 ## Public API
-
-The module should export:
 
 ```typescript
 /** Register a goose session ID → local session ID binding. */
@@ -256,8 +233,6 @@ export function handleSessionNotification(notification: SessionNotification): Pr
 ```
 
 ## Porting Checklist
-
-Port each piece from the Rust source, mapping to the TS equivalent:
 
 | Rust Source | Rust Function/Method | TS Equivalent |
 |-------------|---------------------|---------------|
@@ -306,7 +281,7 @@ The notification handler calls these existing Zustand store methods (no changes 
 
 ## Registration
 
-During app initialization (Step 08), after creating the notification handler, register it with the connection manager:
+During app initialization (Step 08), register the handler with the connection manager:
 
 ```typescript
 import { setNotificationHandler } from "@/shared/api/acpConnection";
@@ -334,7 +309,7 @@ setNotificationHandler(notificationHandler);
 
 ## Notes
 
-- The Rust dispatcher uses `Arc<Mutex<HashMap>>` for thread safety. In single-threaded JS, a plain `Map` suffices.
-- The Rust dispatcher has a `replay_events` counter and `wait_for_replay_drain` for timing. In TS, we rely on the `replay_complete` signal from the backend (which the Rust code also emits after draining). The `loadSession` RPC resolves, then the backend sends remaining notifications, then sends `replay_complete`. We just need to handle the `replay_complete` notification to flush the buffer.
-- The `SessionNotification` type from `@agentclientprotocol/sdk` has a `sessionId` field (the goose session ID) and an `update` field with the variant. Check the SDK types for the exact shape — it may differ slightly from the Rust `agent_client_protocol::SessionNotification`.
-- The `shouldTrackStreamingEvent` guard from `useAcpStream.ts` should be ported — it prevents stale events from updating already-completed messages.
+- In single-threaded JS, a plain `Map` replaces the Rust `Arc<Mutex<HashMap>>` for route storage.
+- Replay buffering relies on the `replay_complete` signal from the backend. The `loadSession` RPC resolves, the backend sends remaining notifications, then sends `replay_complete`. The handler flushes the buffer at that point.
+- The `SessionNotification` type from `@agentclientprotocol/sdk` has a `sessionId` field (the goose session ID) and an `update` field with the variant. Check the SDK types for the exact shape.
+- Port the `shouldTrackStreamingEvent` guard from `useAcpStream.ts` — it prevents stale events from updating already-completed messages.

--- a/ui/goose2/acp-plus-migration-plan/05-create-ts-session-manager.md
+++ b/ui/goose2/acp-plus-migration-plan/05-create-ts-session-manager.md
@@ -1,0 +1,495 @@
+# Step 05: Create the TypeScript Session Manager
+
+## Objective
+
+Port the session state management and ACP operations from the Rust `session_ops.rs`, `command_dispatch.rs`, and `registry.rs` to TypeScript. This module orchestrates all ACP calls (prepare session, send prompt, cancel, load, list, export, import, fork, set model, list providers).
+
+## Why
+
+The Rust `GooseAcpManager` + `session_ops` is the core orchestration layer that:
+1. Tracks which goose sessions are prepared (composite key → goose session ID)
+2. Creates or loads goose sessions on demand
+3. Sets provider/model/working-dir on sessions
+4. Sends prompts and coordinates with the notification handler for streaming
+5. Handles cancellation
+6. Provides session CRUD (list, export, import, fork)
+
+All of this is pure protocol logic with no native OS access — it belongs in TypeScript.
+
+## New File
+
+### `src/shared/api/acpSessionManager.ts`
+
+## Key Data Structures
+
+### Prepared Session Cache
+
+Port from `session_ops.rs`:
+
+```typescript
+interface PreparedSession {
+  gooseSessionId: string;
+  providerId: string;
+  workingDir: string;
+}
+
+/** Maps composite key (sessionId or sessionId__personaId) → PreparedSession */
+const preparedSessions = new Map<string, PreparedSession>();
+```
+
+### Composite Key Helpers
+
+Port from `mod.rs`:
+
+```typescript
+export function makeCompositeKey(sessionId: string, personaId?: string): string {
+  if (personaId && personaId.length > 0) {
+    return `${sessionId}__${personaId}`;
+  }
+  return sessionId;
+}
+
+export function splitCompositeKey(key: string): { sessionId: string; personaId: string | null } {
+  const idx = key.indexOf("__");
+  if (idx >= 0) {
+    const personaId = key.substring(idx + 2);
+    if (personaId.length > 0) {
+      return { sessionId: key.substring(0, idx), personaId };
+    }
+  }
+  return { sessionId: key, personaId: null };
+}
+```
+
+### Running Session Tracking
+
+Port from `registry.rs`:
+
+```typescript
+interface RunningSession {
+  compositeKey: string;
+  providerId: string;
+  startedAt: number; // Date.now()
+  assistantMessageId: string | null;
+  abortController: AbortController;
+}
+
+const runningSessions = new Map<string, RunningSession>();
+```
+
+## Core Operations to Port
+
+### 1. `prepareSession`
+
+Port from `prepare_session_inner` in `session_ops.rs`. This is the most complex function — it:
+
+1. Checks if a session is already prepared for this composite key
+2. If yes, reuses it (updating working dir / provider if changed)
+3. If no, tries to load an existing goose session by ID
+4. If that fails, creates a new goose session via `client.newSession()`
+5. Binds the goose session ID to the local session ID in the notification handler
+6. Sets the provider via `client.setSessionConfigOption()` if needed
+7. Emits model state to the session store
+
+```typescript
+export async function prepareSession(
+  compositeKey: string,
+  localSessionId: string,
+  providerId: string,
+  workingDir: string,
+): Promise<string> {
+  const client = await getClient();
+
+  // Check for existing prepared session
+  const existing = preparedSessions.get(compositeKey) ?? preparedSessions.get(localSessionId);
+  if (existing) {
+    bindSession(existing.gooseSessionId, localSessionId, providerId);
+    // Update working dir if changed
+    if (existing.workingDir !== workingDir) {
+      await client.goose.gooseWorkingDirUpdate({ sessionId: existing.gooseSessionId, workingDir });
+      // ... update cache
+    }
+    // Update provider if changed
+    if (existing.providerId !== providerId) {
+      const response = await client.setSessionConfigOption({
+        sessionId: existing.gooseSessionId,
+        optionId: "provider",
+        value: providerId,
+      });
+      // ... emit model state from response.configOptions
+    }
+    return existing.gooseSessionId;
+  }
+
+  // Try to load existing session
+  let gooseSessionId: string | null = null;
+  try {
+    const loadResponse = await client.loadSession({
+      sessionId: localSessionId,
+      workingDir,
+    });
+    gooseSessionId = localSessionId;
+    bindSession(gooseSessionId, localSessionId, providerId);
+    // ... handle model state from loadResponse
+    // ... update provider if needed
+  } catch {
+    // Session doesn't exist — create new
+  }
+
+  if (!gooseSessionId) {
+    const meta: Record<string, unknown> = {};
+    if (providerId !== "goose") {
+      meta.provider = providerId;
+    }
+    const newResponse = await client.newSession({
+      workingDir,
+      ...(Object.keys(meta).length > 0 ? { meta } : {}),
+    });
+    gooseSessionId = newResponse.sessionId;
+    bindSession(gooseSessionId, localSessionId, providerId);
+    // ... handle model state from newResponse
+  }
+
+  // Cache the prepared session
+  const prepared: PreparedSession = { gooseSessionId, providerId, workingDir };
+  preparedSessions.set(compositeKey, prepared);
+  preparedSessions.set(localSessionId, prepared);
+
+  return gooseSessionId;
+}
+```
+
+### 2. `sendPrompt`
+
+Port from `send_prompt_inner` in `prompt_ops.rs`:
+
+```typescript
+export async function sendPrompt(
+  sessionId: string,
+  providerId: string,
+  prompt: string,
+  options: {
+    workingDir?: string;
+    systemPrompt?: string;
+    personaId?: string;
+    personaName?: string;
+    images?: [string, string][]; // [base64, mimeType]
+  } = {},
+): Promise<void> {
+  const client = await getClient();
+  const compositeKey = makeCompositeKey(sessionId, options.personaId);
+
+  // Build effective prompt with persona instructions
+  const effectivePrompt = buildEffectivePrompt(prompt, options.systemPrompt);
+
+  // Register running session
+  const abort = new AbortController();
+  const assistantMessageId = crypto.randomUUID();
+  runningSessions.set(compositeKey, {
+    compositeKey,
+    providerId,
+    startedAt: Date.now(),
+    assistantMessageId,
+    abortController: abort,
+  });
+
+  try {
+    // Prepare session (creates/loads goose session if needed)
+    const workingDir = options.workingDir ?? defaultArtifactsWorkingDir();
+    const gooseSessionId = await prepareSession(compositeKey, sessionId, providerId, workingDir);
+
+    // Attach writer in notification handler (so streaming events go to this message)
+    attachWriter(gooseSessionId, sessionId, providerId, assistantMessageId, options.personaId, options.personaName);
+
+    // Build content blocks
+    const content: ContentBlock[] = [{ type: "text", text: effectivePrompt }];
+    for (const [data, mimeType] of (options.images ?? [])) {
+      content.push({ type: "image", data, mimeType });
+    }
+
+    // Send the prompt — this blocks until the agent finishes
+    await client.prompt({
+      sessionId: gooseSessionId,
+      content,
+    });
+
+    // Finalize the message
+    clearWriter(gooseSessionId);
+    finalizeMessage(sessionId, assistantMessageId);
+  } catch (error) {
+    clearWriter(/* gooseSessionId */);
+    throw error;
+  } finally {
+    runningSessions.delete(compositeKey);
+  }
+}
+```
+
+### 3. `cancelSession`
+
+Port from `cancel_session_inner`:
+
+```typescript
+export async function cancelSession(sessionId: string, personaId?: string): Promise<boolean> {
+  const compositeKey = makeCompositeKey(sessionId, personaId);
+  const running = runningSessions.get(compositeKey);
+
+  // Find the goose session ID
+  const prepared = preparedSessions.get(compositeKey) ?? preparedSessions.get(sessionId);
+  if (!prepared) {
+    return running !== undefined; // still preparing
+  }
+
+  markCanceled(prepared.gooseSessionId);
+
+  try {
+    const client = await getClient();
+    await client.cancel({ sessionId: prepared.gooseSessionId });
+  } catch {
+    // Best-effort cancellation
+  }
+
+  return true;
+}
+```
+
+### 4. `listSessions`
+
+```typescript
+export interface AcpSessionInfo {
+  sessionId: string;
+  title: string | null;
+  updatedAt: string | null;
+  messageCount: number;
+}
+
+export async function listSessions(): Promise<AcpSessionInfo[]> {
+  const client = await getClient();
+  const response = await client.unstable_listSessions({});
+  return response.sessions.map((info) => ({
+    sessionId: info.sessionId,
+    title: info.title ?? null,
+    updatedAt: info.updatedAt ?? null,
+    messageCount: (info.meta?.messageCount as number) ?? 0,
+  }));
+}
+```
+
+### 5. `loadSession`
+
+Port from `load_session_inner`:
+
+```typescript
+export async function loadSession(
+  localSessionId: string,
+  gooseSessionId: string,
+  workingDir: string,
+): Promise<void> {
+  const client = await getClient();
+
+  // Start replay buffering
+  bindSession(gooseSessionId, localSessionId);
+  startReplayBuffer(localSessionId);
+
+  const response = await client.loadSession({
+    sessionId: gooseSessionId,
+    workingDir,
+  });
+
+  // The backend sends replay notifications asynchronously.
+  // We wait for the replay_complete signal (handled by the notification handler)
+  // which calls flushReplayBuffer().
+
+  // Handle model state from response
+  if (response.models) {
+    handleModelState(localSessionId, null, /* extract from response.models */);
+  }
+  if (response.configOptions) {
+    const modelState = extractModelOptionsFromConfigOptions(response.configOptions);
+    if (modelState) handleModelState(localSessionId, null, modelState);
+  }
+
+  // Register in prepared sessions cache
+  preparedSessions.set(localSessionId, {
+    gooseSessionId,
+    providerId: "goose", // will be updated on next prepare
+    workingDir,
+  });
+}
+```
+
+### 6. `exportSession`, `importSession`, `forkSession`
+
+```typescript
+export async function exportSession(sessionId: string): Promise<string> {
+  const client = await getClient();
+  const result = await client.goose.gooseSessionExport({ sessionId });
+  return result.data;
+}
+
+export async function importSession(json: string): Promise<AcpSessionInfo> {
+  const client = await getClient();
+  return await client.goose.gooseSessionImport({ data: json });
+}
+
+export async function forkSession(sessionId: string): Promise<AcpSessionInfo> {
+  const client = await getClient();
+  const response = await client.unstable_forkSession({
+    sessionId,
+    workingDir: defaultArtifactsWorkingDir(),
+  });
+  return {
+    sessionId: response.sessionId,
+    title: (response.meta?.title as string) ?? null,
+    updatedAt: null,
+    messageCount: (response.meta?.messageCount as number) ?? 0,
+  };
+}
+```
+
+### 7. `setModel`
+
+```typescript
+export async function setModel(localSessionId: string, modelId: string): Promise<void> {
+  const client = await getClient();
+
+  // Find all prepared sessions for this local session ID
+  for (const [key, prepared] of preparedSessions) {
+    const { sessionId } = splitCompositeKey(key);
+    if (sessionId !== localSessionId) continue;
+
+    const response = await client.setSessionConfigOption({
+      sessionId: prepared.gooseSessionId,
+      optionId: "model",
+      value: modelId,
+    });
+    // Emit model state from response
+    const modelState = extractModelOptionsFromConfigOptions(response.configOptions);
+    if (modelState) handleModelState(localSessionId, prepared.providerId, modelState);
+  }
+}
+```
+
+### 8. `listProviders`
+
+```typescript
+const DEPRECATED_PROVIDER_IDS = new Set(["claude-code", "codex", "gemini-cli"]);
+
+export interface AcpProvider {
+  id: string;
+  label: string;
+}
+
+export async function listProviders(): Promise<AcpProvider[]> {
+  const client = await getClient();
+  const result = await client.goose.gooseProvidersList({});
+  return result.providers
+    .filter((p: { id: string }) => !DEPRECATED_PROVIDER_IDS.has(p.id))
+    .map((p: { id: string; label: string }) => ({ id: p.id, label: p.label }));
+}
+```
+
+### 9. `listRunning`
+
+```typescript
+export interface AcpRunningSession {
+  sessionId: string;
+  personaId: string | null;
+  providerId: string;
+  runningForSecs: number;
+}
+
+export function listRunning(): AcpRunningSession[] {
+  const now = Date.now();
+  return [...runningSessions.values()].map((entry) => {
+    const { sessionId, personaId } = splitCompositeKey(entry.compositeKey);
+    return {
+      sessionId,
+      personaId,
+      providerId: entry.providerId,
+      runningForSecs: Math.floor((now - entry.startedAt) / 1000),
+    };
+  });
+}
+```
+
+### 10. `cancelAll`
+
+```typescript
+export function cancelAll(): void {
+  for (const entry of runningSessions.values()) {
+    entry.abortController.abort();
+  }
+}
+```
+
+## Helper: Build Effective Prompt
+
+Port the persona instruction wrapping from `mod.rs`:
+
+```typescript
+function buildEffectivePrompt(prompt: string, systemPrompt?: string): string {
+  if (!systemPrompt || systemPrompt.trim().length === 0) {
+    return prompt;
+  }
+  return [
+    `<persona-instructions>\n${systemPrompt}\n</persona-instructions>`,
+    `<user-message>\n${prompt}\n</user-message>`,
+  ].join("\n\n");
+}
+```
+
+## Helper: Default Artifacts Working Dir
+
+```typescript
+function defaultArtifactsWorkingDir(): string {
+  // This will be fetched from the Rust backend via getHomeDir()
+  // or cached at startup. For now, use a reasonable default.
+  return "~/.goose/artifacts";
+}
+```
+
+Note: The Rust code resolves `~` to the actual home directory and creates the directory. In the TS version, the `goose serve` backend handles working directory resolution. We just need to pass a reasonable path.
+
+## Imports from Other Modules
+
+```typescript
+import { getClient } from "./acpConnection";
+import {
+  bindSession,
+  attachWriter,
+  clearWriter,
+  markCanceled,
+  startReplayBuffer,
+  finalizeReplay,
+  flushReplayBuffer,
+  finalizeMessage,
+  handleModelState,
+  extractModelOptionsFromConfigOptions,
+} from "./acpNotificationHandler";
+```
+
+## Verification
+
+1. `pnpm typecheck` passes.
+2. `pnpm check` passes.
+3. Unit tests for `makeCompositeKey`, `splitCompositeKey`, `buildEffectivePrompt`.
+4. Port relevant tests from `session_ops/tests.rs`.
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `src/shared/api/acpSessionManager.ts` | Session state management and ACP operations |
+
+## Dependencies
+
+- Step 03 (`acpConnection.ts` — provides `getClient()`)
+- Step 04 (`acpNotificationHandler.ts` — provides bind/attach/clear/finalize functions)
+
+## Notes
+
+- The Rust code uses per-session `Mutex` locks (`op_locks`) to prevent concurrent mutations. In single-threaded JS, this isn't needed for correctness, but you may want a simple promise-based lock to prevent concurrent `prepareSession` calls for the same composite key from racing.
+- The Rust `pending_cancels` / `preparing_sessions` sets coordinate cancellation during preparation. Port these as simple `Set<string>` module-level variables.
+- The `GooseExtClient` methods (e.g., `client.goose.gooseProvidersList()`) are generated from the ACP schema. Check the actual method names in `ui/acp/src/generated/client.gen.ts` — they may use camelCase versions of the `goose/providers/list` method name.
+- The `client.prompt()` call blocks until the agent finishes responding. During this time, `SessionNotification` events stream in via the `Client` callback (handled by the notification handler). This is the same flow as the Rust code.

--- a/ui/goose2/acp-plus-migration-plan/05-create-ts-session-manager.md
+++ b/ui/goose2/acp-plus-migration-plan/05-create-ts-session-manager.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Port the session state management and ACP operations from the Rust `session_ops.rs`, `command_dispatch.rs`, and `registry.rs` to TypeScript. This module orchestrates all ACP calls (prepare session, send prompt, cancel, load, list, export, import, fork, set model, list providers).
+Port session state management and ACP operations from the Rust `session_ops.rs`, `command_dispatch.rs`, and `registry.rs` to TypeScript. This module orchestrates all ACP calls: prepare session, send prompt, cancel, load, list, export, import, fork, set model, and list providers.
 
 ## Why
 
@@ -24,8 +24,6 @@ All of this is pure protocol logic with no native OS access — it belongs in Ty
 
 ### Prepared Session Cache
 
-Port from `session_ops.rs`:
-
 ```typescript
 interface PreparedSession {
   gooseSessionId: string;
@@ -38,8 +36,6 @@ const preparedSessions = new Map<string, PreparedSession>();
 ```
 
 ### Composite Key Helpers
-
-Port from `mod.rs`:
 
 ```typescript
 export function makeCompositeKey(sessionId: string, personaId?: string): string {
@@ -63,8 +59,6 @@ export function splitCompositeKey(key: string): { sessionId: string; personaId: 
 
 ### Running Session Tracking
 
-Port from `registry.rs`:
-
 ```typescript
 interface RunningSession {
   compositeKey: string;
@@ -77,11 +71,11 @@ interface RunningSession {
 const runningSessions = new Map<string, RunningSession>();
 ```
 
-## Core Operations to Port
+## Core Operations
 
 ### 1. `prepareSession`
 
-Port from `prepare_session_inner` in `session_ops.rs`. This is the most complex function — it:
+This is the most complex function. It:
 
 1. Checks if a session is already prepared for this composite key
 2. If yes, reuses it (updating working dir / provider if changed)
@@ -100,16 +94,13 @@ export async function prepareSession(
 ): Promise<string> {
   const client = await getClient();
 
-  // Check for existing prepared session
   const existing = preparedSessions.get(compositeKey) ?? preparedSessions.get(localSessionId);
   if (existing) {
     bindSession(existing.gooseSessionId, localSessionId, providerId);
-    // Update working dir if changed
     if (existing.workingDir !== workingDir) {
       await client.goose.gooseWorkingDirUpdate({ sessionId: existing.gooseSessionId, workingDir });
       // ... update cache
     }
-    // Update provider if changed
     if (existing.providerId !== providerId) {
       const response = await client.setSessionConfigOption({
         sessionId: existing.gooseSessionId,
@@ -121,7 +112,6 @@ export async function prepareSession(
     return existing.gooseSessionId;
   }
 
-  // Try to load existing session
   let gooseSessionId: string | null = null;
   try {
     const loadResponse = await client.loadSession({
@@ -150,7 +140,6 @@ export async function prepareSession(
     // ... handle model state from newResponse
   }
 
-  // Cache the prepared session
   const prepared: PreparedSession = { gooseSessionId, providerId, workingDir };
   preparedSessions.set(compositeKey, prepared);
   preparedSessions.set(localSessionId, prepared);
@@ -160,8 +149,6 @@ export async function prepareSession(
 ```
 
 ### 2. `sendPrompt`
-
-Port from `send_prompt_inner` in `prompt_ops.rs`:
 
 ```typescript
 export async function sendPrompt(
@@ -179,10 +166,8 @@ export async function sendPrompt(
   const client = await getClient();
   const compositeKey = makeCompositeKey(sessionId, options.personaId);
 
-  // Build effective prompt with persona instructions
   const effectivePrompt = buildEffectivePrompt(prompt, options.systemPrompt);
 
-  // Register running session
   const abort = new AbortController();
   const assistantMessageId = crypto.randomUUID();
   runningSessions.set(compositeKey, {
@@ -194,26 +179,21 @@ export async function sendPrompt(
   });
 
   try {
-    // Prepare session (creates/loads goose session if needed)
     const workingDir = options.workingDir ?? defaultArtifactsWorkingDir();
     const gooseSessionId = await prepareSession(compositeKey, sessionId, providerId, workingDir);
 
-    // Attach writer in notification handler (so streaming events go to this message)
     attachWriter(gooseSessionId, sessionId, providerId, assistantMessageId, options.personaId, options.personaName);
 
-    // Build content blocks
     const content: ContentBlock[] = [{ type: "text", text: effectivePrompt }];
     for (const [data, mimeType] of (options.images ?? [])) {
       content.push({ type: "image", data, mimeType });
     }
 
-    // Send the prompt — this blocks until the agent finishes
     await client.prompt({
       sessionId: gooseSessionId,
       content,
     });
 
-    // Finalize the message
     clearWriter(gooseSessionId);
     finalizeMessage(sessionId, assistantMessageId);
   } catch (error) {
@@ -227,14 +207,11 @@ export async function sendPrompt(
 
 ### 3. `cancelSession`
 
-Port from `cancel_session_inner`:
-
 ```typescript
 export async function cancelSession(sessionId: string, personaId?: string): Promise<boolean> {
   const compositeKey = makeCompositeKey(sessionId, personaId);
   const running = runningSessions.get(compositeKey);
 
-  // Find the goose session ID
   const prepared = preparedSessions.get(compositeKey) ?? preparedSessions.get(sessionId);
   if (!prepared) {
     return running !== undefined; // still preparing
@@ -277,8 +254,6 @@ export async function listSessions(): Promise<AcpSessionInfo[]> {
 
 ### 5. `loadSession`
 
-Port from `load_session_inner`:
-
 ```typescript
 export async function loadSession(
   localSessionId: string,
@@ -287,7 +262,6 @@ export async function loadSession(
 ): Promise<void> {
   const client = await getClient();
 
-  // Start replay buffering
   bindSession(gooseSessionId, localSessionId);
   startReplayBuffer(localSessionId);
 
@@ -297,10 +271,8 @@ export async function loadSession(
   });
 
   // The backend sends replay notifications asynchronously.
-  // We wait for the replay_complete signal (handled by the notification handler)
-  // which calls flushReplayBuffer().
+  // The notification handler flushes the replay buffer on replay_complete.
 
-  // Handle model state from response
   if (response.models) {
     handleModelState(localSessionId, null, /* extract from response.models */);
   }
@@ -309,10 +281,9 @@ export async function loadSession(
     if (modelState) handleModelState(localSessionId, null, modelState);
   }
 
-  // Register in prepared sessions cache
   preparedSessions.set(localSessionId, {
     gooseSessionId,
-    providerId: "goose", // will be updated on next prepare
+    providerId: "goose", // updated on next prepare
     workingDir,
   });
 }
@@ -353,7 +324,6 @@ export async function forkSession(sessionId: string): Promise<AcpSessionInfo> {
 export async function setModel(localSessionId: string, modelId: string): Promise<void> {
   const client = await getClient();
 
-  // Find all prepared sessions for this local session ID
   for (const [key, prepared] of preparedSessions) {
     const { sessionId } = splitCompositeKey(key);
     if (sessionId !== localSessionId) continue;
@@ -363,7 +333,6 @@ export async function setModel(localSessionId: string, modelId: string): Promise
       optionId: "model",
       value: modelId,
     });
-    // Emit model state from response
     const modelState = extractModelOptionsFromConfigOptions(response.configOptions);
     if (modelState) handleModelState(localSessionId, prepared.providerId, modelState);
   }
@@ -425,8 +394,6 @@ export function cancelAll(): void {
 
 ## Helper: Build Effective Prompt
 
-Port the persona instruction wrapping from `mod.rs`:
-
 ```typescript
 function buildEffectivePrompt(prompt: string, systemPrompt?: string): string {
   if (!systemPrompt || systemPrompt.trim().length === 0) {
@@ -443,13 +410,11 @@ function buildEffectivePrompt(prompt: string, systemPrompt?: string): string {
 
 ```typescript
 function defaultArtifactsWorkingDir(): string {
-  // This will be fetched from the Rust backend via getHomeDir()
-  // or cached at startup. For now, use a reasonable default.
   return "~/.goose/artifacts";
 }
 ```
 
-Note: The Rust code resolves `~` to the actual home directory and creates the directory. In the TS version, the `goose serve` backend handles working directory resolution. We just need to pass a reasonable path.
+The `goose serve` backend handles working directory resolution and `~` expansion. This function only needs to supply a reasonable path.
 
 ## Imports from Other Modules
 
@@ -469,6 +434,18 @@ import {
 } from "./acpNotificationHandler";
 ```
 
+## Concurrency
+
+The Rust code uses per-session `Mutex` locks (`op_locks`) and `pending_cancels` / `preparing_sessions` sets to prevent concurrent mutations and coordinate cancellation during preparation. In single-threaded JS, mutex locks aren't needed for correctness, but a simple promise-based lock prevents concurrent `prepareSession` calls for the same composite key from racing. Port `pending_cancels` and `preparing_sessions` as module-level `Set<string>` variables.
+
+## Generated Client Method Names
+
+The `GooseExtClient` methods (e.g., `client.goose.gooseProvidersList()`) are generated from the ACP schema. Verify actual method names in `ui/acp/src/generated/client.gen.ts` — they use camelCase versions of the `goose/providers/list` method name.
+
+## Streaming Model
+
+The `client.prompt()` call blocks until the agent finishes responding. During this time, `SessionNotification` events stream in via the `Client` callback, handled by the notification handler. This matches the Rust flow.
+
 ## Verification
 
 1. `pnpm typecheck` passes.
@@ -486,10 +463,3 @@ import {
 
 - Step 03 (`acpConnection.ts` — provides `getClient()`)
 - Step 04 (`acpNotificationHandler.ts` — provides bind/attach/clear/finalize functions)
-
-## Notes
-
-- The Rust code uses per-session `Mutex` locks (`op_locks`) to prevent concurrent mutations. In single-threaded JS, this isn't needed for correctness, but you may want a simple promise-based lock to prevent concurrent `prepareSession` calls for the same composite key from racing.
-- The Rust `pending_cancels` / `preparing_sessions` sets coordinate cancellation during preparation. Port these as simple `Set<string>` module-level variables.
-- The `GooseExtClient` methods (e.g., `client.goose.gooseProvidersList()`) are generated from the ACP schema. Check the actual method names in `ui/acp/src/generated/client.gen.ts` — they may use camelCase versions of the `goose/providers/list` method name.
-- The `client.prompt()` call blocks until the agent finishes responding. During this time, `SessionNotification` events stream in via the `Client` callback (handled by the notification handler). This is the same flow as the Rust code.

--- a/ui/goose2/acp-plus-migration-plan/06-port-session-search.md
+++ b/ui/goose2/acp-plus-migration-plan/06-port-session-search.md
@@ -1,0 +1,363 @@
+# Step 06: Port Session Content Search to TypeScript
+
+## Objective
+
+Port the session content search logic from `src-tauri/src/services/acp/search.rs` to TypeScript. This is pure text processing on exported JSON — no native access needed.
+
+## Why
+
+The Rust search code:
+1. Exports each session as JSON via the ACP `goose/session/export` extension method
+2. Parses the JSON to extract user/assistant/system messages
+3. Performs case-insensitive substring matching
+4. Builds snippets around the first match
+
+All of this is string processing that runs fine in JavaScript. Moving it to TypeScript eliminates the Rust→TS round-trip for each session export during search.
+
+## New File
+
+### `src/features/sessions/lib/sessionContentSearch.ts`
+
+```typescript
+/**
+ * Search session message content via exported Goose sessions.
+ *
+ * Ported from src-tauri/src/services/acp/search.rs
+ */
+import { exportSession } from "@/shared/api/acpSessionManager"; // from Step 05
+
+const SNIPPET_PREFIX_BYTES = 40;
+const SNIPPET_SUFFIX_BYTES = 60;
+
+export interface SessionSearchResult {
+  sessionId: string;
+  snippet: string;
+  messageId: string;
+  messageRole?: "user" | "assistant" | "system";
+  matchCount: number;
+}
+```
+
+## Functions to Port
+
+### 1. `searchSessionsViaExports`
+
+The top-level function that iterates over session IDs, exports each, and searches:
+
+```typescript
+export async function searchSessionsViaExports(
+  query: string,
+  sessionIds: string[],
+): Promise<SessionSearchResult[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const seen = new Set<string>();
+  const results: SessionSearchResult[] = [];
+
+  for (const sessionId of sessionIds) {
+    if (seen.has(sessionId)) continue;
+    seen.add(sessionId);
+
+    try {
+      const exported = await exportSession(sessionId);
+      const result = searchExportedSession(sessionId, exported, trimmed);
+      if (result) results.push(result);
+    } catch {
+      // Skip sessions that fail to export
+    }
+  }
+
+  return results;
+}
+```
+
+### 2. `searchExportedSession`
+
+```typescript
+function searchExportedSession(
+  sessionId: string,
+  exportedJson: string,
+  query: string,
+): SessionSearchResult | null {
+  let root: unknown;
+  try {
+    root = JSON.parse(exportedJson);
+  } catch {
+    return null;
+  }
+
+  const obj = root as Record<string, unknown>;
+  const conversation = obj.conversation ?? obj.messages;
+  if (!conversation) return null;
+
+  const messages = extractMessages(conversation);
+  if (messages.length === 0) return null;
+
+  let firstMatch: { messageId: string; role: string | null; snippet: string } | null = null;
+  let matchCount = 0;
+
+  for (const message of messages) {
+    for (const text of message.searchableTexts) {
+      const occurrences = countOccurrences(text, query);
+      if (occurrences === 0) continue;
+
+      matchCount += occurrences;
+
+      if (!firstMatch) {
+        firstMatch = {
+          messageId: message.id,
+          role: message.role,
+          snippet: buildSnippet(text, query),
+        };
+      }
+    }
+  }
+
+  if (!firstMatch) return null;
+
+  return {
+    sessionId,
+    snippet: firstMatch.snippet,
+    messageId: firstMatch.messageId,
+    messageRole: firstMatch.role as SessionSearchResult["messageRole"],
+    matchCount,
+  };
+}
+```
+
+### 3. `extractMessages`
+
+Recursively walks the JSON structure to find message objects:
+
+```typescript
+interface ExportedMessage {
+  id: string;
+  role: string | null;
+  searchableTexts: string[];
+}
+
+function extractMessages(value: unknown): ExportedMessage[] {
+  const messages: ExportedMessage[] = [];
+  collectMessages(value, messages);
+  return messages;
+}
+
+function collectMessages(value: unknown, messages: ExportedMessage[]): void {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      collectMessages(item, messages);
+    }
+    return;
+  }
+
+  if (typeof value !== "object" || value === null) return;
+  const obj = value as Record<string, unknown>;
+
+  if (obj.message !== undefined) {
+    collectMessages(obj.message, messages);
+    return;
+  }
+
+  if (obj.messages !== undefined) {
+    collectMessages(obj.messages, messages);
+    return;
+  }
+
+  if (looksLikeMessage(obj)) {
+    const fallbackId = `message-${messages.length}`;
+    const message = extractMessage(obj, fallbackId);
+    if (message) messages.push(message);
+  }
+}
+
+function looksLikeMessage(obj: Record<string, unknown>): boolean {
+  return "role" in obj && ("content" in obj || "text" in obj);
+}
+```
+
+### 4. `extractMessage`
+
+```typescript
+function extractMessage(
+  obj: Record<string, unknown>,
+  fallbackId: string,
+): ExportedMessage | null {
+  const role = normalizeRole(obj.role as string | undefined);
+  const searchableTexts: string[] = [];
+
+  if (obj.content !== undefined) {
+    searchableTexts.push(...extractSearchableTexts(obj.content, role));
+  } else if (typeof obj.text === "string") {
+    if (role && obj.text.trim().length > 0) {
+      searchableTexts.push(obj.text.trim());
+    }
+  }
+
+  if (searchableTexts.length === 0) return null;
+
+  return {
+    id: typeof obj.id === "string" ? obj.id : fallbackId,
+    role,
+    searchableTexts,
+  };
+}
+```
+
+### 5. `extractSearchableTexts`
+
+```typescript
+function extractSearchableTexts(value: unknown, role: string | null): string[] {
+  if (typeof value === "string") {
+    if (role && isSearchableRole(role)) {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? [trimmed] : [];
+    }
+    return [];
+  }
+
+  if (Array.isArray(value)) {
+    return value.flatMap((item) => extractSearchableBlockText(item, role));
+  }
+
+  if (typeof value === "object" && value !== null) {
+    return extractSearchableBlockText(value, role);
+  }
+
+  return [];
+}
+
+function extractSearchableBlockText(value: unknown, role: string | null): string[] {
+  if (typeof value !== "object" || value === null) return [];
+  const obj = value as Record<string, unknown>;
+
+  const blockType = obj.type as string | undefined;
+  const text = obj.text as string | undefined;
+
+  switch (blockType) {
+    case "text":
+    case "input_text":
+    case "output_text":
+    case "systemNotification":
+    case "system_notification": {
+      const trimmed = text?.trim();
+      return trimmed && trimmed.length > 0 ? [trimmed] : [];
+    }
+    case "toolRequest":
+    case "toolResponse":
+    case "thinking":
+    case "redactedThinking":
+    case "reasoning":
+    case "image":
+      return [];
+    default: {
+      if (role && isSearchableRole(role)) {
+        const trimmed = text?.trim();
+        return trimmed && trimmed.length > 0 ? [trimmed] : [];
+      }
+      return [];
+    }
+  }
+}
+```
+
+### 6. Helper functions
+
+```typescript
+function normalizeRole(role: string | undefined): string | null {
+  if (!role) return null;
+  const trimmed = role.trim().toLowerCase();
+  if (trimmed === "user") return "user";
+  if (trimmed === "assistant") return "assistant";
+  if (trimmed === "system") return "system";
+  return null;
+}
+
+function isSearchableRole(role: string): boolean {
+  return role === "user" || role === "assistant" || role === "system";
+}
+
+function countOccurrences(text: string, query: string): number {
+  const haystack = text.toLowerCase();
+  const needle = query.toLowerCase();
+  if (needle.length === 0) return 0;
+
+  let count = 0;
+  let searchStart = 0;
+
+  while (true) {
+    const index = haystack.indexOf(needle, searchStart);
+    if (index === -1) break;
+    count += 1;
+    searchStart = index + needle.length;
+  }
+
+  return count;
+}
+
+function buildSnippet(text: string, query: string): string {
+  const haystack = text.toLowerCase();
+  const needle = query.toLowerCase();
+  const matchIndex = haystack.indexOf(needle);
+  const effectiveMatchIndex = matchIndex >= 0 ? matchIndex : 0;
+
+  const start = Math.max(0, effectiveMatchIndex - SNIPPET_PREFIX_BYTES);
+  const end = Math.min(
+    text.length,
+    effectiveMatchIndex + query.length + SNIPPET_SUFFIX_BYTES,
+  );
+
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < text.length ? "..." : "";
+  const body = text.substring(start, end).trim();
+
+  return `${prefix}${body}${suffix}`;
+}
+```
+
+## Tests to Port
+
+Port the tests from `search.rs` `mod tests`:
+
+```typescript
+// src/features/sessions/lib/__tests__/sessionContentSearch.test.ts
+
+import { describe, it, expect } from "vitest";
+// Import the internal functions (may need to export them for testing)
+
+describe("sessionContentSearch", () => {
+  it("finds user and assistant text matches", () => { /* ... */ });
+  it("includes system notifications", () => { /* ... */ });
+  it("skips tool and reasoning content", () => { /* ... */ });
+  it("counts multiple matches in one session", () => { /* ... */ });
+  it("builds trimmed snippets around first match", () => { /* ... */ });
+  // ... port all tests from search.rs
+});
+```
+
+## Integration with `useSessionSearch`
+
+The existing `useSessionSearch` hook calls `acpSearchSessions()` from `@/shared/api/acp`. In Step 07, that function will be rewired to call `searchSessionsViaExports` from this module instead of `invoke("acp_search_sessions")`.
+
+## Verification
+
+1. `pnpm typecheck` passes.
+2. `pnpm check` passes.
+3. `pnpm test` — all ported search tests pass.
+
+## Files Created
+
+| File | Purpose |
+|------|---------|
+| `src/features/sessions/lib/sessionContentSearch.ts` | Session content search logic |
+| `src/features/sessions/lib/__tests__/sessionContentSearch.test.ts` | Tests |
+
+## Dependencies
+
+- Step 05 (`acpSessionManager.ts` — provides `exportSession()`)
+
+## Notes
+
+- The Rust `build_snippet` uses byte-level `floor_char_boundary` / `ceil_char_boundary` for UTF-8 safety. In JavaScript, `String.substring()` operates on UTF-16 code units and is already safe for slicing. The snippet boundaries may differ slightly from the Rust version for multi-byte characters, but this is cosmetic.
+- The Rust search is sequential (one session at a time). The TS version could parallelize with `Promise.all` for better performance, but sequential is simpler and matches the Rust behavior. Consider parallelizing later if search is slow.
+- The `exportSession` call goes through the ACP client to `goose serve`, which reads from its database. This is the same path as the Rust code — no change in data source.

--- a/ui/goose2/acp-plus-migration-plan/06-port-session-search.md
+++ b/ui/goose2/acp-plus-migration-plan/06-port-session-search.md
@@ -2,17 +2,17 @@
 
 ## Objective
 
-Port the session content search logic from `src-tauri/src/services/acp/search.rs` to TypeScript. This is pure text processing on exported JSON — no native access needed.
+Port the session content search logic to TypeScript. This is pure text processing on exported JSON and requires no native access.
 
 ## Why
 
-The Rust search code:
+The search code:
 1. Exports each session as JSON via the ACP `goose/session/export` extension method
 2. Parses the JSON to extract user/assistant/system messages
 3. Performs case-insensitive substring matching
 4. Builds snippets around the first match
 
-All of this is string processing that runs fine in JavaScript. Moving it to TypeScript eliminates the Rust→TS round-trip for each session export during search.
+All of this is string processing that runs fine in JavaScript. Moving it to TypeScript eliminates the native round-trip for each session export during search.
 
 ## New File
 
@@ -21,8 +21,6 @@ All of this is string processing that runs fine in JavaScript. Moving it to Type
 ```typescript
 /**
  * Search session message content via exported Goose sessions.
- *
- * Ported from src-tauri/src/services/acp/search.rs
  */
 import { exportSession } from "@/shared/api/acpSessionManager"; // from Step 05
 
@@ -38,11 +36,11 @@ export interface SessionSearchResult {
 }
 ```
 
-## Functions to Port
+## Functions
 
 ### 1. `searchSessionsViaExports`
 
-The top-level function that iterates over session IDs, exports each, and searches:
+Top-level function that iterates over session IDs, exports each, and searches:
 
 ```typescript
 export async function searchSessionsViaExports(
@@ -261,7 +259,7 @@ function extractSearchableBlockText(value: unknown, role: string | null): string
 }
 ```
 
-### 6. Helper functions
+### 6. Helper Functions
 
 ```typescript
 function normalizeRole(role: string | undefined): string | null {
@@ -315,15 +313,12 @@ function buildSnippet(text: string, query: string): string {
 }
 ```
 
-## Tests to Port
+## Tests
 
-Port the tests from `search.rs` `mod tests`:
+### `src/features/sessions/lib/__tests__/sessionContentSearch.test.ts`
 
 ```typescript
-// src/features/sessions/lib/__tests__/sessionContentSearch.test.ts
-
 import { describe, it, expect } from "vitest";
-// Import the internal functions (may need to export them for testing)
 
 describe("sessionContentSearch", () => {
   it("finds user and assistant text matches", () => { /* ... */ });
@@ -331,7 +326,6 @@ describe("sessionContentSearch", () => {
   it("skips tool and reasoning content", () => { /* ... */ });
   it("counts multiple matches in one session", () => { /* ... */ });
   it("builds trimmed snippets around first match", () => { /* ... */ });
-  // ... port all tests from search.rs
 });
 ```
 
@@ -343,7 +337,7 @@ The existing `useSessionSearch` hook calls `acpSearchSessions()` from `@/shared/
 
 1. `pnpm typecheck` passes.
 2. `pnpm check` passes.
-3. `pnpm test` — all ported search tests pass.
+3. `pnpm test` — all search tests pass.
 
 ## Files Created
 
@@ -358,6 +352,6 @@ The existing `useSessionSearch` hook calls `acpSearchSessions()` from `@/shared/
 
 ## Notes
 
-- The Rust `build_snippet` uses byte-level `floor_char_boundary` / `ceil_char_boundary` for UTF-8 safety. In JavaScript, `String.substring()` operates on UTF-16 code units and is already safe for slicing. The snippet boundaries may differ slightly from the Rust version for multi-byte characters, but this is cosmetic.
-- The Rust search is sequential (one session at a time). The TS version could parallelize with `Promise.all` for better performance, but sequential is simpler and matches the Rust behavior. Consider parallelizing later if search is slow.
-- The `exportSession` call goes through the ACP client to `goose serve`, which reads from its database. This is the same path as the Rust code — no change in data source.
+- In JavaScript, `String.substring()` operates on UTF-16 code units and is already safe for slicing. Snippet boundaries may differ slightly for multi-byte characters, but this is cosmetic.
+- The search is sequential (one session at a time). Parallelization via `Promise.all` is a future optimization if search latency becomes a problem.
+- The `exportSession` call goes through the ACP client to `goose serve`, which reads from its database. There is no change in data source.

--- a/ui/goose2/acp-plus-migration-plan/07-rewire-shared-api-acp.md
+++ b/ui/goose2/acp-plus-migration-plan/07-rewire-shared-api-acp.md
@@ -1,0 +1,248 @@
+# Step 07: Rewire `src/shared/api/acp.ts` to Use the TypeScript ACP Client
+
+## Objective
+
+Replace all `invoke()` calls in `src/shared/api/acp.ts` with calls to the new TypeScript ACP session manager (Step 05) and search module (Step 06). Keep the same public API signatures so consumers don't need to change.
+
+## Why
+
+`src/shared/api/acp.ts` is the single import point for all ACP operations in the frontend. Currently every function calls `invoke("acp_*")` which goes through Tauri IPC → Rust → WebSocket → goose serve. After this step, they call the TypeScript session manager which goes directly through HTTP+SSE → goose serve.
+
+## Changes
+
+### `src/shared/api/acp.ts`
+
+Replace the entire file contents. The public API (function names, parameter types, return types) stays the same. Only the implementation changes.
+
+**Before (current):**
+```typescript
+import { invoke } from "@tauri-apps/api/core";
+
+export async function discoverAcpProviders(): Promise<AcpProvider[]> {
+  return invoke("discover_acp_providers");
+}
+
+export async function acpSendMessage(sessionId, providerId, prompt, options): Promise<void> {
+  return invoke("acp_send_message", { ... });
+}
+// ... etc
+```
+
+**After:**
+```typescript
+import {
+  listProviders,
+  sendPrompt,
+  prepareSession,
+  setModel,
+  cancelSession,
+  listSessions,
+  loadSession,
+  exportSession,
+  importSession,
+  forkSession,
+  listRunning,
+  cancelAll,
+} from "./acpSessionManager";
+import { searchSessionsViaExports } from "@/features/sessions/lib/sessionContentSearch";
+
+// Re-export types (unchanged)
+export type { AcpProvider, AcpSessionInfo, AcpRunningSession } from "./acpSessionManager";
+export type { SessionSearchResult as AcpSessionSearchResult } from "@/features/sessions/lib/sessionContentSearch";
+```
+
+### Function-by-function rewiring
+
+#### `discoverAcpProviders`
+
+```typescript
+export async function discoverAcpProviders(): Promise<AcpProvider[]> {
+  return listProviders();
+}
+```
+
+#### `acpSendMessage`
+
+```typescript
+export async function acpSendMessage(
+  sessionId: string,
+  providerId: string,
+  prompt: string,
+  options: AcpSendMessageOptions = {},
+): Promise<void> {
+  return sendPrompt(sessionId, providerId, prompt, {
+    workingDir: options.workingDir,
+    systemPrompt: options.systemPrompt,
+    personaId: options.personaId,
+    personaName: options.personaName,
+    images: options.images,
+  });
+}
+```
+
+#### `acpPrepareSession`
+
+```typescript
+export async function acpPrepareSession(
+  sessionId: string,
+  providerId: string,
+  options: AcpPrepareSessionOptions = {},
+): Promise<void> {
+  const { makeCompositeKey } = await import("./acpSessionManager");
+  const compositeKey = makeCompositeKey(sessionId, options.personaId);
+  const workingDir = options.workingDir ?? "~/.goose/artifacts";
+  await prepareSession(compositeKey, sessionId, providerId, workingDir);
+}
+```
+
+#### `acpSetModel`
+
+```typescript
+export async function acpSetModel(
+  sessionId: string,
+  modelId: string,
+): Promise<void> {
+  return setModel(sessionId, modelId);
+}
+```
+
+#### `acpListSessions`
+
+```typescript
+export async function acpListSessions(): Promise<AcpSessionInfo[]> {
+  return listSessions();
+}
+```
+
+#### `acpSearchSessions`
+
+```typescript
+export async function acpSearchSessions(
+  query: string,
+  sessionIds: string[],
+): Promise<AcpSessionSearchResult[]> {
+  return searchSessionsViaExports(query, sessionIds);
+}
+```
+
+#### `acpLoadSession`
+
+```typescript
+export async function acpLoadSession(
+  sessionId: string,
+  gooseSessionId: string,
+  workingDir?: string,
+): Promise<void> {
+  return loadSession(sessionId, gooseSessionId, workingDir ?? "~/.goose/artifacts");
+}
+```
+
+#### `acpExportSession`
+
+```typescript
+export async function acpExportSession(sessionId: string): Promise<string> {
+  return exportSession(sessionId);
+}
+```
+
+#### `acpImportSession`
+
+```typescript
+export async function acpImportSession(json: string): Promise<AcpSessionInfo> {
+  return importSession(json);
+}
+```
+
+#### `acpDuplicateSession`
+
+```typescript
+export async function acpDuplicateSession(sessionId: string): Promise<AcpSessionInfo> {
+  return forkSession(sessionId);
+}
+```
+
+#### `acpCancelSession`
+
+```typescript
+export async function acpCancelSession(
+  sessionId: string,
+  personaId?: string,
+): Promise<boolean> {
+  return cancelSession(sessionId, personaId);
+}
+```
+
+### Keep the interface types
+
+The `AcpSendMessageOptions`, `AcpPrepareSessionOptions`, `AcpSessionInfo`, `AcpSessionSearchResult`, `AcpProvider` interfaces should remain exported from this file (or re-exported from the session manager). Consumers import them from `@/shared/api/acp`.
+
+If the types are now defined in `acpSessionManager.ts` or `sessionContentSearch.ts`, re-export them:
+
+```typescript
+export type { AcpProvider, AcpSessionInfo } from "./acpSessionManager";
+export type { SessionSearchResult as AcpSessionSearchResult } from "@/features/sessions/lib/sessionContentSearch";
+
+// Keep these interfaces here since they're specific to this API surface
+export interface AcpSendMessageOptions {
+  systemPrompt?: string;
+  workingDir?: string;
+  personaId?: string;
+  personaName?: string;
+  images?: [string, string][];
+}
+
+export interface AcpPrepareSessionOptions {
+  workingDir?: string;
+  personaId?: string;
+}
+```
+
+### Update `src/shared/api/index.ts`
+
+No changes needed — it already re-exports from `./acp`:
+
+```typescript
+export * from "./acp";
+```
+
+## Consumers That Import from `@/shared/api/acp`
+
+Verify these files still work without changes (they should, since the public API is unchanged):
+
+| File | Imports Used |
+|------|-------------|
+| `src/features/chat/hooks/useChat.ts` | `acpSendMessage`, `acpCancelSession`, `acpPrepareSession`, `acpSetModel` |
+| `src/features/chat/stores/chatSessionStore.ts` | `acpListSessions`, `AcpSessionInfo` |
+| `src/features/sessions/hooks/useSessionSearch.ts` | `acpSearchSessions` |
+| `src/features/sessions/lib/buildSessionSearchResults.ts` | `AcpSessionSearchResult` |
+| `src/app/AppShell.tsx` | `acpPrepareSession`, `acpLoadSession` |
+| `src/app/hooks/useAppStartup.ts` | `discoverAcpProviders` |
+
+## Remove `invoke` Import
+
+The file should no longer import from `@tauri-apps/api/core` since all `invoke()` calls are replaced.
+
+## Verification
+
+1. `pnpm typecheck` passes — all consumers still type-check against the same API.
+2. `pnpm check` passes.
+3. `pnpm test` passes — existing tests that mock `invoke()` may need updating. Check `src/features/chat/hooks/__tests__/useAcpStream.test.ts` and `src/features/chat/hooks/__tests__/useChat.test.ts`.
+4. Manual testing: start the app, verify sessions load, messages send, search works.
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/shared/api/acp.ts` | Replace all `invoke()` calls with session manager / search calls |
+
+## Dependencies
+
+- Step 05 (`acpSessionManager.ts` — all session operations)
+- Step 06 (`sessionContentSearch.ts` — search)
+
+## Notes
+
+- This is the "flip the switch" step. After this, the frontend no longer calls any `acp_*` Tauri commands (except `get_goose_serve_url` which is called by `acpConnection.ts`).
+- The old Rust ACP commands still exist and are registered but are no longer called. They'll be removed in Step 09.
+- If you want a gradual rollout, you could add a feature flag that switches between the old `invoke()` path and the new direct path. But since the public API is identical, it's simpler to just swap.
+- The `@tauri-apps/api/core` import can be removed from this file entirely. Other files (agents, git, system, etc.) still use `invoke()` for non-ACP commands.

--- a/ui/goose2/acp-plus-migration-plan/07-rewire-shared-api-acp.md
+++ b/ui/goose2/acp-plus-migration-plan/07-rewire-shared-api-acp.md
@@ -6,7 +6,7 @@ Replace all `invoke()` calls in `src/shared/api/acp.ts` with calls to the new Ty
 
 ## Why
 
-`src/shared/api/acp.ts` is the single import point for all ACP operations in the frontend. Currently every function calls `invoke("acp_*")` which goes through Tauri IPC → Rust → WebSocket → goose serve. After this step, they call the TypeScript session manager which goes directly through HTTP+SSE → goose serve.
+`src/shared/api/acp.ts` is the single import point for all ACP operations in the frontend. Currently every function calls `invoke("acp_*")` which goes through Tauri IPC → Rust → WebSocket → goose serve. After this step, they call the TypeScript session manager which goes directly through WebSocket → goose serve.
 
 ## Changes
 

--- a/ui/goose2/acp-plus-migration-plan/07-rewire-shared-api-acp.md
+++ b/ui/goose2/acp-plus-migration-plan/07-rewire-shared-api-acp.md
@@ -2,11 +2,11 @@
 
 ## Objective
 
-Replace all `invoke()` calls in `src/shared/api/acp.ts` with calls to the new TypeScript ACP session manager (Step 05) and search module (Step 06). Keep the same public API signatures so consumers don't need to change.
+Replace all `invoke()` calls in `src/shared/api/acp.ts` with calls to the TypeScript ACP session manager (Step 05) and search module (Step 06). Keep the same public API signatures so consumers don't need to change.
 
 ## Why
 
-`src/shared/api/acp.ts` is the single import point for all ACP operations in the frontend. Currently every function calls `invoke("acp_*")` which goes through Tauri IPC → Rust → WebSocket → goose serve. After this step, they call the TypeScript session manager which goes directly through WebSocket → goose serve.
+`src/shared/api/acp.ts` is the single import point for all ACP operations in the frontend. Currently every function calls `invoke("acp_*")`, which goes through Tauri IPC → Rust → WebSocket → goose serve. After this step, they call the TypeScript session manager, which goes directly through WebSocket → goose serve.
 
 ## Changes
 
@@ -172,17 +172,14 @@ export async function acpCancelSession(
 }
 ```
 
-### Keep the interface types
+### Interface types
 
-The `AcpSendMessageOptions`, `AcpPrepareSessionOptions`, `AcpSessionInfo`, `AcpSessionSearchResult`, `AcpProvider` interfaces should remain exported from this file (or re-exported from the session manager). Consumers import them from `@/shared/api/acp`.
-
-If the types are now defined in `acpSessionManager.ts` or `sessionContentSearch.ts`, re-export them:
+`AcpSendMessageOptions` and `AcpPrepareSessionOptions` remain defined in this file since they are specific to this API surface. Types originating from the session manager and search module are re-exported:
 
 ```typescript
 export type { AcpProvider, AcpSessionInfo } from "./acpSessionManager";
 export type { SessionSearchResult as AcpSessionSearchResult } from "@/features/sessions/lib/sessionContentSearch";
 
-// Keep these interfaces here since they're specific to this API surface
 export interface AcpSendMessageOptions {
   systemPrompt?: string;
   workingDir?: string;
@@ -197,7 +194,7 @@ export interface AcpPrepareSessionOptions {
 }
 ```
 
-### Update `src/shared/api/index.ts`
+### `src/shared/api/index.ts`
 
 No changes needed — it already re-exports from `./acp`:
 
@@ -205,9 +202,9 @@ No changes needed — it already re-exports from `./acp`:
 export * from "./acp";
 ```
 
-## Consumers That Import from `@/shared/api/acp`
+## Consumers
 
-Verify these files still work without changes (they should, since the public API is unchanged):
+These files import from `@/shared/api/acp` and require no changes since the public API is unchanged:
 
 | File | Imports Used |
 |------|-------------|
@@ -220,14 +217,14 @@ Verify these files still work without changes (they should, since the public API
 
 ## Remove `invoke` Import
 
-The file should no longer import from `@tauri-apps/api/core` since all `invoke()` calls are replaced.
+The file no longer imports from `@tauri-apps/api/core`. Other files (agents, git, system, etc.) still use `invoke()` for non-ACP commands.
 
 ## Verification
 
-1. `pnpm typecheck` passes — all consumers still type-check against the same API.
+1. `pnpm typecheck` passes — all consumers type-check against the same API.
 2. `pnpm check` passes.
-3. `pnpm test` passes — existing tests that mock `invoke()` may need updating. Check `src/features/chat/hooks/__tests__/useAcpStream.test.ts` and `src/features/chat/hooks/__tests__/useChat.test.ts`.
-4. Manual testing: start the app, verify sessions load, messages send, search works.
+3. `pnpm test` passes — existing tests that mock `invoke()` need updating (check `src/features/chat/hooks/__tests__/useAcpStream.test.ts` and `src/features/chat/hooks/__tests__/useChat.test.ts`).
+4. Manual testing: start the app, confirm sessions load, messages send, and search works.
 
 ## Files Modified
 
@@ -242,7 +239,6 @@ The file should no longer import from `@tauri-apps/api/core` since all `invoke()
 
 ## Notes
 
-- This is the "flip the switch" step. After this, the frontend no longer calls any `acp_*` Tauri commands (except `get_goose_serve_url` which is called by `acpConnection.ts`).
-- The old Rust ACP commands still exist and are registered but are no longer called. They'll be removed in Step 09.
-- If you want a gradual rollout, you could add a feature flag that switches between the old `invoke()` path and the new direct path. But since the public API is identical, it's simpler to just swap.
-- The `@tauri-apps/api/core` import can be removed from this file entirely. Other files (agents, git, system, etc.) still use `invoke()` for non-ACP commands.
+- After this step, the frontend no longer calls any `acp_*` Tauri commands. The only remaining Tauri invoke for ACP infrastructure is `get_goose_serve_url`, called by `acpConnection.ts`.
+- The old Rust ACP commands still exist and are registered but are no longer called. They are removed in Step 09.
+- The `@tauri-apps/api/core` import is removed from this file entirely.

--- a/ui/goose2/acp-plus-migration-plan/07-rewire-shared-api-acp.md
+++ b/ui/goose2/acp-plus-migration-plan/07-rewire-shared-api-acp.md
@@ -2,54 +2,43 @@
 
 ## Objective
 
-Replace all `invoke()` calls in `src/shared/api/acp.ts` with calls to the TypeScript ACP session manager (Step 05) and search module (Step 06). Keep the same public API signatures so consumers don't need to change.
+Replace all `invoke()` calls in `src/shared/api/acp.ts` with calls to the TypeScript ACP session manager (Step 05) and search module (Step 06). Keep the same public API signatures so consumers don't need to change. Use the feature flag from Step 03 to route between old and new paths.
 
 ## Why
 
 `src/shared/api/acp.ts` is the single import point for all ACP operations in the frontend. Currently every function calls `invoke("acp_*")`, which goes through Tauri IPC → Rust → WebSocket → goose serve. After this step, they call the TypeScript session manager, which goes directly through WebSocket → goose serve.
 
+The feature flag (`useDirectAcp`) allows both paths to coexist. This means:
+- The swap is gradual and reversible
+- We can test the new path per-user without affecting everyone
+- Instant rollback by flipping the flag
+
 ## Changes
 
 ### `src/shared/api/acp.ts`
 
-Replace the entire file contents. The public API (function names, parameter types, return types) stays the same. Only the implementation changes.
+Keep the existing `invoke()` implementations. Add the new direct-ACP implementations alongside them. Route via the feature flag.
 
-**Before (current):**
+**Pattern:**
 ```typescript
 import { invoke } from "@tauri-apps/api/core";
+import { useDirectAcp } from "./acpFeatureFlag";
+
+// Lazy imports to avoid loading the new modules when flag is off
+async function getSessionManager() {
+  return import("./acpSessionManager");
+}
 
 export async function discoverAcpProviders(): Promise<AcpProvider[]> {
+  if (useDirectAcp()) {
+    const { listProviders } = await getSessionManager();
+    return listProviders();
+  }
   return invoke("discover_acp_providers");
 }
-
-export async function acpSendMessage(sessionId, providerId, prompt, options): Promise<void> {
-  return invoke("acp_send_message", { ... });
-}
-// ... etc
 ```
 
-**After:**
-```typescript
-import {
-  listProviders,
-  sendPrompt,
-  prepareSession,
-  setModel,
-  cancelSession,
-  listSessions,
-  loadSession,
-  exportSession,
-  importSession,
-  forkSession,
-  listRunning,
-  cancelAll,
-} from "./acpSessionManager";
-import { searchSessionsViaExports } from "@/features/sessions/lib/sessionContentSearch";
-
-// Re-export types (unchanged)
-export type { AcpProvider, AcpSessionInfo, AcpRunningSession } from "./acpSessionManager";
-export type { SessionSearchResult as AcpSessionSearchResult } from "@/features/sessions/lib/sessionContentSearch";
-```
+Once validated, a follow-up removes the `invoke()` branches and the feature flag (Step 09).
 
 ### Function-by-function rewiring
 
@@ -57,7 +46,11 @@ export type { SessionSearchResult as AcpSessionSearchResult } from "@/features/s
 
 ```typescript
 export async function discoverAcpProviders(): Promise<AcpProvider[]> {
-  return listProviders();
+  if (useDirectAcp()) {
+    const { listProviders } = await getSessionManager();
+    return listProviders();
+  }
+  return invoke("discover_acp_providers");
 }
 ```
 

--- a/ui/goose2/acp-plus-migration-plan/08-rewire-hooks.md
+++ b/ui/goose2/acp-plus-migration-plan/08-rewire-hooks.md
@@ -1,0 +1,259 @@
+# Step 08: Remove `useAcpStream`, Update Hooks and App Initialization
+
+## Objective
+
+Remove the `useAcpStream` hook (which listens to Tauri events) since the notification handler (Step 04) now updates stores directly. Update app initialization to set up the new ACP connection and notification handler. Update `useChat` and `AppShell` to use the new code paths.
+
+## Why
+
+With the notification handler updating Zustand stores directly from ACP callbacks, the Tauri event bus is no longer in the loop. The `useAcpStream` hook — which listens to `acp:text`, `acp:done`, `acp:tool_call`, etc. — is now dead code.
+
+## Changes
+
+### 1. Remove `useAcpStream` from `AppShell`
+
+**File:** `src/app/AppShell.tsx`
+
+Remove the import and call:
+
+```diff
+- import { useAcpStream } from "@/features/chat/hooks/useAcpStream";
+
+  // Inside the component:
+- useAcpStream(true);
+```
+
+### 2. Initialize the ACP connection and notification handler on startup
+
+**File:** `src/app/hooks/useAppStartup.ts`
+
+Add ACP initialization as the first step. The notification handler must be registered before any ACP calls are made (so that session notifications from `loadSessions` are handled).
+
+```typescript
+import { useEffect } from "react";
+import { useAgentStore } from "@/features/agents/stores/agentStore";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+
+export function useAppStartup() {
+  useEffect(() => {
+    (async () => {
+      // Step 1: Initialize ACP connection and notification handler.
+      // This must happen before any ACP calls.
+      try {
+        const { getClient, setNotificationHandler } = await import(
+          "@/shared/api/acpConnection"
+        );
+        const notificationHandler = await import(
+          "@/shared/api/acpNotificationHandler"
+        );
+        setNotificationHandler(notificationHandler);
+
+        // Trigger connection initialization (fetches URL, creates client, handshake).
+        // This blocks until goose serve is ready.
+        await getClient();
+      } catch (err) {
+        console.error("Failed to initialize ACP connection:", err);
+        // The app can still show the UI, but ACP operations will fail.
+        // Individual operations will retry getClient() and show errors.
+      }
+
+      // Step 2: Load data in parallel (same as before, but now using the TS ACP client)
+      const store = useAgentStore.getState();
+
+      const loadPersonas = async () => {
+        store.setPersonasLoading(true);
+        try {
+          const { listPersonas } = await import("@/shared/api/agents");
+          const personas = await listPersonas();
+          store.setPersonas(personas);
+        } catch (err) {
+          console.error("Failed to load personas on startup:", err);
+        } finally {
+          store.setPersonasLoading(false);
+        }
+      };
+
+      const loadProviders = async () => {
+        store.setProvidersLoading(true);
+        try {
+          const { discoverAcpProviders } = await import("@/shared/api/acp");
+          const providers = await discoverAcpProviders();
+          store.setProviders(providers);
+        } catch (err) {
+          console.error("Failed to load ACP providers on startup:", err);
+        } finally {
+          store.setProvidersLoading(false);
+        }
+      };
+
+      const loadSessionState = async () => {
+        const t0 = performance.now();
+        console.log("[perf:startup] loadSessionState start");
+        const { loadSessions, setActiveSession } =
+          useChatSessionStore.getState();
+        await loadSessions();
+        console.log(
+          `[perf:startup] loadSessions done in ${(performance.now() - t0).toFixed(1)}ms`,
+        );
+        setActiveSession(null);
+      };
+
+      await Promise.allSettled([
+        loadPersonas(),
+        loadProviders(),
+        loadSessionState(),
+      ]);
+    })();
+  }, []);
+}
+```
+
+### 3. Update `AppShell.loadSessionMessages`
+
+**File:** `src/app/AppShell.tsx`
+
+The `loadSessionMessages` callback currently dynamically imports `acpLoadSession` from `@/shared/api/acp`. This still works because Step 07 rewired that function. **No changes needed** to this callback — it already calls `acpLoadSession()` which now goes through the TS session manager.
+
+However, verify the import path is correct:
+
+```typescript
+const { acpLoadSession } = await import("@/shared/api/acp");
+```
+
+This should still work since `acpLoadSession` is still exported from `@/shared/api/acp` (Step 07 kept the same exports).
+
+### 4. Update `useChat` — no changes needed
+
+**File:** `src/features/chat/hooks/useChat.ts`
+
+This hook imports `acpSendMessage`, `acpCancelSession`, `acpPrepareSession`, `acpSetModel` from `@/shared/api/acp`. Since Step 07 kept the same API, **no changes are needed** in this file.
+
+Verify the imports still resolve:
+```typescript
+import {
+  acpSendMessage,
+  acpCancelSession,
+  acpPrepareSession,
+  acpSetModel,
+} from "@/shared/api/acp";
+```
+
+### 5. Handle app shutdown
+
+**File:** `src/app/AppShell.tsx` or `src/app/App.tsx`
+
+Add cleanup on window close to cancel running sessions:
+
+```typescript
+import { useEffect } from "react";
+
+useEffect(() => {
+  const handleBeforeUnload = () => {
+    // Best-effort cancel all running sessions
+    import("@/shared/api/acpSessionManager").then(({ cancelAll }) => {
+      cancelAll();
+    }).catch(() => {});
+  };
+
+  window.addEventListener("beforeunload", handleBeforeUnload);
+  return () => window.removeEventListener("beforeunload", handleBeforeUnload);
+}, []);
+```
+
+The Rust backend also cancels all sessions on `RunEvent::Exit` via `acp_registry_for_exit.cancel_all()`. After migration, the Rust registry is empty (no sessions are registered there), so the Rust cleanup is a no-op. The TS cleanup above replaces it.
+
+### 6. Delete or deprecate old files
+
+These files are no longer needed after this step:
+
+**Delete:**
+- `src/features/chat/hooks/useAcpStream.ts` — replaced by `acpNotificationHandler.ts`
+- `src/features/chat/hooks/acpStreamTypes.ts` — types are now in the notification handler or imported from the SDK
+- `src/features/chat/hooks/replayBuffer.ts` — logic moved into the notification handler
+
+**Keep but verify:**
+- `src/features/chat/hooks/useSSE.ts` — check if anything else uses it. If it was only used by `useAcpStream`, delete it.
+
+### 7. Update test files
+
+**Files to update or delete:**
+- `src/features/chat/hooks/__tests__/useAcpStream.test.ts` — **Delete** (the hook no longer exists)
+- `src/features/chat/hooks/__tests__/useChat.test.ts` — **Update** if it mocks `invoke()` for ACP commands. The mocks should now target the session manager functions instead.
+
+For `useChat.test.ts`, if it currently mocks like:
+```typescript
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+```
+
+It should instead mock:
+```typescript
+vi.mock("@/shared/api/acp", () => ({
+  acpSendMessage: vi.fn().mockResolvedValue(undefined),
+  acpPrepareSession: vi.fn().mockResolvedValue(undefined),
+  acpSetModel: vi.fn().mockResolvedValue(undefined),
+  acpCancelSession: vi.fn().mockResolvedValue(true),
+}));
+```
+
+This may already be the case if the tests mock at the `@/shared/api/acp` level rather than `invoke()` directly.
+
+### 8. Remove Tauri event listener cleanup
+
+The `useAcpStream` hook registered listeners for `acp:text`, `acp:done`, `acp:tool_call`, `acp:tool_title`, `acp:tool_result`, `acp:message_created`, `acp:session_info`, `acp:session_bound`, `acp:model_state`, `acp:usage_update`, `acp:replay_complete`, `acp:replay_user_message`. These are all gone now.
+
+No other code should be listening to these events. Verify with a search:
+
+```bash
+cd ui/goose2/src
+rg "acp:" --include="*.ts" --include="*.tsx" | grep -v "__tests__" | grep -v "node_modules"
+```
+
+After this step, the only `acp:` references should be in test files (which should be updated/deleted) and possibly in the notification handler (which doesn't use Tauri events).
+
+## Verification
+
+1. `pnpm typecheck` passes.
+2. `pnpm check` passes.
+3. `pnpm test` passes (after updating/deleting affected tests).
+4. Manual testing:
+   - App starts and shows the home screen
+   - Session list loads
+   - Creating a new chat and sending a message works
+   - Streaming text appears in real-time
+   - Tool calls display correctly
+   - Cancelling a running session works
+   - Loading a historical session replays messages
+   - Session search returns results
+   - Model switching works
+   - Session export/import/duplicate works
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src/app/AppShell.tsx` | Remove `useAcpStream(true)`, add shutdown cleanup |
+| `src/app/hooks/useAppStartup.ts` | Add ACP connection + notification handler initialization |
+
+## Files Deleted
+
+| File | Reason |
+|------|--------|
+| `src/features/chat/hooks/useAcpStream.ts` | Replaced by `acpNotificationHandler.ts` |
+| `src/features/chat/hooks/acpStreamTypes.ts` | Types moved to notification handler |
+| `src/features/chat/hooks/replayBuffer.ts` | Logic moved to notification handler |
+| `src/features/chat/hooks/__tests__/useAcpStream.test.ts` | Hook deleted |
+
+## Dependencies
+
+- Step 03 (`acpConnection.ts`)
+- Step 04 (`acpNotificationHandler.ts`)
+- Step 07 (rewired `acp.ts`)
+
+## Notes
+
+- The `useAcpStream` hook was the **only** consumer of the `acp:*` Tauri events. Once it's removed, no frontend code listens to those events. The Rust backend will still emit them (until Step 09 removes the Rust code), but they'll go nowhere — this is harmless.
+- The `useChat` hook's `sendMessage` function currently sets `chatState` to `"thinking"` before calling `acpPrepareSession`, then to `"streaming"` before `acpSendMessage`. This flow is unchanged — the session manager handles the ACP calls, and the notification handler updates the store as streaming events arrive.
+- The `stopGeneration` function in `useChat` calls `acpCancelSession` — this now goes through the TS session manager which calls `client.cancel()` directly.
+- The `loadSessionMessages` callback in `AppShell` sets `store.setSessionLoading(sessionId, true)` before calling `acpLoadSession`. The notification handler's replay logic checks `loadingSessionIds` to decide whether to buffer. This flow is preserved — the notification handler reads from `useChatStore.getState().loadingSessionIds` just like `useAcpStream` did.

--- a/ui/goose2/acp-plus-migration-plan/08-rewire-hooks.md
+++ b/ui/goose2/acp-plus-migration-plan/08-rewire-hooks.md
@@ -2,7 +2,7 @@
 
 ## Objective
 
-Remove the `useAcpStream` hook (which listens to Tauri events) since the notification handler (Step 04) now updates stores directly. Update app initialization to set up the new ACP connection and notification handler. Update `useChat` and `AppShell` to use the new code paths.
+Remove the `useAcpStream` hook (which listens to Tauri events) since the notification handler (Step 04) now updates stores directly. Update app initialization to set up the new ACP connection and notification handler. Update `AppShell` to use the new code paths.
 
 ## Why
 
@@ -27,7 +27,7 @@ Remove the import and call:
 
 **File:** `src/app/hooks/useAppStartup.ts`
 
-Add ACP initialization as the first step. The notification handler must be registered before any ACP calls are made (so that session notifications from `loadSessions` are handled).
+Add ACP initialization as the first step. The notification handler must be registered before any ACP calls so that session notifications from `loadSessions` are handled.
 
 ```typescript
 import { useEffect } from "react";
@@ -108,27 +108,22 @@ export function useAppStartup() {
 }
 ```
 
-### 3. Update `AppShell.loadSessionMessages`
+### 3. `AppShell.loadSessionMessages` — no changes needed
 
 **File:** `src/app/AppShell.tsx`
 
-The `loadSessionMessages` callback currently dynamically imports `acpLoadSession` from `@/shared/api/acp`. This still works because Step 07 rewired that function. **No changes needed** to this callback — it already calls `acpLoadSession()` which now goes through the TS session manager.
-
-However, verify the import path is correct:
+The `loadSessionMessages` callback dynamically imports `acpLoadSession` from `@/shared/api/acp`. This still works because Step 07 rewired that function to go through the TS session manager.
 
 ```typescript
 const { acpLoadSession } = await import("@/shared/api/acp");
 ```
 
-This should still work since `acpLoadSession` is still exported from `@/shared/api/acp` (Step 07 kept the same exports).
-
-### 4. Update `useChat` — no changes needed
+### 4. `useChat` — no changes needed
 
 **File:** `src/features/chat/hooks/useChat.ts`
 
-This hook imports `acpSendMessage`, `acpCancelSession`, `acpPrepareSession`, `acpSetModel` from `@/shared/api/acp`. Since Step 07 kept the same API, **no changes are needed** in this file.
+This hook imports `acpSendMessage`, `acpCancelSession`, `acpPrepareSession`, `acpSetModel` from `@/shared/api/acp`. Step 07 kept the same API surface, so no changes are needed.
 
-Verify the imports still resolve:
 ```typescript
 import {
   acpSendMessage,
@@ -149,7 +144,6 @@ import { useEffect } from "react";
 
 useEffect(() => {
   const handleBeforeUnload = () => {
-    // Best-effort cancel all running sessions
     import("@/shared/api/acpSessionManager").then(({ cancelAll }) => {
       cancelAll();
     }).catch(() => {});
@@ -160,35 +154,34 @@ useEffect(() => {
 }, []);
 ```
 
-The Rust backend also cancels all sessions on `RunEvent::Exit` via `acp_registry_for_exit.cancel_all()`. After migration, the Rust registry is empty (no sessions are registered there), so the Rust cleanup is a no-op. The TS cleanup above replaces it.
+The Rust backend's `acp_registry_for_exit.cancel_all()` on `RunEvent::Exit` becomes a no-op after migration (no sessions are registered in the Rust registry). The TS cleanup above replaces it.
 
-### 6. Delete or deprecate old files
+### 6. Delete old files
 
-These files are no longer needed after this step:
+These files are no longer needed:
 
-**Delete:**
 - `src/features/chat/hooks/useAcpStream.ts` — replaced by `acpNotificationHandler.ts`
-- `src/features/chat/hooks/acpStreamTypes.ts` — types are now in the notification handler or imported from the SDK
+- `src/features/chat/hooks/acpStreamTypes.ts` — types moved to the notification handler / SDK imports
 - `src/features/chat/hooks/replayBuffer.ts` — logic moved into the notification handler
-
-**Keep but verify:**
-- `src/features/chat/hooks/useSSE.ts` — check if anything else uses it. If it was only used by `useAcpStream`, delete it.
+- `src/features/chat/hooks/useSSE.ts` — only consumer was `useAcpStream`
 
 ### 7. Update test files
 
-**Files to update or delete:**
-- `src/features/chat/hooks/__tests__/useAcpStream.test.ts` — **Delete** (the hook no longer exists)
-- `src/features/chat/hooks/__tests__/useChat.test.ts` — **Update** if it mocks `invoke()` for ACP commands. The mocks should now target the session manager functions instead.
+**Delete:**
+- `src/features/chat/hooks/__tests__/useAcpStream.test.ts` — the hook no longer exists
 
-For `useChat.test.ts`, if it currently mocks like:
+**Update:**
+- `src/features/chat/hooks/__tests__/useChat.test.ts` — mocks should target the session manager functions instead of `invoke()`.
+
+Replace any `invoke()`-level mocks:
+
 ```typescript
+// Before
 vi.mock("@tauri-apps/api/core", () => ({
   invoke: vi.fn(),
 }));
-```
 
-It should instead mock:
-```typescript
+// After
 vi.mock("@/shared/api/acp", () => ({
   acpSendMessage: vi.fn().mockResolvedValue(undefined),
   acpPrepareSession: vi.fn().mockResolvedValue(undefined),
@@ -197,20 +190,18 @@ vi.mock("@/shared/api/acp", () => ({
 }));
 ```
 
-This may already be the case if the tests mock at the `@/shared/api/acp` level rather than `invoke()` directly.
-
 ### 8. Remove Tauri event listener cleanup
 
-The `useAcpStream` hook registered listeners for `acp:text`, `acp:done`, `acp:tool_call`, `acp:tool_title`, `acp:tool_result`, `acp:message_created`, `acp:session_info`, `acp:session_bound`, `acp:model_state`, `acp:usage_update`, `acp:replay_complete`, `acp:replay_user_message`. These are all gone now.
+The `useAcpStream` hook registered listeners for `acp:text`, `acp:done`, `acp:tool_call`, `acp:tool_title`, `acp:tool_result`, `acp:message_created`, `acp:session_info`, `acp:session_bound`, `acp:model_state`, `acp:usage_update`, `acp:replay_complete`, `acp:replay_user_message`. All of these are gone now.
 
-No other code should be listening to these events. Verify with a search:
+Confirm no other code listens to these events:
 
 ```bash
 cd ui/goose2/src
 rg "acp:" --include="*.ts" --include="*.tsx" | grep -v "__tests__" | grep -v "node_modules"
 ```
 
-After this step, the only `acp:` references should be in test files (which should be updated/deleted) and possibly in the notification handler (which doesn't use Tauri events).
+After this step, the only `acp:` references should be in test files (updated/deleted above).
 
 ## Verification
 
@@ -243,6 +234,7 @@ After this step, the only `acp:` references should be in test files (which shoul
 | `src/features/chat/hooks/useAcpStream.ts` | Replaced by `acpNotificationHandler.ts` |
 | `src/features/chat/hooks/acpStreamTypes.ts` | Types moved to notification handler |
 | `src/features/chat/hooks/replayBuffer.ts` | Logic moved to notification handler |
+| `src/features/chat/hooks/useSSE.ts` | Only consumer was `useAcpStream` |
 | `src/features/chat/hooks/__tests__/useAcpStream.test.ts` | Hook deleted |
 
 ## Dependencies
@@ -253,7 +245,7 @@ After this step, the only `acp:` references should be in test files (which shoul
 
 ## Notes
 
-- The `useAcpStream` hook was the **only** consumer of the `acp:*` Tauri events. Once it's removed, no frontend code listens to those events. The Rust backend will still emit them (until Step 09 removes the Rust code), but they'll go nowhere — this is harmless.
-- The `useChat` hook's `sendMessage` function currently sets `chatState` to `"thinking"` before calling `acpPrepareSession`, then to `"streaming"` before `acpSendMessage`. This flow is unchanged — the session manager handles the ACP calls, and the notification handler updates the store as streaming events arrive.
-- The `stopGeneration` function in `useChat` calls `acpCancelSession` — this now goes through the TS session manager which calls `client.cancel()` directly.
-- The `loadSessionMessages` callback in `AppShell` sets `store.setSessionLoading(sessionId, true)` before calling `acpLoadSession`. The notification handler's replay logic checks `loadingSessionIds` to decide whether to buffer. This flow is preserved — the notification handler reads from `useChatStore.getState().loadingSessionIds` just like `useAcpStream` did.
+- `useAcpStream` was the only consumer of the `acp:*` Tauri events. Once removed, no frontend code listens to those events. The Rust backend still emits them until Step 09 removes the Rust code, but they go nowhere — this is harmless.
+- The `useChat` hook's `sendMessage` function sets `chatState` to `"thinking"` before `acpPrepareSession`, then `"streaming"` before `acpSendMessage`. This flow is unchanged — the session manager handles the ACP calls, and the notification handler updates the store as streaming events arrive.
+- The `stopGeneration` function in `useChat` calls `acpCancelSession`, which now goes through the TS session manager calling `client.cancel()` directly.
+- The `loadSessionMessages` callback in `AppShell` sets `store.setSessionLoading(sessionId, true)` before calling `acpLoadSession`. The notification handler's replay logic checks `loadingSessionIds` to decide whether to buffer. This flow is preserved — the notification handler reads from `useChatStore.getState().loadingSessionIds` just as `useAcpStream` did.

--- a/ui/goose2/acp-plus-migration-plan/09-delete-rust-acp-code.md
+++ b/ui/goose2/acp-plus-migration-plan/09-delete-rust-acp-code.md
@@ -1,0 +1,393 @@
+# Step 09: Delete the Rust ACP Middleware and Unused Dependencies
+
+## Objective
+
+Remove all Rust ACP protocol handling code that is no longer called by the frontend. This is the cleanup step — only do this after Steps 01–08 are working and tested.
+
+## Why
+
+After Steps 01–08, the frontend communicates directly with `goose serve` via HTTP+SSE. The Rust ACP middleware (WebSocket bridge, session dispatcher, message writer, session registry, search) is dead code. Removing it:
+
+- Eliminates ~3,500 lines of Rust
+- Removes 5–6 heavy crate dependencies
+- Reduces compile times
+- Simplifies the codebase
+
+## Changes
+
+### 1. Delete the ACP manager subtree
+
+**Delete these files entirely:**
+
+```
+src-tauri/src/services/acp/manager/
+  command_dispatch.rs
+  dispatcher.rs
+  dispatcher_tests.rs
+  session_ops.rs
+  session_ops/
+    prompt_ops.rs
+    tests.rs
+  thread.rs
+```
+
+**Delete these files:**
+
+```
+src-tauri/src/services/acp/manager.rs
+src-tauri/src/services/acp/writer.rs
+src-tauri/src/services/acp/payloads.rs
+src-tauri/src/services/acp/registry.rs
+src-tauri/src/services/acp/search.rs
+```
+
+### 2. Simplify `services/acp/mod.rs`
+
+**File:** `src-tauri/src/services/acp/mod.rs`
+
+Replace the entire file with:
+
+```rust
+pub(crate) mod goose_serve;
+
+pub(crate) use goose_serve::GooseServeProcess;
+```
+
+All the old re-exports (`GooseAcpManager`, `AcpSessionRegistry`, `TauriMessageWriter`, `search_sessions_via_exports`, `make_composite_key`, `split_composite_key`, `AcpService`, `AcpRunningSession`, `AcpSessionInfo`, `SessionSearchResult`) are removed.
+
+### 3. Simplify `commands/acp.rs`
+
+**File:** `src-tauri/src/commands/acp.rs`
+
+Replace the entire file with just the URL command:
+
+```rust
+use crate::services::acp::GooseServeProcess;
+
+/// Return the HTTP base URL of the running goose serve process.
+///
+/// This command blocks until the server is confirmed ready. The frontend
+/// uses this URL to establish a direct HTTP+SSE ACP connection.
+#[tauri::command]
+pub async fn get_goose_serve_url() -> Result<String, String> {
+    GooseServeProcess::start().await?;
+    let process = GooseServeProcess::get()?;
+    Ok(process.http_url())
+}
+```
+
+All other ACP commands are deleted:
+- `discover_acp_providers`
+- `acp_prepare_session`
+- `acp_set_model`
+- `acp_send_message`
+- `acp_cancel_session`
+- `acp_list_sessions`
+- `acp_search_sessions`
+- `acp_load_session`
+- `acp_list_running`
+- `acp_cancel_all`
+- `acp_export_session`
+- `acp_import_session`
+- `acp_duplicate_session`
+
+Also delete the helper functions that were only used by those commands:
+- `AcpProviderResponse` struct
+- `should_include_provider`
+- `default_artifacts_working_dir`
+- `expand_home_dir`
+- `resolve_working_dir`
+- The `#[cfg(test)] mod tests` block (the tests tested those helpers)
+
+### 4. Update `lib.rs`
+
+**File:** `src-tauri/src/lib.rs`
+
+Remove the `AcpSessionRegistry` from managed state and remove all old ACP command registrations.
+
+**Before:**
+```rust
+use std::sync::Arc;
+use services::acp::AcpSessionRegistry;
+
+// ...
+let acp_registry = Arc::new(AcpSessionRegistry::new());
+let acp_registry_for_exit = Arc::clone(&acp_registry);
+
+let builder = tauri::Builder::default()
+    // ...
+    .manage(acp_registry);
+
+// In invoke_handler:
+commands::acp::discover_acp_providers,
+commands::acp::acp_prepare_session,
+commands::acp::acp_set_model,
+commands::acp::acp_send_message,
+commands::acp::acp_cancel_session,
+commands::acp::acp_list_sessions,
+commands::acp::acp_search_sessions,
+commands::acp::acp_load_session,
+commands::acp::acp_list_running,
+commands::acp::acp_cancel_all,
+commands::acp::acp_export_session,
+commands::acp::acp_import_session,
+commands::acp::acp_duplicate_session,
+
+// In run closure:
+.run(move |_app, event| {
+    if let tauri::RunEvent::Exit = event {
+        acp_registry_for_exit.cancel_all();
+    }
+});
+```
+
+**After:**
+```rust
+// Remove: use std::sync::Arc;
+// Remove: use services::acp::AcpSessionRegistry;
+
+// Remove: let acp_registry = ...
+// Remove: let acp_registry_for_exit = ...
+
+let builder = tauri::Builder::default()
+    // ...
+    // Remove: .manage(acp_registry)
+    ;
+
+// In invoke_handler, replace all old ACP commands with just:
+commands::acp::get_goose_serve_url,
+
+// Simplify the run closure:
+.run(|_app, _event| {});
+```
+
+The `Arc` import can be removed if nothing else uses it. Check if `PersonaStore` or `GooseConfig` need it — they don't (they use `tauri::State` which handles the wrapping).
+
+### 5. Clean up `goose_serve.rs`
+
+**File:** `src-tauri/src/services/acp/goose_serve.rs`
+
+The file is mostly kept as-is. Make these changes:
+
+1. Add the `http_url()` method (from Step 01):
+```rust
+impl GooseServeProcess {
+    pub fn http_url(&self) -> String {
+        format!("http://{LOCALHOST}:{}", self.port)
+    }
+}
+```
+
+2. Remove the `WS_BRIDGE_BUFFER_BYTES` constant — it was only used by the WebSocket bridge in `thread.rs`:
+```rust
+// DELETE:
+pub(crate) const WS_BRIDGE_BUFFER_BYTES: usize = 64 * 1024;
+```
+
+3. The `resolve_goose_binary` function is still needed by `model_setup.rs` (which runs `goose configure`). Keep it exported as `pub(crate)`.
+
+### 6. Remove unused Cargo dependencies
+
+**File:** `src-tauri/Cargo.toml`
+
+Remove these dependencies that were only used by the deleted ACP code:
+
+```toml
+# DELETE these lines:
+agent-client-protocol = { version = "0.10.4", features = ["unstable_session_fork"] }
+acp-client = { git = "https://github.com/block/builderbot", rev = "db184d20cb48e0c90bbd3fea4a4a871fc9d8a6ad" }
+tokio-tungstenite = "0.21.0"
+async-trait = "0.1"
+```
+
+**Check before removing — these may still be used by remaining code:**
+
+- `futures = "0.3"` — check if any remaining code uses it. `goose_serve.rs` uses `futures::{SinkExt, StreamExt}` for the WebSocket readiness probe. After removing the WS probe... wait, the readiness probe in `wait_for_server_ready` uses `tokio-tungstenite` and `futures`. We need to replace the readiness check.
+
+**Replace the WebSocket readiness probe with an HTTP health check:**
+
+The `wait_for_server_ready` function currently connects via WebSocket to check if the server is up. Replace it with a simple HTTP GET to `/health`:
+
+```rust
+async fn wait_for_server_ready(base_url: &str, child: &mut Child) -> Result<(), String> {
+    let deadline = Instant::now() + GOOSE_SERVE_CONNECT_TIMEOUT;
+    let health_url = format!("{base_url}/health");
+
+    loop {
+        match reqwest::get(&health_url).await {
+            Ok(response) if response.status().is_success() => return Ok(()),
+            Ok(_) | Err(_) => {
+                if let Some(status) = child
+                    .try_wait()
+                    .map_err(|e| format!("Failed to poll goose serve process: {e}"))?
+                {
+                    return Err(format!(
+                        "Goose serve exited before becoming ready: {status}"
+                    ));
+                }
+
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "Timed out waiting for goose serve at {health_url}"
+                    ));
+                }
+
+                tokio::time::sleep(GOOSE_SERVE_CONNECT_RETRY_DELAY).await;
+            }
+        }
+    }
+}
+```
+
+Wait — adding `reqwest` is a new dependency. A simpler approach: use `tokio::net::TcpStream::connect` to check if the port is open:
+
+```rust
+async fn wait_for_server_ready(port: u16, child: &mut Child) -> Result<(), String> {
+    let deadline = Instant::now() + GOOSE_SERVE_CONNECT_TIMEOUT;
+    let addr = format!("{LOCALHOST}:{port}");
+
+    loop {
+        match tokio::net::TcpStream::connect(&addr).await {
+            Ok(_) => return Ok(()),
+            Err(_) => {
+                if let Some(status) = child
+                    .try_wait()
+                    .map_err(|e| format!("Failed to poll goose serve process: {e}"))?
+                {
+                    return Err(format!(
+                        "Goose serve exited before becoming ready: {status}"
+                    ));
+                }
+
+                if Instant::now() >= deadline {
+                    return Err(format!(
+                        "Timed out waiting for goose serve on port {port}"
+                    ));
+                }
+
+                tokio::time::sleep(GOOSE_SERVE_CONNECT_RETRY_DELAY).await;
+            }
+        }
+    }
+}
+```
+
+This only needs `tokio` (already a dependency). Update the `spawn` method to call `wait_for_server_ready(port, &mut child)` instead of `wait_for_server_ready(&ws_url, &mut child)`.
+
+With this change, `futures`, `tokio-tungstenite` can be removed.
+
+- `tokio-util = { version = "0.7", features = ["compat", "rt"] }` — check if anything else uses it. It was used by `thread.rs` for `TokioAsyncReadCompatExt`/`TokioAsyncWriteCompatExt`. If nothing else uses it, remove it.
+
+After all removals, the remaining dependencies should be:
+
+```toml
+[dependencies]
+tauri = { version = "2", features = ["protocol-asset"] }
+tauri-plugin-app-test-driver = { path = "plugins/app-test-driver" }
+tauri-plugin-opener = "2"
+tauri-plugin-dialog = ">=2,<2.7"
+tauri-plugin-window-state = "2"
+tauri-plugin-log = "2"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+dirs = "6.0.0"
+log = "0.4.29"
+tokio = { version = "1.50.0", features = ["full"] }
+uuid = { version = "1", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+serde_yaml = "0.9"
+etcetera = "0.8"
+ignore = "0.4.25"
+doctor = { git = "https://github.com/block/builderbot", rev = "8e1c3ec145edc0df5f04b4427cfd758378036862" }
+keyring = { ... } # platform-specific
+```
+
+Use `cargo remove` or edit `Cargo.toml` directly, then run `cargo check` to verify nothing breaks.
+
+### 7. Run full verification
+
+```bash
+cd ui/goose2/src-tauri
+
+# Format
+cargo fmt
+
+# Check compilation
+cargo check
+
+# Clippy
+cargo clippy --all-targets -- -D warnings
+
+# Run any remaining Rust tests
+cargo test
+```
+
+Then from the `ui/goose2` directory:
+
+```bash
+source ./bin/activate-hermit
+just check
+just test
+just tauri-check
+```
+
+## Summary of Deletions
+
+| Path | Lines | Purpose (was) |
+|------|-------|---------------|
+| `services/acp/manager/command_dispatch.rs` | ~258 | Command dispatch loop |
+| `services/acp/manager/dispatcher.rs` | ~532 | Session event dispatcher + Client trait impl |
+| `services/acp/manager/dispatcher_tests.rs` | ~28 | Dispatcher tests |
+| `services/acp/manager/session_ops.rs` | ~611 | Session prepare/load/cancel/set-model |
+| `services/acp/manager/session_ops/prompt_ops.rs` | ~(inline) | Send prompt logic |
+| `services/acp/manager/session_ops/tests.rs` | ~(inline) | Session ops tests |
+| `services/acp/manager/thread.rs` | ~169 | Manager thread + WebSocket bridge |
+| `services/acp/manager.rs` | ~308 | GooseAcpManager struct + ManagerCommand enum |
+| `services/acp/writer.rs` | ~156 | TauriMessageWriter |
+| `services/acp/payloads.rs` | ~106 | Tauri event payload structs |
+| `services/acp/registry.rs` | ~114 | AcpSessionRegistry |
+| `services/acp/search.rs` | ~467 | Session content search |
+| **Total** | **~2,749** | |
+
+Plus significant simplification of `commands/acp.rs` (~330 → ~15 lines) and `services/acp/mod.rs` (~147 → ~4 lines) and `lib.rs` (~114 → ~80 lines).
+
+## Cargo Dependencies Removed
+
+| Crate | Why it was needed |
+|-------|-------------------|
+| `agent-client-protocol` | Rust ACP client types (Agent, ClientSideConnection, etc.) |
+| `acp-client` | Agent discovery, MessageWriter trait |
+| `tokio-tungstenite` | WebSocket connection to goose serve |
+| `async-trait` | MessageWriter + Client trait impls |
+| `futures` | WebSocket stream splitting (SinkExt, StreamExt) |
+| `tokio-util` | Compat adapters for async read/write |
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `src-tauri/src/services/acp/mod.rs` | Simplified to just goose_serve re-export |
+| `src-tauri/src/services/acp/goose_serve.rs` | Add `http_url()`, remove WS constants, replace readiness probe |
+| `src-tauri/src/commands/acp.rs` | Replaced with single `get_goose_serve_url` command |
+| `src-tauri/src/lib.rs` | Remove AcpSessionRegistry, old ACP commands, simplify run closure |
+| `src-tauri/Cargo.toml` | Remove 6 dependencies |
+| `src-tauri/Cargo.lock` | Auto-updated |
+
+## Files Deleted
+
+All files listed in the "Summary of Deletions" table above.
+
+## Dependencies
+
+- Steps 01–08 must be working and tested before this cleanup step.
+
+## Notes
+
+- Run `cargo check` after each deletion batch to catch any remaining references.
+- The `doctor` crate dependency stays — it's used by `commands/doctor.rs` which is not part of this migration.
+- The `acp-client` crate was also used by `goose_serve.rs` for `acp_client::find_acp_agent_by_id("goose")` in binary resolution. Check if this import still exists. If so, you need an alternative way to find the goose binary. Options:
+  - Keep `acp-client` just for binary discovery (lightweight — only uses the `find_acp_agent_by_id` function)
+  - Inline the binary discovery logic (look for `goose` on PATH, check `GOOSE_BIN` env var)
+  - The `GOOSE_BIN` env var path is already handled. The `acp_client::find_acp_agent_by_id` fallback scans login shell PATH. You could replace it with a simple `which goose` equivalent.
+  
+  If keeping `acp-client` just for binary discovery is acceptable, that's the simplest path. Otherwise, port the discovery logic.

--- a/ui/goose2/acp-plus-migration-plan/09-delete-rust-acp-code.md
+++ b/ui/goose2/acp-plus-migration-plan/09-delete-rust-acp-code.md
@@ -6,7 +6,7 @@ Remove all Rust ACP protocol handling code that is no longer called by the front
 
 ## Why
 
-After Steps 01–08, the frontend communicates directly with `goose serve` via HTTP+SSE. The Rust ACP middleware (WebSocket bridge, session dispatcher, message writer, session registry, search) is dead code. Removing it:
+After Steps 01–08, the frontend communicates directly with `goose serve` via WebSocket. The Rust ACP middleware (WebSocket bridge, session dispatcher, message writer, session registry, search) is dead code. Removing it:
 
 - Eliminates ~3,500 lines of Rust
 - Removes 5–6 heavy crate dependencies
@@ -64,15 +64,15 @@ Replace the entire file with just the URL command:
 ```rust
 use crate::services::acp::GooseServeProcess;
 
-/// Return the HTTP base URL of the running goose serve process.
+/// Return the WebSocket URL of the running goose serve process.
 ///
 /// This command blocks until the server is confirmed ready. The frontend
-/// uses this URL to establish a direct HTTP+SSE ACP connection.
+/// uses this URL to establish a direct WebSocket ACP connection.
 #[tauri::command]
 pub async fn get_goose_serve_url() -> Result<String, String> {
     GooseServeProcess::start().await?;
     let process = GooseServeProcess::get()?;
-    Ok(process.http_url())
+    Ok(process.ws_url())
 }
 ```
 
@@ -169,14 +169,7 @@ The `Arc` import can be removed if nothing else uses it. Check if `PersonaStore`
 
 The file is mostly kept as-is. Make these changes:
 
-1. Add the `http_url()` method (from Step 01):
-```rust
-impl GooseServeProcess {
-    pub fn http_url(&self) -> String {
-        format!("http://{LOCALHOST}:{}", self.port)
-    }
-}
-```
+1. The `ws_url()` method already exists on `GooseServeProcess` — no new method needed. Step 01 already wired `get_goose_serve_url` to call `process.ws_url()`.
 
 2. Remove the `WS_BRIDGE_BUFFER_BYTES` constant — it was only used by the WebSocket bridge in `thread.rs`:
 ```rust
@@ -367,7 +360,7 @@ Plus significant simplification of `commands/acp.rs` (~330 → ~15 lines) and `s
 | File | Change |
 |------|--------|
 | `src-tauri/src/services/acp/mod.rs` | Simplified to just goose_serve re-export |
-| `src-tauri/src/services/acp/goose_serve.rs` | Add `http_url()`, remove WS constants, replace readiness probe |
+| `src-tauri/src/services/acp/goose_serve.rs` | Remove `WS_BRIDGE_BUFFER_BYTES` constant, replace readiness probe with TCP connect |
 | `src-tauri/src/commands/acp.rs` | Replaced with single `get_goose_serve_url` command |
 | `src-tauri/src/lib.rs` | Remove AcpSessionRegistry, old ACP commands, simplify run closure |
 | `src-tauri/Cargo.toml` | Remove 6 dependencies |

--- a/ui/goose2/acp-plus-migration-plan/09-delete-rust-acp-code.md
+++ b/ui/goose2/acp-plus-migration-plan/09-delete-rust-acp-code.md
@@ -97,7 +97,7 @@ Also delete the helper functions that were only used by those commands:
 - `default_artifacts_working_dir`
 - `expand_home_dir`
 - `resolve_working_dir`
-- The `#[cfg(test)] mod tests` block (the tests tested those helpers)
+- The `#[cfg(test)] mod tests` block
 
 ### 4. Update `lib.rs`
 
@@ -161,78 +161,21 @@ commands::acp::get_goose_serve_url,
 .run(|_app, _event| {});
 ```
 
-The `Arc` import can be removed if nothing else uses it. Check if `PersonaStore` or `GooseConfig` need it — they don't (they use `tauri::State` which handles the wrapping).
+The `Arc` import can be removed — `PersonaStore` and `GooseConfig` use `tauri::State` which handles the wrapping.
 
 ### 5. Clean up `goose_serve.rs`
 
 **File:** `src-tauri/src/services/acp/goose_serve.rs`
 
-The file is mostly kept as-is. Make these changes:
-
-1. The `ws_url()` method already exists on `GooseServeProcess` — no new method needed. Step 01 already wired `get_goose_serve_url` to call `process.ws_url()`.
-
-2. Remove the `WS_BRIDGE_BUFFER_BYTES` constant — it was only used by the WebSocket bridge in `thread.rs`:
+1. Remove the `WS_BRIDGE_BUFFER_BYTES` constant (only used by the deleted `thread.rs`):
 ```rust
 // DELETE:
 pub(crate) const WS_BRIDGE_BUFFER_BYTES: usize = 64 * 1024;
 ```
 
-3. The `resolve_goose_binary` function is still needed by `model_setup.rs` (which runs `goose configure`). Keep it exported as `pub(crate)`.
+2. Keep `resolve_goose_binary` exported as `pub(crate)` — it is still needed by `model_setup.rs` (which runs `goose configure`).
 
-### 6. Remove unused Cargo dependencies
-
-**File:** `src-tauri/Cargo.toml`
-
-Remove these dependencies that were only used by the deleted ACP code:
-
-```toml
-# DELETE these lines:
-agent-client-protocol = { version = "0.10.4", features = ["unstable_session_fork"] }
-acp-client = { git = "https://github.com/block/builderbot", rev = "db184d20cb48e0c90bbd3fea4a4a871fc9d8a6ad" }
-tokio-tungstenite = "0.21.0"
-async-trait = "0.1"
-```
-
-**Check before removing — these may still be used by remaining code:**
-
-- `futures = "0.3"` — check if any remaining code uses it. `goose_serve.rs` uses `futures::{SinkExt, StreamExt}` for the WebSocket readiness probe. After removing the WS probe... wait, the readiness probe in `wait_for_server_ready` uses `tokio-tungstenite` and `futures`. We need to replace the readiness check.
-
-**Replace the WebSocket readiness probe with an HTTP health check:**
-
-The `wait_for_server_ready` function currently connects via WebSocket to check if the server is up. Replace it with a simple HTTP GET to `/health`:
-
-```rust
-async fn wait_for_server_ready(base_url: &str, child: &mut Child) -> Result<(), String> {
-    let deadline = Instant::now() + GOOSE_SERVE_CONNECT_TIMEOUT;
-    let health_url = format!("{base_url}/health");
-
-    loop {
-        match reqwest::get(&health_url).await {
-            Ok(response) if response.status().is_success() => return Ok(()),
-            Ok(_) | Err(_) => {
-                if let Some(status) = child
-                    .try_wait()
-                    .map_err(|e| format!("Failed to poll goose serve process: {e}"))?
-                {
-                    return Err(format!(
-                        "Goose serve exited before becoming ready: {status}"
-                    ));
-                }
-
-                if Instant::now() >= deadline {
-                    return Err(format!(
-                        "Timed out waiting for goose serve at {health_url}"
-                    ));
-                }
-
-                tokio::time::sleep(GOOSE_SERVE_CONNECT_RETRY_DELAY).await;
-            }
-        }
-    }
-}
-```
-
-Wait — adding `reqwest` is a new dependency. A simpler approach: use `tokio::net::TcpStream::connect` to check if the port is open:
+3. Replace the WebSocket readiness probe with a TCP connect check. This eliminates the `tokio-tungstenite` and `futures` dependencies:
 
 ```rust
 async fn wait_for_server_ready(port: u16, child: &mut Child) -> Result<(), String> {
@@ -265,11 +208,36 @@ async fn wait_for_server_ready(port: u16, child: &mut Child) -> Result<(), Strin
 }
 ```
 
-This only needs `tokio` (already a dependency). Update the `spawn` method to call `wait_for_server_ready(port, &mut child)` instead of `wait_for_server_ready(&ws_url, &mut child)`.
+Update the `spawn` method to call `wait_for_server_ready(port, &mut child)` instead of `wait_for_server_ready(&ws_url, &mut child)`.
 
-With this change, `futures`, `tokio-tungstenite` can be removed.
+### 6. Handle `acp-client` binary discovery
 
-- `tokio-util = { version = "0.7", features = ["compat", "rt"] }` — check if anything else uses it. It was used by `thread.rs` for `TokioAsyncReadCompatExt`/`TokioAsyncWriteCompatExt`. If nothing else uses it, remove it.
+The `acp-client` crate is used by `goose_serve.rs` for `acp_client::find_acp_agent_by_id("goose")` in binary resolution. Two options:
+
+- **Option A (simplest):** Keep `acp-client` solely for binary discovery. It only uses the `find_acp_agent_by_id` function.
+- **Option B:** Inline the discovery logic — look for `goose` on PATH and check the `GOOSE_BIN` env var. The `GOOSE_BIN` path is already handled; the `find_acp_agent_by_id` fallback scans the login shell PATH, which can be replaced with a simple `which goose` equivalent.
+
+Choose one approach and apply it consistently.
+
+### 7. Remove unused Cargo dependencies
+
+**File:** `src-tauri/Cargo.toml`
+
+Remove these dependencies:
+
+```toml
+agent-client-protocol = { version = "0.10.4", features = ["unstable_session_fork"] }
+tokio-tungstenite = "0.21.0"
+async-trait = "0.1"
+futures = "0.3"
+tokio-util = { version = "0.7", features = ["compat", "rt"] }
+```
+
+If Option A from §6 is chosen, keep `acp-client`. If Option B is chosen, also remove:
+
+```toml
+acp-client = { git = "https://github.com/block/builderbot", rev = "db184d20cb48e0c90bbd3fea4a4a871fc9d8a6ad" }
+```
 
 After all removals, the remaining dependencies should be:
 
@@ -295,23 +263,16 @@ doctor = { git = "https://github.com/block/builderbot", rev = "8e1c3ec145edc0df5
 keyring = { ... } # platform-specific
 ```
 
-Use `cargo remove` or edit `Cargo.toml` directly, then run `cargo check` to verify nothing breaks.
+Run `cargo check` after editing `Cargo.toml` to verify nothing breaks.
 
-### 7. Run full verification
+### 8. Run full verification
 
 ```bash
 cd ui/goose2/src-tauri
 
-# Format
 cargo fmt
-
-# Check compilation
 cargo check
-
-# Clippy
 cargo clippy --all-targets -- -D warnings
-
-# Run any remaining Rust tests
 cargo test
 ```
 
@@ -342,14 +303,14 @@ just tauri-check
 | `services/acp/search.rs` | ~467 | Session content search |
 | **Total** | **~2,749** | |
 
-Plus significant simplification of `commands/acp.rs` (~330 → ~15 lines) and `services/acp/mod.rs` (~147 → ~4 lines) and `lib.rs` (~114 → ~80 lines).
+Plus significant simplification of `commands/acp.rs` (~330 → ~15 lines), `services/acp/mod.rs` (~147 → ~4 lines), and `lib.rs` (~114 → ~80 lines).
 
 ## Cargo Dependencies Removed
 
 | Crate | Why it was needed |
 |-------|-------------------|
 | `agent-client-protocol` | Rust ACP client types (Agent, ClientSideConnection, etc.) |
-| `acp-client` | Agent discovery, MessageWriter trait |
+| `acp-client` | Agent discovery, MessageWriter trait (kept if using Option A for binary discovery) |
 | `tokio-tungstenite` | WebSocket connection to goose serve |
 | `async-trait` | MessageWriter + Client trait impls |
 | `futures` | WebSocket stream splitting (SinkExt, StreamExt) |
@@ -363,7 +324,7 @@ Plus significant simplification of `commands/acp.rs` (~330 → ~15 lines) and `s
 | `src-tauri/src/services/acp/goose_serve.rs` | Remove `WS_BRIDGE_BUFFER_BYTES` constant, replace readiness probe with TCP connect |
 | `src-tauri/src/commands/acp.rs` | Replaced with single `get_goose_serve_url` command |
 | `src-tauri/src/lib.rs` | Remove AcpSessionRegistry, old ACP commands, simplify run closure |
-| `src-tauri/Cargo.toml` | Remove 6 dependencies |
+| `src-tauri/Cargo.toml` | Remove 5–6 dependencies |
 | `src-tauri/Cargo.lock` | Auto-updated |
 
 ## Files Deleted
@@ -376,11 +337,5 @@ All files listed in the "Summary of Deletions" table above.
 
 ## Notes
 
-- Run `cargo check` after each deletion batch to catch any remaining references.
+- Run `cargo check` after each deletion batch to catch remaining references.
 - The `doctor` crate dependency stays — it's used by `commands/doctor.rs` which is not part of this migration.
-- The `acp-client` crate was also used by `goose_serve.rs` for `acp_client::find_acp_agent_by_id("goose")` in binary resolution. Check if this import still exists. If so, you need an alternative way to find the goose binary. Options:
-  - Keep `acp-client` just for binary discovery (lightweight — only uses the `find_acp_agent_by_id` function)
-  - Inline the binary discovery logic (look for `goose` on PATH, check `GOOSE_BIN` env var)
-  - The `GOOSE_BIN` env var path is already handled. The `acp_client::find_acp_agent_by_id` fallback scans login shell PATH. You could replace it with a simple `which goose` equivalent.
-  
-  If keeping `acp-client` just for binary discovery is acceptable, that's the simplest path. Otherwise, port the discovery logic.

--- a/ui/goose2/acp-plus-migration-plan/10-phase-b-future-native-migration.md
+++ b/ui/goose2/acp-plus-migration-plan/10-phase-b-future-native-migration.md
@@ -1,0 +1,325 @@
+# Step 10: Phase B — Migrate Config, Personas, Skills, Projects, Git, Doctor to `goose serve`
+
+## Objective
+
+This step is a roadmap for the long-term migration. Each subsystem currently handled by Rust Tauri commands will move behind `goose serve` ACP extension methods, callable from TypeScript via `client.extMethod("goose/<domain>/<action>", params)` or via generated `GooseExtClient` methods.
+
+**This step requires backend changes to the goose crate** — adding new ACP extension methods to `goose serve`. It cannot be done purely in the Tauri app.
+
+## Current State After Phase A (Steps 01–09)
+
+After Phase A, the Rust Tauri backend still handles:
+
+| Module | Rust File(s) | Lines | Native Dependency |
+|--------|-------------|-------|-------------------|
+| Config (config.yaml, secrets, keyring) | `services/goose_config.rs`, `services/provider_defs.rs` | ~590 | Keyring, file system |
+| Credentials commands | `commands/credentials.rs` | ~50 | GooseConfig |
+| Personas | `services/personas.rs`, `types/agents.rs`, `types/builtin_personas.rs` | ~920 | File system |
+| Persona commands | `commands/agents.rs` | ~210 | PersonaStore |
+| Skills | `commands/skills.rs` | ~320 | File system |
+| Projects | `commands/projects.rs` | ~495 | File system |
+| Git operations | `commands/git.rs`, `commands/git_changes.rs` | ~570 | Shell commands |
+| Doctor | `commands/doctor.rs` | ~15 | `doctor` crate |
+| Agent setup | `commands/agent_setup.rs` | ~310 | Shell commands, streaming output |
+| Model setup | `commands/model_setup.rs` | ~220 | Shell commands, streaming output |
+| System utilities | `commands/system.rs` | ~360 | File system, dialog |
+| **Total** | | **~4,060** | |
+
+## Migration Pattern
+
+For each subsystem, the pattern is:
+
+1. **Backend**: Add ACP extension methods to `goose serve` (in the `goose-acp` or `goose` crate)
+2. **Schema**: Regenerate the ACP schema (`npm run build:schema` in `ui/acp/`)
+3. **Client**: The `GooseExtClient` auto-generates typed methods from the schema
+4. **Frontend**: Replace `invoke("rust_command")` calls with `client.goose.<method>()` calls
+5. **Cleanup**: Delete the Rust Tauri command and service code
+
+## Subsystem Migration Details
+
+### B1: Config Management
+
+**Priority: High** — Config is needed for provider setup, which is part of the core onboarding flow.
+
+#### New `goose serve` Extension Methods
+
+| Method | Request | Response |
+|--------|---------|----------|
+| `goose/config/get` | `{ key: string }` | `{ value: string \| null }` |
+| `goose/config/set` | `{ key: string, value: string }` | `{}` |
+| `goose/config/delete` | `{ key: string }` | `{ removed: boolean }` |
+| `goose/secret/getMasked` | `{ key: string }` | `{ value: string \| null }` |
+| `goose/secret/set` | `{ key: string, value: string }` | `{}` |
+| `goose/secret/delete` | `{ key: string }` | `{ removed: boolean }` |
+| `goose/provider/status` | `{ providerId: string }` | `{ providerId: string, isConfigured: boolean }` |
+| `goose/provider/statusAll` | `{}` | `{ providers: [{ providerId: string, isConfigured: boolean }] }` |
+| `goose/provider/fields` | `{ providerId: string }` | `{ fields: [{ key: string, value: string \| null, isSet: boolean, isSecret: boolean, required: boolean }] }` |
+| `goose/provider/deleteConfig` | `{ providerId: string }` | `{}` |
+
+#### Backend Implementation Notes
+
+- The goose binary already has config management internally (`goose configure` command). The extension methods expose the same logic over ACP.
+- Keyring access happens in the `goose serve` process (which runs natively), so there's no loss of capability.
+- The `provider_defs.rs` static definitions should move to the goose crate (or already exist there).
+
+#### Frontend Changes
+
+- Replace `invoke("get_provider_config")` → `client.goose.gooseProviderFields({ providerId })`
+- Replace `invoke("save_provider_field")` → `client.goose.gooseSecretSet({ key, value })` or `client.goose.gooseConfigSet({ key, value })`
+- Replace `invoke("delete_provider_config")` → `client.goose.gooseProviderDeleteConfig({ providerId })`
+- Replace `invoke("check_all_provider_status")` → `client.goose.gooseProviderStatusAll({})`
+- Replace `invoke("restart_app")` → keep in Rust (native window management)
+
+#### Files Deleted After B1
+
+- `src-tauri/src/services/goose_config.rs`
+- `src-tauri/src/services/provider_defs.rs`
+- `src-tauri/src/commands/credentials.rs` (except `restart_app` which stays)
+- Remove `keyring` dependency from `Cargo.toml` (all 3 platform variants)
+- Remove `etcetera` dependency
+
+---
+
+### B2: Personas
+
+**Priority: Medium** — Personas are used in the chat flow but not on the critical path.
+
+#### New `goose serve` Extension Methods
+
+| Method | Request | Response |
+|--------|---------|----------|
+| `goose/personas/list` | `{}` | `{ personas: Persona[] }` |
+| `goose/personas/create` | `CreatePersonaRequest` | `{ persona: Persona }` |
+| `goose/personas/update` | `{ id: string, ...UpdatePersonaRequest }` | `{ persona: Persona }` |
+| `goose/personas/delete` | `{ id: string }` | `{}` |
+| `goose/personas/refresh` | `{}` | `{ personas: Persona[] }` |
+| `goose/personas/export` | `{ id: string }` | `{ json: string, suggestedFilename: string }` |
+| `goose/personas/import` | `{ fileBytes: number[], fileName: string }` | `{ personas: Persona[] }` |
+| `goose/personas/saveAvatar` | `{ personaId: string, bytes: number[], extension: string }` | `{ filename: string }` |
+| `goose/personas/avatarsDir` | `{}` | `{ path: string }` |
+
+#### Backend Implementation Notes
+
+- Persona storage (`~/.goose/personas.json`, `~/.goose/agents/*.md`) is file-based. The goose binary can read/write these.
+- Avatar handling (`~/.goose/avatars/`) is also file-based.
+- Builtin personas are currently defined in `types/builtin_personas.rs` — these should move to the goose crate.
+
+#### Files Deleted After B2
+
+- `src-tauri/src/services/personas.rs`
+- `src-tauri/src/types/agents.rs`
+- `src-tauri/src/types/builtin_personas.rs`
+- `src-tauri/src/types/messages.rs`
+- `src-tauri/src/types/mod.rs`
+- `src-tauri/src/commands/agents.rs`
+
+---
+
+### B3: Skills
+
+**Priority: Low** — Skills are a secondary feature.
+
+#### New `goose serve` Extension Methods
+
+| Method | Request | Response |
+|--------|---------|----------|
+| `goose/skills/list` | `{}` | `{ skills: SkillInfo[] }` |
+| `goose/skills/create` | `{ name, description, instructions }` | `{}` |
+| `goose/skills/update` | `{ name, description, instructions }` | `{ skill: SkillInfo }` |
+| `goose/skills/delete` | `{ name: string }` | `{}` |
+| `goose/skills/export` | `{ name: string }` | `{ json: string, filename: string }` |
+| `goose/skills/import` | `{ fileBytes: number[], fileName: string }` | `{ skills: SkillInfo[] }` |
+
+#### Files Deleted After B3
+
+- `src-tauri/src/commands/skills.rs`
+
+---
+
+### B4: Projects
+
+**Priority: Low** — Projects are a secondary feature.
+
+#### New `goose serve` Extension Methods
+
+| Method | Request | Response |
+|--------|---------|----------|
+| `goose/projects/list` | `{}` | `{ projects: ProjectInfo[] }` |
+| `goose/projects/create` | `{ name, description, prompt, icon, color, ... }` | `{ project: ProjectInfo }` |
+| `goose/projects/update` | `{ id, name, description, prompt, icon, color, ... }` | `{ project: ProjectInfo }` |
+| `goose/projects/delete` | `{ id: string }` | `{}` |
+| `goose/projects/get` | `{ id: string }` | `{ project: ProjectInfo }` |
+| `goose/projects/listArchived` | `{}` | `{ projects: ProjectInfo[] }` |
+| `goose/projects/archive` | `{ id: string }` | `{}` |
+| `goose/projects/restore` | `{ id: string }` | `{}` |
+
+#### Files Deleted After B4
+
+- `src-tauri/src/commands/projects.rs`
+
+---
+
+### B5: Git Operations
+
+**Priority: Medium** — Git state is shown in the workspace widget and context panel.
+
+#### New `goose serve` Extension Methods
+
+| Method | Request | Response |
+|--------|---------|----------|
+| `goose/git/state` | `{ path: string }` | `GitState` |
+| `goose/git/changedFiles` | `{ path: string }` | `{ files: ChangedFile[] }` |
+| `goose/git/switchBranch` | `{ path, branch }` | `{}` |
+| `goose/git/stash` | `{ path }` | `{}` |
+| `goose/git/init` | `{ path }` | `{}` |
+| `goose/git/fetch` | `{ path }` | `{}` |
+| `goose/git/pull` | `{ path }` | `{}` |
+| `goose/git/createBranch` | `{ path, name, baseBranch }` | `{}` |
+| `goose/git/createWorktree` | `{ path, name, branch, createBranch, baseBranch? }` | `CreatedWorktree` |
+
+#### Backend Implementation Notes
+
+- Git operations run shell commands (`git status`, `git switch`, etc.). The goose binary can run these the same way.
+- The `ignore` crate is used for `.gitignore`-aware file scanning in `list_files_for_mentions`. This could also move to goose serve.
+
+#### Files Deleted After B5
+
+- `src-tauri/src/commands/git.rs`
+- `src-tauri/src/commands/git_changes.rs`
+
+---
+
+### B6: Doctor
+
+**Priority: Low** — Doctor is a diagnostic tool, not on the critical path.
+
+#### New `goose serve` Extension Methods
+
+| Method | Request | Response |
+|--------|---------|----------|
+| `goose/doctor/run` | `{}` | `DoctorReport` |
+| `goose/doctor/fix` | `{ checkId: string, fixType: string }` | `{}` |
+
+#### Backend Implementation Notes
+
+- The `doctor` crate already exists in the goose ecosystem. The extension methods just expose it over ACP.
+
+#### Files Deleted After B6
+
+- `src-tauri/src/commands/doctor.rs`
+- Remove `doctor` dependency from `Cargo.toml`
+
+---
+
+### B7: Agent & Model Setup
+
+**Priority: Medium** — Needed for onboarding third-party agents and OAuth flows.
+
+This is the trickiest subsystem because it involves **interactive shell commands with streaming output**. The current Rust code spawns a child process and streams stdout/stderr lines as Tauri events (`agent-setup:output`, `model-setup:output`).
+
+#### Options
+
+**Option A: ACP extension methods with streaming notifications**
+
+Add extension methods that return immediately but stream progress via `SessionNotification` events (or a new notification type). The frontend listens for these notifications the same way it listens for chat streaming.
+
+**Option B: Keep in Rust as the last native commands**
+
+These commands are inherently interactive (they open browsers for OAuth, wait for user input). They may be better suited to native handling. Keep them as the last remaining Tauri commands.
+
+**Option C: Move the logic into `goose serve` as a long-running task**
+
+The goose binary already handles `goose configure` (which is what `model_setup.rs` wraps). Expose a `goose/setup/authenticateProvider` extension method that runs the configure flow and streams output.
+
+#### Recommendation
+
+Start with **Option B** (keep in Rust) and migrate to Option A or C later. These commands are rarely called (only during onboarding) and the streaming output pattern would need a new ACP notification type.
+
+---
+
+### B8: System Utilities
+
+**Priority: Low** — These are helper functions, not core features.
+
+#### New `goose serve` Extension Methods
+
+| Method | Request | Response |
+|--------|---------|----------|
+| `goose/system/homeDir` | `{}` | `{ path: string }` |
+| `goose/system/pathExists` | `{ path: string }` | `{ exists: boolean }` |
+| `goose/system/listDir` | `{ path: string }` | `{ entries: FileTreeEntry[] }` |
+| `goose/system/listFilesForMentions` | `{ roots: string[], maxResults?: number }` | `{ files: string[] }` |
+
+#### Special Case: `saveExportedSessionFile`
+
+This command uses `tauri_plugin_dialog` to show a native save dialog. This is inherently a Tauri/native operation — it cannot move to `goose serve`. **Keep this in Rust.**
+
+#### Files Deleted After B8
+
+- `src-tauri/src/commands/system.rs` (except `save_exported_session_file` which stays)
+- Remove `ignore` dependency from `Cargo.toml`
+
+---
+
+## End State After All Phase B Steps
+
+**Rust Tauri backend:**
+
+```
+src-tauri/src/
+  lib.rs                    — ~40 lines: spawn goose serve, register ~3 commands
+  main.rs                   — 6 lines (unchanged)
+  commands/
+    mod.rs                  — 3 modules
+    acp.rs                  — get_goose_serve_url (~15 lines)
+    system.rs               — save_exported_session_file (~40 lines)
+    agent_setup.rs          — install/auth agents (~310 lines, if kept)
+    model_setup.rs          — model provider auth (~220 lines, if kept)
+  services/
+    mod.rs                  — 1 module
+    acp/
+      mod.rs                — 1 module
+      goose_serve.rs        — GooseServeProcess (~150 lines)
+```
+
+**Total: ~780 lines** if keeping agent/model setup, or **~250 lines** if those also move.
+
+**Cargo.toml dependencies (minimal):**
+```toml
+tauri = "2"
+tauri-plugin-opener = "2"
+tauri-plugin-dialog = ">=2,<2.7"
+tauri-plugin-window-state = "2"
+tauri-plugin-log = "2"
+serde = "1"
+serde_json = "1"
+tokio = "1"
+dirs = "6"
+log = "0.4"
+```
+
+## Migration Priority Summary
+
+| Step | Effort | Blocking On | Value | Recommended Order |
+|------|--------|-------------|-------|-------------------|
+| B1 (Config) | Medium | Backend ACP methods | High (removes keyring dep) | 1st |
+| B5 (Git) | Medium | Backend ACP methods | Medium | 2nd |
+| B2 (Personas) | Medium | Backend ACP methods | Medium | 3rd |
+| B3 (Skills) | Small | Backend ACP methods | Small | 4th |
+| B4 (Projects) | Small | Backend ACP methods | Small | 5th |
+| B6 (Doctor) | Small | Backend ACP methods | Small | 6th |
+| B8 (System utils) | Small | Backend ACP methods | Small | 7th |
+| B7 (Agent/Model setup) | Large | Streaming notification design | Medium | Last (or keep in Rust) |
+
+## How to Propose Backend Changes
+
+For each subsystem, the process is:
+
+1. **Design the ACP extension method schemas** in `crates/goose-acp/`
+2. **Implement the handlers** in the goose serve server
+3. **Regenerate the schema**: `cd ui/acp && npm run build:schema`
+4. **Rebuild the TS client**: `cd ui/acp && npm run build`
+5. **Update goose2**: use the new `client.goose.<method>()` calls
+6. **Delete the Rust Tauri code**
+
+Each subsystem can be migrated independently. The frontend can use a mix of `invoke()` (for not-yet-migrated subsystems) and `client.goose.*()` (for migrated ones) during the transition.

--- a/ui/goose2/acp-plus-migration-plan/10-phase-b-future-native-migration.md
+++ b/ui/goose2/acp-plus-migration-plan/10-phase-b-future-native-migration.md
@@ -2,13 +2,9 @@
 
 ## Objective
 
-This step is a roadmap for the long-term migration. Each subsystem currently handled by Rust Tauri commands will move behind `goose serve` ACP extension methods, callable from TypeScript via `client.extMethod("goose/<domain>/<action>", params)` or via generated `GooseExtClient` methods.
-
-**This step requires backend changes to the goose crate** — adding new ACP extension methods to `goose serve`. It cannot be done purely in the Tauri app.
+Migrate each remaining Rust Tauri subsystem behind `goose serve` ACP extension methods, callable from TypeScript via `client.goose.<method>()`. This requires backend changes to the goose crate — adding new ACP extension methods to `goose serve`.
 
 ## Current State After Phase A (Steps 01–09)
-
-After Phase A, the Rust Tauri backend still handles:
 
 | Module | Rust File(s) | Lines | Native Dependency |
 |--------|-------------|-------|-------------------|
@@ -27,11 +23,11 @@ After Phase A, the Rust Tauri backend still handles:
 
 ## Migration Pattern
 
-For each subsystem, the pattern is:
+For each subsystem:
 
-1. **Backend**: Add ACP extension methods to `goose serve` (in the `goose-acp` or `goose` crate)
+1. **Backend**: Add ACP extension methods to `goose serve` (in `goose-acp` or `goose` crate)
 2. **Schema**: Regenerate the ACP schema (`npm run build:schema` in `ui/acp/`)
-3. **Client**: The `GooseExtClient` auto-generates typed methods from the schema
+3. **Client**: `GooseExtClient` auto-generates typed methods from the schema
 4. **Frontend**: Replace `invoke("rust_command")` calls with `client.goose.<method>()` calls
 5. **Cleanup**: Delete the Rust Tauri command and service code
 
@@ -39,9 +35,9 @@ For each subsystem, the pattern is:
 
 ### B1: Config Management
 
-**Priority: High** — Config is needed for provider setup, which is part of the core onboarding flow.
+**Priority: High** — Config is needed for provider setup, part of the core onboarding flow.
 
-#### New `goose serve` Extension Methods
+#### Extension Methods
 
 | Method | Request | Response |
 |--------|---------|----------|
@@ -56,35 +52,35 @@ For each subsystem, the pattern is:
 | `goose/provider/fields` | `{ providerId: string }` | `{ fields: [{ key: string, value: string \| null, isSet: boolean, isSecret: boolean, required: boolean }] }` |
 | `goose/provider/deleteConfig` | `{ providerId: string }` | `{}` |
 
-#### Backend Implementation Notes
+#### Backend Notes
 
-- The goose binary already has config management internally (`goose configure` command). The extension methods expose the same logic over ACP.
-- Keyring access happens in the `goose serve` process (which runs natively), so there's no loss of capability.
-- The `provider_defs.rs` static definitions should move to the goose crate (or already exist there).
+- The goose binary already has config management internally (`goose configure`). The extension methods expose the same logic over ACP.
+- Keyring access happens in the `goose serve` process (which runs natively), so there is no loss of capability.
+- Move `provider_defs.rs` static definitions to the goose crate.
 
 #### Frontend Changes
 
-- Replace `invoke("get_provider_config")` → `client.goose.gooseProviderFields({ providerId })`
-- Replace `invoke("save_provider_field")` → `client.goose.gooseSecretSet({ key, value })` or `client.goose.gooseConfigSet({ key, value })`
-- Replace `invoke("delete_provider_config")` → `client.goose.gooseProviderDeleteConfig({ providerId })`
-- Replace `invoke("check_all_provider_status")` → `client.goose.gooseProviderStatusAll({})`
-- Replace `invoke("restart_app")` → keep in Rust (native window management)
+- `invoke("get_provider_config")` → `client.goose.gooseProviderFields({ providerId })`
+- `invoke("save_provider_field")` → `client.goose.gooseSecretSet({ key, value })` or `client.goose.gooseConfigSet({ key, value })`
+- `invoke("delete_provider_config")` → `client.goose.gooseProviderDeleteConfig({ providerId })`
+- `invoke("check_all_provider_status")` → `client.goose.gooseProviderStatusAll({})`
+- `invoke("restart_app")` — remains in Rust (native window management)
 
-#### Files Deleted After B1
+#### Files Deleted
 
 - `src-tauri/src/services/goose_config.rs`
 - `src-tauri/src/services/provider_defs.rs`
-- `src-tauri/src/commands/credentials.rs` (except `restart_app` which stays)
-- Remove `keyring` dependency from `Cargo.toml` (all 3 platform variants)
-- Remove `etcetera` dependency
+- `src-tauri/src/commands/credentials.rs` (except `restart_app`)
+- `keyring` dependency from `Cargo.toml` (all 3 platform variants)
+- `etcetera` dependency
 
 ---
 
 ### B2: Personas
 
-**Priority: Medium** — Personas are used in the chat flow but not on the critical path.
+**Priority: Medium** — Used in the chat flow but not on the critical path.
 
-#### New `goose serve` Extension Methods
+#### Extension Methods
 
 | Method | Request | Response |
 |--------|---------|----------|
@@ -98,13 +94,12 @@ For each subsystem, the pattern is:
 | `goose/personas/saveAvatar` | `{ personaId: string, bytes: number[], extension: string }` | `{ filename: string }` |
 | `goose/personas/avatarsDir` | `{}` | `{ path: string }` |
 
-#### Backend Implementation Notes
+#### Backend Notes
 
-- Persona storage (`~/.goose/personas.json`, `~/.goose/agents/*.md`) is file-based. The goose binary can read/write these.
-- Avatar handling (`~/.goose/avatars/`) is also file-based.
-- Builtin personas are currently defined in `types/builtin_personas.rs` — these should move to the goose crate.
+- Persona storage (`~/.goose/personas.json`, `~/.goose/agents/*.md`) and avatar handling (`~/.goose/avatars/`) are file-based. The goose binary can read/write these directly.
+- Move builtin persona definitions from `types/builtin_personas.rs` to the goose crate.
 
-#### Files Deleted After B2
+#### Files Deleted
 
 - `src-tauri/src/services/personas.rs`
 - `src-tauri/src/types/agents.rs`
@@ -117,9 +112,9 @@ For each subsystem, the pattern is:
 
 ### B3: Skills
 
-**Priority: Low** — Skills are a secondary feature.
+**Priority: Low**
 
-#### New `goose serve` Extension Methods
+#### Extension Methods
 
 | Method | Request | Response |
 |--------|---------|----------|
@@ -130,7 +125,7 @@ For each subsystem, the pattern is:
 | `goose/skills/export` | `{ name: string }` | `{ json: string, filename: string }` |
 | `goose/skills/import` | `{ fileBytes: number[], fileName: string }` | `{ skills: SkillInfo[] }` |
 
-#### Files Deleted After B3
+#### Files Deleted
 
 - `src-tauri/src/commands/skills.rs`
 
@@ -138,9 +133,9 @@ For each subsystem, the pattern is:
 
 ### B4: Projects
 
-**Priority: Low** — Projects are a secondary feature.
+**Priority: Low**
 
-#### New `goose serve` Extension Methods
+#### Extension Methods
 
 | Method | Request | Response |
 |--------|---------|----------|
@@ -153,7 +148,7 @@ For each subsystem, the pattern is:
 | `goose/projects/archive` | `{ id: string }` | `{}` |
 | `goose/projects/restore` | `{ id: string }` | `{}` |
 
-#### Files Deleted After B4
+#### Files Deleted
 
 - `src-tauri/src/commands/projects.rs`
 
@@ -163,7 +158,7 @@ For each subsystem, the pattern is:
 
 **Priority: Medium** — Git state is shown in the workspace widget and context panel.
 
-#### New `goose serve` Extension Methods
+#### Extension Methods
 
 | Method | Request | Response |
 |--------|---------|----------|
@@ -177,12 +172,12 @@ For each subsystem, the pattern is:
 | `goose/git/createBranch` | `{ path, name, baseBranch }` | `{}` |
 | `goose/git/createWorktree` | `{ path, name, branch, createBranch, baseBranch? }` | `CreatedWorktree` |
 
-#### Backend Implementation Notes
+#### Backend Notes
 
-- Git operations run shell commands (`git status`, `git switch`, etc.). The goose binary can run these the same way.
-- The `ignore` crate is used for `.gitignore`-aware file scanning in `list_files_for_mentions`. This could also move to goose serve.
+- Git operations run shell commands (`git status`, `git switch`, etc.). The goose binary runs these the same way.
+- The `ignore` crate for `.gitignore`-aware file scanning in `list_files_for_mentions` moves to goose serve as well.
 
-#### Files Deleted After B5
+#### Files Deleted
 
 - `src-tauri/src/commands/git.rs`
 - `src-tauri/src/commands/git_changes.rs`
@@ -191,23 +186,23 @@ For each subsystem, the pattern is:
 
 ### B6: Doctor
 
-**Priority: Low** — Doctor is a diagnostic tool, not on the critical path.
+**Priority: Low** — Diagnostic tool, not on the critical path.
 
-#### New `goose serve` Extension Methods
+#### Extension Methods
 
 | Method | Request | Response |
 |--------|---------|----------|
 | `goose/doctor/run` | `{}` | `DoctorReport` |
 | `goose/doctor/fix` | `{ checkId: string, fixType: string }` | `{}` |
 
-#### Backend Implementation Notes
+#### Backend Notes
 
-- The `doctor` crate already exists in the goose ecosystem. The extension methods just expose it over ACP.
+The `doctor` crate already exists in the goose ecosystem. The extension methods expose it over ACP.
 
-#### Files Deleted After B6
+#### Files Deleted
 
 - `src-tauri/src/commands/doctor.rs`
-- Remove `doctor` dependency from `Cargo.toml`
+- `doctor` dependency from `Cargo.toml`
 
 ---
 
@@ -215,33 +210,19 @@ For each subsystem, the pattern is:
 
 **Priority: Medium** — Needed for onboarding third-party agents and OAuth flows.
 
-This is the trickiest subsystem because it involves **interactive shell commands with streaming output**. The current Rust code spawns a child process and streams stdout/stderr lines as Tauri events (`agent-setup:output`, `model-setup:output`).
+This subsystem involves interactive shell commands with streaming output. The current Rust code spawns a child process and streams stdout/stderr lines as Tauri events (`agent-setup:output`, `model-setup:output`).
 
-#### Options
+#### Recommendation: Keep in Rust
 
-**Option A: ACP extension methods with streaming notifications**
-
-Add extension methods that return immediately but stream progress via `SessionNotification` events (or a new notification type). The frontend listens for these notifications the same way it listens for chat streaming.
-
-**Option B: Keep in Rust as the last native commands**
-
-These commands are inherently interactive (they open browsers for OAuth, wait for user input). They may be better suited to native handling. Keep them as the last remaining Tauri commands.
-
-**Option C: Move the logic into `goose serve` as a long-running task**
-
-The goose binary already handles `goose configure` (which is what `model_setup.rs` wraps). Expose a `goose/setup/authenticateProvider` extension method that runs the configure flow and streams output.
-
-#### Recommendation
-
-Start with **Option B** (keep in Rust) and migrate to Option A or C later. These commands are rarely called (only during onboarding) and the streaming output pattern would need a new ACP notification type.
+These commands remain as Tauri-native commands. They are inherently interactive (opening browsers for OAuth, waiting for user input), are rarely called (only during onboarding), and migrating them would require designing a new ACP streaming notification type. They stay as the last remaining Tauri commands.
 
 ---
 
 ### B8: System Utilities
 
-**Priority: Low** — These are helper functions, not core features.
+**Priority: Low**
 
-#### New `goose serve` Extension Methods
+#### Extension Methods
 
 | Method | Request | Response |
 |--------|---------|----------|
@@ -250,20 +231,20 @@ Start with **Option B** (keep in Rust) and migrate to Option A or C later. These
 | `goose/system/listDir` | `{ path: string }` | `{ entries: FileTreeEntry[] }` |
 | `goose/system/listFilesForMentions` | `{ roots: string[], maxResults?: number }` | `{ files: string[] }` |
 
-#### Special Case: `saveExportedSessionFile`
+#### Stays in Rust: `saveExportedSessionFile`
 
-This command uses `tauri_plugin_dialog` to show a native save dialog. This is inherently a Tauri/native operation — it cannot move to `goose serve`. **Keep this in Rust.**
+This command uses `tauri_plugin_dialog` to show a native save dialog. It cannot move to `goose serve`.
 
-#### Files Deleted After B8
+#### Files Deleted
 
-- `src-tauri/src/commands/system.rs` (except `save_exported_session_file` which stays)
-- Remove `ignore` dependency from `Cargo.toml`
+- `src-tauri/src/commands/system.rs` (except `save_exported_session_file`)
+- `ignore` dependency from `Cargo.toml`
 
 ---
 
-## End State After All Phase B Steps
+## End State After Phase B
 
-**Rust Tauri backend:**
+**Rust Tauri backend (~780 lines):**
 
 ```
 src-tauri/src/
@@ -273,8 +254,8 @@ src-tauri/src/
     mod.rs                  — 3 modules
     acp.rs                  — get_goose_serve_url (~15 lines)
     system.rs               — save_exported_session_file (~40 lines)
-    agent_setup.rs          — install/auth agents (~310 lines, if kept)
-    model_setup.rs          — model provider auth (~220 lines, if kept)
+    agent_setup.rs          — install/auth agents (~310 lines)
+    model_setup.rs          — model provider auth (~220 lines)
   services/
     mod.rs                  — 1 module
     acp/
@@ -282,9 +263,8 @@ src-tauri/src/
       goose_serve.rs        — GooseServeProcess (~150 lines)
 ```
 
-**Total: ~780 lines** if keeping agent/model setup, or **~250 lines** if those also move.
-
 **Cargo.toml dependencies (minimal):**
+
 ```toml
 tauri = "2"
 tauri-plugin-opener = "2"
@@ -298,28 +278,28 @@ dirs = "6"
 log = "0.4"
 ```
 
-## Migration Priority Summary
+## Migration Order
 
-| Step | Effort | Blocking On | Value | Recommended Order |
-|------|--------|-------------|-------|-------------------|
-| B1 (Config) | Medium | Backend ACP methods | High (removes keyring dep) | 1st |
-| B5 (Git) | Medium | Backend ACP methods | Medium | 2nd |
-| B2 (Personas) | Medium | Backend ACP methods | Medium | 3rd |
-| B3 (Skills) | Small | Backend ACP methods | Small | 4th |
-| B4 (Projects) | Small | Backend ACP methods | Small | 5th |
-| B6 (Doctor) | Small | Backend ACP methods | Small | 6th |
-| B8 (System utils) | Small | Backend ACP methods | Small | 7th |
-| B7 (Agent/Model setup) | Large | Streaming notification design | Medium | Last (or keep in Rust) |
+| Step | Effort | Value | Order |
+|------|--------|-------|-------|
+| B1 (Config) | Medium | High (removes keyring dep) | 1st |
+| B5 (Git) | Medium | Medium | 2nd |
+| B2 (Personas) | Medium | Medium | 3rd |
+| B3 (Skills) | Small | Small | 4th |
+| B4 (Projects) | Small | Small | 5th |
+| B6 (Doctor) | Small | Small | 6th |
+| B8 (System utils) | Small | Small | 7th |
+| B7 (Agent/Model setup) | — | — | Keep in Rust |
 
-## How to Propose Backend Changes
+All steps are blocked on implementing the corresponding backend ACP methods, except B7 which remains native.
 
-For each subsystem, the process is:
+## Workflow Per Subsystem
 
-1. **Design the ACP extension method schemas** in `crates/goose-acp/`
-2. **Implement the handlers** in the goose serve server
-3. **Regenerate the schema**: `cd ui/acp && npm run build:schema`
-4. **Rebuild the TS client**: `cd ui/acp && npm run build`
-5. **Update goose2**: use the new `client.goose.<method>()` calls
-6. **Delete the Rust Tauri code**
+1. Design the ACP extension method schemas in `crates/goose-acp/`
+2. Implement the handlers in the goose serve server
+3. Regenerate the schema: `cd ui/acp && npm run build:schema`
+4. Rebuild the TS client: `cd ui/acp && npm run build`
+5. Update goose2: use the new `client.goose.<method>()` calls
+6. Delete the Rust Tauri code
 
-Each subsystem can be migrated independently. The frontend can use a mix of `invoke()` (for not-yet-migrated subsystems) and `client.goose.*()` (for migrated ones) during the transition.
+Each subsystem migrates independently. The frontend can use a mix of `invoke()` (not-yet-migrated) and `client.goose.*()` (migrated) during the transition.

--- a/ui/goose2/package.json
+++ b/ui/goose2/package.json
@@ -27,6 +27,8 @@
     "test-driver": "tsx tests/app-e2e/lib/test-driver-cli.ts"
   },
   "dependencies": {
+    "@aaif/goose-acp": "^0.16.0",
+    "@agentclientprotocol/sdk": "^0.19.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.8",

--- a/ui/goose2/pnpm-lock.yaml
+++ b/ui/goose2/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     dependencies:
+      '@aaif/goose-acp':
+        specifier: ^0.16.0
+        version: 0.16.0(@agentclientprotocol/sdk@0.19.0(zod@4.3.6))
+      '@agentclientprotocol/sdk':
+        specifier: ^0.19.0
+        version: 0.19.0(zod@4.3.6)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -289,13 +295,23 @@ importers:
         specifier: ^7.0.4
         version: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
-        specifier: ^3.2.1
-        version: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^4.1.0
+        version: 4.1.2(@opentelemetry/api@1.9.0)(jsdom@26.1.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
 
 packages:
 
+  '@aaif/goose-acp@0.16.0':
+    resolution: {integrity: sha512-LJLn01pqobvQAsagScROFOnjKRSQPaDuP7v17oyrK1IDfvZzOM20ZkQcvGDWhYCRUHXWBJgJ9dD6iZkVtNYYwg==}
+    peerDependencies:
+      '@agentclientprotocol/sdk': '*'
+
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@agentclientprotocol/sdk@0.19.0':
+    resolution: {integrity: sha512-U9I8ws9WTOk6jCBAWpXefGSDgVXn14/kV6HFzwWGcstQ02mOQgClMAROHmoIn9GqZbDBDEOkdIbP4P4TEMQdug==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@ai-sdk/gateway@3.0.84':
     resolution: {integrity: sha512-RnUw6UNvkaw9MEaJU9cIjA+WBP+ZR5+M/9nfbfJHcGKtTbcWXijJuYKx9nYRnm+qU+iiakb0XvQA/vvho6lTsw==}
@@ -2033,34 +2049,34 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   '@xyflow/react@12.10.2':
     resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
@@ -2136,10 +2152,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
@@ -2151,8 +2163,8 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
@@ -2166,10 +2178,6 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.3.1:
     resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
@@ -2420,10 +2428,6 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
@@ -2474,8 +2478,8 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-toolkit@1.45.1:
     resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
@@ -2716,9 +2720,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
@@ -2840,9 +2841,6 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -3103,6 +3101,9 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
@@ -3123,10 +3124,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3439,8 +3436,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   streamdown@2.5.0:
     resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
@@ -3454,9 +3451,6 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -3486,9 +3480,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -3497,16 +3488,8 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -3644,11 +3627,6 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3689,26 +3667,33 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -3792,6 +3777,9 @@ packages:
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
@@ -3833,7 +3821,16 @@ packages:
 
 snapshots:
 
+  '@aaif/goose-acp@0.16.0(@agentclientprotocol/sdk@0.19.0(zod@4.3.6))':
+    dependencies:
+      '@agentclientprotocol/sdk': 0.19.0(zod@4.3.6)
+      zod: 3.25.76
+
   '@adobe/css-tools@4.4.4': {}
+
+  '@agentclientprotocol/sdk@0.19.0(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
 
   '@ai-sdk/gateway@3.0.84(zod@4.3.6)':
     dependencies:
@@ -5492,47 +5489,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.2':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.2':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.2':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.2
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.2': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -5611,8 +5607,6 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  cac@6.7.14: {}
-
   caniuse-lite@1.0.30001781: {}
 
   ccount@2.0.1: {}
@@ -5621,13 +5615,7 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -5636,8 +5624,6 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
-
-  check-error@2.1.3: {}
 
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
@@ -5909,8 +5895,6 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  deep-eql@5.0.2: {}
-
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
@@ -5954,7 +5938,7 @@ snapshots:
 
   entities@6.0.1: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.0.0: {}
 
   es-toolkit@1.45.1: {}
 
@@ -6254,8 +6238,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.1: {}
-
   jsdom@26.1.0:
     dependencies:
       cssstyle: 4.6.0
@@ -6363,8 +6345,6 @@ snapshots:
   lodash-es@4.17.23: {}
 
   longest-streak@3.1.0: {}
-
-  loupe@3.2.1: {}
 
   lowlight@1.20.0:
     dependencies:
@@ -6864,6 +6844,8 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
+  obug@2.1.1: {}
+
   oniguruma-parser@0.12.1: {}
 
   oniguruma-to-es@4.3.5:
@@ -6891,8 +6873,6 @@ snapshots:
   path-data-parser@0.1.0: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -7294,7 +7274,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.0.0: {}
 
   streamdown@2.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -7328,10 +7308,6 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -7354,8 +7330,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
@@ -7363,11 +7337,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   tldts-core@6.1.86: {}
 
@@ -7530,27 +7500,6 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
@@ -7565,47 +7514,33 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0):
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(jsdom@26.1.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
       vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
-      vite-node: 3.2.4(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.13
+      '@opentelemetry/api': 1.9.0
       jsdom: 26.1.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   void-elements@3.1.0: {}
 
@@ -7657,6 +7592,8 @@ snapshots:
   xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
+
+  zod@3.25.76: {}
 
   zod@4.3.6: {}
 

--- a/ui/goose2/src-tauri/src/commands/acp.rs
+++ b/ui/goose2/src-tauri/src/commands/acp.rs
@@ -5,7 +5,7 @@ use tauri::{AppHandle, State};
 
 use crate::services::acp::{
     make_composite_key, search_sessions_via_exports, AcpRunningSession, AcpService, AcpSessionInfo,
-    AcpSessionRegistry, GooseAcpManager, SessionSearchResult,
+    AcpSessionRegistry, GooseAcpManager, GooseServeProcess, SessionSearchResult,
 };
 
 const DEPRECATED_PROVIDER_IDS: &[&str] = &["claude-code", "codex", "gemini-cli"];
@@ -78,6 +78,13 @@ fn resolve_working_dir(
             working_dir.display()
         )
     })
+}
+
+#[tauri::command]
+pub async fn get_goose_serve_url() -> Result<String, String> {
+    GooseServeProcess::start().await?;
+    let process = GooseServeProcess::get()?;
+    Ok(process.ws_url())
 }
 
 /// Return the list of providers available through goose serve.

--- a/ui/goose2/src-tauri/src/lib.rs
+++ b/ui/goose2/src-tauri/src/lib.rs
@@ -49,6 +49,7 @@ pub fn run() {
             commands::agents::save_persona_avatar,
             commands::agents::save_persona_avatar_bytes,
             commands::agents::get_avatars_dir,
+            commands::acp::get_goose_serve_url,
             commands::acp::discover_acp_providers,
             commands::acp::acp_prepare_session,
             commands::acp::acp_set_model,

--- a/ui/goose2/src-tauri/src/services/acp/mod.rs
+++ b/ui/goose2/src-tauri/src/services/acp/mod.rs
@@ -6,6 +6,7 @@ mod search;
 mod writer;
 
 pub(crate) use goose_serve::resolve_goose_binary;
+pub(crate) use goose_serve::GooseServeProcess;
 pub use manager::{AcpSessionInfo, GooseAcpManager};
 pub use registry::{AcpRunningSession, AcpSessionRegistry};
 pub use search::{search_sessions_via_exports, SessionSearchResult};

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -98,6 +98,7 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
           ? resolveEffectiveWorkingDir(null, await getHomeDir())
           : undefined);
       await acpLoadSession(sessionId, gooseSessionId, workingDir);
+      useChatStore.getState().setSessionLoading(sessionId, false);
       const t3 = performance.now();
       console.log(
         `[perf:load] ${sessionId.slice(0, 8)} acpLoadSession resolved in ${(t3 - t2).toFixed(1)}ms (total ${(t3 - t0).toFixed(1)}ms)`,

--- a/ui/goose2/src/app/hooks/useAppStartup.ts
+++ b/ui/goose2/src/app/hooks/useAppStartup.ts
@@ -1,10 +1,22 @@
 import { useEffect } from "react";
 import { useAgentStore } from "@/features/agents/stores/agentStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import { USE_DIRECT_ACP } from "@/shared/api/acpFeatureFlag";
+import { setNotificationHandler, getClient } from "@/shared/api/acpConnection";
+import notificationHandler from "@/shared/api/acpNotificationHandler";
 
 export function useAppStartup() {
   useEffect(() => {
     (async () => {
+      if (USE_DIRECT_ACP) {
+        try {
+          setNotificationHandler(notificationHandler);
+          await getClient();
+        } catch (err) {
+          console.error("Failed to initialize ACP connection:", err);
+        }
+      }
+
       const store = useAgentStore.getState();
       const loadPersonas = async () => {
         store.setPersonasLoading(true);

--- a/ui/goose2/src/app/hooks/useAppStartup.ts
+++ b/ui/goose2/src/app/hooks/useAppStartup.ts
@@ -61,7 +61,6 @@ export function useAppStartup() {
         loadProviders(),
         loadSessionState(),
       ]);
-
     })();
   }, []);
 }

--- a/ui/goose2/src/app/hooks/useAppStartup.ts
+++ b/ui/goose2/src/app/hooks/useAppStartup.ts
@@ -49,6 +49,7 @@ export function useAppStartup() {
         loadProviders(),
         loadSessionState(),
       ]);
+
     })();
   }, []);
 }

--- a/ui/goose2/src/features/chat/hooks/useChat.ts
+++ b/ui/goose2/src/features/chat/hooks/useChat.ts
@@ -229,6 +229,9 @@ export function useChat(
           ),
         });
 
+        store.setChatState(sessionId, "idle");
+        store.setStreamingMessageId(sessionId, null);
+
         if (wasDraft) {
           const promoted = sessionStore.getSession(sessionId);
           if (promoted) {

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -2,6 +2,8 @@ import { invoke } from "@tauri-apps/api/core";
 import { USE_DIRECT_ACP } from "./acpFeatureFlag";
 import * as directAcp from "./acpApi";
 import * as sessionTracker from "./acpSessionTracker";
+import { useChatStore } from "@/features/chat/stores/chatStore";
+import { setActiveMessageId, clearActiveMessageId } from "./acpNotificationHandler";
 
 export interface AcpProvider {
   id: string;
@@ -59,7 +61,14 @@ export async function acpSendMessage(
       }
     }
 
+    const messageId = crypto.randomUUID();
+    setActiveMessageId(gooseSessionId, messageId);
+
     await directAcp.prompt(gooseSessionId, content);
+
+    clearActiveMessageId(gooseSessionId);
+    useChatStore.getState().setChatState(sessionId, "idle");
+    useChatStore.getState().setStreamingMessageId(sessionId, null);
     return;
   }
   const { systemPrompt, workingDir, personaId, personaName, images } = options;

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -1,6 +1,7 @@
 import { invoke } from "@tauri-apps/api/core";
 import { USE_DIRECT_ACP } from "./acpFeatureFlag";
 import * as directAcp from "./acpApi";
+import * as sessionTracker from "./acpSessionTracker";
 
 export interface AcpProvider {
   id: string;
@@ -36,7 +37,31 @@ export async function acpSendMessage(
   prompt: string,
   options: AcpSendMessageOptions = {},
 ): Promise<void> {
-  // TODO: wire up streaming path via acpApi.prompt()
+  if (USE_DIRECT_ACP) {
+    const { systemPrompt, personaId, images } = options;
+
+    const gooseSessionId = sessionTracker.getGooseSessionId(sessionId, personaId);
+    if (!gooseSessionId) {
+      throw new Error("Session not prepared. Call acpPrepareSession first.");
+    }
+
+    const hasSystem = systemPrompt && systemPrompt.trim().length > 0;
+    const effectivePrompt = hasSystem
+      ? `<persona-instructions>\n${systemPrompt}\n</persona-instructions>\n\n<user-message>\n${prompt}\n</user-message>`
+      : prompt;
+
+    const content: import("@agentclientprotocol/sdk").ContentBlock[] = [
+      { type: "text", text: effectivePrompt },
+    ];
+    if (images) {
+      for (const [data, mimeType] of images) {
+        content.push({ type: "image", data, mimeType } as any);
+      }
+    }
+
+    await directAcp.prompt(gooseSessionId, content);
+    return;
+  }
   const { systemPrompt, workingDir, personaId, personaName, images } = options;
   return invoke("acp_send_message", {
     sessionId,
@@ -56,7 +81,11 @@ export async function acpPrepareSession(
   providerId: string,
   options: AcpPrepareSessionOptions = {},
 ): Promise<void> {
-  // TODO: wire up session preparation via acpApi.newSession()
+  if (USE_DIRECT_ACP) {
+    const workingDir = options.workingDir ?? "~/.goose/artifacts";
+    await sessionTracker.prepareSession(sessionId, providerId, workingDir, options.personaId);
+    return;
+  }
   const { workingDir, personaId } = options;
   return invoke("acp_prepare_session", {
     sessionId,
@@ -122,7 +151,10 @@ export async function acpLoadSession(
   gooseSessionId: string,
   workingDir?: string,
 ): Promise<void> {
-  // TODO: wire up session loading via acpApi.loadSession()
+  if (USE_DIRECT_ACP) {
+    await directAcp.loadSession(gooseSessionId, workingDir ?? "~/.goose/artifacts");
+    return;
+  }
   return invoke("acp_load_session", {
     sessionId,
     gooseSessionId,

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -2,7 +2,6 @@ import { invoke } from "@tauri-apps/api/core";
 import { USE_DIRECT_ACP } from "./acpFeatureFlag";
 import * as directAcp from "./acpApi";
 import * as sessionTracker from "./acpSessionTracker";
-import { useChatStore } from "@/features/chat/stores/chatStore";
 import { setActiveMessageId, clearActiveMessageId } from "./acpNotificationHandler";
 import { searchSessionsViaExports } from "./sessionSearch";
 
@@ -68,8 +67,6 @@ export async function acpSendMessage(
     await directAcp.prompt(gooseSessionId, content);
 
     clearActiveMessageId(gooseSessionId);
-    useChatStore.getState().setChatState(sessionId, "idle");
-    useChatStore.getState().setStreamingMessageId(sessionId, null);
     return;
   }
   const { systemPrompt, workingDir, personaId, personaName, images } = options;
@@ -164,8 +161,9 @@ export async function acpLoadSession(
   workingDir?: string,
 ): Promise<void> {
   if (USE_DIRECT_ACP) {
-    await directAcp.loadSession(gooseSessionId, workingDir ?? "~/.goose/artifacts");
-    useChatStore.getState().setSessionLoading(sessionId, false);
+    const effectiveWorkingDir = workingDir ?? "~/.goose/artifacts";
+    await directAcp.loadSession(gooseSessionId, effectiveWorkingDir);
+    sessionTracker.registerSession(sessionId, gooseSessionId, "goose", effectiveWorkingDir);
     return;
   }
   return invoke("acp_load_session", {

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -162,6 +162,7 @@ export async function acpLoadSession(
 ): Promise<void> {
   if (USE_DIRECT_ACP) {
     await directAcp.loadSession(gooseSessionId, workingDir ?? "~/.goose/artifacts");
+    useChatStore.getState().setSessionLoading(sessionId, false);
     return;
   }
   return invoke("acp_load_session", {

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -1,4 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
+import { USE_DIRECT_ACP } from "./acpFeatureFlag";
+import * as directAcp from "./acpApi";
 
 export interface AcpProvider {
   id: string;
@@ -21,6 +23,9 @@ export interface AcpPrepareSessionOptions {
 
 /** Discover ACP providers installed on the system. */
 export async function discoverAcpProviders(): Promise<AcpProvider[]> {
+  if (USE_DIRECT_ACP) {
+    return directAcp.listProviders();
+  }
   return invoke("discover_acp_providers");
 }
 
@@ -31,6 +36,7 @@ export async function acpSendMessage(
   prompt: string,
   options: AcpSendMessageOptions = {},
 ): Promise<void> {
+  // TODO: wire up streaming path via acpApi.prompt()
   const { systemPrompt, workingDir, personaId, personaName, images } = options;
   return invoke("acp_send_message", {
     sessionId,
@@ -50,6 +56,7 @@ export async function acpPrepareSession(
   providerId: string,
   options: AcpPrepareSessionOptions = {},
 ): Promise<void> {
+  // TODO: wire up session preparation via acpApi.newSession()
   const { workingDir, personaId } = options;
   return invoke("acp_prepare_session", {
     sessionId,
@@ -63,6 +70,9 @@ export async function acpSetModel(
   sessionId: string,
   modelId: string,
 ): Promise<void> {
+  if (USE_DIRECT_ACP) {
+    return directAcp.setModel(sessionId, modelId);
+  }
   return invoke("acp_set_model", {
     sessionId,
     modelId,
@@ -87,6 +97,9 @@ export interface AcpSessionSearchResult {
 
 /** List all sessions known to the goose binary. */
 export async function acpListSessions(): Promise<AcpSessionInfo[]> {
+  if (USE_DIRECT_ACP) {
+    return directAcp.listSessions();
+  }
   return invoke("acp_list_sessions");
 }
 
@@ -94,6 +107,7 @@ export async function acpSearchSessions(
   query: string,
   sessionIds: string[],
 ): Promise<AcpSessionSearchResult[]> {
+  // TODO: port search to direct ACP (Step 06)
   return invoke("acp_search_sessions", { query, sessionIds });
 }
 
@@ -108,6 +122,7 @@ export async function acpLoadSession(
   gooseSessionId: string,
   workingDir?: string,
 ): Promise<void> {
+  // TODO: wire up session loading via acpApi.loadSession()
   return invoke("acp_load_session", {
     sessionId,
     gooseSessionId,
@@ -117,11 +132,17 @@ export async function acpLoadSession(
 
 /** Export a session as JSON via the goose binary. */
 export async function acpExportSession(sessionId: string): Promise<string> {
+  if (USE_DIRECT_ACP) {
+    return directAcp.exportSession(sessionId);
+  }
   return invoke("acp_export_session", { sessionId });
 }
 
 /** Import a session from JSON via the goose binary. Returns new session metadata. */
 export async function acpImportSession(json: string): Promise<AcpSessionInfo> {
+  if (USE_DIRECT_ACP) {
+    return directAcp.importSession(json);
+  }
   return invoke("acp_import_session", { json });
 }
 
@@ -129,6 +150,9 @@ export async function acpImportSession(json: string): Promise<AcpSessionInfo> {
 export async function acpDuplicateSession(
   sessionId: string,
 ): Promise<AcpSessionInfo> {
+  if (USE_DIRECT_ACP) {
+    return directAcp.forkSession(sessionId);
+  }
   return invoke("acp_duplicate_session", { sessionId });
 }
 
@@ -137,6 +161,10 @@ export async function acpCancelSession(
   sessionId: string,
   personaId?: string,
 ): Promise<boolean> {
+  if (USE_DIRECT_ACP) {
+    await directAcp.cancelSession(sessionId);
+    return true;
+  }
   return invoke("acp_cancel_session", {
     sessionId,
     personaId: personaId ?? null,

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -195,7 +195,9 @@ export async function acpDuplicateSession(
   sessionId: string,
 ): Promise<AcpSessionInfo> {
   if (USE_DIRECT_ACP) {
-    return directAcp.forkSession(sessionId);
+    const gooseSessionId =
+      sessionTracker.getGooseSessionId(sessionId) ?? sessionId;
+    return directAcp.forkSession(gooseSessionId);
   }
   return invoke("acp_duplicate_session", { sessionId });
 }

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -107,7 +107,8 @@ export async function acpSetModel(
   modelId: string,
 ): Promise<void> {
   if (USE_DIRECT_ACP) {
-    return directAcp.setModel(sessionId, modelId);
+    const gooseSessionId = sessionTracker.getGooseSessionId(sessionId);
+    return directAcp.setModel(gooseSessionId ?? sessionId, modelId);
   }
   return invoke("acp_set_model", {
     sessionId,
@@ -205,7 +206,8 @@ export async function acpCancelSession(
   personaId?: string,
 ): Promise<boolean> {
   if (USE_DIRECT_ACP) {
-    await directAcp.cancelSession(sessionId);
+    const gooseSessionId = sessionTracker.getGooseSessionId(sessionId, personaId);
+    await directAcp.cancelSession(gooseSessionId ?? sessionId);
     return true;
   }
   return invoke("acp_cancel_session", {

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -4,6 +4,7 @@ import * as directAcp from "./acpApi";
 import * as sessionTracker from "./acpSessionTracker";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { setActiveMessageId, clearActiveMessageId } from "./acpNotificationHandler";
+import { searchSessionsViaExports } from "./sessionSearch";
 
 export interface AcpProvider {
   id: string;
@@ -145,7 +146,9 @@ export async function acpSearchSessions(
   query: string,
   sessionIds: string[],
 ): Promise<AcpSessionSearchResult[]> {
-  // TODO: port search to direct ACP (Step 06)
+  if (USE_DIRECT_ACP) {
+    return searchSessionsViaExports(query, sessionIds);
+  }
   return invoke("acp_search_sessions", { query, sessionIds });
 }
 

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -2,7 +2,10 @@ import { invoke } from "@tauri-apps/api/core";
 import { USE_DIRECT_ACP } from "./acpFeatureFlag";
 import * as directAcp from "./acpApi";
 import * as sessionTracker from "./acpSessionTracker";
-import { setActiveMessageId, clearActiveMessageId } from "./acpNotificationHandler";
+import {
+  setActiveMessageId,
+  clearActiveMessageId,
+} from "./acpNotificationHandler";
 import { searchSessionsViaExports } from "./sessionSearch";
 
 export interface AcpProvider {
@@ -42,7 +45,10 @@ export async function acpSendMessage(
   if (USE_DIRECT_ACP) {
     const { systemPrompt, personaId, images } = options;
 
-    const gooseSessionId = sessionTracker.getGooseSessionId(sessionId, personaId);
+    const gooseSessionId = sessionTracker.getGooseSessionId(
+      sessionId,
+      personaId,
+    );
     if (!gooseSessionId) {
       throw new Error("Session not prepared. Call acpPrepareSession first.");
     }
@@ -90,7 +96,12 @@ export async function acpPrepareSession(
 ): Promise<void> {
   if (USE_DIRECT_ACP) {
     const workingDir = options.workingDir ?? "~/.goose/artifacts";
-    await sessionTracker.prepareSession(sessionId, providerId, workingDir, options.personaId);
+    await sessionTracker.prepareSession(
+      sessionId,
+      providerId,
+      workingDir,
+      options.personaId,
+    );
     return;
   }
   const { workingDir, personaId } = options;
@@ -164,7 +175,12 @@ export async function acpLoadSession(
   if (USE_DIRECT_ACP) {
     const effectiveWorkingDir = workingDir ?? "~/.goose/artifacts";
     await directAcp.loadSession(gooseSessionId, effectiveWorkingDir);
-    sessionTracker.registerSession(sessionId, gooseSessionId, "goose", effectiveWorkingDir);
+    sessionTracker.registerSession(
+      sessionId,
+      gooseSessionId,
+      "goose",
+      effectiveWorkingDir,
+    );
     return;
   }
   return invoke("acp_load_session", {
@@ -208,7 +224,10 @@ export async function acpCancelSession(
   personaId?: string,
 ): Promise<boolean> {
   if (USE_DIRECT_ACP) {
-    const gooseSessionId = sessionTracker.getGooseSessionId(sessionId, personaId);
+    const gooseSessionId = sessionTracker.getGooseSessionId(
+      sessionId,
+      personaId,
+    );
     await directAcp.cancelSession(gooseSessionId ?? sessionId);
     return true;
   }

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -105,7 +105,9 @@ export async function cancelSession(sessionId: string): Promise<void> {
   await client.cancel({ sessionId });
 }
 
-export async function newSession(workingDir: string): Promise<NewSessionResponse> {
+export async function newSession(
+  workingDir: string,
+): Promise<NewSessionResponse> {
   const client = await getClient();
   return client.newSession({ cwd: workingDir, mcpServers: [] });
 }

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -1,0 +1,104 @@
+import type {
+  ContentBlock,
+  NewSessionResponse,
+  LoadSessionResponse,
+  PromptResponse,
+} from "@agentclientprotocol/sdk";
+import { getClient } from "./acpConnection";
+
+export interface AcpProvider {
+  id: string;
+  label: string;
+}
+
+export interface AcpSessionInfo {
+  sessionId: string;
+  title: string | null;
+  updatedAt: string | null;
+  messageCount: number;
+}
+
+const DEPRECATED_PROVIDER_IDS = new Set(["claude-code", "codex", "gemini-cli"]);
+
+export async function listProviders(): Promise<AcpProvider[]> {
+  const client = await getClient();
+  const result = await client.goose.GooseProvidersList({});
+  return (result as any).providers
+    .filter((p: any) => !DEPRECATED_PROVIDER_IDS.has(p.id))
+    .map((p: any) => ({ id: p.id, label: p.label }));
+}
+
+export async function listSessions(): Promise<AcpSessionInfo[]> {
+  const client = await getClient();
+  const response = await client.unstable_listSessions({});
+  return response.sessions.map((info) => ({
+    sessionId: info.sessionId,
+    title: info.title ?? null,
+    updatedAt: info.updatedAt ?? null,
+    messageCount: (info._meta?.messageCount as number) ?? 0,
+  }));
+}
+
+export async function exportSession(sessionId: string): Promise<string> {
+  const client = await getClient();
+  const result = await client.goose.GooseSessionExport({ sessionId });
+  return (result as any).data;
+}
+
+export async function importSession(json: string): Promise<AcpSessionInfo> {
+  const client = await getClient();
+  const result = await client.goose.GooseSessionImport({ data: json });
+  return result as unknown as AcpSessionInfo;
+}
+
+export async function forkSession(sessionId: string): Promise<AcpSessionInfo> {
+  const client = await getClient();
+  const response = await client.unstable_forkSession({
+    sessionId,
+    cwd: "~/.goose/artifacts",
+  });
+  return {
+    sessionId: response.sessionId,
+    title: (response._meta?.title as string) ?? null,
+    updatedAt: null,
+    messageCount: (response._meta?.messageCount as number) ?? 0,
+  };
+}
+
+export async function setModel(
+  sessionId: string,
+  modelId: string,
+): Promise<void> {
+  const client = await getClient();
+  await client.setSessionConfigOption({
+    sessionId,
+    configId: "model",
+    value: modelId,
+  });
+}
+
+export async function cancelSession(sessionId: string): Promise<void> {
+  const client = await getClient();
+  await client.cancel({ sessionId });
+}
+
+export async function newSession(workingDir: string): Promise<NewSessionResponse> {
+  const client = await getClient();
+  return client.newSession({ cwd: workingDir, mcpServers: [] });
+}
+
+export async function loadSession(
+  sessionId: string,
+  workingDir: string,
+): Promise<LoadSessionResponse> {
+  const client = await getClient();
+  return client.loadSession({ sessionId, cwd: workingDir, mcpServers: [] });
+}
+
+export async function prompt(
+  sessionId: string,
+  content: ContentBlock[],
+): Promise<PromptResponse> {
+  const client = await getClient();
+  return client.prompt({ sessionId, prompt: content });
+}

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -30,8 +30,11 @@ export async function listProviders(): Promise<AcpProvider[]> {
 
 export async function listSessions(): Promise<AcpSessionInfo[]> {
   const client = await getClient();
-  const response = await client.unstable_listSessions({});
-  return response.sessions.map((info) => ({
+  // GooseClient.unstable_listSessions doesn't work with SDK 0.19 (renamed to listSessions).
+  // Bypass GooseClient and call the connection directly. Fix when ui/acp is updated.
+  const conn = (client as any).conn;
+  const response = await conn.listSessions({});
+  return response.sessions.map((info: any) => ({
     sessionId: info.sessionId,
     title: info.title ?? null,
     updatedAt: info.updatedAt ?? null,

--- a/ui/goose2/src/shared/api/acpApi.ts
+++ b/ui/goose2/src/shared/api/acpApi.ts
@@ -80,6 +80,26 @@ export async function setModel(
   });
 }
 
+export async function setProvider(
+  sessionId: string,
+  providerId: string,
+): Promise<void> {
+  const client = await getClient();
+  await client.setSessionConfigOption({
+    sessionId,
+    configId: "provider",
+    value: providerId,
+  });
+}
+
+export async function updateWorkingDir(
+  sessionId: string,
+  workingDir: string,
+): Promise<void> {
+  const client = await getClient();
+  await client.extMethod("goose/working_dir/update", { sessionId, workingDir });
+}
+
 export async function cancelSession(sessionId: string): Promise<void> {
   const client = await getClient();
   await client.cancel({ sessionId });

--- a/ui/goose2/src/shared/api/acpConnection.ts
+++ b/ui/goose2/src/shared/api/acpConnection.ts
@@ -1,10 +1,11 @@
 import { invoke } from "@tauri-apps/api/core";
 import { GooseClient } from "@aaif/goose-acp";
-import type {
-  Client,
-  SessionNotification,
-  RequestPermissionRequest,
-  RequestPermissionResponse,
+import {
+  PROTOCOL_VERSION,
+  type Client,
+  type SessionNotification,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
 } from "@agentclientprotocol/sdk";
 import { createWebSocketStream } from "./createWebSocketStream";
 
@@ -67,7 +68,7 @@ async function initializeConnection(): Promise<GooseClient> {
   const client = new GooseClient(createClientCallbacks(), stream);
 
   await client.initialize({
-    protocolVersion: 20250326,
+    protocolVersion: PROTOCOL_VERSION,
     clientCapabilities: {},
     clientInfo: {
       name: "goose2",

--- a/ui/goose2/src/shared/api/acpConnection.ts
+++ b/ui/goose2/src/shared/api/acpConnection.ts
@@ -1,0 +1,109 @@
+import { invoke } from "@tauri-apps/api/core";
+import { GooseClient } from "@aaif/goose-acp";
+import type {
+  Client,
+  SessionNotification,
+  RequestPermissionRequest,
+  RequestPermissionResponse,
+} from "@agentclientprotocol/sdk";
+import { createWebSocketStream } from "./createWebSocketStream";
+
+let notificationHandler: AcpNotificationHandler | null = null;
+
+export interface AcpNotificationHandler {
+  handleSessionNotification(notification: SessionNotification): Promise<void>;
+}
+
+export function setNotificationHandler(handler: AcpNotificationHandler): void {
+  notificationHandler = handler;
+}
+
+let clientPromise: Promise<GooseClient> | null = null;
+let resolvedClient: GooseClient | null = null;
+
+function createClientCallbacks(): () => Client {
+  return () => ({
+    requestPermission: async (
+      args: RequestPermissionRequest,
+    ): Promise<RequestPermissionResponse> => {
+      const optionId = args.options?.[0]?.optionId ?? "approve";
+      return {
+        outcome: {
+          outcome: "selected",
+          optionId,
+        },
+      };
+    },
+
+    sessionUpdate: async (
+      notification: SessionNotification,
+    ): Promise<void> => {
+      if (notificationHandler) {
+        await notificationHandler.handleSessionNotification(notification);
+      }
+    },
+  });
+}
+
+function monitorConnection(client: GooseClient): void {
+  client.closed
+    .then(() => {
+      console.warn("[acp] Connection closed. Will reconnect on next getClient().");
+      resolvedClient = null;
+      clientPromise = null;
+    })
+    .catch(() => {
+      console.warn("[acp] Connection error. Will reconnect on next getClient().");
+      resolvedClient = null;
+      clientPromise = null;
+    });
+}
+
+async function initializeConnection(): Promise<GooseClient> {
+  const wsUrl: string = await invoke("get_goose_serve_url");
+
+  const stream = createWebSocketStream(wsUrl);
+
+  const client = new GooseClient(createClientCallbacks(), stream);
+
+  await client.initialize({
+    protocolVersion: 20250326,
+    clientCapabilities: {},
+    clientInfo: {
+      name: "goose2",
+      version: "0.1.0",
+    },
+  });
+
+  monitorConnection(client);
+
+  return client;
+}
+
+export async function getClient(): Promise<GooseClient> {
+  if (resolvedClient) {
+    return resolvedClient;
+  }
+
+  if (!clientPromise) {
+    clientPromise = initializeConnection()
+      .then((client) => {
+        resolvedClient = client;
+        return client;
+      })
+      .catch((error) => {
+        clientPromise = null;
+        throw error;
+      });
+  }
+
+  return clientPromise;
+}
+
+export function isClientReady(): boolean {
+  return resolvedClient !== null;
+}
+
+export function getClientSync(): GooseClient | null {
+  return resolvedClient;
+}

--- a/ui/goose2/src/shared/api/acpConnection.ts
+++ b/ui/goose2/src/shared/api/acpConnection.ts
@@ -36,9 +36,7 @@ function createClientCallbacks(): () => Client {
       };
     },
 
-    sessionUpdate: async (
-      notification: SessionNotification,
-    ): Promise<void> => {
+    sessionUpdate: async (notification: SessionNotification): Promise<void> => {
       if (notificationHandler) {
         await notificationHandler.handleSessionNotification(notification);
       }
@@ -49,12 +47,16 @@ function createClientCallbacks(): () => Client {
 function monitorConnection(client: GooseClient): void {
   client.closed
     .then(() => {
-      console.warn("[acp] Connection closed. Will reconnect on next getClient().");
+      console.warn(
+        "[acp] Connection closed. Will reconnect on next getClient().",
+      );
       resolvedClient = null;
       clientPromise = null;
     })
     .catch(() => {
-      console.warn("[acp] Connection error. Will reconnect on next getClient().");
+      console.warn(
+        "[acp] Connection error. Will reconnect on next getClient().",
+      );
       resolvedClient = null;
       clientPromise = null;
     });

--- a/ui/goose2/src/shared/api/acpFeatureFlag.ts
+++ b/ui/goose2/src/shared/api/acpFeatureFlag.ts
@@ -1,1 +1,1 @@
-export const USE_DIRECT_ACP = false;
+export const USE_DIRECT_ACP = true;

--- a/ui/goose2/src/shared/api/acpFeatureFlag.ts
+++ b/ui/goose2/src/shared/api/acpFeatureFlag.ts
@@ -1,0 +1,1 @@
+export const USE_DIRECT_ACP = false;

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -8,20 +8,31 @@ import {
 } from "@/features/chat/hooks/replayBuffer";
 import type { ToolRequestContent, ToolResponseContent } from "@/shared/types/messages";
 import type { AcpNotificationHandler } from "./acpConnection";
+import { getLocalSessionId } from "./acpSessionTracker";
 
-// Track which messageIds we've already created, to avoid duplicates
-const knownMessageIds = new Set<string>();
+// Pre-set message ID for the next live stream per goose session
+const presetMessageIds = new Map<string, string>();
+
+export function setActiveMessageId(gooseSessionId: string, messageId: string): void {
+  presetMessageIds.set(gooseSessionId, messageId);
+}
+
+export function clearActiveMessageId(gooseSessionId: string): void {
+  presetMessageIds.delete(gooseSessionId);
+}
 
 export async function handleSessionNotification(
   notification: SessionNotification,
 ): Promise<void> {
-  const { sessionId, update } = notification;
+  const gooseSessionId = notification.sessionId;
+  const sessionId = getLocalSessionId(gooseSessionId) ?? gooseSessionId;
+  const { update } = notification;
   const isReplay = useChatStore.getState().loadingSessionIds.has(sessionId);
 
   if (isReplay) {
     handleReplay(sessionId, update);
   } else {
-    handleLive(sessionId, update);
+    handleLive(sessionId, gooseSessionId, update);
   }
 }
 
@@ -138,31 +149,26 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
   }
 }
 
-function handleLive(sessionId: string, update: SessionUpdate): void {
+function handleLive(sessionId: string, gooseSessionId: string, update: SessionUpdate): void {
   const store = useChatStore.getState();
 
   switch (update.sessionUpdate) {
     case "agent_message_chunk": {
-      const messageId = update.messageId ?? crypto.randomUUID();
+      const messageId = update.messageId ?? presetMessageIds.get(gooseSessionId) ?? crypto.randomUUID();
+      const existing = store.messagesBySession[sessionId]?.find(m => m.id === messageId);
 
-      if (!knownMessageIds.has(messageId)) {
-        knownMessageIds.add(messageId);
-        const existing = store.messagesBySession[sessionId]?.find(
-          (m) => m.id === messageId,
-        );
-        if (!existing) {
-          store.addMessage(sessionId, {
-            id: messageId,
-            role: "assistant",
-            created: Date.now(),
-            content: [],
-            metadata: {
-              userVisible: true,
-              agentVisible: true,
-              completionStatus: "inProgress",
-            },
-          });
-        }
+      if (!existing) {
+        store.addMessage(sessionId, {
+          id: messageId,
+          role: "assistant",
+          created: Date.now(),
+          content: [],
+          metadata: {
+            userVisible: true,
+            agentVisible: true,
+            completionStatus: "inProgress",
+          },
+        });
         store.setPendingAssistantProvider(sessionId, null);
         store.setStreamingMessageId(sessionId, messageId);
       }
@@ -356,7 +362,7 @@ function extractToolResultText(update: { content?: Array<any> | null; rawOutput?
 }
 
 export function clearMessageTracking(): void {
-  knownMessageIds.clear();
+  presetMessageIds.clear();
 }
 
 const handler: AcpNotificationHandler = {

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -1,4 +1,7 @@
-import type { SessionNotification, SessionUpdate } from "@agentclientprotocol/sdk";
+import type {
+  SessionNotification,
+  SessionUpdate,
+} from "@agentclientprotocol/sdk";
 import { useChatStore } from "@/features/chat/stores/chatStore";
 import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
 import {
@@ -6,14 +9,20 @@ import {
   getBufferedMessage,
   findLatestUnpairedToolRequest,
 } from "@/features/chat/hooks/replayBuffer";
-import type { ToolRequestContent, ToolResponseContent } from "@/shared/types/messages";
+import type {
+  ToolRequestContent,
+  ToolResponseContent,
+} from "@/shared/types/messages";
 import type { AcpNotificationHandler } from "./acpConnection";
 import { getLocalSessionId } from "./acpSessionTracker";
 
 // Pre-set message ID for the next live stream per goose session
 const presetMessageIds = new Map<string, string>();
 
-export function setActiveMessageId(gooseSessionId: string, messageId: string): void {
+export function setActiveMessageId(
+  gooseSessionId: string,
+  messageId: string,
+): void {
   presetMessageIds.set(gooseSessionId, messageId);
 }
 
@@ -70,7 +79,11 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
       const messageId = update.messageId ?? crypto.randomUUID();
       const buffer = ensureReplayBuffer(sessionId);
       const existing = getBufferedMessage(sessionId, messageId);
-      if (!existing && update.content.type === "text" && "text" in update.content) {
+      if (
+        !existing &&
+        update.content.type === "text" &&
+        "text" in update.content
+      ) {
         buffer.push({
           id: messageId,
           role: "user",
@@ -78,7 +91,11 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
           content: [{ type: "text", text: update.content.text }],
           metadata: { userVisible: true, agentVisible: true },
         });
-      } else if (existing && update.content.type === "text" && "text" in update.content) {
+      } else if (
+        existing &&
+        update.content.type === "text" &&
+        "text" in update.content
+      ) {
         const last = existing.content[existing.content.length - 1];
         if (last?.type === "text") {
           (last as { type: "text"; text: string }).text += update.content.text;
@@ -122,7 +139,10 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
           if (tc && tc.type === "toolRequest") {
             const idx = msg.content.indexOf(tc);
             if (idx >= 0) {
-              msg.content[idx] = { ...tc, status: "completed" } as ToolRequestContent;
+              msg.content[idx] = {
+                ...tc,
+                status: "completed",
+              } as ToolRequestContent;
             }
           }
           const resultText = extractToolResultText(update);
@@ -149,13 +169,22 @@ function handleReplay(sessionId: string, update: SessionUpdate): void {
   }
 }
 
-function handleLive(sessionId: string, gooseSessionId: string, update: SessionUpdate): void {
+function handleLive(
+  sessionId: string,
+  gooseSessionId: string,
+  update: SessionUpdate,
+): void {
   const store = useChatStore.getState();
 
   switch (update.sessionUpdate) {
     case "agent_message_chunk": {
-      const messageId = update.messageId ?? presetMessageIds.get(gooseSessionId) ?? crypto.randomUUID();
-      const existing = store.messagesBySession[sessionId]?.find(m => m.id === messageId);
+      const messageId =
+        update.messageId ??
+        presetMessageIds.get(gooseSessionId) ??
+        crypto.randomUUID();
+      const existing = store.messagesBySession[sessionId]?.find(
+        (m) => m.id === messageId,
+      );
 
       if (!existing) {
         store.addMessage(sessionId, {
@@ -257,22 +286,28 @@ function handleLive(sessionId: string, gooseSessionId: string, update: SessionUp
 function handleShared(sessionId: string, update: SessionUpdate): void {
   switch (update.sessionUpdate) {
     case "session_info_update": {
-      const info = update as SessionUpdate & { sessionUpdate: "session_info_update" };
+      const info = update as SessionUpdate & {
+        sessionUpdate: "session_info_update";
+      };
       if ("title" in info && info.title) {
         const session = useChatSessionStore.getState().getSession(sessionId);
         if (session && !session.userSetName) {
-          useChatSessionStore.getState().updateSession(
-            sessionId,
-            { title: info.title as string },
-            { persistOverlay: false },
-          );
+          useChatSessionStore
+            .getState()
+            .updateSession(
+              sessionId,
+              { title: info.title as string },
+              { persistOverlay: false },
+            );
         }
       }
       break;
     }
 
     case "config_option_update": {
-      const configUpdate = update as SessionUpdate & { sessionUpdate: "config_option_update" };
+      const configUpdate = update as SessionUpdate & {
+        sessionUpdate: "config_option_update";
+      };
       if ("options" in configUpdate && Array.isArray(configUpdate.options)) {
         const modelOption = configUpdate.options.find(
           (opt: any) => opt.category === "model",
@@ -295,7 +330,8 @@ function handleShared(sessionId: string, update: SessionUpdate): void {
           }
 
           const currentModelName =
-            availableModels.find((m) => m.id === currentModelId)?.name ?? currentModelId;
+            availableModels.find((m) => m.id === currentModelId)?.name ??
+            currentModelId;
 
           const sessionStore = useChatSessionStore.getState();
           sessionStore.setSessionModels(sessionId, availableModels);
@@ -326,26 +362,38 @@ function handleShared(sessionId: string, update: SessionUpdate): void {
 // Helpers
 
 function findStreamingMessageId(sessionId: string): string | null {
-  return useChatStore.getState().getSessionRuntime(sessionId).streamingMessageId;
+  return useChatStore.getState().getSessionRuntime(sessionId)
+    .streamingMessageId;
 }
 
-function findMessageInBuffer(sessionId: string, _toolCallId: string): ReturnType<typeof getBufferedMessage> {
+function findMessageInBuffer(
+  sessionId: string,
+  _toolCallId: string,
+): ReturnType<typeof getBufferedMessage> {
   const buffer = ensureReplayBuffer(sessionId);
   return buffer[buffer.length - 1];
 }
 
-function findMessageWithToolCall(sessionId: string, toolCallId: string): ReturnType<typeof getBufferedMessage> {
+function findMessageWithToolCall(
+  sessionId: string,
+  toolCallId: string,
+): ReturnType<typeof getBufferedMessage> {
   const buffer = ensureReplayBuffer(sessionId);
   for (let i = buffer.length - 1; i >= 0; i--) {
     const msg = buffer[i];
-    if (msg.content.some((c) => c.type === "toolRequest" && c.id === toolCallId)) {
+    if (
+      msg.content.some((c) => c.type === "toolRequest" && c.id === toolCallId)
+    ) {
       return msg;
     }
   }
   return buffer[buffer.length - 1];
 }
 
-function extractToolResultText(update: { content?: Array<any> | null; rawOutput?: unknown }): string {
+function extractToolResultText(update: {
+  content?: Array<any> | null;
+  rawOutput?: unknown;
+}): string {
   if (update.content && update.content.length > 0) {
     for (const item of update.content) {
       if (item.type === "content" && item.content?.type === "text") {

--- a/ui/goose2/src/shared/api/acpNotificationHandler.ts
+++ b/ui/goose2/src/shared/api/acpNotificationHandler.ts
@@ -1,0 +1,366 @@
+import type { SessionNotification, SessionUpdate } from "@agentclientprotocol/sdk";
+import { useChatStore } from "@/features/chat/stores/chatStore";
+import { useChatSessionStore } from "@/features/chat/stores/chatSessionStore";
+import {
+  ensureReplayBuffer,
+  getBufferedMessage,
+  findLatestUnpairedToolRequest,
+} from "@/features/chat/hooks/replayBuffer";
+import type { ToolRequestContent, ToolResponseContent } from "@/shared/types/messages";
+import type { AcpNotificationHandler } from "./acpConnection";
+
+// Track which messageIds we've already created, to avoid duplicates
+const knownMessageIds = new Set<string>();
+
+export async function handleSessionNotification(
+  notification: SessionNotification,
+): Promise<void> {
+  const { sessionId, update } = notification;
+  const isReplay = useChatStore.getState().loadingSessionIds.has(sessionId);
+
+  if (isReplay) {
+    handleReplay(sessionId, update);
+  } else {
+    handleLive(sessionId, update);
+  }
+}
+
+function handleReplay(sessionId: string, update: SessionUpdate): void {
+  switch (update.sessionUpdate) {
+    case "agent_message_chunk": {
+      const messageId = update.messageId ?? crypto.randomUUID();
+      const buffer = ensureReplayBuffer(sessionId);
+      if (!getBufferedMessage(sessionId, messageId)) {
+        buffer.push({
+          id: messageId,
+          role: "assistant",
+          created: Date.now(),
+          content: [],
+          metadata: {
+            userVisible: true,
+            agentVisible: true,
+            completionStatus: "inProgress",
+          },
+        });
+      }
+      const msg = getBufferedMessage(sessionId, messageId);
+      if (msg && update.content.type === "text" && "text" in update.content) {
+        const last = msg.content[msg.content.length - 1];
+        if (last?.type === "text") {
+          (last as { type: "text"; text: string }).text += update.content.text;
+        } else {
+          msg.content.push({ type: "text", text: update.content.text });
+        }
+      }
+      break;
+    }
+
+    case "user_message_chunk": {
+      const messageId = update.messageId ?? crypto.randomUUID();
+      const buffer = ensureReplayBuffer(sessionId);
+      const existing = getBufferedMessage(sessionId, messageId);
+      if (!existing && update.content.type === "text" && "text" in update.content) {
+        buffer.push({
+          id: messageId,
+          role: "user",
+          created: Date.now(),
+          content: [{ type: "text", text: update.content.text }],
+          metadata: { userVisible: true, agentVisible: true },
+        });
+      } else if (existing && update.content.type === "text" && "text" in update.content) {
+        const last = existing.content[existing.content.length - 1];
+        if (last?.type === "text") {
+          (last as { type: "text"; text: string }).text += update.content.text;
+        } else {
+          existing.content.push({ type: "text", text: update.content.text });
+        }
+      }
+      break;
+    }
+
+    case "tool_call": {
+      const msg = findMessageInBuffer(sessionId, update.toolCallId);
+      if (msg) {
+        msg.content.push({
+          type: "toolRequest",
+          id: update.toolCallId,
+          name: update.title,
+          arguments: {},
+          status: "executing",
+          startedAt: Date.now(),
+        });
+      }
+      break;
+    }
+
+    case "tool_call_update": {
+      const msg = findMessageWithToolCall(sessionId, update.toolCallId);
+      if (msg) {
+        if (update.title) {
+          const tc = msg.content.find(
+            (c) => c.type === "toolRequest" && c.id === update.toolCallId,
+          );
+          if (tc && tc.type === "toolRequest") {
+            (tc as ToolRequestContent).name = update.title;
+          }
+        }
+        if (update.status === "completed" || update.status === "failed") {
+          const tc = msg.content.find(
+            (c) => c.type === "toolRequest" && c.id === update.toolCallId,
+          );
+          if (tc && tc.type === "toolRequest") {
+            const idx = msg.content.indexOf(tc);
+            if (idx >= 0) {
+              msg.content[idx] = { ...tc, status: "completed" } as ToolRequestContent;
+            }
+          }
+          const resultText = extractToolResultText(update);
+          msg.content.push({
+            type: "toolResponse",
+            id: update.toolCallId,
+            name: (tc as ToolRequestContent)?.name ?? "",
+            result: resultText,
+            isError: update.status === "failed",
+          });
+        }
+      }
+      break;
+    }
+
+    case "session_info_update":
+    case "config_option_update":
+    case "usage_update":
+      handleShared(sessionId, update);
+      break;
+
+    default:
+      break;
+  }
+}
+
+function handleLive(sessionId: string, update: SessionUpdate): void {
+  const store = useChatStore.getState();
+
+  switch (update.sessionUpdate) {
+    case "agent_message_chunk": {
+      const messageId = update.messageId ?? crypto.randomUUID();
+
+      if (!knownMessageIds.has(messageId)) {
+        knownMessageIds.add(messageId);
+        const existing = store.messagesBySession[sessionId]?.find(
+          (m) => m.id === messageId,
+        );
+        if (!existing) {
+          store.addMessage(sessionId, {
+            id: messageId,
+            role: "assistant",
+            created: Date.now(),
+            content: [],
+            metadata: {
+              userVisible: true,
+              agentVisible: true,
+              completionStatus: "inProgress",
+            },
+          });
+        }
+        store.setPendingAssistantProvider(sessionId, null);
+        store.setStreamingMessageId(sessionId, messageId);
+      }
+
+      if (update.content.type === "text" && "text" in update.content) {
+        store.setStreamingMessageId(sessionId, messageId);
+        store.updateStreamingText(sessionId, update.content.text);
+      }
+      break;
+    }
+
+    case "tool_call": {
+      const messageId = findStreamingMessageId(sessionId);
+      if (!messageId) break;
+
+      const toolRequest: ToolRequestContent = {
+        type: "toolRequest",
+        id: update.toolCallId,
+        name: update.title,
+        arguments: {},
+        status: "executing",
+        startedAt: Date.now(),
+      };
+      store.setStreamingMessageId(sessionId, messageId);
+      store.appendToStreamingMessage(sessionId, toolRequest);
+      break;
+    }
+
+    case "tool_call_update": {
+      const messageId = findStreamingMessageId(sessionId);
+      if (!messageId) break;
+
+      if (update.title) {
+        store.updateMessage(sessionId, messageId, (msg) => ({
+          ...msg,
+          content: msg.content.map((c) =>
+            c.type === "toolRequest" && c.id === update.toolCallId
+              ? { ...c, name: update.title! }
+              : c,
+          ),
+        }));
+      }
+
+      if (update.status === "completed" || update.status === "failed") {
+        const streamingMessage = store.messagesBySession[sessionId]?.find(
+          (m) => m.id === messageId,
+        );
+        const toolRequest = streamingMessage
+          ? findLatestUnpairedToolRequest(streamingMessage.content)
+          : null;
+
+        store.updateMessage(sessionId, messageId, (msg) => ({
+          ...msg,
+          content: msg.content.map((block) =>
+            block.type === "toolRequest" && block.id === update.toolCallId
+              ? { ...block, status: "completed" }
+              : block,
+          ),
+        }));
+
+        const resultText = extractToolResultText(update);
+        const toolResponse: ToolResponseContent = {
+          type: "toolResponse",
+          id: update.toolCallId,
+          name: toolRequest?.name ?? "",
+          result: resultText,
+          isError: update.status === "failed",
+        };
+        store.setStreamingMessageId(sessionId, messageId);
+        store.appendToStreamingMessage(sessionId, toolResponse);
+      }
+      break;
+    }
+
+    case "session_info_update":
+    case "config_option_update":
+    case "usage_update":
+      handleShared(sessionId, update);
+      break;
+
+    default:
+      break;
+  }
+}
+
+function handleShared(sessionId: string, update: SessionUpdate): void {
+  switch (update.sessionUpdate) {
+    case "session_info_update": {
+      const info = update as SessionUpdate & { sessionUpdate: "session_info_update" };
+      if ("title" in info && info.title) {
+        const session = useChatSessionStore.getState().getSession(sessionId);
+        if (session && !session.userSetName) {
+          useChatSessionStore.getState().updateSession(
+            sessionId,
+            { title: info.title as string },
+            { persistOverlay: false },
+          );
+        }
+      }
+      break;
+    }
+
+    case "config_option_update": {
+      const configUpdate = update as SessionUpdate & { sessionUpdate: "config_option_update" };
+      if ("options" in configUpdate && Array.isArray(configUpdate.options)) {
+        const modelOption = configUpdate.options.find(
+          (opt: any) => opt.category === "model",
+        );
+        if (modelOption?.kind?.type === "select") {
+          const select = modelOption.kind;
+          const currentModelId = select.currentValue;
+          const availableModels: Array<{ id: string; name: string }> = [];
+
+          if (select.options?.type === "ungrouped") {
+            for (const v of select.options.values) {
+              availableModels.push({ id: v.value, name: v.name });
+            }
+          } else if (select.options?.type === "grouped") {
+            for (const group of select.options.groups) {
+              for (const v of group.options) {
+                availableModels.push({ id: v.value, name: v.name });
+              }
+            }
+          }
+
+          const currentModelName =
+            availableModels.find((m) => m.id === currentModelId)?.name ?? currentModelId;
+
+          const sessionStore = useChatSessionStore.getState();
+          sessionStore.setSessionModels(sessionId, availableModels);
+          sessionStore.updateSession(
+            sessionId,
+            { modelId: currentModelId, modelName: currentModelName },
+            { persistOverlay: false },
+          );
+        }
+      }
+      break;
+    }
+
+    case "usage_update": {
+      const usage = update as SessionUpdate & { sessionUpdate: "usage_update" };
+      useChatStore.getState().updateTokenState(sessionId, {
+        accumulatedTotal: usage.used,
+        contextLimit: usage.size,
+      });
+      break;
+    }
+
+    default:
+      break;
+  }
+}
+
+// Helpers
+
+function findStreamingMessageId(sessionId: string): string | null {
+  return useChatStore.getState().getSessionRuntime(sessionId).streamingMessageId;
+}
+
+function findMessageInBuffer(sessionId: string, _toolCallId: string): ReturnType<typeof getBufferedMessage> {
+  const buffer = ensureReplayBuffer(sessionId);
+  return buffer[buffer.length - 1];
+}
+
+function findMessageWithToolCall(sessionId: string, toolCallId: string): ReturnType<typeof getBufferedMessage> {
+  const buffer = ensureReplayBuffer(sessionId);
+  for (let i = buffer.length - 1; i >= 0; i--) {
+    const msg = buffer[i];
+    if (msg.content.some((c) => c.type === "toolRequest" && c.id === toolCallId)) {
+      return msg;
+    }
+  }
+  return buffer[buffer.length - 1];
+}
+
+function extractToolResultText(update: { content?: Array<any> | null; rawOutput?: unknown }): string {
+  if (update.content && update.content.length > 0) {
+    for (const item of update.content) {
+      if (item.type === "content" && item.content?.type === "text") {
+        return item.content.text;
+      }
+    }
+  }
+  if (update.rawOutput !== undefined && update.rawOutput !== null) {
+    return typeof update.rawOutput === "string"
+      ? update.rawOutput
+      : JSON.stringify(update.rawOutput);
+  }
+  return "";
+}
+
+export function clearMessageTracking(): void {
+  knownMessageIds.clear();
+}
+
+const handler: AcpNotificationHandler = {
+  handleSessionNotification,
+};
+
+export default handler;

--- a/ui/goose2/src/shared/api/acpSessionTracker.ts
+++ b/ui/goose2/src/shared/api/acpSessionTracker.ts
@@ -50,6 +50,8 @@ export async function prepareSession(
     gooseSessionId = response.sessionId;
   }
 
+  await acpApi.setProvider(gooseSessionId, providerId);
+
   prepared.set(key, { gooseSessionId, providerId, workingDir });
   prepared.set(sessionId, { gooseSessionId, providerId, workingDir });
   gooseToLocal.set(gooseSessionId, sessionId);

--- a/ui/goose2/src/shared/api/acpSessionTracker.ts
+++ b/ui/goose2/src/shared/api/acpSessionTracker.ts
@@ -58,3 +58,14 @@ export function getLocalSessionId(gooseSessionId: string): string | null {
   return gooseToLocal.get(gooseSessionId) ?? null;
 }
 
+export function registerSession(
+  sessionId: string,
+  gooseSessionId: string,
+  providerId: string,
+  workingDir: string,
+): void {
+  const entry = { gooseSessionId, providerId, workingDir };
+  prepared.set(sessionId, entry);
+  gooseToLocal.set(gooseSessionId, sessionId);
+}
+

--- a/ui/goose2/src/shared/api/acpSessionTracker.ts
+++ b/ui/goose2/src/shared/api/acpSessionTracker.ts
@@ -26,6 +26,14 @@ export async function prepareSession(
 
   const existing = prepared.get(key) ?? prepared.get(sessionId);
   if (existing) {
+    if (existing.workingDir !== workingDir) {
+      await acpApi.updateWorkingDir(existing.gooseSessionId, workingDir);
+      existing.workingDir = workingDir;
+    }
+    if (existing.providerId !== providerId) {
+      await acpApi.setProvider(existing.gooseSessionId, providerId);
+      existing.providerId = providerId;
+    }
     return existing.gooseSessionId;
   }
 

--- a/ui/goose2/src/shared/api/acpSessionTracker.ts
+++ b/ui/goose2/src/shared/api/acpSessionTracker.ts
@@ -1,0 +1,55 @@
+import * as acpApi from "./acpApi";
+
+interface PreparedSession {
+  gooseSessionId: string;
+  providerId: string;
+  workingDir: string;
+}
+
+const prepared = new Map<string, PreparedSession>();
+
+function makeKey(sessionId: string, personaId?: string): string {
+  if (personaId && personaId.length > 0) {
+    return `${sessionId}__${personaId}`;
+  }
+  return sessionId;
+}
+
+export async function prepareSession(
+  sessionId: string,
+  providerId: string,
+  workingDir: string,
+  personaId?: string,
+): Promise<string> {
+  const key = makeKey(sessionId, personaId);
+
+  const existing = prepared.get(key) ?? prepared.get(sessionId);
+  if (existing) {
+    return existing.gooseSessionId;
+  }
+
+  let gooseSessionId: string | null = null;
+
+  try {
+    await acpApi.loadSession(sessionId, workingDir);
+    gooseSessionId = sessionId;
+  } catch {
+    // session doesn't exist — create new
+  }
+
+  if (!gooseSessionId) {
+    const response = await acpApi.newSession(workingDir);
+    gooseSessionId = response.sessionId;
+  }
+
+  prepared.set(key, { gooseSessionId, providerId, workingDir });
+  prepared.set(sessionId, { gooseSessionId, providerId, workingDir });
+
+  return gooseSessionId;
+}
+
+export function getGooseSessionId(sessionId: string, personaId?: string): string | null {
+  const key = makeKey(sessionId, personaId);
+  return prepared.get(key)?.gooseSessionId ?? prepared.get(sessionId)?.gooseSessionId ?? null;
+}
+

--- a/ui/goose2/src/shared/api/acpSessionTracker.ts
+++ b/ui/goose2/src/shared/api/acpSessionTracker.ts
@@ -7,6 +7,7 @@ interface PreparedSession {
 }
 
 const prepared = new Map<string, PreparedSession>();
+const gooseToLocal = new Map<string, string>();
 
 function makeKey(sessionId: string, personaId?: string): string {
   if (personaId && personaId.length > 0) {
@@ -34,7 +35,6 @@ export async function prepareSession(
     await acpApi.loadSession(sessionId, workingDir);
     gooseSessionId = sessionId;
   } catch {
-    // session doesn't exist — create new
   }
 
   if (!gooseSessionId) {
@@ -44,6 +44,7 @@ export async function prepareSession(
 
   prepared.set(key, { gooseSessionId, providerId, workingDir });
   prepared.set(sessionId, { gooseSessionId, providerId, workingDir });
+  gooseToLocal.set(gooseSessionId, sessionId);
 
   return gooseSessionId;
 }
@@ -51,5 +52,9 @@ export async function prepareSession(
 export function getGooseSessionId(sessionId: string, personaId?: string): string | null {
   const key = makeKey(sessionId, personaId);
   return prepared.get(key)?.gooseSessionId ?? prepared.get(sessionId)?.gooseSessionId ?? null;
+}
+
+export function getLocalSessionId(gooseSessionId: string): string | null {
+  return gooseToLocal.get(gooseSessionId) ?? null;
 }
 

--- a/ui/goose2/src/shared/api/acpSessionTracker.ts
+++ b/ui/goose2/src/shared/api/acpSessionTracker.ts
@@ -42,8 +42,7 @@ export async function prepareSession(
   try {
     await acpApi.loadSession(sessionId, workingDir);
     gooseSessionId = sessionId;
-  } catch {
-  }
+  } catch {}
 
   if (!gooseSessionId) {
     const response = await acpApi.newSession(workingDir);
@@ -59,9 +58,16 @@ export async function prepareSession(
   return gooseSessionId;
 }
 
-export function getGooseSessionId(sessionId: string, personaId?: string): string | null {
+export function getGooseSessionId(
+  sessionId: string,
+  personaId?: string,
+): string | null {
   const key = makeKey(sessionId, personaId);
-  return prepared.get(key)?.gooseSessionId ?? prepared.get(sessionId)?.gooseSessionId ?? null;
+  return (
+    prepared.get(key)?.gooseSessionId ??
+    prepared.get(sessionId)?.gooseSessionId ??
+    null
+  );
 }
 
 export function getLocalSessionId(gooseSessionId: string): string | null {
@@ -78,4 +84,3 @@ export function registerSession(
   prepared.set(sessionId, entry);
   gooseToLocal.set(gooseSessionId, sessionId);
 }
-

--- a/ui/goose2/src/shared/api/createWebSocketStream.ts
+++ b/ui/goose2/src/shared/api/createWebSocketStream.ts
@@ -1,0 +1,80 @@
+import type { AnyMessage, Stream } from "@agentclientprotocol/sdk";
+
+export function createWebSocketStream(wsUrl: string): Stream {
+  const ws = new WebSocket(wsUrl);
+
+  const incoming: AnyMessage[] = [];
+  const waiters: Array<() => void> = [];
+  let closed = false;
+
+  function pushMessage(msg: AnyMessage): void {
+    incoming.push(msg);
+    const waiter = waiters.shift();
+    if (waiter) waiter();
+  }
+
+  function waitForMessage(): Promise<void> {
+    if (incoming.length > 0 || closed) return Promise.resolve();
+    return new Promise<void>((resolve) => waiters.push(resolve));
+  }
+
+  const openPromise = new Promise<void>((resolve, reject) => {
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener(
+      "error",
+      (event) => {
+        reject(new Error(`WebSocket connection failed: ${event}`));
+      },
+      { once: true },
+    );
+  });
+
+  ws.addEventListener("message", (event) => {
+    if (typeof event.data !== "string") return;
+    try {
+      const msg = JSON.parse(event.data) as AnyMessage;
+      pushMessage(msg);
+    } catch {
+      // ignore malformed JSON
+    }
+  });
+
+  ws.addEventListener("close", () => {
+    closed = true;
+    for (const waiter of waiters) waiter();
+    waiters.length = 0;
+  });
+
+  ws.addEventListener("error", () => {
+    closed = true;
+    for (const waiter of waiters) waiter();
+    waiters.length = 0;
+  });
+
+  const readable = new ReadableStream<AnyMessage>({
+    async pull(controller) {
+      await waitForMessage();
+      while (incoming.length > 0) {
+        controller.enqueue(incoming.shift()!);
+      }
+      if (closed && incoming.length === 0) {
+        controller.close();
+      }
+    },
+  });
+
+  const writable = new WritableStream<AnyMessage>({
+    async write(msg) {
+      await openPromise;
+      ws.send(JSON.stringify(msg));
+    },
+    close() {
+      ws.close();
+    },
+    abort() {
+      ws.close();
+    },
+  });
+
+  return { readable, writable };
+}

--- a/ui/goose2/src/shared/api/sessionSearch.ts
+++ b/ui/goose2/src/shared/api/sessionSearch.ts
@@ -8,11 +8,20 @@ type MessageRole = "user" | "assistant" | "system";
 const SEARCHABLE_ROLES = new Set<MessageRole>(["user", "assistant", "system"]);
 
 const SEARCHABLE_BLOCK_TYPES = new Set([
-  "text", "input_text", "output_text", "systemNotification", "system_notification",
+  "text",
+  "input_text",
+  "output_text",
+  "systemNotification",
+  "system_notification",
 ]);
 
 const SKIPPED_BLOCK_TYPES = new Set([
-  "toolRequest", "toolResponse", "thinking", "redactedThinking", "reasoning", "image",
+  "toolRequest",
+  "toolResponse",
+  "thinking",
+  "redactedThinking",
+  "reasoning",
+  "image",
 ]);
 
 export interface SessionSearchResult {
@@ -66,7 +75,11 @@ function searchSession(
   const messages = flattenMessages(conversation);
   if (!messages.length) return null;
 
-  let firstMatch: { messageId: string; role: MessageRole | null; snippet: string } | null = null;
+  let firstMatch: {
+    messageId: string;
+    role: MessageRole | null;
+    snippet: string;
+  } | null = null;
   let matchCount = 0;
 
   for (const msg of messages) {
@@ -74,7 +87,11 @@ function searchSession(
       const count = countMatches(text, query);
       if (!count) continue;
       matchCount += count;
-      firstMatch ??= { messageId: msg.id, role: msg.role, snippet: buildSnippet(text, query) };
+      firstMatch ??= {
+        messageId: msg.id,
+        role: msg.role,
+        snippet: buildSnippet(text, query),
+      };
     }
   }
 
@@ -90,7 +107,11 @@ function searchSession(
 }
 
 function safeParse(json: string): Record<string, any> | null {
-  try { return JSON.parse(json); } catch { return null; }
+  try {
+    return JSON.parse(json);
+  } catch {
+    return null;
+  }
 }
 
 function flattenMessages(value: unknown): ParsedMessage[] {
@@ -108,11 +129,12 @@ function tryParseMessage(obj: Record<string, unknown>): ParsedMessage | null {
   if (!("role" in obj) || !("content" in obj || "text" in obj)) return null;
 
   const role = toRole(obj.role);
-  const texts = obj.content !== undefined
-    ? getSearchableTexts(obj.content, role)
-    : typeof obj.text === "string" && role && obj.text.trim()
-      ? [obj.text.trim()]
-      : [];
+  const texts =
+    obj.content !== undefined
+      ? getSearchableTexts(obj.content, role)
+      : typeof obj.text === "string" && role && obj.text.trim()
+        ? [obj.text.trim()]
+        : [];
 
   if (!texts.length) return null;
 
@@ -123,11 +145,16 @@ function tryParseMessage(obj: Record<string, unknown>): ParsedMessage | null {
   };
 }
 
-function getSearchableTexts(value: unknown, role: MessageRole | null): string[] {
+function getSearchableTexts(
+  value: unknown,
+  role: MessageRole | null,
+): string[] {
   if (typeof value === "string") {
-    return role && SEARCHABLE_ROLES.has(role) && value.trim() ? [value.trim()] : [];
+    return role && SEARCHABLE_ROLES.has(role) && value.trim()
+      ? [value.trim()]
+      : [];
   }
-  if (Array.isArray(value)) return value.flatMap(v => getBlockText(v, role));
+  if (Array.isArray(value)) return value.flatMap((v) => getBlockText(v, role));
   if (isObject(value)) return getBlockText(value, role);
   return [];
 }
@@ -159,10 +186,10 @@ function countMatches(text: string, query: string): number {
   if (!needle) return 0;
 
   let count = 0;
-  let pos = 0;
-  while ((pos = hay.indexOf(needle, pos)) !== -1) {
+  let pos = hay.indexOf(needle);
+  while (pos !== -1) {
     count++;
-    pos += needle.length;
+    pos = hay.indexOf(needle, pos + needle.length);
   }
   return count;
 }

--- a/ui/goose2/src/shared/api/sessionSearch.ts
+++ b/ui/goose2/src/shared/api/sessionSearch.ts
@@ -1,0 +1,179 @@
+import { exportSession } from "./acpApi";
+
+const SNIPPET_PREFIX = 40;
+const SNIPPET_SUFFIX = 60;
+
+type MessageRole = "user" | "assistant" | "system";
+
+const SEARCHABLE_ROLES = new Set<MessageRole>(["user", "assistant", "system"]);
+
+const SEARCHABLE_BLOCK_TYPES = new Set([
+  "text", "input_text", "output_text", "systemNotification", "system_notification",
+]);
+
+const SKIPPED_BLOCK_TYPES = new Set([
+  "toolRequest", "toolResponse", "thinking", "redactedThinking", "reasoning", "image",
+]);
+
+export interface SessionSearchResult {
+  sessionId: string;
+  snippet: string;
+  messageId: string;
+  messageRole?: MessageRole;
+  matchCount: number;
+}
+
+interface ParsedMessage {
+  id: string;
+  role: MessageRole | null;
+  texts: string[];
+}
+
+export async function searchSessionsViaExports(
+  query: string,
+  sessionIds: string[],
+): Promise<SessionSearchResult[]> {
+  const trimmed = query.trim();
+  if (!trimmed) return [];
+
+  const unique = [...new Set(sessionIds)];
+  const results: SessionSearchResult[] = [];
+
+  for (const sessionId of unique) {
+    try {
+      const exported = await exportSession(sessionId);
+      const result = searchSession(sessionId, exported, trimmed);
+      if (result) results.push(result);
+    } catch {
+      // skip sessions that fail to export
+    }
+  }
+
+  return results;
+}
+
+function searchSession(
+  sessionId: string,
+  json: string,
+  query: string,
+): SessionSearchResult | null {
+  const root = safeParse(json);
+  if (!root) return null;
+
+  const conversation = root.conversation ?? root.messages;
+  if (!conversation) return null;
+
+  const messages = flattenMessages(conversation);
+  if (!messages.length) return null;
+
+  let firstMatch: { messageId: string; role: MessageRole | null; snippet: string } | null = null;
+  let matchCount = 0;
+
+  for (const msg of messages) {
+    for (const text of msg.texts) {
+      const count = countMatches(text, query);
+      if (!count) continue;
+      matchCount += count;
+      firstMatch ??= { messageId: msg.id, role: msg.role, snippet: buildSnippet(text, query) };
+    }
+  }
+
+  if (!firstMatch) return null;
+
+  return {
+    sessionId,
+    snippet: firstMatch.snippet,
+    messageId: firstMatch.messageId,
+    messageRole: firstMatch.role ?? undefined,
+    matchCount,
+  };
+}
+
+function safeParse(json: string): Record<string, any> | null {
+  try { return JSON.parse(json); } catch { return null; }
+}
+
+function flattenMessages(value: unknown): ParsedMessage[] {
+  if (Array.isArray(value)) return value.flatMap(flattenMessages);
+  if (!isObject(value)) return [];
+
+  if ("message" in value) return flattenMessages(value.message);
+  if ("messages" in value) return flattenMessages(value.messages);
+
+  const msg = tryParseMessage(value);
+  return msg ? [msg] : [];
+}
+
+function tryParseMessage(obj: Record<string, unknown>): ParsedMessage | null {
+  if (!("role" in obj) || !("content" in obj || "text" in obj)) return null;
+
+  const role = toRole(obj.role);
+  const texts = obj.content !== undefined
+    ? getSearchableTexts(obj.content, role)
+    : typeof obj.text === "string" && role && obj.text.trim()
+      ? [obj.text.trim()]
+      : [];
+
+  if (!texts.length) return null;
+
+  return {
+    id: typeof obj.id === "string" ? obj.id : crypto.randomUUID(),
+    role,
+    texts,
+  };
+}
+
+function getSearchableTexts(value: unknown, role: MessageRole | null): string[] {
+  if (typeof value === "string") {
+    return role && SEARCHABLE_ROLES.has(role) && value.trim() ? [value.trim()] : [];
+  }
+  if (Array.isArray(value)) return value.flatMap(v => getBlockText(v, role));
+  if (isObject(value)) return getBlockText(value, role);
+  return [];
+}
+
+function getBlockText(value: unknown, role: MessageRole | null): string[] {
+  if (!isObject(value)) return [];
+  const type = value.type as string | undefined;
+  const text = (value.text as string | undefined)?.trim();
+  if (!text) return [];
+
+  if (SKIPPED_BLOCK_TYPES.has(type ?? "")) return [];
+  if (SEARCHABLE_BLOCK_TYPES.has(type ?? "")) return [text];
+  return role && SEARCHABLE_ROLES.has(role) ? [text] : [];
+}
+
+function toRole(value: unknown): MessageRole | null {
+  if (typeof value !== "string") return null;
+  const r = value.trim().toLowerCase();
+  return SEARCHABLE_ROLES.has(r as MessageRole) ? (r as MessageRole) : null;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function countMatches(text: string, query: string): number {
+  const hay = text.toLowerCase();
+  const needle = query.toLowerCase();
+  if (!needle) return 0;
+
+  let count = 0;
+  let pos = 0;
+  while ((pos = hay.indexOf(needle, pos)) !== -1) {
+    count++;
+    pos += needle.length;
+  }
+  return count;
+}
+
+function buildSnippet(text: string, query: string): string {
+  const idx = text.toLowerCase().indexOf(query.toLowerCase());
+  const at = idx >= 0 ? idx : 0;
+  const start = Math.max(0, at - SNIPPET_PREFIX);
+  const end = Math.min(text.length, at + query.length + SNIPPET_SUFFIX);
+
+  const prefix = start > 0 ? "..." : "";
+  const suffix = end < text.length ? "..." : "";
+  return `${prefix}${text.substring(start, end).trim()}${suffix}`;
+}

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -378,6 +378,12 @@ importers:
 
   goose2:
     dependencies:
+      '@aaif/goose-acp':
+        specifier: ^0.16.0
+        version: 0.16.0(@agentclientprotocol/sdk@0.19.0(zod@4.3.6))
+      '@agentclientprotocol/sdk':
+        specifier: ^0.19.0
+        version: 0.19.0(zod@4.3.6)
       '@radix-ui/react-accordion':
         specifier: ^1.2.12
         version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -729,6 +735,11 @@ importers:
 
 packages:
 
+  '@aaif/goose-acp@0.16.0':
+    resolution: {integrity: sha512-LJLn01pqobvQAsagScROFOnjKRSQPaDuP7v17oyrK1IDfvZzOM20ZkQcvGDWhYCRUHXWBJgJ9dD6iZkVtNYYwg==}
+    peerDependencies:
+      '@agentclientprotocol/sdk': '*'
+
   '@acemir/cssom@0.9.31':
     resolution: {integrity: sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==}
 
@@ -737,6 +748,11 @@ packages:
 
   '@agentclientprotocol/sdk@0.14.1':
     resolution: {integrity: sha512-b6r3PS3Nly+Wyw9U+0nOr47bV8tfS476EgyEMhoKvJCZLbgqoDFN7DJwkxL88RR0aiOqOYV1ZnESHqb+RmdH8w==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+
+  '@agentclientprotocol/sdk@0.19.0':
+    resolution: {integrity: sha512-U9I8ws9WTOk6jCBAWpXefGSDgVXn14/kV6HFzwWGcstQ02mOQgClMAROHmoIn9GqZbDBDEOkdIbP4P4TEMQdug==}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
 
@@ -8838,6 +8854,11 @@ packages:
 
 snapshots:
 
+  '@aaif/goose-acp@0.16.0(@agentclientprotocol/sdk@0.19.0(zod@4.3.6))':
+    dependencies:
+      '@agentclientprotocol/sdk': 0.19.0(zod@4.3.6)
+      zod: 3.25.76
+
   '@acemir/cssom@0.9.31': {}
 
   '@adobe/css-tools@4.4.4': {}
@@ -8847,6 +8868,10 @@ snapshots:
       zod: 3.25.76
 
   '@agentclientprotocol/sdk@0.14.1(zod@4.3.6)':
+    dependencies:
+      zod: 4.3.6
+
+  '@agentclientprotocol/sdk@0.19.0(zod@4.3.6)':
     dependencies:
       zod: 4.3.6
 


### PR DESCRIPTION
## Summary
Calling goose serve via web socket from tauri frontend

### Why
- Tauri IPC doesn't stream natively,  but the browser does
- Frontend does not tie to Tauri, can be portable to other web clients
- We can reuse the goose acp client 

### Changes

- Move ACP protocol handling from Rust Tauri backend to TypeScript
- Frontend talks directly to goose serve over WebSocket, bypassing the Rust middleware
- Controlled by feature flag (USE_DIRECT_ACP)
- functions in `acp.ts` wired through the new path using `USE_DIRECT_ACP` feature flag
- Old Rust path still works when flag is off

### TODO
- Cleanup and remove the feature toggle
- ui/acp (@aaif/goose-acp) upgrades to be compatible with @agentclientprotocol/sdk@0.19.0 (latest version)
- goose serve includes messageId on each ContentChunk notification
- move create websocket stream logic to @aaif/goose-acp

### Testing
Manual

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

