### PR TITLE
fix: work around rmcp OAuth discovery bug for remote MCP servers

### DIFF
--- a/crates/goose/src/agents/extension_manager.rs
+++ b/crates/goose/src/agents/extension_manager.rs
@@ -492,7 +492,15 @@ async fn create_streamable_http_client(
                     .await?,
                 ))
             }
-            Err(_) => Ok(Box::new(client_res?)),
+            Err(e) => {
+                tracing::warn!(
+                    extension = %name,
+                    uri = %uri,
+                    error = %e,
+                    "OAuth flow failed, returning original auth error"
+                );
+                Ok(Box::new(client_res?))
+            }
         }
     } else {
         Ok(Box::new(client_res?))

--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -153,26 +153,93 @@ pub async fn oauth_flow(
     Ok(auth_manager)
 }
 
+/// Minimal subset of RFC 9728 Protected Resource Metadata, used only in the fallback
+/// discovery path. The full type in rmcp is not public.
+#[derive(Deserialize)]
+struct ProtectedResourceMetadata {
+    authorization_servers: Option<Vec<String>>,
+}
+
 /// Fallback for when OAuthState::start_authorization_with_metadata_url fails due to
-/// the resource metadata discovery bug. Fetches OAuth metadata directly from the
-/// .well-known/oauth-authorization-server endpoint and creates the session manually.
+/// the resource metadata discovery bug. Follows the MCP spec discovery flow:
+/// 1. Fetch Protected Resource Metadata from .well-known/oauth-protected-resource
+/// 2. Extract the authorization server URL
+/// 3. Fetch Authorization Server Metadata from that URL
+/// 4. Create the session manually using rmcp's public APIs
 async fn start_authorization_with_wellknown_fallback(
     mcp_server_url: &str,
     redirect_uri: &str,
 ) -> Result<OAuthState, anyhow::Error> {
     let base_url = Url::parse(mcp_server_url)?;
-    let wellknown_url = format!(
-        "{}/.well-known/oauth-authorization-server",
-        base_url.origin().ascii_serialization()
-    );
-    let metadata = reqwest::get(&wellknown_url)
-        .await?
-        .error_for_status()?
-        .json::<AuthorizationMetadata>()
-        .await?;
+    let origin = base_url.origin().ascii_serialization();
+    let path = base_url.path().trim_matches('/');
 
+    // Step 1: Discover Protected Resource Metadata (RFC 9728)
+    // Try path-specific endpoint first, then root, per the MCP spec.
+    let resource_metadata = {
+        let mut candidates = Vec::new();
+        if !path.is_empty() {
+            candidates.push(format!(
+                "{origin}/.well-known/oauth-protected-resource/{path}"
+            ));
+        }
+        candidates.push(format!("{origin}/.well-known/oauth-protected-resource"));
+
+        let mut result = None;
+        for url in &candidates {
+            if let Ok(resp) = reqwest::get(url).await {
+                if let Ok(meta) = resp.json::<ProtectedResourceMetadata>().await {
+                    result = Some(meta);
+                    break;
+                }
+            }
+        }
+        result.ok_or_else(|| anyhow::anyhow!("no protected resource metadata found"))?
+    };
+
+    // Step 2: Extract authorization server URL
+    let auth_server_url = resource_metadata
+        .authorization_servers
+        .as_ref()
+        .and_then(|servers| servers.first())
+        .ok_or_else(|| anyhow::anyhow!("no authorization_servers in resource metadata"))?;
+
+    // Step 3: Discover Authorization Server Metadata (RFC 8414)
+    // Try path-qualified and root well-known URLs per the MCP spec.
+    let auth_server = Url::parse(auth_server_url)?;
+    let as_origin = auth_server.origin().ascii_serialization();
+    let as_path = auth_server.path().trim_matches('/');
+
+    let as_metadata = {
+        let mut candidates = Vec::new();
+        if !as_path.is_empty() {
+            candidates.push(format!(
+                "{as_origin}/.well-known/oauth-authorization-server/{as_path}"
+            ));
+            candidates.push(format!(
+                "{as_origin}/.well-known/openid-configuration/{as_path}"
+            ));
+        }
+        candidates.push(format!(
+            "{as_origin}/.well-known/oauth-authorization-server"
+        ));
+        candidates.push(format!("{as_origin}/.well-known/openid-configuration"));
+
+        let mut result = None;
+        for url in &candidates {
+            if let Ok(resp) = reqwest::get(url).await {
+                if let Ok(meta) = resp.json::<AuthorizationMetadata>().await {
+                    result = Some(meta);
+                    break;
+                }
+            }
+        }
+        result.ok_or_else(|| anyhow::anyhow!("no authorization server metadata found"))?
+    };
+
+    // Step 4: Create session using rmcp public APIs
     let mut manager = AuthorizationManager::new(mcp_server_url).await?;
-    manager.set_metadata(metadata);
+    manager.set_metadata(as_metadata);
 
     let session = AuthorizationSession::new(
         manager,

--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -101,16 +101,13 @@ pub async fn oauth_flow(
             "OAuth authorization failed, retrying with direct metadata discovery: {}",
             e
         );
-        oauth_state = start_authorization_with_wellknown_fallback(
-            mcp_server_url,
-            &redirect_uri,
-        )
-        .await
-        .map_err(|fallback_err| {
-            anyhow::anyhow!(
-                "OAuth authorization failed: {e}; fallback also failed: {fallback_err}"
-            )
-        })?;
+        oauth_state = start_authorization_with_wellknown_fallback(mcp_server_url, &redirect_uri)
+            .await
+            .map_err(|fallback_err| {
+                anyhow::anyhow!(
+                    "OAuth authorization failed: {e}; fallback also failed: {fallback_err}"
+                )
+            })?;
     }
 
     let authorization_url = oauth_state.get_authorization_url().await?;

--- a/crates/goose/src/oauth/mod.rs
+++ b/crates/goose/src/oauth/mod.rs
@@ -6,13 +6,16 @@ use axum::routing::get;
 use axum::Router;
 use minijinja::render;
 use oauth2::TokenResponse;
-use rmcp::transport::auth::{CredentialStore, OAuthState, StoredCredentials};
+use rmcp::transport::auth::{
+    AuthorizationMetadata, AuthorizationSession, CredentialStore, OAuthState, StoredCredentials,
+};
 use rmcp::transport::AuthorizationManager;
 use serde::Deserialize;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{oneshot, Mutex};
 use tracing::warn;
+use url::Url;
 
 use crate::oauth::persist::GooseCredentialStore;
 
@@ -81,14 +84,34 @@ pub async fn oauth_flow(
     let mut oauth_state = OAuthState::new(mcp_server_url, None).await?;
 
     let redirect_uri = format!("http://127.0.0.1:{}/oauth_callback", used_addr.port());
-    oauth_state
+    if let Err(e) = oauth_state
         .start_authorization_with_metadata_url(
             &[],
             redirect_uri.as_str(),
             Some("goose"),
             Some(CLIENT_METADATA_URL),
         )
-        .await?;
+        .await
+    {
+        // Workaround for an rmcp bug where resource metadata discovery fails fatally
+        // when the MCP server returns non-JSON (e.g. HTML) at its base URL with HTTP 200,
+        // preventing fallback to .well-known/oauth-authorization-server discovery.
+        // See: https://github.com/modelcontextprotocol/rust-sdk/pull/810
+        warn!(
+            "OAuth authorization failed, retrying with direct metadata discovery: {}",
+            e
+        );
+        oauth_state = start_authorization_with_wellknown_fallback(
+            mcp_server_url,
+            &redirect_uri,
+        )
+        .await
+        .map_err(|fallback_err| {
+            anyhow::anyhow!(
+                "OAuth authorization failed: {e}; fallback also failed: {fallback_err}"
+            )
+        })?;
+    }
 
     let authorization_url = oauth_state.get_authorization_url().await?;
     if webbrowser::open(authorization_url.as_str()).is_err() {
@@ -131,4 +154,37 @@ pub async fn oauth_flow(
     auth_manager.set_credential_store(credential_store);
 
     Ok(auth_manager)
+}
+
+/// Fallback for when OAuthState::start_authorization_with_metadata_url fails due to
+/// the resource metadata discovery bug. Fetches OAuth metadata directly from the
+/// .well-known/oauth-authorization-server endpoint and creates the session manually.
+async fn start_authorization_with_wellknown_fallback(
+    mcp_server_url: &str,
+    redirect_uri: &str,
+) -> Result<OAuthState, anyhow::Error> {
+    let base_url = Url::parse(mcp_server_url)?;
+    let wellknown_url = format!(
+        "{}/.well-known/oauth-authorization-server",
+        base_url.origin().ascii_serialization()
+    );
+    let metadata = reqwest::get(&wellknown_url)
+        .await?
+        .error_for_status()?
+        .json::<AuthorizationMetadata>()
+        .await?;
+
+    let mut manager = AuthorizationManager::new(mcp_server_url).await?;
+    manager.set_metadata(metadata);
+
+    let session = AuthorizationSession::new(
+        manager,
+        &[],
+        redirect_uri,
+        Some("goose"),
+        Some(CLIENT_METADATA_URL),
+    )
+    .await?;
+
+    Ok(OAuthState::Session(session))
 }


### PR DESCRIPTION
## Summary

Fixes the OAuth flow never opening a browser for remote MCP servers that require authentication (e.g. Attio). The root cause is an rmcp bug where resource metadata discovery fails fatally when the MCP server returns HTTP 200 with non-JSON content at its base URL, preventing fallback to `.well-known/oauth-authorization-server` discovery.

This PR adds a fallback in `oauth_flow` that catches the discovery failure and retries by fetching `.well-known/oauth-authorization-server` directly, using rmcp's public `AuthorizationManager`/`AuthorizationSession` APIs. It also logs the actual error when `oauth_flow` fails, instead of silently swallowing it.

### Testing

Manual testing with the Attio MCP server (`https://mcp.attio.com/mcp`).

### Related Issues
Relates to #8453
Upstream PR: https://github.com/modelcontextprotocol/rust-sdk/pull/810