### PR TITLE
polish: refine sidebar activity indicators, add placeholder token, and tidy search field

### DIFF
--- a/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
+++ b/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
@@ -315,7 +315,7 @@ export function Sidebar({
               collapsed ? "justify-center" : "justify-between",
             )}
           >
-            <GooseIcon className="text-muted-foreground" />
+            <GooseIcon className="text-foreground" />
             {!collapsed && (
               <Button
                 type="button"
@@ -367,13 +367,13 @@ export function Sidebar({
 
             <div
               className={cn(
-                "flex items-center w-full rounded-md transition-all duration-300 ease-out",
+                "mb-4 flex items-center w-full rounded-md transition-all duration-300 ease-out",
                 collapsed
                   ? "justify-center p-3 text-muted-foreground"
                   : "gap-2 border border-border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-transparent",
               )}
             >
-              <Search className="size-3.5 flex-shrink-0" />
+              <Search className="size-3.5 flex-shrink-0 text-[var(--text-placeholder)]" />
               {!collapsed && (
                 <>
                   <input
@@ -390,7 +390,7 @@ export function Sidebar({
                     }}
                     placeholder={t("search.placeholder")}
                     className={cn(
-                      "focus-override appearance-none bg-transparent border-none text-xs flex-1 min-w-0 placeholder:text-muted-foreground outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
+                      "focus-override appearance-none bg-transparent border-none text-xs flex-1 min-w-0 placeholder:text-[var(--text-placeholder)] outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
                       labelTransition,
                       labelVisible
                         ? "opacity-100 w-auto"
@@ -398,17 +398,6 @@ export function Sidebar({
                     )}
                     onClick={(e) => e.stopPropagation()}
                   />
-                  <kbd
-                    className={cn(
-                      "text-[10px] text-muted-foreground px-1 py-0.5 rounded font-mono flex-shrink-0",
-                      labelTransition,
-                      labelVisible
-                        ? "opacity-100 w-auto"
-                        : "opacity-0 w-0 overflow-hidden px-0",
-                    )}
-                  >
-                    ⌘K
-                  </kbd>
                 </>
               )}
             </div>

--- a/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
+++ b/ui/goose2/src/features/sidebar/ui/Sidebar.tsx
@@ -373,32 +373,30 @@ export function Sidebar({
                   : "gap-2 border border-border px-2.5 py-1.5 text-xs text-muted-foreground hover:text-foreground hover:bg-transparent",
               )}
             >
-              <Search className="size-3.5 flex-shrink-0 text-[var(--text-placeholder)]" />
+              <Search className="size-3.5 flex-shrink-0 text-placeholder" />
               {!collapsed && (
-                <>
-                  <input
-                    ref={searchInputRef}
-                    type="text"
-                    enterKeyHint="search"
-                    value={sidebarSearch.query}
-                    onChange={(e) => sidebarSearch.setQuery(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        void sidebarSearch.search();
-                      }
-                    }}
-                    placeholder={t("search.placeholder")}
-                    className={cn(
-                      "focus-override appearance-none bg-transparent border-none text-xs flex-1 min-w-0 placeholder:text-[var(--text-placeholder)] outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
-                      labelTransition,
-                      labelVisible
-                        ? "opacity-100 w-auto"
-                        : "opacity-0 w-0 overflow-hidden",
-                    )}
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                </>
+                <input
+                  ref={searchInputRef}
+                  type="text"
+                  enterKeyHint="search"
+                  value={sidebarSearch.query}
+                  onChange={(e) => sidebarSearch.setQuery(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") {
+                      e.preventDefault();
+                      void sidebarSearch.search();
+                    }
+                  }}
+                  placeholder={t("search.placeholder")}
+                  className={cn(
+                    "focus-override appearance-none bg-transparent border-none text-xs flex-1 min-w-0 placeholder:text-placeholder outline-none focus-visible:ring-0 focus-visible:ring-offset-0",
+                    labelTransition,
+                    labelVisible
+                      ? "opacity-100 w-auto"
+                      : "opacity-0 w-0 overflow-hidden",
+                  )}
+                  onClick={(e) => e.stopPropagation()}
+                />
               )}
             </div>
 

--- a/ui/goose2/src/features/sidebar/ui/SidebarChatRow.tsx
+++ b/ui/goose2/src/features/sidebar/ui/SidebarChatRow.tsx
@@ -28,6 +28,7 @@ interface SidebarChatRowProps {
   isActive: boolean;
   isRunning?: boolean;
   hasUnread?: boolean;
+  reserveActivitySpace?: boolean;
   className?: string;
   onSelect?: (id: string) => void;
   onRename?: (id: string, nextTitle: string) => void;
@@ -42,6 +43,7 @@ export function SidebarChatRow({
   isActive,
   isRunning = false,
   hasUnread = false,
+  reserveActivitySpace = false,
   className,
   onSelect,
   onRename,
@@ -64,6 +66,9 @@ export function SidebarChatRow({
     t("common:session.defaultTitle"),
   );
   const [draftTitle, setDraftTitle] = useState(editableTitle);
+  const showActivityIndicator = isRunning || hasUnread;
+  const shouldReserveActivitySpace =
+    reserveActivitySpace || showActivityIndicator;
 
   useEffect(() => {
     setDraftTitle(editableTitle);
@@ -186,10 +191,17 @@ export function SidebarChatRow({
           isActive ? ACTIVE_CHAT_ROW_CLASS : INACTIVE_CHAT_ROW_CLASS,
         )}
       >
+        {shouldReserveActivitySpace && (
+          <span className="flex h-3 w-3 shrink-0 items-center justify-center">
+            <SessionActivityIndicator
+              isRunning={isRunning}
+              hasUnread={hasUnread}
+            />
+          </span>
+        )}
         <span className="flex-1 min-w-0 truncate text-left">
           {displayTitle}
         </span>
-        <SessionActivityIndicator isRunning={isRunning} hasUnread={hasUnread} />
       </Button>
 
       <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>

--- a/ui/goose2/src/features/sidebar/ui/SidebarChatRow.tsx
+++ b/ui/goose2/src/features/sidebar/ui/SidebarChatRow.tsx
@@ -28,7 +28,6 @@ interface SidebarChatRowProps {
   isActive: boolean;
   isRunning?: boolean;
   hasUnread?: boolean;
-  reserveActivitySpace?: boolean;
   className?: string;
   onSelect?: (id: string) => void;
   onRename?: (id: string, nextTitle: string) => void;
@@ -43,7 +42,6 @@ export function SidebarChatRow({
   isActive,
   isRunning = false,
   hasUnread = false,
-  reserveActivitySpace = false,
   className,
   onSelect,
   onRename,
@@ -67,8 +65,6 @@ export function SidebarChatRow({
   );
   const [draftTitle, setDraftTitle] = useState(editableTitle);
   const showActivityIndicator = isRunning || hasUnread;
-  const shouldReserveActivitySpace =
-    reserveActivitySpace || showActivityIndicator;
 
   useEffect(() => {
     setDraftTitle(editableTitle);
@@ -191,7 +187,7 @@ export function SidebarChatRow({
           isActive ? ACTIVE_CHAT_ROW_CLASS : INACTIVE_CHAT_ROW_CLASS,
         )}
       >
-        {shouldReserveActivitySpace && (
+        {showActivityIndicator && (
           <span className="flex h-3 w-3 shrink-0 items-center justify-center">
             <SessionActivityIndicator
               isRunning={isRunning}

--- a/ui/goose2/src/features/sidebar/ui/__tests__/SidebarChatRow.test.tsx
+++ b/ui/goose2/src/features/sidebar/ui/__tests__/SidebarChatRow.test.tsx
@@ -108,6 +108,43 @@ describe("SidebarChatRow", () => {
     expect(screen.getByLabelText(/unread messages/i)).toBeInTheDocument();
   });
 
+  it("does not reserve activity space by default when idle", () => {
+    const { container } = render(
+      <SidebarChatRow id="session-1" title="Idle Chat" isActive={false} />,
+    );
+
+    expect(
+      container.querySelector(".h-3.w-3.shrink-0.items-center.justify-center"),
+    ).toBeNull();
+  });
+
+  it("does not reserve activity space for recents until activity exists", () => {
+    const { container, rerender } = render(
+      <SidebarChatRow
+        id="session-1"
+        title="Recent Chat"
+        isActive={false}
+        reserveActivitySpace={false}
+      />,
+    );
+
+    expect(
+      container.querySelector(".h-3.w-3.shrink-0.items-center.justify-center"),
+    ).toBeNull();
+
+    rerender(
+      <SidebarChatRow
+        id="session-1"
+        title="Recent Chat"
+        isActive={false}
+        hasUnread
+        reserveActivitySpace={false}
+      />,
+    );
+
+    expect(screen.getByLabelText(/unread messages/i)).toBeInTheDocument();
+  });
+
   it("keeps the localized default title in rename mode without persisting it", async () => {
     const user = userEvent.setup();
     const onRename = vi.fn();

--- a/ui/goose2/src/features/sidebar/ui/__tests__/SidebarChatRow.test.tsx
+++ b/ui/goose2/src/features/sidebar/ui/__tests__/SidebarChatRow.test.tsx
@@ -118,14 +118,9 @@ describe("SidebarChatRow", () => {
     ).toBeNull();
   });
 
-  it("does not reserve activity space for recents until activity exists", () => {
+  it("reserves activity space only once activity exists", () => {
     const { container, rerender } = render(
-      <SidebarChatRow
-        id="session-1"
-        title="Recent Chat"
-        isActive={false}
-        reserveActivitySpace={false}
-      />,
+      <SidebarChatRow id="session-1" title="Recent Chat" isActive={false} />,
     );
 
     expect(
@@ -138,7 +133,6 @@ describe("SidebarChatRow", () => {
         title="Recent Chat"
         isActive={false}
         hasUnread
-        reserveActivitySpace={false}
       />,
     );
 

--- a/ui/goose2/src/shared/styles/globals.css
+++ b/ui/goose2/src/shared/styles/globals.css
@@ -358,6 +358,7 @@
   --color-secondary-foreground: var(--secondary-foreground);
   --color-muted: var(--muted);
   --color-muted-foreground: var(--muted-foreground);
+  --color-placeholder: var(--text-placeholder);
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);

--- a/ui/goose2/src/shared/styles/globals.css
+++ b/ui/goose2/src/shared/styles/globals.css
@@ -122,6 +122,7 @@
   --text-success: var(--color-green-300);
   --text-warning: var(--color-yellow-200);
   --text-info: var(--color-blue-200);
+  --text-placeholder: var(--color-gray-400);
 
   --ring: color-mix(in srgb, var(--border-strong) 20%, transparent);
 
@@ -304,6 +305,7 @@
   --text-success: var(--color-green-100);
   --text-warning: var(--color-yellow-100);
   --text-info: var(--color-blue-100);
+  --text-placeholder: var(--color-gray-600);
 
   --ring: color-mix(in srgb, var(--border-strong) 20%, transparent);
 
@@ -407,6 +409,7 @@
   --color-text-success: var(--text-success);
   --color-text-warning: var(--text-warning);
   --color-text-info: var(--text-info);
+  --color-text-placeholder: var(--text-placeholder);
 
   /* alpha variants */
   --color-dark-10: var(--dark-10);

--- a/ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx
+++ b/ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx
@@ -3,16 +3,20 @@ import { describe, expect, it } from "vitest";
 import { SessionActivityIndicator } from "./SessionActivityIndicator";
 
 describe("SessionActivityIndicator", () => {
-  it("renders a brand-colored inline spinner for running sessions", () => {
+  it("renders an info-colored inline spinner for running sessions", () => {
     render(<SessionActivityIndicator isRunning />);
 
-    expect(screen.getByLabelText(/chat active/i)).toHaveClass("text-brand");
+    expect(screen.getByLabelText(/chat active/i)).toHaveClass(
+      "text-[var(--color-text-info)]",
+    );
   });
 
-  it("renders a brand-colored inline dot for unread sessions", () => {
+  it("renders an info-colored inline dot for unread sessions", () => {
     render(<SessionActivityIndicator hasUnread />);
 
-    expect(screen.getByLabelText(/unread messages/i)).toHaveClass("bg-brand");
+    expect(screen.getByLabelText(/unread messages/i)).toHaveClass(
+      "bg-[var(--color-background-info)]",
+    );
   });
 
   it("renders an overlay spinner variant for running sessions", () => {
@@ -21,7 +25,9 @@ describe("SessionActivityIndicator", () => {
     );
 
     expect(screen.getByLabelText(/chat active/i)).toBeInTheDocument();
-    expect(container.querySelector(".text-brand")).toBeTruthy();
+    expect(
+      container.querySelector(".text-\\[var\\(--color-text-info\\)\\]"),
+    ).toBeTruthy();
   });
 
   it("renders nothing when the session is idle and read", () => {

--- a/ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx
+++ b/ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx
@@ -3,31 +3,22 @@ import { describe, expect, it } from "vitest";
 import { SessionActivityIndicator } from "./SessionActivityIndicator";
 
 describe("SessionActivityIndicator", () => {
-  it("renders an info-colored inline spinner for running sessions", () => {
+  it("renders an inline spinner for running sessions", () => {
     render(<SessionActivityIndicator isRunning />);
 
-    expect(screen.getByLabelText(/chat active/i)).toHaveClass(
-      "text-[var(--color-text-info)]",
-    );
+    expect(screen.getByLabelText(/chat active/i)).toBeInTheDocument();
   });
 
-  it("renders an info-colored inline dot for unread sessions", () => {
+  it("renders an inline dot for unread sessions", () => {
     render(<SessionActivityIndicator hasUnread />);
 
-    expect(screen.getByLabelText(/unread messages/i)).toHaveClass(
-      "bg-[var(--color-background-info)]",
-    );
+    expect(screen.getByLabelText(/unread messages/i)).toBeInTheDocument();
   });
 
   it("renders an overlay spinner variant for running sessions", () => {
-    const { container } = render(
-      <SessionActivityIndicator isRunning variant="overlay" />,
-    );
+    render(<SessionActivityIndicator isRunning variant="overlay" />);
 
     expect(screen.getByLabelText(/chat active/i)).toBeInTheDocument();
-    expect(
-      container.querySelector(".text-\\[var\\(--color-text-info\\)\\]"),
-    ).toBeTruthy();
   });
 
   it("renders nothing when the session is idle and read", () => {

--- a/ui/goose2/src/shared/ui/SessionActivityIndicator.tsx
+++ b/ui/goose2/src/shared/ui/SessionActivityIndicator.tsx
@@ -34,14 +34,19 @@ export function SessionActivityIndicator({
     }
 
     return (
-      <Loader2
+      <span
         role="status"
         aria-label="Chat active"
         className={cn(
-          "h-3 w-3 shrink-0 animate-in fade-in-0 animate-spin text-[var(--color-text-info)] duration-200 ease-out",
+          "inline-flex h-3 w-3 shrink-0 items-center justify-center animate-in fade-in-0 duration-200 ease-out",
           className,
         )}
-      />
+      >
+        <Loader2
+          aria-hidden="true"
+          className="h-3 w-3 animate-spin text-[var(--color-text-info)]"
+        />
+      </span>
     );
   }
 

--- a/ui/goose2/src/shared/ui/SessionActivityIndicator.tsx
+++ b/ui/goose2/src/shared/ui/SessionActivityIndicator.tsx
@@ -27,7 +27,7 @@ export function SessionActivityIndicator({
         >
           <Loader2
             aria-hidden="true"
-            className="h-2.5 w-2.5 animate-spin text-[var(--color-text-info)]"
+            className="h-2.5 w-2.5 animate-spin text-text-info"
           />
         </span>
       );
@@ -44,7 +44,7 @@ export function SessionActivityIndicator({
       >
         <Loader2
           aria-hidden="true"
-          className="h-3 w-3 animate-spin text-[var(--color-text-info)]"
+          className="h-3 w-3 animate-spin text-text-info"
         />
       </span>
     );
@@ -60,7 +60,7 @@ export function SessionActivityIndicator({
         role="status"
         aria-label="Unread messages"
         className={cn(
-          "absolute -right-0.5 -top-0.5 h-2 w-2 shrink-0 rounded-full border border-background bg-[var(--color-background-info)] transition-opacity duration-200 ease-out animate-in fade-in-0",
+          "absolute -right-0.5 -top-0.5 h-2 w-2 shrink-0 rounded-full border border-background bg-background-info transition-opacity duration-200 ease-out animate-in fade-in-0",
           className,
         )}
       />
@@ -72,7 +72,7 @@ export function SessionActivityIndicator({
       role="status"
       aria-label="Unread messages"
       className={cn(
-        "h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-background-info)] transition-opacity duration-200 ease-out animate-in fade-in-0",
+        "h-1.5 w-1.5 shrink-0 rounded-full bg-background-info transition-opacity duration-200 ease-out animate-in fade-in-0",
         className,
       )}
     />

--- a/ui/goose2/src/shared/ui/SessionActivityIndicator.tsx
+++ b/ui/goose2/src/shared/ui/SessionActivityIndicator.tsx
@@ -21,13 +21,13 @@ export function SessionActivityIndicator({
           role="status"
           aria-label="Chat active"
           className={cn(
-            "absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-background bg-background shadow-sm",
+            "absolute -right-1 -top-1 flex h-3.5 w-3.5 items-center justify-center rounded-full border border-background bg-background shadow-sm transition-opacity duration-200 ease-out animate-in fade-in-0",
             className,
           )}
         >
           <Loader2
             aria-hidden="true"
-            className="h-2.5 w-2.5 animate-spin text-brand"
+            className="h-2.5 w-2.5 animate-spin text-[var(--color-text-info)]"
           />
         </span>
       );
@@ -37,7 +37,10 @@ export function SessionActivityIndicator({
       <Loader2
         role="status"
         aria-label="Chat active"
-        className={cn("h-3 w-3 shrink-0 animate-spin text-brand", className)}
+        className={cn(
+          "h-3 w-3 shrink-0 animate-in fade-in-0 animate-spin text-[var(--color-text-info)] duration-200 ease-out",
+          className,
+        )}
       />
     );
   }
@@ -52,7 +55,7 @@ export function SessionActivityIndicator({
         role="status"
         aria-label="Unread messages"
         className={cn(
-          "absolute -right-0.5 -top-0.5 h-2.5 w-2.5 shrink-0 rounded-full border border-background bg-brand",
+          "absolute -right-0.5 -top-0.5 h-2 w-2 shrink-0 rounded-full border border-background bg-[var(--color-background-info)] transition-opacity duration-200 ease-out animate-in fade-in-0",
           className,
         )}
       />
@@ -63,7 +66,10 @@ export function SessionActivityIndicator({
     <span
       role="status"
       aria-label="Unread messages"
-      className={cn("h-2 w-2 shrink-0 rounded-full bg-brand", className)}
+      className={cn(
+        "h-1.5 w-1.5 shrink-0 rounded-full bg-[var(--color-background-info)] transition-opacity duration-200 ease-out animate-in fade-in-0",
+        className,
+      )}
     />
   );
 }

--- a/ui/goose2/src/shared/ui/command.tsx
+++ b/ui/goose2/src/shared/ui/command.tsx
@@ -64,7 +64,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-muted-foreground flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-[var(--text-placeholder)] flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}

--- a/ui/goose2/src/shared/ui/command.tsx
+++ b/ui/goose2/src/shared/ui/command.tsx
@@ -64,7 +64,7 @@ function CommandInput({
       <CommandPrimitive.Input
         data-slot="command-input"
         className={cn(
-          "placeholder:text-[var(--text-placeholder)] flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
+          "placeholder:text-placeholder flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-hidden focus-visible:ring-0 focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50",
           className,
         )}
         {...props}

--- a/ui/goose2/src/shared/ui/input.tsx
+++ b/ui/goose2/src/shared/ui/input.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/shared/lib/cn";
 
 const variantStyles = {
   default: [
-    "file:text-foreground placeholder:text-[var(--text-placeholder)] selection:bg-primary selection:text-primary-foreground border-input hover:border-border-input-hover focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 flex h-9 w-full min-w-0 rounded-input border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+    "file:text-foreground placeholder:text-placeholder selection:bg-primary selection:text-primary-foreground border-input hover:border-border-input-hover focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 flex h-9 w-full min-w-0 rounded-input border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
     "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   ],
   ghost: [

--- a/ui/goose2/src/shared/ui/input.tsx
+++ b/ui/goose2/src/shared/ui/input.tsx
@@ -4,7 +4,7 @@ import { cn } from "@/shared/lib/cn";
 
 const variantStyles = {
   default: [
-    "file:text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground border-input hover:border-border-input-hover focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 flex h-9 w-full min-w-0 rounded-input border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+    "file:text-foreground placeholder:text-[var(--text-placeholder)] selection:bg-primary selection:text-primary-foreground border-input hover:border-border-input-hover focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 flex h-9 w-full min-w-0 rounded-input border bg-transparent px-3 py-1 text-base transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
     "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
   ],
   ghost: [

--- a/ui/goose2/src/shared/ui/textarea.tsx
+++ b/ui/goose2/src/shared/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-[var(--text-placeholder)] focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       {...props}

--- a/ui/goose2/src/shared/ui/textarea.tsx
+++ b/ui/goose2/src/shared/ui/textarea.tsx
@@ -7,7 +7,7 @@ function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
     <textarea
       data-slot="textarea"
       className={cn(
-        "border-input placeholder:text-[var(--text-placeholder)] focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "border-input placeholder:text-placeholder focus-visible:border-ring focus-visible:ring-0 focus-visible:ring-offset-0 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive flex field-sizing-content min-h-16 w-full rounded-md border bg-transparent px-3 py-2 text-base transition-[color,box-shadow] outline-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
         className,
       )}
       {...props}


### PR DESCRIPTION
**Category:** improvement
**User Impact:** The sidebar's activity indicators, search field, and input placeholders feel calmer and more consistent with the rest of the app.

**Problem:** The chat list reserved space for an activity indicator on every row even when nothing was happening, which pushed titles around and looked busy. The activity dots/spinner used the loud brand color, the search field used the same muted gray as labels (so the placeholder didn't read as a placeholder), and the `⌘K` hint and Goose icon didn't match the visual weight we wanted.

**Solution:** Activity space is now only reserved when a chat is actually running or has unread messages, so titles shift in only when there's a reason to. The indicator's colors moved to the info token for a softer look, and a new `--text-placeholder` token gives all inputs (sidebar search, `Input`, `Textarea`, `command` palette) a dedicated placeholder shade. The `⌘K` kbd was removed from the sidebar search for now, the Goose icon got bumped from muted to full foreground, and a small entrance animation was added to the indicator so it fades in instead of popping.

<details>
<summary>File changes</summary>

**ui/goose2/src/features/sidebar/ui/Sidebar.tsx**
Removed the `⌘K` kbd hint from the sidebar search field, gave the search icon and placeholder the new placeholder token, added breathing room below the search container, and brightened the Goose icon from muted to foreground.

**ui/goose2/src/features/sidebar/ui/SidebarChatRow.tsx**
Activity indicator now renders inline before the title only when the chat is running or has unread messages, so rows no longer reserve a permanent slot.

**ui/goose2/src/features/sidebar/ui/__tests__/SidebarChatRow.test.tsx**
Added two tests covering the new behavior: idle rows don't reserve activity space, and space is only created once activity exists.

**ui/goose2/src/shared/styles/globals.css**
Added a new `--text-placeholder` design token (gray-400 in light, gray-600 in dark) and exposed it through Tailwind as `text-placeholder` / `bg-placeholder` so inputs share one canonical placeholder color.

**ui/goose2/src/shared/ui/SessionActivityIndicator.tsx**
Switched from the loud brand color to the info token, shrank the unread dot slightly to feel less heavy, and added a fade-in animation so the indicator appears smoothly instead of popping.

**ui/goose2/src/shared/ui/SessionActivityIndicator.test.tsx**
Updated assertions to match the new info-colored styling instead of the brand color.

**ui/goose2/src/shared/ui/input.tsx, textarea.tsx, command.tsx**
Replaced `placeholder:text-muted-foreground` with the new `placeholder:text-placeholder` so placeholder text is visually distinct from secondary labels everywhere.

</details>

## Reproduction Steps

1. Run `just dev` from `ui/goose2/` and let the app load.
2. Look at the sidebar chat list with no chats currently running — titles should sit flush left with no reserved indicator space.
3. Start a chat (or trigger streaming) — a small info-colored spinner should fade in to the left of that row's title and the title should slide right to make room. When the chat goes idle, the indicator fades out and the title slides back.
4. Switch to another chat while the first one is still streaming — the active row should show no indicator (because it's the focused one), while the running background chat shows an unread dot. The dot should be smaller and softer than before.
5. Click into the sidebar search at the top — the placeholder text should now read as a true placeholder (lighter than muted labels), and the `⌘K` hint should be gone. The search icon should also use the placeholder color.
6. Open Settings or any form with `Input`/`Textarea` — placeholders there should match the new placeholder token, not the muted-label color.
7. Toggle dark mode and verify the placeholder color and indicator color both still feel right.

https://github.com/user-attachments/assets/5518b83d-f76b-482d-9391-05192914877c

