### PR TITLE
show individual untracked files in git changes widget

### DIFF
--- a/ui/goose2/src-tauri/src/commands/git_changes.rs
+++ b/ui/goose2/src-tauri/src/commands/git_changes.rs
@@ -20,7 +20,10 @@ pub fn get_changed_files(path: String) -> Result<Vec<ChangedFile>, String> {
         return Ok(Vec::new());
     }
 
-    let status_output = run_git_success(&repo_path, &["status", "--porcelain"])?;
+    let status_output = run_git_success(
+        &repo_path,
+        &["status", "--porcelain", "--untracked-files=all"],
+    )?;
     if status_output.trim().is_empty() {
         return Ok(Vec::new());
     }

--- a/ui/goose2/src/features/chat/ui/widgets/Widget.tsx
+++ b/ui/goose2/src/features/chat/ui/widgets/Widget.tsx
@@ -11,12 +11,12 @@ interface WidgetProps {
 export function Widget({ title, icon, action, flush, children }: WidgetProps) {
   return (
     <div className="overflow-hidden rounded-md border border-border">
-      <div className="flex h-8 items-center justify-between bg-background-alt px-3">
+      <div className="flex h-8 items-center justify-between gap-2 bg-background-alt px-3">
         <div className="flex min-w-0 items-center gap-2 text-xs font-medium text-foreground">
           {icon}
           {title}
         </div>
-        {action}
+        {action && <div className="shrink-0">{action}</div>}
       </div>
       {flush ? (
         children


### PR DESCRIPTION
**Category:** fix
**User Impact:** The git changes widget now lists each untracked file individually instead of collapsing them into directory entries.

**Problem:** When new untracked files existed inside a directory, `git status --porcelain` collapsed them into a single directory entry (e.g., `?? src/`). This made it impossible to see which specific files were untracked.

**Solution:** Pass `--untracked-files=all` to the underlying git status call so every untracked file is enumerated individually. Also fixes the widget header layout so the action button doesn't get squeezed when the title is long.

<details>
<summary>File changes</summary>

**ui/goose2/src-tauri/src/commands/git_changes.rs**
Added `--untracked-files=all` flag to the `git status --porcelain` call so individual untracked files are listed rather than collapsed directories.

**ui/goose2/src/features/chat/ui/widgets/Widget.tsx**
Added `gap-2` to the widget header for consistent spacing and wrapped the action slot in a `shrink-0` container to prevent it from being compressed when the title is long.

</details>

## Reproduction Steps

1. Open a project that has a directory with multiple new untracked files
2. Look at the git changes widget in the chat view
3. Verify each untracked file is listed individually instead of showing a single directory entry
4. Verify the widget header action button (e.g., "View Diff") doesn't get squeezed when the title text is long

widget padding fix:
<img width="344" height="160" alt="image" src="https://github.com/user-attachments/assets/9991027b-4f83-4d63-aeb4-6617bd0c0379" />
