### PR TITLE
docs: remove stale gemini-acp references

### DIFF
--- a/crates/goose/src/acp/provider.rs
+++ b/crates/goose/src/acp/provider.rs
@@ -1553,7 +1553,7 @@ mod tests {
                 ],
             ))
         => Ok(("auto-gemini-3".to_string(), vec!["auto-gemini-3".to_string(), "auto-gemini-2.5".to_string(), "gemini-2.5-pro".to_string()]))
-        ; "gemini-acp falls back to models"
+        ; "gemini falls back to models"
     )]
     #[test_case(
         NewSessionResponse::new("s1")

--- a/documentation/blog/2026-03-19-use-goose-with-your-ai-subscription/index.md
+++ b/documentation/blog/2026-03-19-use-goose-with-your-ai-subscription/index.md
@@ -8,7 +8,7 @@ authors:
 You can use your subscriptions for codex, claude and gemini now with goose, thanks to ACP! (Agent Client Protocol).
 Codex is also special in that you can login directly to chatgpt - nothing else needs to be installed. 
 
-Gemini natively supports ACP, so it now works with a gemini acp provider in goose. At the time of writing, claude requires just one utility installed just once.
+Gemini now works via OAuth — just sign in with your Google account. At the time of writing, claude requires just one utility installed just once.
 
 <!--truncate-->
 
@@ -47,17 +47,11 @@ The first time you run it, goose will open a browser window for you to sign in w
 
 The recommended model is `gpt-5.3-codex`, which is the default. You can also select `gpt-5.4` (OpenAI's latest omni model) or `gpt-5.2-codex` from the model picker.
 
-## Gemini — via ACP (native)
+## Gemini — via OAuth
 
-If you have a Google account with Gemini access, the Gemini CLI speaks ACP natively — no separate adapter needed. Just install the Gemini CLI itself:
+If you have a Google account with Gemini access, the `Gemini` (`gemini_oauth`) provider lets you use goose with your existing account. Just pick Gemini when setting up goose for the first time (or changing providers).
 
-```bash
-npm install -g @google/gemini-cli
-```
-
-... and run `gemini` at least once. 
-
-On first run, Gemini CLI will ask you to authenticate with your Google account. After that, goose passes your extensions directly through to Gemini via ACP. 
+The first time you run it, goose will open a browser window for you to sign in with your Google account. After that, your session is cached locally.
 
 ## What about the old CLI providers?
 
@@ -69,6 +63,6 @@ Goose previously supported `claude-code`, `codex`, and `gemini-cli` as "pass-thr
 |---|---|---|---|
 | Claude Code | `claude-acp` | `npm install -g @zed-industries/claude-agent-acp` | ✅ via MCP |
 | ChatGPT Plus/Pro | `chatgpt_codex` | Nothing — OAuth sign-in | ✅ via MCP |
-| Gemini | `gemini-acp` | `npm install -g @google/gemini-cli` | ✅ via MCP |
+| Gemini | `gemini_oauth` | Nothing — OAuth sign-in | ✅ native |
 
 Pick the one that matches what you're already paying for, and you're good to go.

--- a/documentation/docs/getting-started/providers.md
+++ b/documentation/docs/getting-started/providers.md
@@ -68,7 +68,6 @@ goose supports [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) a
 |-----------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | [Claude ACP](https://github.com/zed-industries/claude-agent-acp) (`claude-acp`) | Uses Claude Code via ACP. Passes goose extensions to the agent as MCP servers. | `npm install -g @zed-industries/claude-agent-acp`, active Claude Code subscription |
 | [Codex ACP](https://github.com/zed-industries/codex-acp) (`codex-acp`) | Uses OpenAI Codex via ACP. Passes goose extensions to the agent as MCP servers. | `npm install -g @zed-industries/codex-acp`, active ChatGPT Plus/Pro subscription |
-| [Gemini ACP](https://github.com/google-gemini/gemini-cli) (`gemini-acp`) | Uses Google's Gemini CLI via ACP (native `--acp` support). Passes goose extensions to the agent as MCP servers. | `npm install -g @google/gemini-cli`, authenticated with Google account |
 
 :::tip ACP Providers
 See the [ACP Providers guide](/docs/guides/acp-providers) for detailed setup instructions.

--- a/documentation/docs/guides/acp-providers.md
+++ b/documentation/docs/guides/acp-providers.md
@@ -12,7 +12,7 @@ goose supports [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) a
 ACP providers pass goose [extensions](/docs/getting-started/using-extensions) through to the agent as MCP servers, so the agent can call your extensions directly.
 
 :::tip Use Your Existing Subscriptions
-ACP providers let you use goose with your existing Claude Code, ChatGPT Plus/Pro, or Google Gemini subscriptions — no per-token API costs. They are the recommended replacement for the deprecated [CLI providers](/docs/guides/cli-providers).
+ACP providers let you use goose with your existing Claude Code or ChatGPT Plus/Pro subscriptions — no per-token API costs. They are the recommended replacement for the deprecated [CLI providers](/docs/guides/cli-providers).
 :::
 
 :::warning Limitations
@@ -49,15 +49,6 @@ Wraps [codex-acp](https://github.com/zed-industries/codex-acp), an ACP adapter f
 - Node.js and npm
 - Active ChatGPT Plus/Pro subscription or OpenAI API credits
 - Authenticated with your OpenAI account (`codex` CLI working)
-
-### Gemini ACP
-
-Uses Google's [Gemini CLI](https://github.com/google-gemini/gemini-cli) directly via its native `--acp` flag. No shim needed — Gemini CLI speaks ACP natively. Replaces the deprecated `gemini-cli` CLI provider.
-
-**Requirements:**
-- Node.js and npm
-- Gemini CLI installed (`npm install -g @google/gemini-cli`)
-- Authenticated with your Google account (run `gemini` once to authenticate via browser)
 
 ### Pi ACP
 
@@ -169,42 +160,6 @@ Wraps `pi-acp`, an ACP adapter for Pi. Uses your existing Pi installation.
    │  gpt-5.2-codex
    ```
 
-### Gemini ACP
-
-1. **Install Gemini CLI**
-
-   ```bash
-   npm install -g @google/gemini-cli
-   ```
-
-2. **Authenticate with Google**
-
-   Run `gemini` once and follow the browser-based authentication flow.
-
-3. **Configure goose**
-
-   Set the provider environment variable:
-   ```bash
-   export GOOSE_PROVIDER=gemini-acp
-   ```
-
-   Or configure through the goose CLI using `goose configure`:
-
-   ```bash
-   ┌   goose-configure
-   │
-   ◇  What would you like to configure?
-   │  Configure Providers
-   │
-   ◇  Which model provider should we use?
-   │  Gemini CLI (ACP)
-   │
-   ◇  Model fetch complete
-   │
-   ◇  Enter a model from that provider:
-   │  default
-   ```
-
 ### Pi ACP
 
 1. **Install the Pi CLI and ACP adapter**
@@ -246,12 +201,6 @@ GOOSE_PROVIDER=claude-acp goose run \
 GOOSE_PROVIDER=codex-acp goose run \
   --with-streamable-http-extension 'https://mcp.kiwi.com' \
   -t 'Search for flights from BKI to SYD tomorrow'
-```
-
-```bash
-GOOSE_PROVIDER=gemini-acp goose run \
-  --with-extension 'npx -y @modelcontextprotocol/server-everything' \
-  -t 'Use the echo tool to say hello'
 ```
 
 ## Configuration Options
@@ -313,25 +262,6 @@ See [claude-agent-acp](https://github.com/zed-industries/claude-agent-acp) for s
 
 See [codex-acp](https://github.com/zed-industries/codex-acp) for approval policy and sandbox details.
 
-### Gemini ACP Configuration
-
-| Environment Variable | Description         | Default     |
-|----------------------|---------------------|-------------|
-| `GOOSE_PROVIDER`     | Set to `gemini-acp` | None        |
-| `GOOSE_MODEL`        | Model to use        | `default`   |
-| `GOOSE_MODE`         | Permission mode     | `auto`      |
-
-**Permission Modes (`GOOSE_MODE`):**
-
-| Mode            | Gemini Mode  | Behavior                                                      |
-|-----------------|-------------|---------------------------------------------------------------|
-| `auto`          | `yolo`      | Auto-approves all tool calls                                  |
-| `smart-approve` | `auto_edit` | Auto-approves file edits, prompts for other operations        |
-| `approve`       | `default`   | Prompts for all permission-required operations                |
-| `chat`          | `plan`      | Planning only, no tool execution                              |
-
-See the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli) for approval mode details.
-
 ### Pi ACP Configuration
 
 | Environment Variable | Description      | Default   |
@@ -344,7 +274,7 @@ See the [Gemini CLI documentation](https://github.com/google-gemini/gemini-cli) 
 
 ACP providers depend on external binaries, so ensure:
 
-- The ACP agent binary is installed and in your PATH (`amp-acp`, `claude-agent-acp`, `codex-acp`, `gemini`, `pi-acp`, or `copilot`)
+- The ACP agent binary is installed and in your PATH (`amp-acp`, `claude-agent-acp`, `codex-acp`, `pi-acp`, or `copilot`)
 - The underlying CLI tool is authenticated and working
 - Subscription limits are not exceeded
 - Node.js and npm are installed (for npm-distributed adapters)

--- a/documentation/docs/guides/cli-providers.md
+++ b/documentation/docs/guides/cli-providers.md
@@ -8,7 +8,7 @@ description: Use Claude Code, Codex, Cursor Agent, or Gemini CLI subscriptions i
 # CLI Providers
 
 :::warning Deprecated — Use ACP Providers
-The Claude Code (`claude-code`), Codex (`codex`), and Gemini CLI (`gemini-cli`) providers are deprecated. Use the [ACP providers](/docs/guides/acp-providers) (`claude-acp`, `codex-acp`, `gemini-acp`) instead, which support goose extensions via MCP and use the standardized Agent Client Protocol. CLI providers are kept for backward compatibility only.
+The Claude Code (`claude-code`), Codex (`codex`), and Gemini CLI (`gemini-cli`) providers are deprecated. Use the [ACP providers](/docs/guides/acp-providers) (`claude-acp`, `codex-acp`) instead, which support goose extensions via MCP and use the standardized Agent Client Protocol. For Gemini, use the `Gemini` (`gemini_oauth`) provider which authenticates via OAuth. CLI providers are kept for backward compatibility only.
 :::
 
 goose can make use of pass-through providers that integrate with existing CLI tools from Anthropic, OpenAI, Cursor, and Google. These providers allow you to use your existing Claude Code, Codex, Cursor Agent, and Google Gemini CLI subscriptions through goose's interface, adding session management, persistence, and workflow integration capabilities to these tools.


### PR DESCRIPTION
Remove references to the removed gemini-acp provider from documentation, blog, and a test string. Points Gemini users to gemini_oauth instead.

Closes #8553