### PR TITLE
fix(kimicode): align model metadata with live Kimi Code API

### DIFF
--- a/crates/goose/src/providers/kimicode.rs
+++ b/crates/goose/src/providers/kimicode.rs
@@ -28,9 +28,13 @@ use futures::future::BoxFuture;
 use rmcp::model::Tool;
 
 const KIMI_CODE_PROVIDER_NAME: &str = "kimi_code";
-pub const KIMI_CODE_DEFAULT_MODEL: &str = "kimi-k2.5";
-pub const KIMI_CODE_DEFAULT_FAST_MODEL: &str = "kimi-k2.5";
-pub const KIMI_CODE_KNOWN_MODELS: &[&str] = &["kimi-k2.5", "kimi-k2-thinking"];
+pub const KIMI_CODE_DEFAULT_MODEL: &str = "kimi-for-coding";
+pub const KIMI_CODE_DEFAULT_FAST_MODEL: &str = "kimi-for-coding";
+/// Known models for the provider metadata registration. The live catalogue is
+/// fetched from `/v1/models` at request time; this constant is only used for
+/// `ProviderMetadata`. As of 2025-10 Kimi Code exposes a single model,
+/// `kimi-for-coding`, and silently routes any other model name to it.
+pub const KIMI_CODE_KNOWN_MODELS: &[&str] = &["kimi-for-coding"];
 
 const KIMI_CODE_DOC_URL: &str = "https://www.kimi.com/code/docs/en/";
 const KIMI_CODE_CLIENT_ID: &str = "17e5f671-d194-4dfb-9706-5516cb48c098";
@@ -585,10 +589,35 @@ impl Provider for KimiCodeProvider {
     }
 
     async fn fetch_supported_models(&self) -> Result<Vec<String>, ProviderError> {
-        Ok(KIMI_CODE_KNOWN_MODELS
-            .iter()
-            .map(|s| s.to_string())
-            .collect())
+        #[derive(Deserialize)]
+        struct ModelEntry {
+            id: String,
+        }
+        #[derive(Deserialize)]
+        struct ModelsResp {
+            data: Vec<ModelEntry>,
+        }
+
+        let access_token = self.get_access_token().await.map_err(|e| {
+            ProviderError::Authentication(format!("Failed to get Kimi access token: {}", e))
+        })?;
+
+        let resp = self
+            .client
+            .get(format!("{}/v1/models", self.api_base))
+            .bearer_auth(access_token)
+            .headers(self.kimi_headers())
+            .send()
+            .await
+            .map_err(|e| ProviderError::RequestFailed(e.to_string()))?;
+        let resp = handle_status_openai_compat(resp).await?;
+
+        let parsed: ModelsResp = resp.json().await.map_err(|e| {
+            ProviderError::RequestFailed(format!("/v1/models body is not valid JSON: {}", e))
+        })?;
+        let mut models: Vec<String> = parsed.data.into_iter().map(|m| m.id).collect();
+        models.sort();
+        Ok(models)
     }
 
     async fn configure_oauth(&self) -> Result<(), ProviderError> {
@@ -876,6 +905,62 @@ mod tests {
             msg.contains("Bad Gateway"),
             "expected body in error: {}",
             msg
+        );
+    }
+
+    // ── fetch_supported_models ────────────────────────────────────────────────
+
+    async fn seed_fresh_token(provider: &KimiCodeProvider) {
+        *provider.cached_token.lock().await = Some(KimiToken {
+            access_token: "fresh-access".to_string(),
+            refresh_token: "fresh-refresh".to_string(),
+            expires_at: Utc::now() + Duration::seconds(3600),
+        });
+    }
+
+    #[tokio::test]
+    async fn fetch_supported_models_returns_server_catalogue() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "data": [
+                    {"id": "kimi-for-coding"},
+                    {"id": "future-model"}
+                ],
+                "object": "list",
+            })))
+            .mount(&server)
+            .await;
+
+        let provider = test_provider(&server.uri(), "abc");
+        seed_fresh_token(&provider).await;
+
+        let models = provider.fetch_supported_models().await.unwrap();
+        // Results are sorted alphabetically, matching peer providers.
+        assert_eq!(
+            models,
+            vec!["future-model".to_string(), "kimi-for-coding".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn fetch_supported_models_propagates_server_error() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/v1/models"))
+            .respond_with(ResponseTemplate::new(503))
+            .mount(&server)
+            .await;
+
+        let provider = test_provider(&server.uri(), "abc");
+        seed_fresh_token(&provider).await;
+
+        let err = provider.fetch_supported_models().await.unwrap_err();
+        assert!(
+            matches!(err, ProviderError::ServerError(_)),
+            "expected ServerError, got {:?}",
+            err
         );
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #8466. After that PR merged I exercised the provider against the real Kimi Code API and found that:

- \`/v1/models\` exposes exactly **one** model: \`kimi-for-coding\` (context_length 262144, reasoning+image+video capable).
- The inference endpoint **silently accepts** any \`model\` field (even made-up names like \`kimi-k2.7-code-preview\` or \`gpt-4\`) and routes them all to \`kimi-for-coding\`, echoing back \`\"model\":\"kimi-for-coding\"\` in responses.

So the \`kimi-k2.5\` / \`kimi-k2-thinking\` entries that #8466 shipped never matched any server-side model on the Kimi Code endpoint and only misled the configure picker. (Those names are valid on the separate Moonshot public API at \`api.moonshot.ai\`, which is a different provider.)

## Changes

- Default model constants now point at \`kimi-for-coding\`.
- \`fetch_supported_models\` queries \`{api_base}/v1/models\` directly and propagates errors (matches the \`openai_compatible\` pattern). No fallback: by the time this runs OAuth has completed, and a real failure is better surfaced than hidden behind a stale static list.
- New wiremock tests:
  - \`fetch_supported_models_returns_server_catalogue\` — happy path
  - \`fetch_supported_models_propagates_server_error\` — 5xx surfaces as \`ProviderError::ServerError\`

## Test plan

- [x] \`cargo test -p goose --lib providers::kimicode\` — 15 passed
- [x] \`cargo clippy -p goose --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt -p goose\`
- [x] Manual verification with the real provider: OAuth device flow, automatic token refresh, live \`/v1/models\` call, and streaming \`/v1/messages\` using \`kimi-for-coding\`.

## Evidence (real API responses)

\`\`\`
$ GET https://api.kimi.com/coding/v1/models
{\"data\":[{\"id\":\"kimi-for-coding\",\"created_at\":\"2025-10-24T00:00:00Z\",\"context_length\":262144,\"supports_reasoning\":true,\"supports_image_in\":true,\"supports_video_in\":true}],\"object\":\"list\"}

$ POST https://api.kimi.com/coding/v1/messages  (model: \"kimi-k2.7-code-preview\" — made up)
{\"model\":\"kimi-for-coding\", ...}     # silently routed
\`\`\`

cc @jh-block — this is one of the follow-ups I mentioned in #8466.