### PR TITLE
feat: wire up voice dictation in goose2 via ACP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4454,6 +4454,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
+ "base64 0.22.1",
  "fs-err",
  "futures",
  "goose",

--- a/crates/goose-acp/Cargo.toml
+++ b/crates/goose-acp/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/bin/generate_acp_schema.rs"
 [features]
 default = ["code-mode", "rustls-tls"]
 code-mode = ["goose/code-mode"]
+local-inference = ["goose/local-inference"]
 rustls-tls = ["goose/rustls-tls", "goose-mcp/rustls-tls"]
 native-tls = ["goose/native-tls", "goose-mcp/native-tls"]
 
@@ -48,6 +49,7 @@ uuid = { workspace = true, features = ["v7"] }
 schemars = { workspace = true, features = ["derive"] }
 goose-acp-macros = { path = "../goose-acp-macros" }
 goose-sdk = { path = "../goose-sdk" }
+base64 = { workspace = true }
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/goose-acp/acp-meta.json
+++ b/crates/goose-acp/acp-meta.json
@@ -109,6 +109,16 @@
       "method": "_goose/session/unarchive",
       "requestType": "UnarchiveSessionRequest",
       "responseType": "EmptyResponse"
+    },
+    {
+      "method": "_goose/dictation/transcribe",
+      "requestType": "DictationTranscribeRequest",
+      "responseType": "DictationTranscribeResponse"
+    },
+    {
+      "method": "_goose/dictation/config",
+      "requestType": "DictationConfigRequest",
+      "responseType": "DictationConfigResponse"
     }
   ]
 }

--- a/crates/goose-acp/src/server.rs
+++ b/crates/goose-acp/src/server.rs
@@ -16,6 +16,13 @@ use goose::config::paths::Paths;
 use goose::config::permission::PermissionManager;
 use goose::config::{Config, GooseMode};
 use goose::conversation::message::{ActionRequiredData, Message, MessageContent};
+#[cfg(feature = "local-inference")]
+use goose::dictation::providers::transcribe_local;
+use goose::dictation::providers::{
+    all_providers, is_configured, transcribe_with_provider, DictationProvider,
+};
+#[cfg(feature = "local-inference")]
+use goose::dictation::whisper;
 use goose::mcp_utils::ToolResult;
 use goose::permission::permission_confirmation::PrincipalType;
 use goose::permission::{Permission, PermissionConfirmation};
@@ -68,6 +75,9 @@ pub type AcpProviderFactory = Arc<
 
 const DEFAULT_PROVIDER_ID: &str = "goose";
 const DEFAULT_PROVIDER_LABEL: &str = "Goose (Default)";
+const OPENAI_TRANSCRIPTION_MODEL: &str = "whisper-1";
+const GROQ_TRANSCRIPTION_MODEL: &str = "whisper-large-v3-turbo";
+const ELEVENLABS_TRANSCRIPTION_MODEL: &str = "scribe_v1";
 
 /// In-memory state for an active ACP session.
 ///
@@ -2650,6 +2660,197 @@ impl GooseAcpAgent {
             .await
             .map_err(|e| sacp::Error::internal_error().data(e.to_string()))?;
         Ok(EmptyResponse {})
+    }
+
+    #[custom_method(DictationTranscribeRequest)]
+    async fn on_dictation_transcribe(
+        &self,
+        req: DictationTranscribeRequest,
+    ) -> Result<DictationTranscribeResponse, sacp::Error> {
+        use base64::{engine::general_purpose::STANDARD as BASE64, Engine};
+
+        let provider: DictationProvider = serde_json::from_value(serde_json::Value::String(
+            req.provider.clone(),
+        ))
+        .map_err(|_| {
+            sacp::Error::invalid_params().data(format!("Unknown provider: {}", req.provider))
+        })?;
+
+        let audio_bytes = BASE64
+            .decode(&req.audio)
+            .map_err(|_| sacp::Error::invalid_params().data("Invalid base64 audio data"))?;
+
+        if audio_bytes.len() > 50 * 1024 * 1024 {
+            return Err(sacp::Error::invalid_params().data("Audio too large (max 50MB)"));
+        }
+
+        let extension = match req.mime_type.as_str() {
+            "audio/webm" | "audio/webm;codecs=opus" => "webm",
+            "audio/mp4" => "mp4",
+            "audio/mpeg" | "audio/mpga" => "mp3",
+            "audio/m4a" => "m4a",
+            "audio/wav" | "audio/x-wav" => "wav",
+            other => {
+                return Err(
+                    sacp::Error::invalid_params().data(format!("Unsupported format: {other}"))
+                )
+            }
+        };
+
+        let text = match provider {
+            DictationProvider::OpenAI => {
+                transcribe_with_provider(
+                    DictationProvider::OpenAI,
+                    "model".to_string(),
+                    "whisper-1".to_string(),
+                    audio_bytes,
+                    extension,
+                    &req.mime_type,
+                )
+                .await
+            }
+            DictationProvider::Groq => {
+                transcribe_with_provider(
+                    DictationProvider::Groq,
+                    "model".to_string(),
+                    "whisper-large-v3-turbo".to_string(),
+                    audio_bytes,
+                    extension,
+                    &req.mime_type,
+                )
+                .await
+            }
+            DictationProvider::ElevenLabs => {
+                transcribe_with_provider(
+                    DictationProvider::ElevenLabs,
+                    "model_id".to_string(),
+                    "scribe_v1".to_string(),
+                    audio_bytes,
+                    extension,
+                    &req.mime_type,
+                )
+                .await
+            }
+            #[cfg(feature = "local-inference")]
+            DictationProvider::Local => transcribe_local(audio_bytes).await,
+            #[cfg(not(feature = "local-inference"))]
+            DictationProvider::Local => {
+                return Err(sacp::Error::invalid_params()
+                    .data("Local inference is not available in this build"));
+            }
+        }
+        .map_err(|e| sacp::Error::internal_error().data(e.to_string()))?;
+
+        Ok(DictationTranscribeResponse { text })
+    }
+
+    #[custom_method(DictationConfigRequest)]
+    async fn on_dictation_config(
+        &self,
+        _req: DictationConfigRequest,
+    ) -> Result<DictationConfigResponse, sacp::Error> {
+        let config = goose::config::Config::global();
+        let mut providers = std::collections::HashMap::new();
+
+        for def in all_providers() {
+            let provider = def.provider;
+            let host = if let Some(host_key) = def.host_key {
+                config
+                    .get(host_key, false)
+                    .ok()
+                    .and_then(|v| v.as_str().map(|s| s.to_string()))
+            } else {
+                None
+            };
+
+            let provider_key = serde_json::to_value(provider)
+                .ok()
+                .and_then(|v| v.as_str().map(|s| s.to_string()))
+                .unwrap_or_else(|| format!("{:?}", provider).to_lowercase());
+            providers.insert(
+                provider_key,
+                DictationProviderStatusEntry {
+                    configured: is_configured(provider),
+                    host,
+                    description: def.description.to_string(),
+                    uses_provider_config: def.uses_provider_config,
+                    settings_path: def.settings_path.map(|s| s.to_string()),
+                    config_key: if !def.uses_provider_config {
+                        Some(def.config_key.to_string())
+                    } else {
+                        None
+                    },
+                    model_config_key: dictation_model_config_key(provider),
+                    default_model: dictation_default_model(provider),
+                    selected_model: dictation_selected_model(&config, provider),
+                    available_models: dictation_available_models(provider),
+                },
+            );
+        }
+
+        Ok(DictationConfigResponse { providers })
+    }
+}
+
+fn dictation_model_config_key(provider: DictationProvider) -> Option<String> {
+    #[cfg(feature = "local-inference")]
+    if provider == DictationProvider::Local {
+        return Some(whisper::LOCAL_WHISPER_MODEL_CONFIG_KEY.to_string());
+    }
+
+    None
+}
+
+fn dictation_default_model(provider: DictationProvider) -> Option<String> {
+    match provider {
+        DictationProvider::OpenAI => Some(OPENAI_TRANSCRIPTION_MODEL.to_string()),
+        DictationProvider::Groq => Some(GROQ_TRANSCRIPTION_MODEL.to_string()),
+        DictationProvider::ElevenLabs => Some(ELEVENLABS_TRANSCRIPTION_MODEL.to_string()),
+        #[cfg(feature = "local-inference")]
+        DictationProvider::Local => Some(whisper::recommend_model().to_string()),
+    }
+}
+
+fn dictation_selected_model(config: &Config, provider: DictationProvider) -> Option<String> {
+    #[cfg(feature = "local-inference")]
+    if provider == DictationProvider::Local {
+        return config
+            .get(whisper::LOCAL_WHISPER_MODEL_CONFIG_KEY, false)
+            .ok()
+            .and_then(|value| value.as_str().map(str::to_owned))
+            .filter(|model_id| whisper::get_model(model_id).is_some())
+            .or_else(|| dictation_default_model(provider));
+    }
+
+    dictation_default_model(provider)
+}
+
+fn dictation_available_models(provider: DictationProvider) -> Vec<DictationModelOption> {
+    match provider {
+        DictationProvider::OpenAI => vec![DictationModelOption {
+            id: OPENAI_TRANSCRIPTION_MODEL.to_string(),
+            label: "Whisper-1".to_string(),
+            description: "OpenAI's hosted Whisper transcription model.".to_string(),
+        }],
+        DictationProvider::Groq => vec![DictationModelOption {
+            id: GROQ_TRANSCRIPTION_MODEL.to_string(),
+            label: "Whisper Large V3 Turbo".to_string(),
+            description: "Groq's fast hosted Whisper transcription model.".to_string(),
+        }],
+        DictationProvider::ElevenLabs => vec![DictationModelOption {
+            id: ELEVENLABS_TRANSCRIPTION_MODEL.to_string(),
+            label: "Scribe v1".to_string(),
+            description: "ElevenLabs' hosted speech-to-text model.".to_string(),
+        }],
+        #[cfg(feature = "local-inference")]
+        DictationProvider::Local => whisper::available_models()
+            .iter()
+            .map(|model| DictationModelOption {
+                id: model.id.to_string(),
+                label: model.id.to_string(),
+                description: model.description.to_string(),
+            })
+            .collect(),
     }
 }
 

--- a/crates/goose-cli/Cargo.toml
+++ b/crates/goose-cli/Cargo.toml
@@ -71,7 +71,7 @@ winapi = { workspace = true }
 [features]
 default = ["code-mode", "local-inference", "aws-providers", "telemetry", "otel", "rustls-tls"]
 code-mode = ["goose/code-mode", "goose-acp/code-mode"]
-local-inference = ["goose/local-inference"]
+local-inference = ["goose/local-inference", "goose-acp/local-inference"]
 aws-providers = ["goose/aws-providers"]
 cuda = ["goose/cuda", "local-inference"]
 telemetry = ["goose/telemetry"]

--- a/crates/goose-sdk/src/custom_requests.rs
+++ b/crates/goose-sdk/src/custom_requests.rs
@@ -330,6 +330,66 @@ pub struct ProviderConfigKey {
     pub primary: bool,
 }
 
+/// Transcribe audio via a dictation provider.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcRequest)]
+#[request(method = "_goose/dictation/transcribe", response = DictationTranscribeResponse)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationTranscribeRequest {
+    /// Base64-encoded audio data
+    pub audio: String,
+    /// MIME type (e.g. "audio/wav", "audio/webm")
+    pub mime_type: String,
+    /// Provider to use: "openai", "groq", "elevenlabs", or "local"
+    pub provider: String,
+}
+
+/// Transcription result.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcResponse)]
+pub struct DictationTranscribeResponse {
+    pub text: String,
+}
+
+/// Get the configuration status of all dictation providers.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcRequest)]
+#[request(method = "_goose/dictation/config", response = DictationConfigResponse)]
+pub struct DictationConfigRequest {}
+
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+pub struct DictationModelOption {
+    pub id: String,
+    pub label: String,
+    pub description: String,
+}
+
+/// Per-provider configuration status.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationProviderStatusEntry {
+    pub configured: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    pub description: String,
+    pub uses_provider_config: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_config_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_model: Option<String>,
+    #[serde(default)]
+    pub available_models: Vec<DictationModelOption>,
+}
+
+/// Dictation config response — map of provider name to status.
+#[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcResponse)]
+pub struct DictationConfigResponse {
+    pub providers: HashMap<String, DictationProviderStatusEntry>,
+}
+
 /// Empty success response for operations that return no data.
 #[derive(Debug, Default, Clone, Serialize, Deserialize, JsonSchema, JsonRpcResponse)]
 pub struct EmptyResponse {}

--- a/ui/goose2/pnpm-lock.yaml
+++ b/ui/goose2/pnpm-lock.yaml
@@ -289,8 +289,8 @@ importers:
         specifier: ^7.0.4
         version: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       vitest:
-        specifier: ^3.2.1
-        version: 3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0)
+        specifier: ^4.1.0
+        version: 4.1.2(@opentelemetry/api@1.9.0)(jsdom@26.1.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
 
 packages:
 
@@ -2033,34 +2033,34 @@ packages:
     peerDependencies:
       vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
 
-  '@vitest/expect@3.2.4':
-    resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+  '@vitest/expect@4.1.2':
+    resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+  '@vitest/mocker@4.1.2':
+    resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
       vite:
         optional: true
 
-  '@vitest/pretty-format@3.2.4':
-    resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
+  '@vitest/pretty-format@4.1.2':
+    resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/runner@4.1.2':
+    resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/snapshot@4.1.2':
+    resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
 
-  '@vitest/spy@3.2.4':
-    resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
+  '@vitest/spy@4.1.2':
+    resolution: {integrity: sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==}
 
-  '@vitest/utils@3.2.4':
-    resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+  '@vitest/utils@4.1.2':
+    resolution: {integrity: sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==}
 
   '@xyflow/react@12.10.2':
     resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
@@ -2136,10 +2136,6 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   caniuse-lite@1.0.30001781:
     resolution: {integrity: sha512-RdwNCyMsNBftLjW6w01z8bKEvT6e/5tpPVEgtn22TiLGlstHOVecsX2KHFkD5e/vRnIE4EGzpuIODb3mtswtkw==}
 
@@ -2151,8 +2147,8 @@ packages:
     peerDependencies:
       react: '>=17.0.0'
 
-  chai@5.3.3:
-    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   character-entities-html4@2.1.0:
@@ -2166,10 +2162,6 @@ packages:
 
   character-reference-invalid@2.0.1:
     resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
-
-  check-error@2.1.3:
-    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
-    engines: {node: '>= 16'}
 
   chevrotain-allstar@0.3.1:
     resolution: {integrity: sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==}
@@ -2420,10 +2412,6 @@ packages:
   decode-named-character-reference@1.3.0:
     resolution: {integrity: sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==}
 
-  deep-eql@5.0.2:
-    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
-    engines: {node: '>=6'}
-
   delaunator@5.1.0:
     resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
@@ -2474,8 +2462,8 @@ packages:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   es-toolkit@1.45.1:
     resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
@@ -2716,9 +2704,6 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
-
   jsdom@26.1.0:
     resolution: {integrity: sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==}
     engines: {node: '>=18'}
@@ -2840,9 +2825,6 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  loupe@3.2.1:
-    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
   lowlight@1.20.0:
     resolution: {integrity: sha512-8Ktj+prEb1RoCPkEOrPMYUN/nCggB7qAWe3a7OpMjWQkh3l2RD5wKRQ+o8Q8YuI9RG/xs95waaI/E6ym/7NsTw==}
@@ -3103,6 +3085,9 @@ packages:
   nwsapi@2.2.23:
     resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
@@ -3123,10 +3108,6 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
-
-  pathval@2.0.1:
-    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
-    engines: {node: '>= 14.16'}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -3439,8 +3420,8 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
-  std-env@3.10.0:
-    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+  std-env@4.1.0:
+    resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
   streamdown@2.5.0:
     resolution: {integrity: sha512-/tTnURfIOxZK/pqJAxsfCvETG/XCJHoWnk3jq9xLcuz6CSpnjjuxSRBTTL4PKGhxiZQf0lqPxGhImdpwcZ2XwA==}
@@ -3454,9 +3435,6 @@ packages:
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
     engines: {node: '>=8'}
-
-  strip-literal@3.1.0:
-    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -3486,9 +3464,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.0.4:
     resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
     engines: {node: '>=18'}
@@ -3497,16 +3472,8 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
-  tinyrainbow@2.0.0:
-    resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
-    engines: {node: '>=14.0.0'}
-
-  tinyspy@4.0.4:
-    resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tldts-core@6.1.86:
@@ -3644,11 +3611,6 @@ packages:
   victory-vendor@37.3.6:
     resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite@7.3.1:
     resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3689,26 +3651,33 @@ packages:
       yaml:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.2:
+    resolution: {integrity: sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.2
+      '@vitest/browser-preview': 4.1.2
+      '@vitest/browser-webdriverio': 4.1.2
+      '@vitest/ui': 4.1.2
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -5492,47 +5461,46 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@3.2.4':
+  '@vitest/expect@4.1.2':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      tinyrainbow: 2.0.0
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@vitest/mocker@4.1.2(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
-  '@vitest/pretty-format@3.2.4':
+  '@vitest/pretty-format@4.1.2':
     dependencies:
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/runner@4.1.2':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.2
       pathe: 2.0.3
-      strip-literal: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/snapshot@4.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/utils': 4.1.2
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@3.2.4':
-    dependencies:
-      tinyspy: 4.0.4
+  '@vitest/spy@4.1.2': {}
 
-  '@vitest/utils@3.2.4':
+  '@vitest/utils@4.1.2':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      loupe: 3.2.1
-      tinyrainbow: 2.0.0
+      '@vitest/pretty-format': 4.1.2
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@xyflow/react@12.10.2(@types/react@19.2.14)(immer@11.1.4)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
     dependencies:
@@ -5611,8 +5579,6 @@ snapshots:
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  cac@6.7.14: {}
-
   caniuse-lite@1.0.30001781: {}
 
   ccount@2.0.1: {}
@@ -5621,13 +5587,7 @@ snapshots:
     dependencies:
       react: 19.2.4
 
-  chai@5.3.3:
-    dependencies:
-      assertion-error: 2.0.1
-      check-error: 2.1.3
-      deep-eql: 5.0.2
-      loupe: 3.2.1
-      pathval: 2.0.1
+  chai@6.2.2: {}
 
   character-entities-html4@2.1.0: {}
 
@@ -5636,8 +5596,6 @@ snapshots:
   character-entities@2.0.2: {}
 
   character-reference-invalid@2.0.1: {}
-
-  check-error@2.1.3: {}
 
   chevrotain-allstar@0.3.1(chevrotain@11.1.2):
     dependencies:
@@ -5909,8 +5867,6 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  deep-eql@5.0.2: {}
-
   delaunator@5.1.0:
     dependencies:
       robust-predicates: 3.0.3
@@ -5954,7 +5910,7 @@ snapshots:
 
   entities@6.0.1: {}
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.0.0: {}
 
   es-toolkit@1.45.1: {}
 
@@ -6254,8 +6210,6 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-tokens@9.0.1: {}
-
   jsdom@26.1.0:
     dependencies:
       cssstyle: 4.6.0
@@ -6363,8 +6317,6 @@ snapshots:
   lodash-es@4.17.23: {}
 
   longest-streak@3.1.0: {}
-
-  loupe@3.2.1: {}
 
   lowlight@1.20.0:
     dependencies:
@@ -6864,6 +6816,8 @@ snapshots:
 
   nwsapi@2.2.23: {}
 
+  obug@2.1.1: {}
+
   oniguruma-parser@0.12.1: {}
 
   oniguruma-to-es@4.3.5:
@@ -6891,8 +6845,6 @@ snapshots:
   path-data-parser@0.1.0: {}
 
   pathe@2.0.3: {}
-
-  pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
 
@@ -7294,7 +7246,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  std-env@3.10.0: {}
+  std-env@4.1.0: {}
 
   streamdown@2.5.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -7328,10 +7280,6 @@ snapshots:
     dependencies:
       min-indent: 1.0.1
 
-  strip-literal@3.1.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   style-to-js@1.1.21:
     dependencies:
       style-to-object: 1.0.14
@@ -7354,8 +7302,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.0.4: {}
 
   tinyglobby@0.2.15:
@@ -7363,11 +7309,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
-  tinyrainbow@2.0.0: {}
-
-  tinyspy@4.0.4: {}
+  tinyrainbow@3.1.0: {}
 
   tldts-core@6.1.86: {}
 
@@ -7530,27 +7472,6 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.3
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.4
@@ -7565,47 +7486,33 @@ snapshots:
       lightningcss: 1.32.0
       tsx: 4.21.0
 
-  vitest@3.2.4(@types/debug@4.1.13)(jiti@2.6.1)(jsdom@26.1.0)(lightningcss@1.32.0)(tsx@4.21.0):
+  vitest@4.1.2(@opentelemetry/api@1.9.0)(jsdom@26.1.0)(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)):
     dependencies:
-      '@types/chai': 5.2.3
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.3.3
-      debug: 4.4.3
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
       expect-type: 1.3.0
       magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.10.0
+      std-env: 4.1.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
+      tinyrainbow: 3.1.0
       vite: 7.3.1(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
-      vite-node: 3.2.4(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.13
+      '@opentelemetry/api': 1.9.0
       jsdom: 26.1.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   void-elements@3.1.0: {}
 

--- a/ui/goose2/src-tauri/Info.plist
+++ b/ui/goose2/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Goose uses your microphone to capture voice input for dictation.</string>
+</dict>
+</plist>

--- a/ui/goose2/src-tauri/src/commands/dictation.rs
+++ b/ui/goose2/src-tauri/src/commands/dictation.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+use tauri::AppHandle;
+
+use crate::services::acp::GooseAcpManager;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationTranscribeRequest {
+    pub audio: String,
+    pub mime_type: String,
+    pub provider: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationTranscribeResponse {
+    pub text: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationModelOptionResponse {
+    pub id: String,
+    pub label: String,
+    pub description: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DictationProviderStatusResponse {
+    pub configured: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub host: Option<String>,
+    pub description: String,
+    pub uses_provider_config: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_config_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub default_model: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_model: Option<String>,
+    #[serde(default)]
+    pub available_models: Vec<DictationModelOptionResponse>,
+}
+
+#[tauri::command]
+pub async fn transcribe_dictation(
+    app_handle: AppHandle,
+    request: DictationTranscribeRequest,
+) -> Result<DictationTranscribeResponse, String> {
+    let manager = GooseAcpManager::start(app_handle).await?;
+    let raw = manager
+        .call_ext(
+            "goose/dictation/transcribe",
+            serde_json::json!({
+                "audio": request.audio,
+                "mimeType": request.mime_type,
+                "provider": request.provider,
+            }),
+        )
+        .await?;
+    serde_json::from_str(&raw).map_err(|e| format!("Failed to parse transcribe response: {e}"))
+}
+
+#[tauri::command]
+pub async fn get_dictation_config(
+    app_handle: AppHandle,
+) -> Result<std::collections::HashMap<String, DictationProviderStatusResponse>, String> {
+    let manager = GooseAcpManager::start(app_handle).await?;
+    let raw = manager
+        .call_ext("goose/dictation/config", serde_json::json!({}))
+        .await?;
+
+    #[derive(Deserialize)]
+    struct ConfigResponse {
+        providers: std::collections::HashMap<String, DictationProviderStatusResponse>,
+    }
+
+    let response: ConfigResponse =
+        serde_json::from_str(&raw).map_err(|e| format!("Failed to parse config response: {e}"))?;
+    Ok(response.providers)
+}

--- a/ui/goose2/src-tauri/src/commands/mod.rs
+++ b/ui/goose2/src-tauri/src/commands/mod.rs
@@ -2,6 +2,7 @@ pub mod acp;
 pub mod agent_setup;
 pub mod agents;
 pub mod credentials;
+pub mod dictation;
 pub mod doctor;
 pub mod extensions;
 pub mod git;

--- a/ui/goose2/src-tauri/src/lib.rs
+++ b/ui/goose2/src-tauri/src/lib.rs
@@ -108,6 +108,8 @@ pub fn run() {
             commands::system::inspect_attachment_paths,
             commands::system::list_files_for_mentions,
             commands::system::read_image_attachment,
+            commands::dictation::get_dictation_config,
+            commands::dictation::transcribe_dictation,
         ])
         .setup(|_app| Ok(()))
         .build(tauri::generate_context!())

--- a/ui/goose2/src-tauri/src/services/acp/manager.rs
+++ b/ui/goose2/src-tauri/src/services/acp/manager.rs
@@ -67,6 +67,11 @@ enum ManagerCommand {
         model_id: String,
         response: oneshot::Sender<Result<(), String>>,
     },
+    CallExt {
+        method: String,
+        params: serde_json::Value,
+        response: oneshot::Sender<Result<String, String>>,
+    },
 }
 
 pub struct GooseAcpManager {
@@ -282,6 +287,26 @@ impl GooseAcpManager {
             .await
             .map_err(|_| "Goose ACP manager dropped fork session request".to_string())?
     }
+
+    /// Call an arbitrary ext_method on the goose binary via ACP.
+    pub async fn call_ext(
+        &self,
+        method: &str,
+        params: serde_json::Value,
+    ) -> Result<String, String> {
+        let method = method.to_string();
+        let (response_tx, response_rx) = oneshot::channel();
+        self.command_tx
+            .send(ManagerCommand::CallExt {
+                method: method.clone(),
+                params,
+                response: response_tx,
+            })
+            .map_err(|_| "Goose ACP manager is unavailable".to_string())?;
+        response_rx
+            .await
+            .map_err(|_| format!("Goose ACP manager dropped {method} request"))?
+    }
 }
 
 /// Call a goose ext_method and return the raw JSON response string.
@@ -290,6 +315,7 @@ async fn call_ext_method(
     method: &str,
     params_json: serde_json::Value,
 ) -> Result<String, String> {
+    let method = normalize_ext_method_name(method);
     let params = RawValue::from_string(params_json.to_string())
         .map_err(|e| format!("Failed to build {method} request: {e}"))?;
     let resp = connection
@@ -299,10 +325,35 @@ async fn call_ext_method(
     Ok(resp.0.get().to_string())
 }
 
+fn normalize_ext_method_name(method: &str) -> &str {
+    method.trim_start_matches('_')
+}
+
 fn run_manager_thread(
     app_handle: tauri::AppHandle,
     command_rx: mpsc::UnboundedReceiver<ManagerCommand>,
     ready_tx: oneshot::Sender<Result<(), String>>,
 ) {
     thread::run_manager_thread(app_handle, command_rx, ready_tx);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_ext_method_name;
+
+    #[test]
+    fn normalize_ext_method_name_strips_wire_prefix() {
+        assert_eq!(
+            normalize_ext_method_name("_goose/dictation/config"),
+            "goose/dictation/config"
+        );
+        assert_eq!(
+            normalize_ext_method_name("goose/dictation/config"),
+            "goose/dictation/config"
+        );
+        assert_eq!(
+            normalize_ext_method_name("__goose/dictation/config"),
+            "goose/dictation/config"
+        );
+    }
 }

--- a/ui/goose2/src-tauri/src/services/acp/manager/command_dispatch.rs
+++ b/ui/goose2/src-tauri/src/services/acp/manager/command_dispatch.rs
@@ -253,6 +253,17 @@ pub(super) async fn dispatch_commands(
                     let _ = response.send(result);
                 });
             }
+            ManagerCommand::CallExt {
+                method,
+                params,
+                response,
+            } => {
+                let connection = Arc::clone(&connection);
+                tokio::task::spawn_local(async move {
+                    let result = call_ext_method(&connection, &method, params).await;
+                    let _ = response.send(result);
+                });
+            }
         }
     }
 }

--- a/ui/goose2/src-tauri/src/services/provider_defs.rs
+++ b/ui/goose2/src-tauri/src/services/provider_defs.rs
@@ -125,6 +125,17 @@ pub(crate) static PROVIDER_CONFIG_DEFS: &[ProviderConfigDef] = &[
         keys: &[],
         oauth_cache_path: None,
     },
+    // Dictation providers (voice input)
+    ProviderConfigDef {
+        id: "dictation_groq",
+        keys: &[key("GROQ_API_KEY", true, true)],
+        oauth_cache_path: None,
+    },
+    ProviderConfigDef {
+        id: "dictation_elevenlabs",
+        keys: &[key("ELEVENLABS_API_KEY", true, true)],
+        oauth_cache_path: None,
+    },
 ];
 
 pub(crate) fn find_config_key(key_name: &str) -> Option<&'static ConfigKey> {

--- a/ui/goose2/src/features/chat/hooks/useDictationRecorder.ts
+++ b/ui/goose2/src/features/chat/hooks/useDictationRecorder.ts
@@ -1,0 +1,317 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { transcribeDictation } from "@/shared/api/dictation";
+import type { DictationProvider } from "@/shared/types/dictation";
+import {
+  advanceVadState,
+  createInitialVadState,
+  getFrameRms,
+} from "../lib/dictationVad";
+
+interface UseDictationRecorderOptions {
+  provider: DictationProvider | null;
+  providerConfigured: boolean;
+  preferredMicrophoneId: string | null;
+  onError: (message: string) => void;
+  onTranscription: (text: string) => void;
+}
+
+const SAMPLE_RATE = 16000;
+
+function encodeWav(samples: Float32Array, sampleRate: number): ArrayBuffer {
+  const buffer = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buffer);
+  const write = (offset: number, value: string) => {
+    for (let index = 0; index < value.length; index += 1) {
+      view.setUint8(offset + index, value.charCodeAt(index));
+    }
+  };
+
+  write(0, "RIFF");
+  view.setUint32(4, 36 + samples.length * 2, true);
+  write(8, "WAVE");
+  write(12, "fmt ");
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  write(36, "data");
+  view.setUint32(40, samples.length * 2, true);
+
+  let offset = 44;
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, samples[index] ?? 0));
+    view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+    offset += 2;
+  }
+
+  return buffer;
+}
+
+function blobToBase64(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onloadend = () => resolve(String(reader.result).split(",")[1] ?? "");
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+function toErrorMessage(error: unknown) {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Voice input failed";
+}
+
+export function useDictationRecorder({
+  provider,
+  providerConfigured,
+  preferredMicrophoneId,
+  onError,
+  onTranscription,
+}: UseDictationRecorderOptions) {
+  const [isRecording, setIsRecording] = useState(false);
+  const [isTranscribing, setIsTranscribing] = useState(false);
+  const audioContextRef = useRef<AudioContext | null>(null);
+  const processorRef = useRef<ScriptProcessorNode | null>(null);
+  const sourceRef = useRef<MediaStreamAudioSourceNode | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+  const samplesRef = useRef<Float32Array[]>([]);
+  const vadStateRef = useRef(createInitialVadState());
+  const pendingTranscriptionsRef = useRef(0);
+  const generationRef = useRef(0);
+  const providerRef = useRef(provider);
+  providerRef.current = provider;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+  const onTranscriptionRef = useRef(onTranscription);
+  onTranscriptionRef.current = onTranscription;
+
+  const isEnabled = Boolean(provider && providerConfigured);
+
+  const cleanupAudioGraph = useCallback(() => {
+    processorRef.current?.disconnect();
+    processorRef.current = null;
+    sourceRef.current?.disconnect();
+    sourceRef.current = null;
+    void audioContextRef.current?.close();
+    audioContextRef.current = null;
+    streamRef.current?.getTracks().forEach((track) => {
+      track.stop();
+    });
+    streamRef.current = null;
+  }, []);
+
+  const transcribeChunk = useCallback(async (samples: Float32Array) => {
+    const activeProvider = providerRef.current;
+    if (!activeProvider) {
+      return;
+    }
+
+    const gen = generationRef.current;
+    pendingTranscriptionsRef.current += 1;
+    setIsTranscribing(true);
+
+    try {
+      const wavBlob = new Blob([encodeWav(samples, SAMPLE_RATE)], {
+        type: "audio/wav",
+      });
+      const audio = await blobToBase64(wavBlob);
+      const response = await transcribeDictation({
+        audio,
+        mimeType: "audio/wav",
+        provider: activeProvider,
+      });
+
+      if (gen !== generationRef.current) {
+        return;
+      }
+
+      if (response.text.trim()) {
+        onTranscriptionRef.current(response.text);
+      }
+    } catch (error) {
+      onErrorRef.current(toErrorMessage(error));
+    } finally {
+      pendingTranscriptionsRef.current -= 1;
+      if (pendingTranscriptionsRef.current === 0) {
+        setIsTranscribing(false);
+      }
+    }
+  }, []);
+
+  const flushPendingSamples = useCallback(() => {
+    const chunks = samplesRef.current;
+    if (chunks.length === 0) {
+      return;
+    }
+
+    const totalSamples = chunks.reduce(
+      (count, chunk) => count + chunk.length,
+      0,
+    );
+    const merged = new Float32Array(totalSamples);
+    let offset = 0;
+    for (const chunk of chunks) {
+      merged.set(chunk, offset);
+      offset += chunk.length;
+    }
+
+    samplesRef.current = [];
+    void transcribeChunk(merged);
+  }, [transcribeChunk]);
+
+  const stopRecording = useCallback(
+    (options?: { flushPending?: boolean }) => {
+      const flushPending = options?.flushPending ?? true;
+
+      if (flushPending && samplesRef.current.length > 0) {
+        flushPendingSamples();
+      } else if (!flushPending) {
+        samplesRef.current = [];
+        generationRef.current += 1;
+      }
+
+      vadStateRef.current = createInitialVadState();
+      cleanupAudioGraph();
+      setIsRecording(false);
+    },
+    [cleanupAudioGraph, flushPendingSamples],
+  );
+
+  const handleFrame = useCallback(
+    (samples: Float32Array) => {
+      const { decision, nextState } = advanceVadState(
+        vadStateRef.current,
+        getFrameRms(samples),
+      );
+      vadStateRef.current = nextState;
+
+      if (decision === "ignore") {
+        return;
+      }
+
+      if (decision === "discard") {
+        samplesRef.current = [];
+        return;
+      }
+
+      samplesRef.current.push(new Float32Array(samples));
+
+      if (decision === "append_and_flush") {
+        flushPendingSamples();
+      }
+    },
+    [flushPendingSamples],
+  );
+
+  const startRecording = useCallback(async () => {
+    if (!isEnabled || !provider) {
+      onError("Voice input is not configured");
+      return;
+    }
+
+    try {
+      const audioConstraints: MediaTrackConstraints = {
+        autoGainControl: true,
+        echoCancellation: true,
+        noiseSuppression: true,
+      };
+
+      if (preferredMicrophoneId) {
+        audioConstraints.deviceId = { exact: preferredMicrophoneId };
+      }
+
+      let stream: MediaStream;
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: audioConstraints,
+        });
+      } catch (error) {
+        if (
+          preferredMicrophoneId &&
+          error instanceof DOMException &&
+          (error.name === "NotFoundError" ||
+            error.name === "OverconstrainedError")
+        ) {
+          delete audioConstraints.deviceId;
+          stream = await navigator.mediaDevices.getUserMedia({
+            audio: audioConstraints,
+          });
+        } else {
+          throw error;
+        }
+      }
+
+      streamRef.current = stream;
+      samplesRef.current = [];
+      vadStateRef.current = createInitialVadState();
+
+      const context = new AudioContext({ sampleRate: SAMPLE_RATE });
+      audioContextRef.current = context;
+      await context.resume();
+
+      const source = context.createMediaStreamSource(stream);
+      const processor = context.createScriptProcessor(1024, 1, 1);
+      const silence = context.createGain();
+      silence.gain.value = 0;
+
+      processor.onaudioprocess = (event) => {
+        const channel = event.inputBuffer.getChannelData(0);
+        handleFrame(new Float32Array(channel));
+      };
+
+      source.connect(processor);
+      processor.connect(silence);
+      silence.connect(context.destination);
+
+      sourceRef.current = source;
+      processorRef.current = processor;
+      setIsRecording(true);
+    } catch (error) {
+      stopRecording({ flushPending: false });
+      onError(toErrorMessage(error));
+    }
+  }, [
+    handleFrame,
+    isEnabled,
+    onError,
+    preferredMicrophoneId,
+    provider,
+    stopRecording,
+  ]);
+
+  const toggleRecording = useCallback(() => {
+    if (isRecording) {
+      stopRecording();
+    } else {
+      void startRecording();
+    }
+  }, [isRecording, startRecording, stopRecording]);
+
+  useEffect(
+    () => () => {
+      stopRecording({ flushPending: false });
+    },
+    [stopRecording],
+  );
+
+  useEffect(() => {
+    if (!provider && isRecording) {
+      stopRecording({ flushPending: false });
+    }
+  }, [isRecording, provider, stopRecording]);
+
+  return {
+    isEnabled,
+    isRecording,
+    isTranscribing,
+    startRecording,
+    stopRecording,
+    toggleRecording,
+  };
+}

--- a/ui/goose2/src/features/chat/hooks/useVoiceDictation.ts
+++ b/ui/goose2/src/features/chat/hooks/useVoiceDictation.ts
@@ -1,0 +1,117 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getDictationConfig } from "@/shared/api/dictation";
+import type { DictationProviderStatus } from "@/shared/types/dictation";
+import type { ChatAttachmentDraft } from "@/shared/types/messages";
+import { useDictationRecorder } from "./useDictationRecorder";
+import { useVoiceInputPreferences } from "./useVoiceInputPreferences";
+import {
+  appendTranscribedText,
+  getAutoSubmitMatch,
+  getDefaultDictationProvider,
+  VOICE_DICTATION_CONFIG_EVENT,
+} from "../lib/voiceInput";
+
+interface UseVoiceDictationOptions {
+  text: string;
+  setText: (value: string) => void;
+  attachments: ChatAttachmentDraft[];
+  clearAttachments: () => void;
+  selectedPersonaId: string | null;
+  onSend: (
+    text: string,
+    personaId?: string,
+    attachments?: ChatAttachmentDraft[],
+  ) => void;
+  resetTextarea: () => void;
+}
+
+export function useVoiceDictation({
+  text,
+  setText,
+  attachments,
+  clearAttachments,
+  selectedPersonaId,
+  onSend,
+  resetTextarea,
+}: UseVoiceDictationOptions) {
+  const voicePrefs = useVoiceInputPreferences();
+  const [providerStatuses, setProviderStatuses] = useState<
+    Partial<Record<string, DictationProviderStatus>>
+  >({});
+
+  const fetchDictationConfig = useCallback(() => {
+    getDictationConfig()
+      .then(setProviderStatuses)
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    fetchDictationConfig();
+    window.addEventListener(VOICE_DICTATION_CONFIG_EVENT, fetchDictationConfig);
+    return () =>
+      window.removeEventListener(
+        VOICE_DICTATION_CONFIG_EVENT,
+        fetchDictationConfig,
+      );
+  }, [fetchDictationConfig]);
+
+  const activeVoiceProvider =
+    voicePrefs.selectedProvider ??
+    (voicePrefs.hasStoredProviderPreference
+      ? null
+      : getDefaultDictationProvider(providerStatuses));
+
+  const providerConfigured =
+    activeVoiceProvider != null &&
+    providerStatuses[activeVoiceProvider]?.configured === true;
+
+  const stopRecordingRef = useRef<
+    (options?: { flushPending?: boolean }) => void
+  >(() => {});
+
+  const handleTranscription = useCallback(
+    (fragment: string) => {
+      const match = getAutoSubmitMatch(fragment, voicePrefs.autoSubmitPhrases);
+      if (match) {
+        const merged = appendTranscribedText(text, match.textWithoutPhrase);
+        if (merged.trim()) {
+          stopRecordingRef.current({ flushPending: false });
+          onSend(
+            merged.trim(),
+            selectedPersonaId ?? undefined,
+            attachments.length > 0 ? attachments : undefined,
+          );
+          setText("");
+          clearAttachments();
+          resetTextarea();
+        }
+      } else {
+        const merged = appendTranscribedText(text, fragment);
+        setText(merged);
+      }
+    },
+    [
+      attachments,
+      clearAttachments,
+      onSend,
+      resetTextarea,
+      selectedPersonaId,
+      setText,
+      text,
+      voicePrefs.autoSubmitPhrases,
+    ],
+  );
+
+  const handleVoiceError = useCallback((_message: string) => {}, []);
+
+  const dictation = useDictationRecorder({
+    provider: activeVoiceProvider,
+    providerConfigured,
+    preferredMicrophoneId: voicePrefs.preferredMicrophoneId,
+    onError: handleVoiceError,
+    onTranscription: handleTranscription,
+  });
+  stopRecordingRef.current = dictation.stopRecording;
+
+  return dictation;
+}

--- a/ui/goose2/src/features/chat/hooks/useVoiceInputPreferences.ts
+++ b/ui/goose2/src/features/chat/hooks/useVoiceInputPreferences.ts
@@ -1,0 +1,161 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  DISABLED_DICTATION_PROVIDER_STORAGE_VALUE,
+  DEFAULT_AUTO_SUBMIT_PHRASES_RAW,
+  VOICE_AUTO_SUBMIT_PHRASES_STORAGE_KEY,
+  VOICE_DICTATION_PREFERRED_MIC_STORAGE_KEY,
+  VOICE_DICTATION_PROVIDER_STORAGE_KEY,
+  normalizeDictationProvider,
+  parseAutoSubmitPhrases,
+} from "../lib/voiceInput";
+import type { DictationProvider } from "@/shared/types/dictation";
+
+const VOICE_INPUT_PREFERENCES_EVENT = "goose:voice-input-preferences";
+
+function readStoredAutoSubmitPhrases() {
+  try {
+    return (
+      window.localStorage.getItem(VOICE_AUTO_SUBMIT_PHRASES_STORAGE_KEY) ??
+      DEFAULT_AUTO_SUBMIT_PHRASES_RAW
+    );
+  } catch {
+    return DEFAULT_AUTO_SUBMIT_PHRASES_RAW;
+  }
+}
+
+function readStoredDictationProvider(): DictationProvider | null {
+  try {
+    const storedValue = window.localStorage.getItem(
+      VOICE_DICTATION_PROVIDER_STORAGE_KEY,
+    );
+
+    if (storedValue === DISABLED_DICTATION_PROVIDER_STORAGE_VALUE) {
+      return null;
+    }
+
+    return normalizeDictationProvider(storedValue);
+  } catch {
+    return null;
+  }
+}
+
+function readHasStoredDictationProviderPreference() {
+  try {
+    return (
+      window.localStorage.getItem(VOICE_DICTATION_PROVIDER_STORAGE_KEY) !== null
+    );
+  } catch {
+    return false;
+  }
+}
+
+function readStoredPreferredMicrophoneId() {
+  try {
+    return window.localStorage.getItem(
+      VOICE_DICTATION_PREFERRED_MIC_STORAGE_KEY,
+    );
+  } catch {
+    return null;
+  }
+}
+
+export function useVoiceInputPreferences() {
+  const [rawAutoSubmitPhrases, setRawAutoSubmitPhrasesState] = useState(
+    readStoredAutoSubmitPhrases,
+  );
+  const [selectedProvider, setSelectedProviderState] = useState(
+    readStoredDictationProvider,
+  );
+  const [hasStoredProviderPreference, setHasStoredProviderPreferenceState] =
+    useState(readHasStoredDictationProviderPreference);
+  const [preferredMicrophoneId, setPreferredMicrophoneIdState] = useState(
+    readStoredPreferredMicrophoneId,
+  );
+
+  useEffect(() => {
+    const syncFromStorage = () => {
+      setRawAutoSubmitPhrasesState(readStoredAutoSubmitPhrases());
+      setSelectedProviderState(readStoredDictationProvider());
+      setHasStoredProviderPreferenceState(
+        readHasStoredDictationProviderPreference(),
+      );
+      setPreferredMicrophoneIdState(readStoredPreferredMicrophoneId());
+    };
+
+    window.addEventListener("storage", syncFromStorage);
+    window.addEventListener(
+      VOICE_INPUT_PREFERENCES_EVENT,
+      syncFromStorage as EventListener,
+    );
+
+    return () => {
+      window.removeEventListener("storage", syncFromStorage);
+      window.removeEventListener(
+        VOICE_INPUT_PREFERENCES_EVENT,
+        syncFromStorage as EventListener,
+      );
+    };
+  }, []);
+
+  const setRawAutoSubmitPhrases = useCallback((value: string) => {
+    setRawAutoSubmitPhrasesState(value);
+
+    try {
+      window.localStorage.setItem(VOICE_AUTO_SUBMIT_PHRASES_STORAGE_KEY, value);
+      window.dispatchEvent(new Event(VOICE_INPUT_PREFERENCES_EVENT));
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, []);
+
+  const setSelectedProvider = useCallback((value: DictationProvider | null) => {
+    setSelectedProviderState(value);
+    setHasStoredProviderPreferenceState(true);
+
+    try {
+      window.localStorage.setItem(
+        VOICE_DICTATION_PROVIDER_STORAGE_KEY,
+        value ?? DISABLED_DICTATION_PROVIDER_STORAGE_VALUE,
+      );
+      window.dispatchEvent(new Event(VOICE_INPUT_PREFERENCES_EVENT));
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, []);
+
+  const setPreferredMicrophoneId = useCallback((value: string | null) => {
+    setPreferredMicrophoneIdState(value);
+
+    try {
+      if (value) {
+        window.localStorage.setItem(
+          VOICE_DICTATION_PREFERRED_MIC_STORAGE_KEY,
+          value,
+        );
+      } else {
+        window.localStorage.removeItem(
+          VOICE_DICTATION_PREFERRED_MIC_STORAGE_KEY,
+        );
+      }
+      window.dispatchEvent(new Event(VOICE_INPUT_PREFERENCES_EVENT));
+    } catch {
+      // localStorage may be unavailable
+    }
+  }, []);
+
+  const autoSubmitPhrases = useMemo(
+    () => parseAutoSubmitPhrases(rawAutoSubmitPhrases),
+    [rawAutoSubmitPhrases],
+  );
+
+  return {
+    autoSubmitPhrases,
+    hasStoredProviderPreference,
+    preferredMicrophoneId,
+    rawAutoSubmitPhrases,
+    selectedProvider,
+    setPreferredMicrophoneId,
+    setRawAutoSubmitPhrases,
+    setSelectedProvider,
+  };
+}

--- a/ui/goose2/src/features/chat/lib/dictationVad.test.ts
+++ b/ui/goose2/src/features/chat/lib/dictationVad.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { advanceVadState, createInitialVadState } from "./dictationVad";
+
+function runFrames(levels: number[]) {
+  const decisions: string[] = [];
+  let state = createInitialVadState();
+
+  for (const level of levels) {
+    const result = advanceVadState(state, level);
+    decisions.push(result.decision);
+    state = result.nextState;
+  }
+
+  return decisions;
+}
+
+describe("dictationVad", () => {
+  it("ignores silence-only audio", () => {
+    expect(runFrames([0, 0, 0, 0])).toEqual([
+      "ignore",
+      "ignore",
+      "ignore",
+      "ignore",
+    ]);
+  });
+
+  it("discards short noise bursts that never confirm speech", () => {
+    expect(runFrames([0.03, 0, 0, 0])).toEqual([
+      "append",
+      "append",
+      "append",
+      "discard",
+    ]);
+  });
+
+  it("flushes a chunk after speech followed by trailing silence", () => {
+    expect(runFrames([0.03, 0.03, 0.03, 0, 0, 0, 0, 0, 0])).toContain(
+      "append_and_flush",
+    );
+  });
+
+  it("returns to ignoring silence after a flush, ready for another chunk", () => {
+    const decisions = runFrames([
+      0.03, 0.03, 0.03, 0, 0, 0, 0, 0, 0, 0.03, 0.03, 0.03, 0, 0, 0, 0, 0, 0,
+    ]);
+
+    expect(
+      decisions.filter((decision) => decision === "append_and_flush"),
+    ).toHaveLength(2);
+  });
+});

--- a/ui/goose2/src/features/chat/lib/dictationVad.ts
+++ b/ui/goose2/src/features/chat/lib/dictationVad.ts
@@ -1,0 +1,147 @@
+export type VadPhase = "idle" | "primed" | "speaking" | "trailing";
+
+export type VadDecision = "ignore" | "append" | "append_and_flush" | "discard";
+
+export interface VadState {
+  phase: VadPhase;
+  speechFrames: number;
+  silenceFrames: number;
+  framesInChunk: number;
+}
+
+const SPEECH_RMS_THRESHOLD = 0.018;
+const SPEECH_CONFIRMATION_FRAMES = 2;
+const MAX_PRIMED_SILENCE_FRAMES = 2;
+const TRAILING_SILENCE_FRAMES = 6;
+const MIN_SPEECH_FRAMES = 3;
+
+export function createInitialVadState(): VadState {
+  return {
+    phase: "idle",
+    speechFrames: 0,
+    silenceFrames: 0,
+    framesInChunk: 0,
+  };
+}
+
+export function getFrameRms(samples: Float32Array): number {
+  let sum = 0;
+  for (let index = 0; index < samples.length; index += 1) {
+    const value = samples[index] ?? 0;
+    sum += value * value;
+  }
+
+  return Math.sqrt(sum / Math.max(samples.length, 1));
+}
+
+export function advanceVadState(
+  state: VadState,
+  frameRms: number,
+): { decision: VadDecision; nextState: VadState } {
+  const isSpeech = frameRms >= SPEECH_RMS_THRESHOLD;
+
+  if (state.phase === "idle") {
+    if (!isSpeech) {
+      return { decision: "ignore" as const, nextState: state };
+    }
+
+    return {
+      decision: "append" as const,
+      nextState: {
+        phase: "primed" as const,
+        speechFrames: 1,
+        silenceFrames: 0,
+        framesInChunk: 1,
+      },
+    };
+  }
+
+  if (state.phase === "primed") {
+    if (isSpeech) {
+      const speechFrames = state.speechFrames + 1;
+      return {
+        decision: "append" as const,
+        nextState: {
+          phase:
+            speechFrames >= SPEECH_CONFIRMATION_FRAMES ? "speaking" : "primed",
+          speechFrames,
+          silenceFrames: 0,
+          framesInChunk: state.framesInChunk + 1,
+        },
+      };
+    }
+
+    const silenceFrames = state.silenceFrames + 1;
+    if (silenceFrames > MAX_PRIMED_SILENCE_FRAMES) {
+      return {
+        decision: "discard" as const,
+        nextState: createInitialVadState(),
+      };
+    }
+
+    return {
+      decision: "append" as const,
+      nextState: {
+        ...state,
+        silenceFrames,
+        framesInChunk: state.framesInChunk + 1,
+      },
+    };
+  }
+
+  if (state.phase === "speaking") {
+    if (isSpeech) {
+      return {
+        decision: "append" as const,
+        nextState: {
+          phase: "speaking" as const,
+          speechFrames: state.speechFrames + 1,
+          silenceFrames: 0,
+          framesInChunk: state.framesInChunk + 1,
+        },
+      };
+    }
+
+    return {
+      decision: "append" as const,
+      nextState: {
+        phase: "trailing" as const,
+        speechFrames: state.speechFrames,
+        silenceFrames: 1,
+        framesInChunk: state.framesInChunk + 1,
+      },
+    };
+  }
+
+  if (isSpeech) {
+    return {
+      decision: "append" as const,
+      nextState: {
+        phase: "speaking" as const,
+        speechFrames: state.speechFrames + 1,
+        silenceFrames: 0,
+        framesInChunk: state.framesInChunk + 1,
+      },
+    };
+  }
+
+  const silenceFrames = state.silenceFrames + 1;
+  if (silenceFrames < TRAILING_SILENCE_FRAMES) {
+    return {
+      decision: "append" as const,
+      nextState: {
+        ...state,
+        silenceFrames,
+        framesInChunk: state.framesInChunk + 1,
+      },
+    };
+  }
+
+  return {
+    decision:
+      state.speechFrames >= MIN_SPEECH_FRAMES
+        ? ("append_and_flush" as const)
+        : ("discard" as const),
+    nextState: createInitialVadState(),
+  };
+}

--- a/ui/goose2/src/features/chat/lib/voiceInput.test.ts
+++ b/ui/goose2/src/features/chat/lib/voiceInput.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import {
+  appendTranscribedText,
+  getDefaultDictationProvider,
+  getAutoSubmitMatch,
+  parseAutoSubmitPhrases,
+  replaceTrailingTranscribedText,
+} from "./voiceInput";
+
+describe("voiceInput helpers", () => {
+  it("parses comma-separated auto-submit phrases", () => {
+    expect(parseAutoSubmitPhrases(" submit, Ship It ,submit ,, ")).toEqual([
+      "submit",
+      "ship it",
+    ]);
+  });
+
+  it("appends dictated text without smashing words together", () => {
+    expect(appendTranscribedText("hello", "world")).toBe("hello world");
+    expect(appendTranscribedText("hello ", "world")).toBe("hello world");
+    expect(appendTranscribedText("hello", ", world")).toBe("hello, world");
+  });
+
+  it("replaces only the trailing dictated segment", () => {
+    expect(
+      replaceTrailingTranscribedText(
+        "draft dictated text",
+        "dictated text",
+        "dictated text submit",
+      ),
+    ).toBe("draft dictated text submit");
+  });
+
+  it("matches auto-submit phrases only at the end of dictated text", () => {
+    expect(getAutoSubmitMatch("please submit now", ["submit"])).toBeNull();
+    expect(getAutoSubmitMatch("please SUBMIT.", ["submit"])).toEqual({
+      matchedPhrase: "submit",
+      textWithoutPhrase: "please",
+    });
+  });
+
+  it("picks the first configured dictation provider by priority", () => {
+    expect(
+      getDefaultDictationProvider({
+        openai: {
+          configured: false,
+          description: "OpenAI",
+          usesProviderConfig: true,
+          availableModels: [],
+        },
+        groq: {
+          configured: true,
+          description: "Groq",
+          usesProviderConfig: false,
+          availableModels: [],
+        },
+        local: {
+          configured: true,
+          description: "Local",
+          usesProviderConfig: false,
+          availableModels: [],
+        },
+      }),
+    ).toBe("groq");
+  });
+
+  it("falls back to the first available provider when none are configured", () => {
+    expect(
+      getDefaultDictationProvider({
+        elevenlabs: {
+          configured: false,
+          description: "ElevenLabs",
+          usesProviderConfig: false,
+          availableModels: [],
+        },
+        local: {
+          configured: false,
+          description: "Local",
+          usesProviderConfig: false,
+          availableModels: [],
+        },
+      }),
+    ).toBe("local");
+  });
+});

--- a/ui/goose2/src/features/chat/lib/voiceInput.ts
+++ b/ui/goose2/src/features/chat/lib/voiceInput.ts
@@ -1,0 +1,177 @@
+import type {
+  DictationProvider,
+  DictationProviderStatus,
+} from "@/shared/types/dictation";
+
+export const VOICE_AUTO_SUBMIT_PHRASES_STORAGE_KEY =
+  "goose:voice-auto-submit-phrases";
+export const VOICE_DICTATION_PROVIDER_STORAGE_KEY =
+  "goose:voice-dictation-provider";
+export const VOICE_DICTATION_PREFERRED_MIC_STORAGE_KEY =
+  "goose:voice-dictation-preferred-mic";
+export const VOICE_DICTATION_CONFIG_EVENT = "goose:voice-dictation-config";
+export const DISABLED_DICTATION_PROVIDER_STORAGE_VALUE = "__disabled__";
+
+export const DEFAULT_AUTO_SUBMIT_PHRASES_RAW = "submit";
+
+const TRAILING_PUNCTUATION_REGEX = /[\s"'`.,!?;:)\]}]+$/u;
+
+function normalizePhrase(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\s+/g, " ")
+    .trim()
+    .replace(TRAILING_PUNCTUATION_REGEX, "")
+    .trim();
+}
+
+export function parseAutoSubmitPhrases(rawValue: string | null | undefined) {
+  if (!rawValue) {
+    return [];
+  }
+
+  return Array.from(
+    new Set(
+      rawValue
+        .split(",")
+        .map((value) => normalizePhrase(value))
+        .filter(Boolean),
+    ),
+  );
+}
+
+export function normalizeDictationProvider(
+  value: string | null | undefined,
+): DictationProvider | null {
+  if (
+    value === "openai" ||
+    value === "groq" ||
+    value === "elevenlabs" ||
+    value === "local"
+  ) {
+    return value;
+  }
+
+  return null;
+}
+
+export function getDefaultDictationProvider(
+  providerStatuses: Partial<Record<DictationProvider, DictationProviderStatus>>,
+): DictationProvider | null {
+  const configuredProviderPriority: DictationProvider[] = [
+    "openai",
+    "groq",
+    "elevenlabs",
+    "local",
+  ];
+  const fallbackProviderPriority: DictationProvider[] = [
+    "local",
+    "openai",
+    "groq",
+    "elevenlabs",
+  ];
+
+  for (const provider of configuredProviderPriority) {
+    if (providerStatuses[provider]?.configured) {
+      return provider;
+    }
+  }
+
+  for (const provider of fallbackProviderPriority) {
+    if (providerStatuses[provider]) {
+      return provider;
+    }
+  }
+
+  return null;
+}
+
+export function appendTranscribedText(baseText: string, fragment: string) {
+  const normalizedFragment = fragment.replace(/\s+/g, " ").trim();
+  if (!normalizedFragment) {
+    return baseText;
+  }
+
+  if (!baseText.trim()) {
+    return normalizedFragment;
+  }
+
+  if (/[\s([{/-]$/.test(baseText) || /^[,.;!?)]/.test(normalizedFragment)) {
+    return `${baseText}${normalizedFragment}`;
+  }
+
+  return `${baseText} ${normalizedFragment}`;
+}
+
+export function replaceTrailingTranscribedText(
+  fullText: string,
+  previousTranscribedText: string,
+  nextTranscribedText: string,
+) {
+  if (!previousTranscribedText) {
+    return appendTranscribedText(fullText, nextTranscribedText);
+  }
+
+  if (fullText.endsWith(previousTranscribedText)) {
+    return appendTranscribedText(
+      fullText.slice(0, -previousTranscribedText.length),
+      nextTranscribedText,
+    );
+  }
+
+  const trimmedPreviousText = previousTranscribedText.trim();
+  if (trimmedPreviousText && fullText.endsWith(trimmedPreviousText)) {
+    return appendTranscribedText(
+      fullText.slice(0, -trimmedPreviousText.length),
+      nextTranscribedText,
+    );
+  }
+
+  return appendTranscribedText(fullText, nextTranscribedText);
+}
+
+export function getAutoSubmitMatch(
+  transcribedText: string,
+  autoSubmitPhrases: string[],
+) {
+  const normalizedTranscribedText = normalizePhrase(transcribedText);
+  if (!normalizedTranscribedText) {
+    return null;
+  }
+
+  const sortedPhrases = [...autoSubmitPhrases].sort(
+    (left, right) => right.length - left.length,
+  );
+
+  for (const phrase of sortedPhrases) {
+    if (!normalizedTranscribedText.endsWith(phrase)) {
+      continue;
+    }
+
+    const phraseStartIndex = normalizedTranscribedText.length - phrase.length;
+    if (
+      phraseStartIndex > 0 &&
+      normalizedTranscribedText[phraseStartIndex - 1] !== " "
+    ) {
+      continue;
+    }
+
+    const trimmedText = transcribedText.replace(TRAILING_PUNCTUATION_REGEX, "");
+    const textWithoutPhrase = trimmedText.slice(0, -phrase.length).trimEnd();
+
+    return {
+      matchedPhrase: phrase,
+      textWithoutPhrase,
+    };
+  }
+
+  return null;
+}
+
+export function notifyVoiceDictationConfigChanged() {
+  try {
+    window.dispatchEvent(new Event(VOICE_DICTATION_CONFIG_EVENT));
+  } catch {
+    // no-op
+  }
+}

--- a/ui/goose2/src/features/chat/ui/ChatInput.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatInput.tsx
@@ -22,6 +22,7 @@ import {
 } from "../hooks/useChatInputAttachments";
 import type { ModelOption } from "../types";
 import { ChatInputAttachments } from "./ChatInputAttachments";
+import { useVoiceDictation } from "../hooks/useVoiceDictation";
 
 export interface ProjectOption {
   id: string;
@@ -115,6 +116,22 @@ export function ChatInput({
     clearAttachments,
   } = useChatInputAttachments();
 
+  const resetTextarea = useCallback(() => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = "auto";
+    }
+  }, []);
+
+  const dictation = useVoiceDictation({
+    text,
+    setText,
+    attachments,
+    clearAttachments,
+    selectedPersonaId,
+    onSend,
+    resetTextarea,
+  });
+
   const activePersona = useMemo(
     () => personas.find((persona) => persona.id === selectedPersonaId) ?? null,
     [personas, selectedPersonaId],
@@ -172,6 +189,14 @@ export function ChatInput({
   useEffect(() => textareaRef.current?.focus(), []);
 
   const handleSend = useCallback(() => {
+    // If recording, stop and flush — the transcription callback will
+    // append text and may auto-submit. Don't send the current text yet
+    // because the final transcription hasn't arrived.
+    if (dictation.isRecording || dictation.isTranscribing) {
+      dictation.stopRecording();
+      return;
+    }
+
     if (!canSend) {
       return;
     }
@@ -190,6 +215,7 @@ export function ChatInput({
     attachments,
     canSend,
     clearAttachments,
+    dictation,
     onSend,
     selectedPersonaId,
     setText,
@@ -402,7 +428,13 @@ export function ChatInput({
                   onChange={handleInput}
                   onKeyDown={handleKeyDown}
                   onPaste={handlePaste}
-                  placeholder={effectivePlaceholder}
+                  placeholder={
+                    dictation.isRecording
+                      ? t("toolbar.voiceInputRecording")
+                      : dictation.isTranscribing
+                        ? t("toolbar.voiceInputTranscribing")
+                        : effectivePlaceholder
+                  }
                   disabled={disabled}
                   rows={1}
                   className="mb-3 min-h-[36px] max-h-[200px] w-full resize-none bg-transparent px-1 text-[14px] leading-relaxed text-foreground placeholder:font-light placeholder:text-muted-foreground/60 focus:outline-none focus-visible:ring-0 focus-visible:ring-offset-0 disabled:opacity-60"
@@ -438,6 +470,10 @@ export function ChatInput({
                 onSend={handleSend}
                 onStop={onStop}
                 isCompact={isCompact}
+                voiceEnabled={dictation.isEnabled}
+                voiceRecording={dictation.isRecording}
+                voiceTranscribing={dictation.isTranscribing}
+                onVoiceToggle={dictation.toggleRecording}
               />
             </div>
           </Popover>

--- a/ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx
@@ -85,6 +85,11 @@ interface ChatInputToolbarProps {
   onAttachFiles?: () => void;
   onAttachFolders?: () => void;
   disabled?: boolean;
+  // Voice
+  voiceEnabled?: boolean;
+  voiceRecording?: boolean;
+  voiceTranscribing?: boolean;
+  onVoiceToggle?: () => void;
   // Layout
   isCompact: boolean;
 }
@@ -116,6 +121,10 @@ export function ChatInputToolbar({
   onAttachFiles,
   onAttachFolders,
   disabled = false,
+  voiceEnabled = false,
+  voiceRecording = false,
+  voiceTranscribing = false,
+  onVoiceToggle,
   isCompact,
 }: ChatInputToolbarProps) {
   const { t } = useTranslation("chat");
@@ -300,14 +309,32 @@ export function ChatInputToolbar({
                   type="button"
                   variant="ghost"
                   size="icon-sm"
-                  disabled
-                  aria-label={t("toolbar.voiceInputSoon")}
+                  disabled={!voiceEnabled || disabled}
+                  onClick={onVoiceToggle}
+                  aria-label={
+                    voiceRecording
+                      ? t("toolbar.voiceInputRecording")
+                      : t("toolbar.voiceInput")
+                  }
+                  className={cn(
+                    voiceRecording &&
+                      "bg-destructive/10 text-destructive hover:bg-destructive/20 hover:text-destructive",
+                    voiceTranscribing && "animate-pulse",
+                  )}
                 >
                   <Mic />
                 </Button>
               </span>
             </TooltipTrigger>
-            <TooltipContent>{t("toolbar.voiceInputSoon")}</TooltipContent>
+            <TooltipContent>
+              {!voiceEnabled
+                ? t("toolbar.voiceInputDisabled")
+                : voiceRecording
+                  ? t("toolbar.voiceInputRecording")
+                  : voiceTranscribing
+                    ? t("toolbar.voiceInputTranscribing")
+                    : t("toolbar.voiceInput")}
+            </TooltipContent>
           </Tooltip>
         </div>
 

--- a/ui/goose2/src/features/settings/ui/SettingsModal.tsx
+++ b/ui/goose2/src/features/settings/ui/SettingsModal.tsx
@@ -21,6 +21,7 @@ import {
   SelectValue,
 } from "@/shared/ui/select";
 import {
+  Mic,
   Palette,
   Settings2,
   FolderKanban,
@@ -34,6 +35,7 @@ import { AppearanceSettings } from "./AppearanceSettings";
 import { DoctorSettings } from "./DoctorSettings";
 import { ProvidersSettings } from "./ProvidersSettings";
 import { ExtensionsSettings } from "@/features/extensions/ui/ExtensionsSettings";
+import { VoiceInputSettings } from "./VoiceInputSettings";
 import {
   listArchivedProjects,
   restoreProject,
@@ -50,6 +52,7 @@ const NAV_ITEMS = [
   { id: "appearance", labelKey: "nav.appearance", icon: Palette },
   { id: "providers", labelKey: "nav.providers", icon: IconPlug },
   { id: "extensions", labelKey: "nav.extensions", icon: IconPuzzle },
+  { id: "voice", labelKey: "nav.voice", icon: Mic },
   { id: "general", labelKey: "nav.general", icon: Settings2 },
   { id: "projects", labelKey: "nav.projects", icon: FolderKanban },
   { id: "chats", labelKey: "nav.chats", icon: MessageSquare },
@@ -241,6 +244,7 @@ export function SettingsModal({
               {activeSection === "appearance" && <AppearanceSettings />}
               {activeSection === "providers" && <ProvidersSettings />}
               {activeSection === "extensions" && <ExtensionsSettings />}
+              {activeSection === "voice" && <VoiceInputSettings />}
               {activeSection === "doctor" && <DoctorSettings />}
               {activeSection === "general" && (
                 <div className="space-y-6">

--- a/ui/goose2/src/features/settings/ui/VoiceInputSettings.tsx
+++ b/ui/goose2/src/features/settings/ui/VoiceInputSettings.tsx
@@ -1,0 +1,465 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  deleteDictationProviderSecret,
+  getDictationConfig,
+  saveDictationModelSelection,
+  saveDictationProviderSecret,
+} from "@/shared/api/dictation";
+import {
+  notifyVoiceDictationConfigChanged,
+  getDefaultDictationProvider,
+} from "@/features/chat/lib/voiceInput";
+import { useVoiceInputPreferences } from "@/features/chat/hooks/useVoiceInputPreferences";
+import type {
+  DictationProvider,
+  DictationProviderStatus,
+} from "@/shared/types/dictation";
+import { useAudioDevices } from "@/shared/ui/ai-elements/mic-selector";
+import { Button } from "@/shared/ui/button";
+import { Input } from "@/shared/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/shared/ui/select";
+
+const DISABLED_PROVIDER = "__disabled__";
+
+export function VoiceInputSettings() {
+  const { t } = useTranslation(["settings", "chat", "common"]);
+  const {
+    hasStoredProviderPreference,
+    preferredMicrophoneId,
+    rawAutoSubmitPhrases,
+    selectedProvider,
+    setPreferredMicrophoneId,
+    setRawAutoSubmitPhrases,
+    setSelectedProvider,
+  } = useVoiceInputPreferences();
+  const [providerStatuses, setProviderStatuses] = useState<
+    Record<DictationProvider, DictationProviderStatus>
+  >({} as Record<DictationProvider, DictationProviderStatus>);
+  const [apiKeyInput, setApiKeyInput] = useState("");
+  const [isEditingApiKey, setIsEditingApiKey] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const {
+    devices,
+    error: devicesError,
+    hasPermission,
+    loadDevices,
+    loading: loadingDevices,
+  } = useAudioDevices();
+  const isMicrophoneSupported =
+    typeof navigator !== "undefined" && !!navigator.mediaDevices;
+  const permissionStatus = hasPermission ? "authorized" : "not_determined";
+  const requestPermission = loadDevices;
+
+  const refreshConfig = useCallback(async () => {
+    const nextConfig = await getDictationConfig();
+    setProviderStatuses(nextConfig);
+
+    if (!hasStoredProviderPreference) {
+      const defaultProvider = getDefaultDictationProvider(nextConfig);
+      if (defaultProvider) {
+        setSelectedProvider(defaultProvider);
+      }
+      return;
+    }
+
+    if (!selectedProvider) {
+      return;
+    }
+
+    if (!nextConfig[selectedProvider]) {
+      setSelectedProvider(null);
+    }
+  }, [hasStoredProviderPreference, selectedProvider, setSelectedProvider]);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        await refreshConfig();
+      } catch (caughtError) {
+        setError(
+          caughtError instanceof Error
+            ? caughtError.message
+            : t("general.voiceInput.loadError"),
+        );
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void load();
+  }, [refreshConfig, t]);
+
+  const selectedStatus = selectedProvider
+    ? providerStatuses[selectedProvider]
+    : null;
+
+  const providerOptions = useMemo(
+    () =>
+      Object.entries(providerStatuses) as Array<
+        [DictationProvider, DictationProviderStatus]
+      >,
+    [providerStatuses],
+  );
+
+  const currentModelValue =
+    selectedStatus?.selectedModel ?? selectedStatus?.defaultModel ?? "";
+
+  const saveApiKey = useCallback(async () => {
+    if (!selectedProvider) {
+      return;
+    }
+
+    setError(null);
+    try {
+      await saveDictationProviderSecret(
+        selectedProvider,
+        apiKeyInput,
+        selectedStatus?.configKey ?? undefined,
+      );
+      setApiKeyInput("");
+      setIsEditingApiKey(false);
+      await refreshConfig();
+      notifyVoiceDictationConfigChanged();
+    } catch (caughtError) {
+      setError(
+        caughtError instanceof Error
+          ? caughtError.message
+          : t("general.voiceInput.saveError"),
+      );
+    }
+  }, [apiKeyInput, refreshConfig, selectedProvider, selectedStatus, t]);
+
+  const removeApiKey = useCallback(async () => {
+    if (!selectedProvider) {
+      return;
+    }
+
+    setError(null);
+    try {
+      await deleteDictationProviderSecret(
+        selectedProvider,
+        selectedStatus?.configKey ?? undefined,
+      );
+      setApiKeyInput("");
+      setIsEditingApiKey(false);
+      await refreshConfig();
+      notifyVoiceDictationConfigChanged();
+    } catch (caughtError) {
+      setError(
+        caughtError instanceof Error
+          ? caughtError.message
+          : t("general.voiceInput.deleteError"),
+      );
+    }
+  }, [refreshConfig, selectedProvider, selectedStatus, t]);
+
+  const handleModelChange = useCallback(
+    async (modelId: string) => {
+      if (!selectedProvider) {
+        return;
+      }
+
+      setError(null);
+      try {
+        await saveDictationModelSelection(selectedProvider, modelId);
+        await refreshConfig();
+        notifyVoiceDictationConfigChanged();
+      } catch (caughtError) {
+        setError(
+          caughtError instanceof Error
+            ? caughtError.message
+            : t("general.voiceInput.saveError"),
+        );
+      }
+    },
+    [refreshConfig, selectedProvider, t],
+  );
+
+  const selectedMicrophoneLabel = useMemo(() => {
+    if (!preferredMicrophoneId) {
+      return t("general.voiceInput.systemMicrophone");
+    }
+
+    return (
+      devices.find((device) => device.deviceId === preferredMicrophoneId)
+        ?.label || t("general.voiceInput.systemMicrophone")
+    );
+  }, [devices, preferredMicrophoneId, t]);
+
+  if (loading) {
+    return (
+      <div className="space-y-3">
+        <h4 className="text-sm font-semibold">
+          {t("general.voiceInput.label")}
+        </h4>
+        <p className="text-xs text-muted-foreground">
+          {t("common:labels.loading")}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <h4 className="text-sm font-semibold">
+          {t("general.voiceInput.label")}
+        </h4>
+        <p className="mt-1 text-xs text-muted-foreground">
+          {t("general.voiceInput.description")}
+        </p>
+      </div>
+
+      <div className="space-y-2 rounded-lg border border-border px-3 py-3">
+        <p className="text-xs font-medium text-foreground">
+          {t("general.voiceInput.providerLabel")}
+        </p>
+        <Select
+          value={selectedProvider ?? DISABLED_PROVIDER}
+          onValueChange={(value) =>
+            setSelectedProvider(
+              value === DISABLED_PROVIDER ? null : (value as DictationProvider),
+            )
+          }
+        >
+          <SelectTrigger className="w-full max-w-sm">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={DISABLED_PROVIDER}>
+              {t("general.voiceInput.disabled")}
+            </SelectItem>
+            {providerOptions.map(([providerId, status]) => (
+              <SelectItem key={providerId} value={providerId}>
+                {t(`general.voiceInput.providers.${providerId}`)}
+                {!status.configured
+                  ? ` ${t("general.voiceInput.notConfiguredSuffix")}`
+                  : ""}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      {selectedStatus ? (
+        <>
+          {!selectedStatus.usesProviderConfig &&
+          selectedProvider !== "local" ? (
+            <div className="space-y-3 rounded-lg border border-border px-3 py-3">
+              {isEditingApiKey ? (
+                <>
+                  <div>
+                    <p className="text-xs font-medium text-foreground">
+                      {t("general.voiceInput.apiKeyLabel")}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {t("general.voiceInput.apiKeyDescription")}
+                    </p>
+                  </div>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Input
+                      type="password"
+                      value={apiKeyInput}
+                      onChange={(event) => setApiKeyInput(event.target.value)}
+                      placeholder={t("general.voiceInput.apiKeyPlaceholder")}
+                      className="max-w-sm"
+                    />
+                    <div className="flex gap-2">
+                      <Button
+                        type="button"
+                        size="sm"
+                        onClick={() => void saveApiKey()}
+                      >
+                        {t("common:actions.save")}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline-flat"
+                        size="sm"
+                        onClick={() => {
+                          setApiKeyInput("");
+                          setIsEditingApiKey(false);
+                        }}
+                      >
+                        {t("common:actions.cancel")}
+                      </Button>
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <p className="text-xs font-medium text-foreground">
+                      {t("general.voiceInput.apiKeyLabel")}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {selectedStatus.configured
+                        ? t("general.voiceInput.apiKeyConfigured")
+                        : t("general.voiceInput.apiKeyDescription")}
+                    </p>
+                  </div>
+                  <div className="flex gap-2 flex-shrink-0">
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline-flat"
+                      onClick={() => setIsEditingApiKey(true)}
+                    >
+                      {selectedStatus.configured
+                        ? t("general.voiceInput.updateApiKey")
+                        : t("general.voiceInput.addApiKey")}
+                    </Button>
+                    {selectedStatus.configured ? (
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        className="text-destructive hover:text-destructive"
+                        onClick={() => void removeApiKey()}
+                      >
+                        {t("general.voiceInput.removeApiKey")}
+                      </Button>
+                    ) : null}
+                  </div>
+                </div>
+              )}
+            </div>
+          ) : null}
+
+          {selectedProvider === "local" ? (
+            <div className="rounded-lg border border-border px-3 py-3">
+              <p className="text-xs font-medium text-foreground">
+                {t("general.voiceInput.localModelLabel")}
+              </p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                {t("general.voiceInput.localModelUnavailable")}
+              </p>
+            </div>
+          ) : (selectedStatus.availableModels ?? []).length > 0 ? (
+            <div className="space-y-2 rounded-lg border border-border px-3 py-3">
+              <p className="text-xs font-medium text-foreground">
+                {t("general.voiceInput.modelLabel")}
+              </p>
+              <Select
+                value={currentModelValue}
+                onValueChange={(value) => void handleModelChange(value)}
+              >
+                <SelectTrigger className="w-full max-w-sm">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {(selectedStatus.availableModels ?? []).map((model) => (
+                    <SelectItem key={model.id} value={model.id}>
+                      {model.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {(selectedStatus.availableModels ?? []).find(
+                  (model) => model.id === currentModelValue,
+                )?.description ?? ""}
+              </p>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+
+      <div className="space-y-2 rounded-lg border border-border px-3 py-3">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <p className="text-xs font-medium text-foreground">
+              {t("general.voiceInput.microphoneLabel")}
+            </p>
+            <p className="mt-1 text-xs text-muted-foreground">
+              {isMicrophoneSupported
+                ? t("general.voiceInput.microphoneDescription")
+                : t("general.voiceInput.microphoneUnavailable")}
+            </p>
+          </div>
+          {isMicrophoneSupported && !hasPermission ? (
+            <Button
+              type="button"
+              size="sm"
+              variant="outline-flat"
+              disabled={loadingDevices}
+              onClick={() => void requestPermission()}
+            >
+              {t("general.voiceInput.grantMicrophone")}
+            </Button>
+          ) : null}
+        </div>
+
+        {!devicesError &&
+        !hasPermission &&
+        permissionStatus === "not_determined" ? (
+          <p className="text-xs text-muted-foreground">
+            {t("general.voiceInput.microphoneAccessPrompt")}
+          </p>
+        ) : null}
+
+        {devicesError ? (
+          <p className="text-xs text-muted-foreground">{devicesError}</p>
+        ) : null}
+
+        {isMicrophoneSupported && hasPermission ? (
+          <Select
+            value={preferredMicrophoneId ?? DISABLED_PROVIDER}
+            onValueChange={(value) =>
+              setPreferredMicrophoneId(
+                value === DISABLED_PROVIDER ? null : value,
+              )
+            }
+          >
+            <SelectTrigger className="w-full max-w-sm">
+              <SelectValue>{selectedMicrophoneLabel}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={DISABLED_PROVIDER}>
+                {t("general.voiceInput.systemMicrophone")}
+              </SelectItem>
+              {devices.map((device) => (
+                <SelectItem key={device.deviceId} value={device.deviceId}>
+                  {device.label || t("general.voiceInput.unknownMicrophone")}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        ) : null}
+      </div>
+
+      <div className="space-y-2 rounded-lg border border-border px-3 py-3">
+        <label
+          htmlFor="voice-auto-submit-phrases"
+          className="text-xs font-medium text-foreground"
+        >
+          {t("general.voiceInput.autoSubmitLabel")}
+        </label>
+        <p className="text-xs text-muted-foreground">
+          {t("general.voiceInput.autoSubmitDescription")}
+        </p>
+        <Input
+          id="voice-auto-submit-phrases"
+          type="text"
+          value={rawAutoSubmitPhrases}
+          onChange={(event) => setRawAutoSubmitPhrases(event.target.value)}
+          placeholder={t("general.voiceInput.placeholder")}
+          className="max-w-sm"
+        />
+      </div>
+
+      {error ? <p className="text-xs text-destructive">{error}</p> : null}
+    </div>
+  );
+}

--- a/ui/goose2/src/shared/api/dictation.ts
+++ b/ui/goose2/src/shared/api/dictation.ts
@@ -1,0 +1,100 @@
+import { invoke } from "@tauri-apps/api/core";
+import type {
+  DictationDownloadProgress,
+  DictationProvider,
+  DictationProviderStatus,
+  DictationTranscribeResponse,
+  MicrophonePermissionStatus,
+  WhisperModelStatus,
+} from "@/shared/types/dictation";
+
+export async function getDictationConfig(): Promise<
+  Record<DictationProvider, DictationProviderStatus>
+> {
+  return invoke("get_dictation_config");
+}
+
+export async function transcribeDictation(request: {
+  audio: string;
+  mimeType: string;
+  provider: DictationProvider;
+}): Promise<DictationTranscribeResponse> {
+  return invoke("transcribe_dictation", {
+    request: {
+      audio: request.audio,
+      mimeType: request.mimeType,
+      provider: request.provider,
+    },
+  });
+}
+
+export async function saveDictationModelSelection(
+  provider: DictationProvider,
+  modelId: string,
+): Promise<void> {
+  return invoke("save_dictation_model_selection", { provider, modelId });
+}
+
+export async function saveDictationProviderSecret(
+  _provider: DictationProvider,
+  value: string,
+  configKey?: string,
+): Promise<void> {
+  if (!configKey) {
+    throw new Error("No config key for this provider");
+  }
+  return invoke("save_provider_field", { key: configKey, value });
+}
+
+export async function deleteDictationProviderSecret(
+  provider: DictationProvider,
+  _configKey?: string,
+): Promise<void> {
+  const providerIdMap: Record<string, string> = {
+    groq: "dictation_groq",
+    elevenlabs: "dictation_elevenlabs",
+  };
+  const providerId = providerIdMap[provider];
+  if (!providerId) {
+    throw new Error("Cannot delete secrets for this provider");
+  }
+  return invoke("delete_provider_config", { providerId });
+}
+
+export async function listDictationLocalModels(): Promise<
+  WhisperModelStatus[]
+> {
+  return invoke("list_dictation_local_models");
+}
+
+export async function downloadDictationLocalModel(
+  modelId: string,
+): Promise<void> {
+  return invoke("download_dictation_local_model", { modelId });
+}
+
+export async function getDictationLocalModelDownloadProgress(
+  modelId: string,
+): Promise<DictationDownloadProgress | null> {
+  return invoke("get_dictation_local_model_download_progress", { modelId });
+}
+
+export async function cancelDictationLocalModelDownload(
+  modelId: string,
+): Promise<void> {
+  return invoke("cancel_dictation_local_model_download", { modelId });
+}
+
+export async function deleteDictationLocalModel(
+  modelId: string,
+): Promise<void> {
+  return invoke("delete_dictation_local_model", { modelId });
+}
+
+export async function getMicrophonePermissionStatus(): Promise<MicrophonePermissionStatus> {
+  return invoke("get_microphone_permission_status");
+}
+
+export async function requestMicrophonePermission(): Promise<MicrophonePermissionStatus> {
+  return invoke("request_microphone_permission");
+}

--- a/ui/goose2/src/shared/i18n/locales/en/chat.json
+++ b/ui/goose2/src/shared/i18n/locales/en/chat.json
@@ -163,7 +163,11 @@
     "selectProject": "Select project",
     "sendMessage": "Send message",
     "stopGeneration": "Stop generation",
-    "voiceInputSoon": "Voice input (coming soon)"
+    "voiceInput": "Voice dictation",
+    "voiceInputDisabled": "Configure a voice provider in Settings to enable dictation",
+    "voiceInputRecording": "Listening...",
+    "voiceInputTranscribing": "Transcribing...",
+    "voiceInputAutoSubmitHint": "Say \"submit\" to send"
   },
   "tools": {
     "fileNotFound": "File not found: {{path}}",

--- a/ui/goose2/src/shared/i18n/locales/en/settings.json
+++ b/ui/goose2/src/shared/i18n/locales/en/settings.json
@@ -124,7 +124,48 @@
       "spanish": "Spanish",
       "system": "System default ({{language}})"
     },
-    "title": "General"
+    "title": "General",
+    "voiceInput": {
+      "label": "Voice Input",
+      "description": "Configure voice dictation for hands-free input.",
+      "providerLabel": "Transcription Provider",
+      "disabled": "Disabled",
+      "active": "Active",
+      "notConfiguredSuffix": "(not configured)",
+      "placeholder": "Select a provider",
+      "modelLabel": "Model",
+      "apiKeyLabel": "API Key",
+      "apiKeyDescription": "Enter your API key for this provider.",
+      "apiKeyPlaceholder": "sk-...",
+      "apiKeyConfigured": "API key configured",
+      "addApiKey": "Add API key",
+      "updateApiKey": "Update API key",
+      "removeApiKey": "Remove API key",
+      "localModelLabel": "Local Whisper Model",
+      "localModelUnavailable": "Local model download is not yet available. Use the Goose CLI to download a Whisper model first.",
+      "download": "Download",
+      "recommended": "Recommended",
+      "microphoneLabel": "Microphone",
+      "microphoneDescription": "Choose which microphone to use for voice input.",
+      "microphoneUnavailable": "Microphone access is not available in this environment.",
+      "microphoneAccessPrompt": "Click \"Grant access\" to allow microphone use.",
+      "grantMicrophone": "Grant access",
+      "systemMicrophone": "System default",
+      "unknownMicrophone": "Unknown microphone",
+      "autoSubmitLabel": "Auto-submit Phrases",
+      "autoSubmitDescription": "Comma-separated words that trigger automatic send (e.g. \"submit\").",
+      "providers": {
+        "openai": "OpenAI Whisper",
+        "groq": "Groq",
+        "elevenlabs": "ElevenLabs",
+        "local": "Local Whisper"
+      },
+      "providerSetupHint": "This provider uses your main provider config. Check {{settingsPath}} to configure it.",
+      "downloadProgress": "Downloading... {{percent}}%",
+      "loadError": "Failed to load voice settings.",
+      "saveError": "Failed to save.",
+      "deleteError": "Failed to delete."
+    }
   },
   "nav": {
     "about": "About",
@@ -134,7 +175,8 @@
     "general": "General",
     "projects": "Projects",
     "extensions": "Extensions",
-    "providers": "Providers"
+    "providers": "Providers",
+    "voice": "Voice"
   },
   "projects": {
     "description": "Manage your projects.",

--- a/ui/goose2/src/shared/i18n/locales/es/chat.json
+++ b/ui/goose2/src/shared/i18n/locales/es/chat.json
@@ -163,7 +163,11 @@
     "selectProject": "Seleccionar proyecto",
     "sendMessage": "Enviar mensaje",
     "stopGeneration": "Detener generación",
-    "voiceInputSoon": "Entrada de voz (pronto)"
+    "voiceInput": "Dictado por voz",
+    "voiceInputDisabled": "Configura un proveedor de voz en Ajustes para activar el dictado",
+    "voiceInputRecording": "Escuchando...",
+    "voiceInputTranscribing": "Transcribiendo...",
+    "voiceInputAutoSubmitHint": "Di \"enviar\" para enviar"
   },
   "tools": {
     "fileNotFound": "Archivo no encontrado: {{path}}",

--- a/ui/goose2/src/shared/i18n/locales/es/settings.json
+++ b/ui/goose2/src/shared/i18n/locales/es/settings.json
@@ -124,7 +124,48 @@
       "spanish": "Español",
       "system": "Predeterminado del sistema ({{language}})"
     },
-    "title": "General"
+    "title": "General",
+    "voiceInput": {
+      "label": "Entrada de voz",
+      "description": "Configura el dictado por voz para entrada manos libres.",
+      "providerLabel": "Proveedor de transcripción",
+      "disabled": "Desactivado",
+      "active": "Activo",
+      "notConfiguredSuffix": "(no configurado)",
+      "placeholder": "Selecciona un proveedor",
+      "modelLabel": "Modelo",
+      "apiKeyLabel": "Clave API",
+      "apiKeyDescription": "Ingresa tu clave API para este proveedor.",
+      "apiKeyPlaceholder": "sk-...",
+      "apiKeyConfigured": "Clave API configurada",
+      "addApiKey": "Agregar clave API",
+      "updateApiKey": "Actualizar clave API",
+      "removeApiKey": "Eliminar clave API",
+      "localModelLabel": "Modelo Whisper local",
+      "localModelUnavailable": "La descarga de modelos locales aún no está disponible. Usa la CLI de Goose para descargar un modelo Whisper primero.",
+      "download": "Descargar",
+      "recommended": "Recomendado",
+      "microphoneLabel": "Micrófono",
+      "microphoneDescription": "Elige qué micrófono usar para la entrada de voz.",
+      "microphoneUnavailable": "El acceso al micrófono no está disponible en este entorno.",
+      "microphoneAccessPrompt": "Haz clic en \"Permitir acceso\" para usar el micrófono.",
+      "grantMicrophone": "Permitir acceso",
+      "systemMicrophone": "Predeterminado del sistema",
+      "unknownMicrophone": "Micrófono desconocido",
+      "autoSubmitLabel": "Frases de envío automático",
+      "autoSubmitDescription": "Palabras separadas por coma que activan el envío automático (ej. \"enviar\").",
+      "providers": {
+        "openai": "OpenAI Whisper",
+        "groq": "Groq",
+        "elevenlabs": "ElevenLabs",
+        "local": "Whisper local"
+      },
+      "providerSetupHint": "Este proveedor usa tu configuración principal. Revisa {{settingsPath}} para configurarlo.",
+      "downloadProgress": "Descargando... {{percent}}%",
+      "loadError": "Error al cargar ajustes de voz.",
+      "saveError": "Error al guardar.",
+      "deleteError": "Error al eliminar."
+    }
   },
   "nav": {
     "about": "Acerca de",
@@ -134,7 +175,8 @@
     "general": "General",
     "projects": "Proyectos",
     "extensions": "Extensiones",
-    "providers": "Proveedores"
+    "providers": "Proveedores",
+    "voice": "Voz"
   },
   "projects": {
     "description": "Administra tus proyectos.",

--- a/ui/goose2/src/shared/types/dictation.ts
+++ b/ui/goose2/src/shared/types/dictation.ts
@@ -1,0 +1,51 @@
+export type DictationProvider = "openai" | "groq" | "elevenlabs" | "local";
+
+export interface DictationModelOption {
+  id: string;
+  label: string;
+  description: string;
+}
+
+export interface DictationProviderStatus {
+  configured: boolean;
+  host?: string | null;
+  description: string;
+  usesProviderConfig: boolean;
+  settingsPath?: string | null;
+  configKey?: string | null;
+  modelConfigKey?: string | null;
+  defaultModel?: string | null;
+  selectedModel?: string | null;
+  availableModels: DictationModelOption[];
+}
+
+export interface DictationTranscribeResponse {
+  text: string;
+}
+
+export type MicrophonePermissionStatus =
+  | "not_determined"
+  | "authorized"
+  | "denied"
+  | "restricted"
+  | "unsupported";
+
+export interface WhisperModelStatus {
+  id: string;
+  sizeMb: number;
+  url: string;
+  description: string;
+  downloaded: boolean;
+  recommended: boolean;
+}
+
+export interface DictationDownloadProgress {
+  modelId: string;
+  status: string;
+  bytesDownloaded: number;
+  totalBytes: number;
+  progressPercent: number;
+  speedBps?: number | null;
+  etaSeconds?: number | null;
+  error?: string | null;
+}


### PR DESCRIPTION
## Overview

**Category:** new-feature
**User Impact:** Users can now dictate messages using their microphone in the Goose2 desktop app, with support for OpenAI Whisper, Groq, and ElevenLabs transcription providers.

**Problem:** Goose2 had voice dictation building blocks (hooks, VAD, settings UI) sitting unused in the codebase. The mic button showed "coming soon" and the backend commands couldn't compile because they imported the goose crate directly instead of going through ACP.

**Solution:** Exposed dictation as ACP custom methods (`_goose/dictation/transcribe` and `_goose/dictation/config`) following the same pattern as existing methods like `_goose/session/export`. Rewrote the Tauri commands to use `call_ext_method`, wired the frontend hooks into ChatInput, and added a Voice settings page.

## Changes

<details>
<summary>File changes</summary>

**crates/goose-sdk/src/custom_requests.rs**
Added `DictationTranscribeRequest/Response`, `DictationConfigRequest/Response`, and `DictationProviderStatusEntry` types for the ACP custom method protocol.

**crates/goose-acp/src/server.rs**
Added `#[custom_method]` handlers for `on_dictation_transcribe` (routes to OpenAI/Groq/ElevenLabs/Local providers) and `on_dictation_config` (returns provider statuses with model metadata).

**crates/goose-acp/acp-meta.json**
Registered the two new dictation methods in the ACP method registry.

**crates/goose-acp/Cargo.toml**
Added `local-inference` feature flag and `base64` dependency for the transcription handler.

**crates/goose-cli/Cargo.toml**
Forwarded `local-inference` feature to `goose-acp` so local Whisper code paths compile into the binary.

**ui/goose2/src-tauri/src/commands/dictation.rs**
New file. Two Tauri commands (`transcribe_dictation`, `get_dictation_config`) that proxy through `GooseAcpManager::call_ext()` to ACP.

**ui/goose2/src-tauri/src/services/acp/manager.rs**
Added generic `CallExt` command variant and `call_ext()` public method on `GooseAcpManager`. Added `normalize_ext_method_name()` to strip leading underscores (the ACP protocol auto-prefixes `_`). Includes regression test.

**ui/goose2/src-tauri/src/services/acp/manager/command_dispatch.rs**
Added match arm for `ManagerCommand::CallExt` dispatch.

**ui/goose2/src/features/chat/ui/ChatInput.tsx**
Wired up `useDictationRecorder` + `useVoiceInputPreferences`. Handles transcription text insertion, auto-submit on keyword, stops recording on manual send, shows "Listening..."/"Transcribing..." placeholder.

**ui/goose2/src/features/chat/ui/ChatInputToolbar.tsx**
Replaced disabled "coming soon" mic button with working toggle. Shows recording (red) and transcribing (pulse) states.

**ui/goose2/src/features/settings/ui/SettingsModal.tsx**
Added Voice nav item with Mic icon, renders VoiceInputSettings.

**ui/goose2/src/features/settings/ui/VoiceInputSettings.tsx**
New file. Voice settings page with provider selection, API key management, microphone picker, and auto-submit phrase configuration.

**ui/goose2/src/features/chat/lib/dictationVad.ts**
Fixed return type annotation on `advanceVadState` (was inferring `string` instead of `VadPhase`).

**ui/goose2/src/shared/i18n/locales/{en,es}/chat.json**
Added voice toolbar strings (recording, transcribing, disabled tooltip).

**ui/goose2/src/shared/i18n/locales/{en,es}/settings.json**
Added voice settings strings (provider names, API key labels, mic labels, auto-submit labels, local model unavailable message).

**ui/goose2/src-tauri/Info.plist**
New file. macOS microphone usage description for permission prompt.

</details>

## Reproduction Steps

1. Build the goose binary: `cargo build --release -p goose-cli`
2. Launch goose2: `GOOSE_BIN=./target/release/goose pnpm tauri dev` from `ui/goose2/`
3. Open Settings → Voice → select OpenAI Whisper (should show as configured if you have an OpenAI API key)
4. Close settings, click the mic button in the chat toolbar
5. Speak — text should appear in the input after a brief delay
6. Say your auto-submit keyword (default: "submit") — message sends and mic turns off
7. While recording, click send or mic button — recording stops

## Known Issues

- **Local Whisper shows "not configured"** even when a model is downloaded and config is set. The `is_downloaded()` path check needs investigation — likely a path resolution mismatch between config and data directories.
- **Keychain popup on first launch** when the backend checks API key status. Goes away after clicking "Always Allow".
- **Local model download not available from UI** — model management ACP methods not yet implemented. Users can download models via the Goose CLI as a workaround.