### PR TITLE
chore(goose2): `just goose2 <command>` with the addition of `just goose2 kill`

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,5 +1,7 @@
 # Justfile
 
+mod goose2 'ui/goose2'
+
 # list all tasks
 default:
   @just --list

--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -1,3 +1,7 @@
+# Derive a stable port from the working directory so the same worktree
+# always gets the same port.
+vite_port := `python3 -c "import hashlib,os; h=int(hashlib.sha256(os.getcwd().encode()).hexdigest(),16); print(10000 + h % 55000)"`
+
 # Default recipe
 default:
     @just --list
@@ -74,11 +78,7 @@ dev:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    # Derive a stable port from the working directory so the same worktree
-    # always gets the same port. This avoids changing TAURI_CONFIG between
-    # runs, which would invalidate Cargo's build cache and trigger a full
-    # Rust rebuild every time.
-    VITE_PORT=$(python3 -c "import hashlib,os; h=int(hashlib.sha256(os.getcwd().encode()).hexdigest(),16); print(10000 + h % 55000)")
+    VITE_PORT={{ vite_port }}
     export VITE_PORT
     PROJECT_DIR=$(pwd)
     TAURI_CONFIG="{\"build\":{\"devUrl\":\"http://localhost:${VITE_PORT}\",\"beforeDevCommand\":{\"script\":\"cd ${PROJECT_DIR} && exec pnpm exec vite --port ${VITE_PORT} --strictPort\",\"cwd\":\".\",\"wait\":false}}}"
@@ -108,7 +108,7 @@ dev-debug:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    VITE_PORT=$(python3 -c "import hashlib,os; h=int(hashlib.sha256(os.getcwd().encode()).hexdigest(),16); print(10000 + h % 55000)")
+    VITE_PORT={{ vite_port }}
     export VITE_PORT
     EXTRA_CONFIG="--config {\"build\":{\"devUrl\":\"http://localhost:${VITE_PORT}\",\"beforeDevCommand\":{\"script\":\"exec ./node_modules/.bin/vite --port ${VITE_PORT} --strictPort\",\"cwd\":\"..\",\"wait\":false}}}"
 
@@ -141,7 +141,7 @@ kill:
     #!/usr/bin/env bash
     set -euo pipefail
 
-    VITE_PORT=$(python3 -c "import hashlib,os; h=int(hashlib.sha256(os.getcwd().encode()).hexdigest(),16); print(10000 + h % 55000)")
+    VITE_PORT={{ vite_port }}
     PID=$(lsof -ti :"$VITE_PORT" 2>/dev/null | head -1) || true
 
     if [[ -z "$PID" ]]; then

--- a/ui/goose2/justfile
+++ b/ui/goose2/justfile
@@ -136,6 +136,28 @@ dev-debug:
 dev-frontend:
     pnpm dev
 
+# Kill the dev process (if running)
+kill:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    VITE_PORT=$(python3 -c "import hashlib,os; h=int(hashlib.sha256(os.getcwd().encode()).hexdigest(),16); print(10000 + h % 55000)")
+    PID=$(lsof -ti :"$VITE_PORT" 2>/dev/null | head -1) || true
+
+    if [[ -z "$PID" ]]; then
+        echo "No process found on port $VITE_PORT"
+        exit 0
+    fi
+
+    PROC_NAME=$(ps -p "$PID" -o comm= 2>/dev/null) || true
+    if [[ "$PROC_NAME" != "node" ]]; then
+        echo "Process on port $VITE_PORT is '$PROC_NAME', not 'node' — refusing to kill"
+        exit 1
+    fi
+
+    echo "Killing node (PID $PID) on port $VITE_PORT"
+    kill -9 "$PID"
+
 # ── Utilities ────────────────────────────────────────────────
 
 # Clean build artifacts


### PR DESCRIPTION
## Summary
- Add a justfile module so that `just goose2 <subcommand>` works
- Add a `kill` recipe to stop the dev server by finding and killing the node process on the derived port based on branch
- Deduplicate the vite port derivation logic into a single `vite_port` variable reused across `dev`, `dev-debug`, and the new `kill` recipe
