### PR TITLE
fix: use sqlx chrono decode for thread timestamps instead of manual parsing

### DIFF
--- a/crates/goose/src/session/thread_manager.rs
+++ b/crates/goose/src/session/thread_manager.rs
@@ -54,9 +54,9 @@ type ThreadRow = (
     String,
     bool,
     Option<String>,
-    String,
-    String,
-    Option<String>,
+    DateTime<Utc>,
+    DateTime<Utc>,
+    Option<DateTime<Utc>>,
     String,
     Option<String>,
     i64,
@@ -70,21 +70,21 @@ fn thread_from_row(
         working_dir,
         created_at,
         updated_at,
-        archived_at_str,
+        archived_at,
         metadata_json,
         current_session_id,
         message_count,
     ): ThreadRow,
 ) -> Result<Thread> {
     let metadata: ThreadMetadata = serde_json::from_str(&metadata_json).unwrap_or_default();
-    let archived_at = archived_at_str.as_deref().and_then(|s| s.parse().ok());
+
     Ok(Thread {
         id,
         name,
         user_set_name,
         working_dir,
-        created_at: created_at.parse().unwrap_or_else(|_| Utc::now()),
-        updated_at: updated_at.parse().unwrap_or_else(|_| Utc::now()),
+        created_at,
+        updated_at,
         archived_at,
         metadata,
         current_session_id,


### PR DESCRIPTION
## Summary

Use sqlx's native `DateTime<Utc>` decoding for thread timestamp columns (`created_at`, `updated_at`, `archived_at`) in `ThreadRow` instead of fetching as `String` and manually parsing with `.parse()`.

## Problem

The current code fetches timestamps as raw strings and parses them manually:
```rust
created_at: created_at.parse().unwrap_or_else(|_| Utc::now()),
updated_at: updated_at.parse().unwrap_or_else(|_| Utc::now()),
```

This has two issues:
1. On parse failure, it silently falls back to `Utc::now()`, producing incorrect timestamps
2. It duplicates work that sqlx already handles natively via the `chrono` feature

## Fix

Change `ThreadRow` to decode timestamps as `DateTime<Utc>` directly, and simplify `thread_from_row` to pass them through without parsing.

## Context

This fix was originally merged into the `baxen/goose2` branch (PR #8502) but was missed when goose2 was moved into main via PR #8516 — the move PR was prepared from a snapshot that predated #8502.