### PR TITLE
feat: support Client ID Metadata Document (CIMD) for OAuth

### DIFF
--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -17,6 +17,7 @@ use tracing::warn;
 use crate::oauth::persist::GooseCredentialStore;
 
 const CALLBACK_TEMPLATE: &str = include_str!("oauth_callback.html");
+const CLIENT_METADATA_URL: &str = "https://goose-docs.ai/oauth/client-metadata.json";
 
 #[derive(Clone)]
 struct AppState {
@@ -81,7 +82,12 @@ pub async fn oauth_flow(
 
     let redirect_uri = format!("http://localhost:{}/oauth_callback", used_addr.port());
     oauth_state
-        .start_authorization(&[], redirect_uri.as_str(), Some("goose"))
+        .start_authorization_with_metadata_url(
+            &[],
+            redirect_uri.as_str(),
+            Some("goose"),
+            Some(CLIENT_METADATA_URL),
+        )
         .await?;
 
     let authorization_url = oauth_state.get_authorization_url().await?;

--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -80,7 +80,7 @@ pub async fn oauth_flow(
 
     let mut oauth_state = OAuthState::new(mcp_server_url, None).await?;
 
-    let redirect_uri = format!("http://localhost:{}/oauth_callback", used_addr.port());
+    let redirect_uri = format!("http://127.0.0.1:{}/oauth_callback", used_addr.port());
     oauth_state
         .start_authorization_with_metadata_url(
             &[],

--- a/documentation/static/oauth/client-metadata.json
+++ b/documentation/static/oauth/client-metadata.json
@@ -1,0 +1,10 @@
+{
+  "client_id": "https://goose-docs.ai/oauth/client-metadata.json",
+  "client_name": "Goose",
+  "redirect_uris": ["http://localhost"],
+  "grant_types": ["authorization_code"],
+  "response_types": ["code"],
+  "token_endpoint_auth_method": "none",
+  "scope": "openid profile email",
+  "code_challenge_methods_supported": ["S256"]
+}

--- a/documentation/static/oauth/client-metadata.json
+++ b/documentation/static/oauth/client-metadata.json
@@ -5,9 +5,8 @@
     "http://127.0.0.1/oauth_callback",
     "http://[::1]/oauth_callback"
   ],
-  "grant_types": ["authorization_code"],
+  "grant_types": ["authorization_code", "refresh_token"],
   "response_types": ["code"],
   "token_endpoint_auth_method": "none",
-  "scope": "openid profile email",
   "code_challenge_methods_supported": ["S256"]
 }

--- a/documentation/static/oauth/client-metadata.json
+++ b/documentation/static/oauth/client-metadata.json
@@ -1,6 +1,6 @@
 {
   "client_id": "https://goose-docs.ai/oauth/client-metadata.json",
-  "client_name": "Goose",
+  "client_name": "goose",
   "redirect_uris": ["http://localhost/oauth_callback"],
   "grant_types": ["authorization_code"],
   "response_types": ["code"],

--- a/documentation/static/oauth/client-metadata.json
+++ b/documentation/static/oauth/client-metadata.json
@@ -1,7 +1,10 @@
 {
   "client_id": "https://goose-docs.ai/oauth/client-metadata.json",
   "client_name": "goose",
-  "redirect_uris": ["http://localhost/oauth_callback"],
+  "redirect_uris": [
+    "http://127.0.0.1/oauth_callback",
+    "http://[::1]/oauth_callback"
+  ],
   "grant_types": ["authorization_code"],
   "response_types": ["code"],
   "token_endpoint_auth_method": "none",

--- a/documentation/static/oauth/client-metadata.json
+++ b/documentation/static/oauth/client-metadata.json
@@ -1,7 +1,7 @@
 {
   "client_id": "https://goose-docs.ai/oauth/client-metadata.json",
   "client_name": "Goose",
-  "redirect_uris": ["http://localhost"],
+  "redirect_uris": ["http://localhost/oauth_callback"],
   "grant_types": ["authorization_code"],
   "response_types": ["code"],
   "token_endpoint_auth_method": "none",


### PR DESCRIPTION
## Summary

Add CIMD (Client ID Metadata Document) support so Goose can connect to MCP servers that support CIMD-based OAuth (SEP-991) without requiring manual client registration or Dynamic Client Registration.

- Adds a client metadata JSON document at `documentation/static/oauth/client-metadata.json`, which will be served at `https://goose-docs.ai/oauth/client-metadata.json` via the existing docs deployment
- Switches the OAuth flow to use rmcp's `start_authorization_with_metadata_url()`, passing the CIMD URL. Servers that support CIMD will use it; others fall back to DCR transparently.

### Testing

- `cargo build -p goose` compiles successfully
- `cargo test -p goose` passes (3 pre-existing unrelated failures)
- After docs deploy: verify the JSON is served at the expected URL
- Manual: connect to a CIMD-supporting MCP server and verify OAuth completes

### Related Issues
Relates to #7071