### PR TITLE
fix(ui/text): stop idle 300ms re-render loop that could OOM the TUI

### DIFF
--- a/ui/text/src/tui.tsx
+++ b/ui/text/src/tui.tsx
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import React, { useState, useEffect, useCallback, useRef } from "react";
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
 import { Box, Text, render, useApp, useInput, useStdout } from "ink";
 import { MultilineInput } from "ink-multiline-input";
 import meow from "meow";
@@ -574,13 +574,18 @@ function App({
   const queueRef = useRef<string[]>([]);
   const isProcessingRef = useRef(false);
 
+  // Only run the animation tick when something is actually animating:
+  // the splash goose while the banner is up, or the spinner while loading.
+  // Otherwise we were re-rendering the entire viewport every 300ms forever,
+  // which rebuilds every turn's markdown and can OOM long-running sessions.
   useEffect(() => {
+    if (!bannerVisible && !loading) return;
     const t = setInterval(() => {
-      setSpinIdx((i) => (i + 1) % SPINNER_FRAMES.length);
-      setGooseFrame((f) => f + 1);
+      if (loading) setSpinIdx((i) => (i + 1) % SPINNER_FRAMES.length);
+      if (bannerVisible) setGooseFrame((f) => (f + 1) % GOOSE_FRAMES.length);
     }, 300);
     return () => clearInterval(t);
-  }, []);
+  }, [bannerVisible, loading]);
 
   useEffect(() => {
     if (turns.length > 0) setBannerVisible(false);
@@ -1046,18 +1051,34 @@ function App({
     3,
   );
 
-  const contentLines = buildContentLines({
-    turn: currentTurn,
-    turnIndex: effectiveTurnIdx,
-    width: contentWidth,
-    loading: isLatest && loading,
-    status,
-    spinIdx,
-    pendingPermission: isLatest ? pendingPermission : null,
-    permissionIdx,
-    toolCallsExpanded,
-    queuedMessages: isLatest ? queuedMessages : [],
-  });
+  const contentLines = useMemo(
+    () =>
+      buildContentLines({
+        turn: currentTurn,
+        turnIndex: effectiveTurnIdx,
+        width: contentWidth,
+        loading: isLatest && loading,
+        status,
+        spinIdx,
+        pendingPermission: isLatest ? pendingPermission : null,
+        permissionIdx,
+        toolCallsExpanded,
+        queuedMessages: isLatest ? queuedMessages : [],
+      }),
+    [
+      currentTurn,
+      effectiveTurnIdx,
+      contentWidth,
+      isLatest,
+      loading,
+      status,
+      spinIdx,
+      pendingPermission,
+      permissionIdx,
+      toolCallsExpanded,
+      queuedMessages,
+    ],
+  );
 
   if (needsOnboarding && clientRef.current) {
     return (


### PR DESCRIPTION
## Problem

The Ink-based text UI (`ui/text`) could crash with a JS heap OOM after running for a while, even when it appeared idle:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```

The native stack showed the crash happening inside a libuv check tick (`uv__run_check` → `Builtins_JSEntryTrampoline`), i.e. a JS timer callback — which pointed at the 300ms animation interval in `App`.

## Root cause

`ui/text/src/tui.tsx` had this at the top of `App`:

```tsx
useEffect(() => {
  const t = setInterval(() => {
    setSpinIdx((i) => (i + 1) % SPINNER_FRAMES.length);
    setGooseFrame((f) => f + 1);   // never wrapped
  }, 300);
  return () => clearInterval(t);
}, []);
```

Two problems compound:

1. `gooseFrame` was incremented without modulo, so state changed every tick even when the splash goose wasn't being shown.
2. The interval ran for the entire lifetime of the process regardless of whether anything was actually animating. That forced a full re-render of `App` every 300ms forever.

Each of those re-renders called `buildContentLines(...)`, which walks every turn's `responseItems` and runs `marked` + `marked-terminal` over every streamed `content_chunk` from scratch, allocating thousands of fresh Ink/Yoga elements per tick.

In a long-running session with a substantial transcript this is roughly `O(total_chars_streamed)` of markdown parsing ~3× per second, indefinitely. Young-gen fills, promotions pile up, mark-compact can't keep up, and V8 eventually gives up at the 4GB heap cap.

This affects real `npx @aaif/goose` users, not just dev — dev just hits it faster because of `tsx` transpile overhead on top.

## Fix

1. **Only tick when something is animating.** The animation `useEffect` now bails unless `bannerVisible` (splash goose) or `loading` (spinner) is true. Once the user dismisses the banner and is sitting at the prompt, the interval is cleared entirely and the UI stops re-rendering on its own.
2. **Wrap `gooseFrame` with modulo `GOOSE_FRAMES.length`** so state doesn't change when the banner isn't visible, and doesn't drift monotonically when it is.
3. **Memoize `buildContentLines` via `useMemo`** so any re-renders that do happen (e.g. window resize, new chunk) don't needlessly re-parse markdown for historical turns.

## Verification

- `tsc --noEmit` (the package `lint` script) passes.
- Manually: leaving the TUI open at the prompt no longer grows RSS over time; previously it climbed steadily.

## Notes

I also wrote up a longer dev-experience audit of `ui/text` (README drift, `stderr: 'ignore'` swallowing backend errors in dev, missing watch mode, etc.). Happy to do those as a follow-up if useful — this PR is scoped to the OOM fix.
