### PR TITLE
goose2 session working dir

### DIFF
--- a/ui/goose2/scripts/check-file-sizes.mjs
+++ b/ui/goose2/scripts/check-file-sizes.mjs
@@ -11,7 +11,7 @@ const EXCEPTIONS = {
       "Drag-and-drop handlers for session-to-project moves and project reorder, plus activeProjectId highlight.",
   },
   "src/features/chat/ui/ChatView.tsx": {
-    limit: 535,
+    limit: 560,
     justification:
       "ACP prewarm guards, project-aware working dir selection, working context sync, and chat bootstrapping still live together here.",
   },

--- a/ui/goose2/src-tauri/src/commands/mod.rs
+++ b/ui/goose2/src-tauri/src/commands/mod.rs
@@ -7,6 +7,7 @@ pub mod extensions;
 pub mod git;
 pub mod git_changes;
 pub mod model_setup;
+pub mod path_resolver;
 pub mod projects;
 pub mod skills;
 pub mod system;

--- a/ui/goose2/src-tauri/src/commands/path_resolver.rs
+++ b/ui/goose2/src-tauri/src/commands/path_resolver.rs
@@ -1,0 +1,97 @@
+use std::path::PathBuf;
+
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvePathRequest {
+    pub parts: Vec<String>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolvePathResponse {
+    pub path: Option<String>,
+}
+
+fn trim_part(part: &str) -> Option<&str> {
+    let trimmed = part.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn expand_home_prefix(part: &str) -> Option<PathBuf> {
+    let home = dirs::home_dir()?;
+    match part {
+        "~" => Some(home),
+        _ => part
+            .strip_prefix("~/")
+            .or_else(|| part.strip_prefix("~\\"))
+            .map(|relative| home.join(relative)),
+    }
+}
+
+fn resolve_path_parts(parts: Vec<String>) -> Option<String> {
+    let mut normalized_parts = parts
+        .iter()
+        .filter_map(|part| trim_part(part))
+        .peekable();
+
+    let first = normalized_parts.next()?;
+    let mut path = expand_home_prefix(first).unwrap_or_else(|| PathBuf::from(first));
+
+    for part in normalized_parts {
+        path.push(part);
+    }
+
+    Some(path.to_string_lossy().into_owned())
+}
+
+#[tauri::command]
+pub fn resolve_path(request: ResolvePathRequest) -> Result<ResolvePathResponse, String> {
+    Ok(ResolvePathResponse {
+        path: resolve_path_parts(request.parts),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::resolve_path_parts;
+
+    #[test]
+    fn joins_absolute_path_and_subpath() {
+        assert_eq!(
+            resolve_path_parts(vec!["/tmp/project".to_string(), "artifacts".to_string()]),
+            Some("/tmp/project/artifacts".to_string())
+        );
+    }
+
+    #[test]
+    fn ignores_empty_parts() {
+        assert_eq!(
+            resolve_path_parts(vec!["  ".to_string(), "/tmp/project".to_string()]),
+            Some("/tmp/project".to_string())
+        );
+    }
+
+    #[test]
+    fn expands_home_segments() {
+        let Some(home) = dirs::home_dir() else {
+            return;
+        };
+
+        assert_eq!(
+            resolve_path_parts(vec!["~".to_string(), ".goose".to_string(), "artifacts".to_string()]),
+            Some(home.join(".goose").join("artifacts").to_string_lossy().into_owned())
+        );
+        assert_eq!(
+            resolve_path_parts(vec!["~/artifacts".to_string()]),
+            Some(home.join("artifacts").to_string_lossy().into_owned())
+        );
+        assert_eq!(
+            resolve_path_parts(vec!["~\\artifacts".to_string()]),
+            Some(home.join("artifacts").to_string_lossy().into_owned())
+        );
+    }
+}

--- a/ui/goose2/src-tauri/src/commands/path_resolver.rs
+++ b/ui/goose2/src-tauri/src/commands/path_resolver.rs
@@ -9,7 +9,7 @@ pub struct ResolvePathRequest {
 #[derive(serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ResolvePathResponse {
-    pub path: Option<String>,
+    pub path: String,
 }
 
 fn trim_part(part: &str) -> Option<&str> {
@@ -32,26 +32,28 @@ fn expand_home_prefix(part: &str) -> Option<PathBuf> {
     }
 }
 
-fn resolve_path_parts(parts: Vec<String>) -> Option<String> {
+fn resolve_path_parts(parts: Vec<String>) -> Result<String, String> {
     let mut normalized_parts = parts
         .iter()
         .filter_map(|part| trim_part(part))
         .peekable();
 
-    let first = normalized_parts.next()?;
+    let first = normalized_parts
+        .next()
+        .ok_or_else(|| "Path parts must include at least one non-empty segment".to_string())?;
     let mut path = expand_home_prefix(first).unwrap_or_else(|| PathBuf::from(first));
 
     for part in normalized_parts {
         path.push(part);
     }
 
-    Some(path.to_string_lossy().into_owned())
+    Ok(path.to_string_lossy().into_owned())
 }
 
 #[tauri::command]
 pub fn resolve_path(request: ResolvePathRequest) -> Result<ResolvePathResponse, String> {
     Ok(ResolvePathResponse {
-        path: resolve_path_parts(request.parts),
+        path: resolve_path_parts(request.parts)?,
     })
 }
 
@@ -63,7 +65,7 @@ mod tests {
     fn joins_absolute_path_and_subpath() {
         assert_eq!(
             resolve_path_parts(vec!["/tmp/project".to_string(), "artifacts".to_string()]),
-            Some("/tmp/project/artifacts".to_string())
+            Ok("/tmp/project/artifacts".to_string())
         );
     }
 
@@ -71,7 +73,7 @@ mod tests {
     fn ignores_empty_parts() {
         assert_eq!(
             resolve_path_parts(vec!["  ".to_string(), "/tmp/project".to_string()]),
-            Some("/tmp/project".to_string())
+            Ok("/tmp/project".to_string())
         );
     }
 
@@ -83,15 +85,23 @@ mod tests {
 
         assert_eq!(
             resolve_path_parts(vec!["~".to_string(), ".goose".to_string(), "artifacts".to_string()]),
-            Some(home.join(".goose").join("artifacts").to_string_lossy().into_owned())
+            Ok(home.join(".goose").join("artifacts").to_string_lossy().into_owned())
         );
         assert_eq!(
             resolve_path_parts(vec!["~/artifacts".to_string()]),
-            Some(home.join("artifacts").to_string_lossy().into_owned())
+            Ok(home.join("artifacts").to_string_lossy().into_owned())
         );
         assert_eq!(
             resolve_path_parts(vec!["~\\artifacts".to_string()]),
-            Some(home.join("artifacts").to_string_lossy().into_owned())
+            Ok(home.join("artifacts").to_string_lossy().into_owned())
+        );
+    }
+
+    #[test]
+    fn errors_when_no_non_empty_parts_exist() {
+        assert_eq!(
+            resolve_path_parts(vec!["  ".to_string(), "".to_string()]),
+            Err("Path parts must include at least one non-empty segment".to_string())
         );
     }
 }

--- a/ui/goose2/src-tauri/src/commands/path_resolver.rs
+++ b/ui/goose2/src-tauri/src/commands/path_resolver.rs
@@ -33,10 +33,7 @@ fn expand_home_prefix(part: &str) -> Option<PathBuf> {
 }
 
 fn resolve_path_parts(parts: Vec<String>) -> Result<String, String> {
-    let mut normalized_parts = parts
-        .iter()
-        .filter_map(|part| trim_part(part))
-        .peekable();
+    let mut normalized_parts = parts.iter().filter_map(|part| trim_part(part)).peekable();
 
     let first = normalized_parts
         .next()
@@ -84,8 +81,16 @@ mod tests {
         };
 
         assert_eq!(
-            resolve_path_parts(vec!["~".to_string(), ".goose".to_string(), "artifacts".to_string()]),
-            Ok(home.join(".goose").join("artifacts").to_string_lossy().into_owned())
+            resolve_path_parts(vec![
+                "~".to_string(),
+                ".goose".to_string(),
+                "artifacts".to_string()
+            ]),
+            Ok(home
+                .join(".goose")
+                .join("artifacts")
+                .to_string_lossy()
+                .into_owned())
         );
         assert_eq!(
             resolve_path_parts(vec!["~/artifacts".to_string()]),

--- a/ui/goose2/src-tauri/src/lib.rs
+++ b/ui/goose2/src-tauri/src/lib.rs
@@ -84,6 +84,7 @@ pub fn run() {
             commands::agent_setup::check_agent_auth,
             commands::agent_setup::install_agent,
             commands::agent_setup::authenticate_agent,
+            commands::path_resolver::resolve_path,
             commands::system::get_home_dir,
             commands::system::save_exported_session_file,
             commands::system::path_exists,

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -21,8 +21,11 @@ import {
   clearReplayBuffer,
   getAndDeleteReplayBuffer,
 } from "@/features/chat/hooks/replayBuffer";
-import { getHomeDir } from "@/shared/api/system";
-import { resolveDefaultSessionCwd } from "@/features/projects/lib/chatProjectContext";
+import {
+  buildSessionCwdParts,
+  resolveSessionCwd,
+} from "@/features/projects/lib/sessionCwdSelection";
+import { resolveOptionalPath } from "@/shared/api/pathResolver";
 
 export type AppView =
   | "home"
@@ -93,12 +96,8 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             .projects.find((candidate) => candidate.id === session.projectId) ??
           null)
         : null;
-      const sessionCwd =
-        resolveDefaultSessionCwd(project) ??
-        (!project
-          ? resolveDefaultSessionCwd(null, await getHomeDir())
-          : undefined);
-      await acpLoadSession(sessionId, gooseSessionId, sessionCwd);
+      const workingDir = await resolveSessionCwd(project);
+      await acpLoadSession(sessionId, gooseSessionId, workingDir);
       useChatStore.getState().setSessionLoading(sessionId, false);
       const buffer = getAndDeleteReplayBuffer(sessionId);
       if (buffer && buffer.length > 0) {
@@ -315,19 +314,16 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             : (useProjectStore
                 .getState()
                 .projects.find((project) => project.id === projectId) ?? null);
-        const nextSessionCwd =
-          resolveDefaultSessionCwd(nextProject) ??
-          (nextProject == null
-            ? resolveDefaultSessionCwd(null, await getHomeDir())
-            : undefined);
-        if (!nextSessionCwd) {
+        const nextWorkingDirParts = buildSessionCwdParts(nextProject);
+        if (!nextWorkingDirParts) {
           return;
         }
+        const workingDir = await resolveOptionalPath(nextWorkingDirParts);
         await acpPrepareSession(
           sessionId,
           session.providerId ?? agentStore.selectedProvider ?? "goose",
           {
-            workingDir: nextSessionCwd,
+            workingDir,
             personaId: session.personaId,
           },
         );

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -21,9 +21,7 @@ import {
   clearReplayBuffer,
   getAndDeleteReplayBuffer,
 } from "@/features/chat/hooks/replayBuffer";
-import {
-  resolveSessionCwd,
-} from "@/features/projects/lib/sessionCwdSelection";
+import { resolveSessionCwd } from "@/features/projects/lib/sessionCwdSelection";
 
 export type AppView =
   | "home"

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -22,10 +22,8 @@ import {
   getAndDeleteReplayBuffer,
 } from "@/features/chat/hooks/replayBuffer";
 import {
-  buildSessionCwdParts,
   resolveSessionCwd,
 } from "@/features/projects/lib/sessionCwdSelection";
-import { resolveOptionalPath } from "@/shared/api/pathResolver";
 
 export type AppView =
   | "home"
@@ -314,16 +312,15 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             : (useProjectStore
                 .getState()
                 .projects.find((project) => project.id === projectId) ?? null);
-        const nextWorkingDirParts = buildSessionCwdParts(nextProject);
-        if (!nextWorkingDirParts) {
+        const workingDir = await resolveSessionCwd(nextProject);
+        if (!workingDir) {
           return;
         }
-        const workingDir = await resolveOptionalPath(nextWorkingDirParts);
         await acpPrepareSession(
           sessionId,
           session.providerId ?? agentStore.selectedProvider ?? "goose",
+          workingDir,
           {
-            workingDir,
             personaId: session.personaId,
           },
         );

--- a/ui/goose2/src/app/AppShell.tsx
+++ b/ui/goose2/src/app/AppShell.tsx
@@ -22,7 +22,7 @@ import {
   getAndDeleteReplayBuffer,
 } from "@/features/chat/hooks/replayBuffer";
 import { getHomeDir } from "@/shared/api/system";
-import { resolveEffectiveWorkingDir } from "@/features/projects/lib/chatProjectContext";
+import { resolveDefaultSessionCwd } from "@/features/projects/lib/chatProjectContext";
 
 export type AppView =
   | "home"
@@ -93,12 +93,12 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             .projects.find((candidate) => candidate.id === session.projectId) ??
           null)
         : null;
-      const workingDir =
-        resolveEffectiveWorkingDir(project) ??
+      const sessionCwd =
+        resolveDefaultSessionCwd(project) ??
         (!project
-          ? resolveEffectiveWorkingDir(null, await getHomeDir())
+          ? resolveDefaultSessionCwd(null, await getHomeDir())
           : undefined);
-      await acpLoadSession(sessionId, gooseSessionId, workingDir);
+      await acpLoadSession(sessionId, gooseSessionId, sessionCwd);
       useChatStore.getState().setSessionLoading(sessionId, false);
       const buffer = getAndDeleteReplayBuffer(sessionId);
       if (buffer && buffer.length > 0) {
@@ -315,19 +315,19 @@ export function AppShell({ children }: { children?: React.ReactNode }) {
             : (useProjectStore
                 .getState()
                 .projects.find((project) => project.id === projectId) ?? null);
-        const nextWorkingDir =
-          resolveEffectiveWorkingDir(nextProject) ??
+        const nextSessionCwd =
+          resolveDefaultSessionCwd(nextProject) ??
           (nextProject == null
-            ? resolveEffectiveWorkingDir(null, await getHomeDir())
+            ? resolveDefaultSessionCwd(null, await getHomeDir())
             : undefined);
-        if (!nextWorkingDir) {
+        if (!nextSessionCwd) {
           return;
         }
         await acpPrepareSession(
           sessionId,
           session.providerId ?? agentStore.selectedProvider ?? "goose",
           {
-            workingDir: nextWorkingDir,
+            workingDir: nextSessionCwd,
             personaId: session.personaId,
           },
         );

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChat.attachments.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChat.attachments.test.ts
@@ -32,7 +32,7 @@ describe("useChat attachments", () => {
       activeSessionId: null,
       isLoading: false,
       contextPanelOpenBySession: {},
-      activeWorkingContextBySession: {},
+      activeWorkspaceBySession: {},
       modelsBySession: {},
       modelCacheByProvider: {},
     });

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts
@@ -361,9 +361,14 @@ describe("useChat", () => {
       await result.current.sendMessage("Hello");
     });
 
-    expect(mockAcpPrepareSession).toHaveBeenCalledWith("session-1", "openai", "/tmp", {
-      personaId: undefined,
-    });
+    expect(mockAcpPrepareSession).toHaveBeenCalledWith(
+      "session-1",
+      "openai",
+      "/tmp",
+      {
+        personaId: undefined,
+      },
+    );
     expect(mockAcpSetModel).toHaveBeenCalledWith("session-1", "gpt-4.1");
     expect(mockAcpSendMessage).toHaveBeenCalledWith("session-1", "Hello", {
       systemPrompt: undefined,

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts
@@ -353,14 +353,15 @@ describe("useChat", () => {
       ],
     });
 
-    const { result } = renderHook(() => useChat("session-1", "openai"));
+    const { result } = renderHook(() =>
+      useChat("session-1", "openai", undefined, undefined, async () => "/tmp"),
+    );
 
     await act(async () => {
       await result.current.sendMessage("Hello");
     });
 
-    expect(mockAcpPrepareSession).toHaveBeenCalledWith("session-1", "openai", {
-      workingDir: undefined,
+    expect(mockAcpPrepareSession).toHaveBeenCalledWith("session-1", "openai", "/tmp", {
       personaId: undefined,
     });
     expect(mockAcpSetModel).toHaveBeenCalledWith("session-1", "gpt-4.1");

--- a/ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts
+++ b/ui/goose2/src/features/chat/hooks/__tests__/useChat.test.ts
@@ -65,7 +65,7 @@ describe("useChat", () => {
       activeSessionId: null,
       isLoading: false,
       contextPanelOpenBySession: {},
-      activeWorkingContextBySession: {},
+      activeWorkspaceBySession: {},
       modelsBySession: {},
       modelCacheByProvider: {},
     });

--- a/ui/goose2/src/features/chat/hooks/useChat.ts
+++ b/ui/goose2/src/features/chat/hooks/useChat.ts
@@ -83,7 +83,7 @@ export function useChat(
   providerOverride?: string,
   systemPromptOverride?: string,
   personaInfo?: { id: string; name: string },
-  workingDirOverride?: string,
+  getWorkingDir?: () => Promise<string | undefined>,
 ) {
   const store = useChatStore();
   const abortRef = useRef<AbortController | null>(null);
@@ -218,8 +218,9 @@ export function useChat(
 
       try {
         if (wasDraft || selectedModelId) {
+          const workingDir = await getWorkingDir?.();
           await acpPrepareSession(sessionId, providerId, {
-            workingDir: workingDirOverride,
+            workingDir,
             personaId: effectivePersonaInfo?.id,
           });
           if (selectedModelId) {
@@ -299,7 +300,7 @@ export function useChat(
       providerOverride,
       systemPromptOverride,
       resolvePersonaInfo,
-      workingDirOverride,
+      getWorkingDir,
     ],
   );
 

--- a/ui/goose2/src/features/chat/hooks/useChat.ts
+++ b/ui/goose2/src/features/chat/hooks/useChat.ts
@@ -219,8 +219,10 @@ export function useChat(
       try {
         if (wasDraft || selectedModelId) {
           const workingDir = await getWorkingDir?.();
-          await acpPrepareSession(sessionId, providerId, {
-            workingDir,
+          if (!workingDir) {
+            throw new Error("Missing session working directory");
+          }
+          await acpPrepareSession(sessionId, providerId, workingDir, {
             personaId: effectivePersonaInfo?.id,
           });
           if (selectedModelId) {

--- a/ui/goose2/src/features/chat/stores/__tests__/chatSessionStore.test.ts
+++ b/ui/goose2/src/features/chat/stores/__tests__/chatSessionStore.test.ts
@@ -20,7 +20,7 @@ function resetStore() {
     activeSessionId: null,
     isLoading: false,
     contextPanelOpenBySession: {},
-    activeWorkingContextBySession: {},
+    activeWorkspaceBySession: {},
     modelsBySession: {},
     modelCacheByProvider: {},
   });

--- a/ui/goose2/src/features/chat/stores/chatSessionStore.ts
+++ b/ui/goose2/src/features/chat/stores/chatSessionStore.ts
@@ -37,7 +37,7 @@ export interface ChatSession {
   userSetName?: boolean;
 }
 
-export interface WorkingContext {
+export interface ActiveWorkspace {
   path: string;
   branch: string | null;
 }
@@ -47,7 +47,7 @@ interface ChatSessionStoreState {
   activeSessionId: string | null;
   isLoading: boolean;
   contextPanelOpenBySession: Record<string, boolean>;
-  activeWorkingContextBySession: Record<string, WorkingContext>;
+  activeWorkspaceBySession: Record<string, ActiveWorkspace>;
   modelsBySession: Record<string, ModelOption[]>;
   modelCacheByProvider: Record<string, ModelOption[]>;
 }
@@ -83,8 +83,8 @@ interface ChatSessionStoreActions {
 
   setActiveSession: (sessionId: string | null) => void;
   setContextPanelOpen: (sessionId: string, open: boolean) => void;
-  setActiveWorkingContext: (sessionId: string, context: WorkingContext) => void;
-  clearActiveWorkingContext: (sessionId: string) => void;
+  setActiveWorkspace: (sessionId: string, context: ActiveWorkspace) => void;
+  clearActiveWorkspace: (sessionId: string) => void;
   setSessionModels: (sessionId: string, models: ModelOption[]) => void;
   switchSessionProvider: (
     sessionId: string,
@@ -300,7 +300,7 @@ export const useChatSessionStore = create<ChatSessionStore>((set, get) => ({
   activeSessionId: null,
   isLoading: false,
   contextPanelOpenBySession: {},
-  activeWorkingContextBySession: {},
+  activeWorkspaceBySession: {},
   modelsBySession: {},
   modelCacheByProvider: loadModelCache(),
 
@@ -346,7 +346,7 @@ export const useChatSessionStore = create<ChatSessionStore>((set, get) => ({
     const { [id]: _ignoredPanelState, ...remainingPanelState } =
       get().contextPanelOpenBySession;
     const { [id]: _ignoredContext, ...remainingContextState } =
-      get().activeWorkingContextBySession;
+      get().activeWorkspaceBySession;
     const remainingModels = { ...get().modelsBySession };
     delete remainingModels[id];
     set((state) => ({
@@ -354,7 +354,7 @@ export const useChatSessionStore = create<ChatSessionStore>((set, get) => ({
       activeSessionId:
         state.activeSessionId === id ? null : state.activeSessionId,
       contextPanelOpenBySession: remainingPanelState,
-      activeWorkingContextBySession: remainingContextState,
+      activeWorkspaceBySession: remainingContextState,
       modelsBySession: remainingModels,
     }));
     removeDraftSessionRecord(id);
@@ -544,19 +544,19 @@ export const useChatSessionStore = create<ChatSessionStore>((set, get) => ({
     }));
   },
 
-  setActiveWorkingContext: (sessionId, context) => {
+  setActiveWorkspace: (sessionId, context) => {
     set((state) => ({
-      activeWorkingContextBySession: {
-        ...state.activeWorkingContextBySession,
+      activeWorkspaceBySession: {
+        ...state.activeWorkspaceBySession,
         [sessionId]: context,
       },
     }));
   },
 
-  clearActiveWorkingContext: (sessionId) => {
+  clearActiveWorkspace: (sessionId) => {
     set((state) => {
-      const { [sessionId]: _, ...rest } = state.activeWorkingContextBySession;
-      return { activeWorkingContextBySession: rest };
+      const { [sessionId]: _, ...rest } = state.activeWorkspaceBySession;
+      return { activeWorkspaceBySession: rest };
     });
   },
 

--- a/ui/goose2/src/features/chat/ui/ChatView.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatView.tsx
@@ -248,9 +248,14 @@ export function ChatView({
             return;
           }
 
-          await acpPrepareSession(activeSessionId, selectedProvider, workingDir, {
-            personaId: selectedPersonaId ?? undefined,
-          });
+          await acpPrepareSession(
+            activeSessionId,
+            selectedProvider,
+            workingDir,
+            {
+              personaId: selectedPersonaId ?? undefined,
+            },
+          );
         }
 
         void updateProjectSessionCwd().catch((error) => {

--- a/ui/goose2/src/features/chat/ui/ChatView.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatView.tsx
@@ -17,9 +17,9 @@ import { acpPrepareSession, acpSetModel } from "@/shared/api/acp";
 import {
   buildProjectSystemPrompt,
   composeSystemPrompt,
-  defaultArtifactsDir,
+  defaultGlobalArtifactRoot,
   getProjectArtifactRoots,
-  resolveProjectWorkingDir,
+  resolveProjectDefaultArtifactRoot,
 } from "@/features/projects/lib/chatProjectContext";
 import { getHomeDir } from "@/shared/api/system";
 import { ArtifactPolicyProvider } from "../hooks/ArtifactPolicyContext";
@@ -55,11 +55,11 @@ export function ChatView({
     (s) => s.contextPanelOpenBySession[activeSessionId] ?? false,
   );
   const setContextPanelOpen = useChatSessionStore((s) => s.setContextPanelOpen);
-  const activeWorkingContext = useChatSessionStore(
-    (s) => s.activeWorkingContextBySession[activeSessionId],
+  const activeWorkspace = useChatSessionStore(
+    (s) => s.activeWorkspaceBySession[activeSessionId],
   );
-  const clearActiveWorkingContext = useChatSessionStore(
-    (s) => s.clearActiveWorkingContext,
+  const clearActiveWorkspace = useChatSessionStore(
+    (s) => s.clearActiveWorkspace,
   );
 
   const {
@@ -85,7 +85,7 @@ export function ChatView({
       ? s.projects.find((candidate) => candidate.id === session.projectId)
       : undefined,
   );
-  const [homeArtifactsRoot, setHomeArtifactsRoot] = useState<string | null>(
+  const [globalArtifactRoot, setGlobalArtifactRoot] = useState<string | null>(
     null,
   );
   const project = storedProject ?? null;
@@ -115,36 +115,36 @@ export function ChatView({
     () => getProjectArtifactRoots(project),
     [project],
   );
-  const resolvedProjectWorkingDir = useMemo(
-    () => resolveProjectWorkingDir(project),
+  const projectDefaultArtifactRoot = useMemo(
+    () => resolveProjectDefaultArtifactRoot(project),
     [project],
   );
   const projectMetadataPending = Boolean(
-    session?.projectId && !resolvedProjectWorkingDir && projectsLoading,
+    session?.projectId && !projectDefaultArtifactRoot && projectsLoading,
   );
-  const defaultWorkingDir = resolvedProjectWorkingDir
-    ? resolvedProjectWorkingDir
+  const defaultSessionCwd = projectDefaultArtifactRoot
+    ? projectDefaultArtifactRoot
     : !session?.projectId
-      ? (homeArtifactsRoot ?? undefined)
+      ? (globalArtifactRoot ?? undefined)
       : undefined;
-  const effectiveWorkingDir = activeWorkingContext?.path ?? defaultWorkingDir;
+  const effectiveSessionCwd = activeWorkspace?.path ?? defaultSessionCwd;
   const allowedArtifactRoots = useMemo(() => {
     const roots = [
       ...projectArtifactRoots.map((path) => path.trim()).filter(Boolean),
     ];
-    if (homeArtifactsRoot) {
-      roots.push(homeArtifactsRoot);
+    if (globalArtifactRoot) {
+      roots.push(globalArtifactRoot);
     }
     return [...new Set(roots)];
-  }, [homeArtifactsRoot, projectArtifactRoots]);
+  }, [globalArtifactRoot, projectArtifactRoots]);
   const projectSystemPrompt = useMemo(
     () => buildProjectSystemPrompt(project),
     [project],
   );
   const workingContextPrompt = useMemo(() => {
-    if (!activeWorkingContext?.branch) return undefined;
-    return `<active-working-context>\nActive branch: ${activeWorkingContext.branch}\nWorking directory: ${activeWorkingContext.path}\n</active-working-context>`;
-  }, [activeWorkingContext?.branch, activeWorkingContext?.path]);
+    if (!activeWorkspace?.branch) return undefined;
+    return `<active-working-context>\nActive branch: ${activeWorkspace.branch}\nWorking directory: ${activeWorkspace.path}\n</active-working-context>`;
+  }, [activeWorkspace?.branch, activeWorkspace?.path]);
 
   const effectiveSystemPrompt = useMemo(
     () =>
@@ -161,11 +161,11 @@ export function ChatView({
     getHomeDir()
       .then((homeDir) => {
         if (cancelled) return;
-        setHomeArtifactsRoot(defaultArtifactsDir(homeDir));
+        setGlobalArtifactRoot(defaultGlobalArtifactRoot(homeDir));
       })
       .catch(() => {
         if (cancelled) return;
-        setHomeArtifactsRoot(null);
+        setGlobalArtifactRoot(null);
       });
     return () => {
       cancelled = true;
@@ -177,31 +177,31 @@ export function ChatView({
     const prevProjectId = prevProjectIdRef.current;
     prevProjectIdRef.current = session?.projectId;
     if (prevProjectId !== undefined && prevProjectId !== session?.projectId) {
-      clearActiveWorkingContext(activeSessionId);
+      clearActiveWorkspace(activeSessionId);
     }
-  }, [session?.projectId, activeSessionId, clearActiveWorkingContext]);
+  }, [session?.projectId, activeSessionId, clearActiveWorkspace]);
 
-  const prevContextRef = useRef(activeWorkingContext);
+  const prevWorkspaceRef = useRef(activeWorkspace);
   useEffect(() => {
-    const prev = prevContextRef.current;
+    const prev = prevWorkspaceRef.current;
     if (
-      !activeWorkingContext ||
+      !activeWorkspace ||
       !selectedProvider ||
       session?.draft ||
-      activeWorkingContext === prev
+      activeWorkspace === prev
     ) {
       return;
     }
-    prevContextRef.current = activeWorkingContext;
-    if (prev && prev.path === activeWorkingContext.path) return;
+    prevWorkspaceRef.current = activeWorkspace;
+    if (prev && prev.path === activeWorkspace.path) return;
     void acpPrepareSession(activeSessionId, selectedProvider, {
-      workingDir: activeWorkingContext.path,
+      workingDir: activeWorkspace.path,
       personaId: selectedPersonaId ?? undefined,
     }).catch((error) => {
       console.error("Failed to prepare ACP session:", error);
     });
   }, [
-    activeWorkingContext,
+    activeWorkspace,
     activeSessionId,
     selectedProvider,
     selectedPersonaId,
@@ -230,17 +230,17 @@ export function ChatView({
               .getState()
               .projects.find((candidate) => candidate.id === projectId) ??
             null);
-      const nextWorkingDir =
-        resolveProjectWorkingDir(nextProject) ??
-        (projectId == null ? (homeArtifactsRoot ?? undefined) : undefined);
+      const nextSessionCwd =
+        resolveProjectDefaultArtifactRoot(nextProject) ??
+        (projectId == null ? (globalArtifactRoot ?? undefined) : undefined);
 
       useChatSessionStore
         .getState()
         .updateSession(activeSessionId, { projectId });
 
-      if (!session?.draft && selectedProvider && nextWorkingDir) {
+      if (!session?.draft && selectedProvider && nextSessionCwd) {
         void acpPrepareSession(activeSessionId, selectedProvider, {
-          workingDir: nextWorkingDir,
+          workingDir: nextSessionCwd,
           personaId: selectedPersonaId ?? undefined,
         }).catch((error) => {
           console.error(
@@ -252,7 +252,7 @@ export function ChatView({
     },
     [
       activeSessionId,
-      homeArtifactsRoot,
+      globalArtifactRoot,
       selectedPersonaId,
       selectedProvider,
       session?.draft,
@@ -343,7 +343,7 @@ export function ChatView({
     selectedProvider,
     effectiveSystemPrompt,
     personaInfo,
-    effectiveWorkingDir,
+    effectiveSessionCwd,
   );
   const isLoadingHistory = useChatStore(
     (s) =>

--- a/ui/goose2/src/features/chat/ui/ChatView.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatView.tsx
@@ -15,12 +15,16 @@ import { useChatSessionStore } from "../stores/chatSessionStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { acpPrepareSession, acpSetModel } from "@/shared/api/acp";
 import {
+  defaultGlobalArtifactRoot,
+  buildSessionCwdParts,
+  resolveProjectDefaultArtifactRoot,
+} from "@/features/projects/lib/sessionCwdSelection";
+import {
   buildProjectSystemPrompt,
   composeSystemPrompt,
-  defaultGlobalArtifactRoot,
   getProjectArtifactRoots,
-  resolveProjectDefaultArtifactRoot,
 } from "@/features/projects/lib/chatProjectContext";
+import { resolveOptionalPath } from "@/shared/api/pathResolver";
 import { getHomeDir } from "@/shared/api/system";
 import { ArtifactPolicyProvider } from "../hooks/ArtifactPolicyContext";
 import type { ModelOption } from "../types";
@@ -122,12 +126,10 @@ export function ChatView({
   const projectMetadataPending = Boolean(
     session?.projectId && !projectDefaultArtifactRoot && projectsLoading,
   );
-  const defaultSessionCwd = projectDefaultArtifactRoot
-    ? projectDefaultArtifactRoot
-    : !session?.projectId
-      ? (globalArtifactRoot ?? undefined)
-      : undefined;
-  const effectiveSessionCwd = activeWorkspace?.path ?? defaultSessionCwd;
+  const sessionCwdParts = useMemo(
+    () => buildSessionCwdParts(project, activeWorkspace?.path),
+    [project, activeWorkspace?.path],
+  );
   const allowedArtifactRoots = useMemo(() => {
     const roots = [
       ...projectArtifactRoots.map((path) => path.trim()).filter(Boolean),
@@ -194,12 +196,16 @@ export function ChatView({
     }
     prevWorkspaceRef.current = activeWorkspace;
     if (prev && prev.path === activeWorkspace.path) return;
-    void acpPrepareSession(activeSessionId, selectedProvider, {
-      workingDir: activeWorkspace.path,
-      personaId: selectedPersonaId ?? undefined,
-    }).catch((error) => {
-      console.error("Failed to prepare ACP session:", error);
-    });
+    void resolveOptionalPath([activeWorkspace.path])
+      .then((path) =>
+        acpPrepareSession(activeSessionId, selectedProvider, {
+          workingDir: path,
+          personaId: selectedPersonaId ?? undefined,
+        }),
+      )
+      .catch((error) => {
+        console.error("Failed to prepare ACP session:", error);
+      });
   }, [
     activeWorkspace,
     activeSessionId,
@@ -230,29 +236,34 @@ export function ChatView({
               .getState()
               .projects.find((candidate) => candidate.id === projectId) ??
             null);
-      const nextSessionCwd =
-        resolveProjectDefaultArtifactRoot(nextProject) ??
-        (projectId == null ? (globalArtifactRoot ?? undefined) : undefined);
+      const nextWorkingDirParts = buildSessionCwdParts(
+        nextProject,
+        activeWorkspace?.path,
+      );
 
       useChatSessionStore
         .getState()
         .updateSession(activeSessionId, { projectId });
 
-      if (!session?.draft && selectedProvider && nextSessionCwd) {
-        void acpPrepareSession(activeSessionId, selectedProvider, {
-          workingDir: nextSessionCwd,
-          personaId: selectedPersonaId ?? undefined,
-        }).catch((error) => {
-          console.error(
-            "Failed to update ACP session working directory:",
-            error,
-          );
-        });
+      if (!session?.draft && selectedProvider && nextWorkingDirParts) {
+        void resolveOptionalPath(nextWorkingDirParts)
+          .then((path) =>
+            acpPrepareSession(activeSessionId, selectedProvider, {
+              workingDir: path,
+              personaId: selectedPersonaId ?? undefined,
+            }),
+          )
+          .catch((error) => {
+            console.error(
+              "Failed to update ACP session working directory:",
+              error,
+            );
+          });
       }
     },
     [
       activeSessionId,
-      globalArtifactRoot,
+      activeWorkspace?.path,
       selectedPersonaId,
       selectedProvider,
       session?.draft,
@@ -331,6 +342,10 @@ export function ChatView({
   const personaInfo = selectedPersona
     ? { id: selectedPersona.id, name: selectedPersona.displayName }
     : undefined;
+  const resolveCurrentSessionCwd = useCallback(
+    () => resolveOptionalPath(sessionCwdParts),
+    [sessionCwdParts],
+  );
   const {
     messages,
     chatState,
@@ -343,7 +358,7 @@ export function ChatView({
     selectedProvider,
     effectiveSystemPrompt,
     personaInfo,
-    effectiveSessionCwd,
+    resolveCurrentSessionCwd,
   );
   const isLoadingHistory = useChatStore(
     (s) =>

--- a/ui/goose2/src/features/chat/ui/ChatView.tsx
+++ b/ui/goose2/src/features/chat/ui/ChatView.tsx
@@ -15,17 +15,13 @@ import { useChatSessionStore } from "../stores/chatSessionStore";
 import { useProjectStore } from "@/features/projects/stores/projectStore";
 import { acpPrepareSession, acpSetModel } from "@/shared/api/acp";
 import {
-  defaultGlobalArtifactRoot,
-  buildSessionCwdParts,
-  resolveProjectDefaultArtifactRoot,
-} from "@/features/projects/lib/sessionCwdSelection";
-import {
   buildProjectSystemPrompt,
   composeSystemPrompt,
+  defaultGlobalArtifactRoot,
   getProjectArtifactRoots,
+  resolveProjectDefaultArtifactRoot,
 } from "@/features/projects/lib/chatProjectContext";
-import { resolveOptionalPath } from "@/shared/api/pathResolver";
-import { getHomeDir } from "@/shared/api/system";
+import { resolveSessionCwd } from "@/features/projects/lib/sessionCwdSelection";
 import { ArtifactPolicyProvider } from "../hooks/ArtifactPolicyContext";
 import type { ModelOption } from "../types";
 import { ChatContextPanel } from "./ChatContextPanel";
@@ -126,10 +122,6 @@ export function ChatView({
   const projectMetadataPending = Boolean(
     session?.projectId && !projectDefaultArtifactRoot && projectsLoading,
   );
-  const sessionCwdParts = useMemo(
-    () => buildSessionCwdParts(project, activeWorkspace?.path),
-    [project, activeWorkspace?.path],
-  );
   const allowedArtifactRoots = useMemo(() => {
     const roots = [
       ...projectArtifactRoots.map((path) => path.trim()).filter(Boolean),
@@ -160,10 +152,10 @@ export function ChatView({
 
   useEffect(() => {
     let cancelled = false;
-    getHomeDir()
-      .then((homeDir) => {
+    defaultGlobalArtifactRoot()
+      .then((artifactRoot) => {
         if (cancelled) return;
-        setGlobalArtifactRoot(defaultGlobalArtifactRoot(homeDir));
+        setGlobalArtifactRoot(artifactRoot);
       })
       .catch(() => {
         if (cancelled) return;
@@ -196,19 +188,24 @@ export function ChatView({
     }
     prevWorkspaceRef.current = activeWorkspace;
     if (prev && prev.path === activeWorkspace.path) return;
-    void resolveOptionalPath([activeWorkspace.path])
-      .then((path) =>
-        acpPrepareSession(activeSessionId, selectedProvider, {
-          workingDir: path,
-          personaId: selectedPersonaId ?? undefined,
-        }),
-      )
-      .catch((error) => {
-        console.error("Failed to prepare ACP session:", error);
+
+    async function prepareWorkspaceSession() {
+      const workingDir = await resolveSessionCwd(project, activeWorkspace.path);
+      if (!workingDir) {
+        return;
+      }
+      await acpPrepareSession(activeSessionId, selectedProvider, workingDir, {
+        personaId: selectedPersonaId ?? undefined,
       });
+    }
+
+    void prepareWorkspaceSession().catch((error) => {
+      console.error("Failed to prepare ACP session:", error);
+    });
   }, [
     activeWorkspace,
     activeSessionId,
+    project,
     selectedProvider,
     selectedPersonaId,
     session?.draft,
@@ -236,29 +233,32 @@ export function ChatView({
               .getState()
               .projects.find((candidate) => candidate.id === projectId) ??
             null);
-      const nextWorkingDirParts = buildSessionCwdParts(
-        nextProject,
-        activeWorkspace?.path,
-      );
 
       useChatSessionStore
         .getState()
         .updateSession(activeSessionId, { projectId });
 
-      if (!session?.draft && selectedProvider && nextWorkingDirParts) {
-        void resolveOptionalPath(nextWorkingDirParts)
-          .then((path) =>
-            acpPrepareSession(activeSessionId, selectedProvider, {
-              workingDir: path,
-              personaId: selectedPersonaId ?? undefined,
-            }),
-          )
-          .catch((error) => {
-            console.error(
-              "Failed to update ACP session working directory:",
-              error,
-            );
+      if (!session?.draft && selectedProvider) {
+        async function updateProjectSessionCwd() {
+          const workingDir = await resolveSessionCwd(
+            nextProject,
+            activeWorkspace?.path,
+          );
+          if (!workingDir) {
+            return;
+          }
+
+          await acpPrepareSession(activeSessionId, selectedProvider, workingDir, {
+            personaId: selectedPersonaId ?? undefined,
           });
+        }
+
+        void updateProjectSessionCwd().catch((error) => {
+          console.error(
+            "Failed to update ACP session working directory:",
+            error,
+          );
+        });
       }
     },
     [
@@ -343,8 +343,8 @@ export function ChatView({
     ? { id: selectedPersona.id, name: selectedPersona.displayName }
     : undefined;
   const resolveCurrentSessionCwd = useCallback(
-    () => resolveOptionalPath(sessionCwdParts),
-    [sessionCwdParts],
+    () => resolveSessionCwd(project, activeWorkspace?.path),
+    [project, activeWorkspace?.path],
   );
   const {
     messages,

--- a/ui/goose2/src/features/chat/ui/ContextPanel.tsx
+++ b/ui/goose2/src/features/chat/ui/ContextPanel.tsx
@@ -44,9 +44,7 @@ export function ContextPanel({
   const activeContext = useChatSessionStore(
     (s) => s.activeWorkspaceBySession[sessionId],
   );
-  const setActiveWorkspace = useChatSessionStore(
-    (s) => s.setActiveWorkspace,
-  );
+  const setActiveWorkspace = useChatSessionStore((s) => s.setActiveWorkspace);
 
   const gitTargetPath = activeContext?.path ?? primaryWorkspaceRoot;
   const {

--- a/ui/goose2/src/features/chat/ui/ContextPanel.tsx
+++ b/ui/goose2/src/features/chat/ui/ContextPanel.tsx
@@ -15,7 +15,7 @@ import {
 import type { CreatedWorktree } from "@/shared/types/git";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/shared/ui/tabs";
 import { useChatSessionStore } from "../stores/chatSessionStore";
-import type { WorkingContext } from "../stores/chatSessionStore";
+import type { ActiveWorkspace } from "../stores/chatSessionStore";
 import { WorkspaceWidget } from "./widgets/WorkspaceWidget";
 import { ChangesWidget } from "./widgets/ChangesWidget";
 import { ArtifactsWidget } from "./widgets/ArtifactsWidget";
@@ -39,35 +39,35 @@ export function ContextPanel({
 }: ContextPanelProps) {
   const { t } = useTranslation("chat");
   const [activeTab, setActiveTab] = useState<ContextPanelTab>("details");
-  const primaryWorkingDir = projectWorkingDirs[0] ?? null;
+  const primaryWorkspaceRoot = projectWorkingDirs[0] ?? null;
 
   const activeContext = useChatSessionStore(
-    (s) => s.activeWorkingContextBySession[sessionId],
+    (s) => s.activeWorkspaceBySession[sessionId],
   );
-  const setActiveWorkingContext = useChatSessionStore(
-    (s) => s.setActiveWorkingContext,
+  const setActiveWorkspace = useChatSessionStore(
+    (s) => s.setActiveWorkspace,
   );
 
-  const gitQueryPath = activeContext?.path ?? primaryWorkingDir;
+  const gitTargetPath = activeContext?.path ?? primaryWorkspaceRoot;
   const {
     data: gitState,
     error,
     isLoading,
     isFetching,
     refetch,
-  } = useGitState(gitQueryPath, activeTab === "details");
+  } = useGitState(gitTargetPath, activeTab === "details");
 
   const {
     data: changedFiles,
     isLoading: isFilesLoading,
     refetch: refetchFiles,
-  } = useChangedFiles(gitQueryPath, activeTab === "details");
+  } = useChangedFiles(gitTargetPath, activeTab === "details");
 
   const handleContextChange = useCallback(
-    (context: WorkingContext) => {
-      setActiveWorkingContext(sessionId, context);
+    (context: ActiveWorkspace) => {
+      setActiveWorkspace(sessionId, context);
     },
-    [sessionId, setActiveWorkingContext],
+    [sessionId, setActiveWorkspace],
   );
 
   const refetchAll = useCallback(async () => {
@@ -149,11 +149,11 @@ export function ContextPanel({
 
   const handleOpenChangedFile = useCallback(
     (filePath: string) => {
-      if (!gitQueryPath) return;
-      const fullPath = `${gitQueryPath}/${filePath}`;
+      if (!gitTargetPath) return;
+      const fullPath = `${gitTargetPath}/${filePath}`;
       void openPath(fullPath);
     },
-    [gitQueryPath],
+    [gitTargetPath],
   );
 
   const handleRefresh = useCallback(() => {
@@ -202,7 +202,7 @@ export function ContextPanel({
             files={changedFiles}
             isLoading={isFilesLoading}
             currentBranch={gitState?.currentBranch ?? null}
-            repoPath={gitQueryPath ?? ""}
+            repoPath={gitTargetPath ?? ""}
             onOpenFile={handleOpenChangedFile}
           />
           <ArtifactsWidget />

--- a/ui/goose2/src/features/chat/ui/widgets/WorkingContextPicker.tsx
+++ b/ui/goose2/src/features/chat/ui/widgets/WorkingContextPicker.tsx
@@ -20,13 +20,13 @@ import {
 import { buttonVariants } from "@/shared/ui/button";
 import { cn } from "@/shared/lib/cn";
 import type { GitState } from "@/shared/types/git";
-import type { WorkingContext } from "../../stores/chatSessionStore";
+import type { ActiveWorkspace } from "../../stores/chatSessionStore";
 
 interface WorkingContextPickerProps {
   currentProjectPath: string | null;
   gitState: GitState | undefined;
-  activeContext: WorkingContext | undefined;
-  onSelect: (context: WorkingContext) => void;
+  activeContext: ActiveWorkspace | undefined;
+  onSelect: (context: ActiveWorkspace) => void;
   onSwitchBranch: (path: string, branch: string) => Promise<void>;
   onStashAndSwitch: (path: string, branch: string) => Promise<void>;
 }
@@ -63,7 +63,7 @@ export function WorkingContextPicker({
 }: WorkingContextPickerProps) {
   const { t } = useTranslation("chat");
   const [open, setOpen] = useState(false);
-  const [pendingSwitch, setPendingSwitch] = useState<WorkingContext | null>(
+  const [pendingSwitch, setPendingSwitch] = useState<ActiveWorkspace | null>(
     null,
   );
   const [switching, setSwitching] = useState(false);

--- a/ui/goose2/src/features/chat/ui/widgets/WorkspaceActionsMenu.tsx
+++ b/ui/goose2/src/features/chat/ui/widgets/WorkspaceActionsMenu.tsx
@@ -5,7 +5,7 @@ import type { CreatedWorktree, GitState } from "@/shared/types/git";
 import { Button } from "@/shared/ui/button";
 import { SplitButton } from "@/shared/ui/split-button";
 import { Spinner } from "@/shared/ui/spinner";
-import type { WorkingContext } from "../../stores/chatSessionStore";
+import type { ActiveWorkspace } from "../../stores/chatSessionStore";
 import { formatErrorMessage } from "./formatError";
 import {
   WorkspaceCreateDialog,
@@ -15,9 +15,9 @@ import {
 interface WorkspaceActionsMenuProps {
   currentProjectPath: string;
   gitState: GitState;
-  activeContext: WorkingContext | undefined;
+  activeContext: ActiveWorkspace | undefined;
   disabled?: boolean;
-  onContextChange: (context: WorkingContext) => void;
+  onContextChange: (context: ActiveWorkspace) => void;
   onFetch: (path: string) => Promise<void>;
   onPull: (path: string) => Promise<void>;
   onCreateBranch: (

--- a/ui/goose2/src/features/chat/ui/widgets/WorkspaceCreateDialog.tsx
+++ b/ui/goose2/src/features/chat/ui/widgets/WorkspaceCreateDialog.tsx
@@ -21,7 +21,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/shared/ui/select";
-import type { WorkingContext } from "../../stores/chatSessionStore";
+import type { ActiveWorkspace } from "../../stores/chatSessionStore";
 import { formatErrorMessage } from "./formatError";
 import { shortenPath } from "./WorkingContextPicker";
 
@@ -35,7 +35,7 @@ interface WorkspaceCreateDialogProps {
   currentPath: string;
   activeBranch: string | null;
   onClose: () => void;
-  onContextChange: (context: WorkingContext) => void;
+  onContextChange: (context: ActiveWorkspace) => void;
   onCreateBranch: (
     path: string,
     name: string,

--- a/ui/goose2/src/features/chat/ui/widgets/WorkspaceWidget.tsx
+++ b/ui/goose2/src/features/chat/ui/widgets/WorkspaceWidget.tsx
@@ -3,7 +3,7 @@ import { IconFolder, IconGitBranch, IconRefresh } from "@tabler/icons-react";
 import type { CreatedWorktree, GitState } from "@/shared/types/git";
 import { Button } from "@/shared/ui/button";
 import { Spinner } from "@/shared/ui/spinner";
-import type { WorkingContext } from "../../stores/chatSessionStore";
+import type { ActiveWorkspace } from "../../stores/chatSessionStore";
 import { Widget } from "./Widget";
 import { WorkspaceActionsMenu } from "./WorkspaceActionsMenu";
 import { WorkingContextPicker, shortenPath } from "./WorkingContextPicker";
@@ -16,8 +16,8 @@ interface WorkspaceWidgetProps {
   isLoading: boolean;
   isFetching: boolean;
   error: Error | null;
-  activeContext: WorkingContext | undefined;
-  onContextChange: (context: WorkingContext) => void;
+  activeContext: ActiveWorkspace | undefined;
+  onContextChange: (context: ActiveWorkspace) => void;
   onSwitchBranch: (path: string, branch: string) => Promise<void>;
   onStashAndSwitch: (path: string, branch: string) => Promise<void>;
   onInitRepo: (path: string) => Promise<void>;
@@ -58,7 +58,7 @@ export function WorkspaceWidget({
   onRefresh,
 }: WorkspaceWidgetProps) {
   const { t } = useTranslation("chat");
-  const primaryWorkingDir = projectWorkingDirs[0] ?? null;
+  const primaryWorkspaceRoot = projectWorkingDirs[0] ?? null;
 
   const gitErrorMessage =
     error instanceof Error ? error.message : t("contextPanel.errors.gitRead");
@@ -73,7 +73,7 @@ export function WorkspaceWidget({
           variant="ghost"
           size="icon-xs"
           onClick={onRefresh}
-          disabled={!primaryWorkingDir || isFetching}
+          disabled={!primaryWorkspaceRoot || isFetching}
           className="rounded-md"
           aria-label={t("contextPanel.actions.refreshGitStatus")}
           title={t("contextPanel.actions.refreshGitStatus")}
@@ -103,7 +103,7 @@ export function WorkspaceWidget({
           </p>
         )}
 
-        {!primaryWorkingDir ? (
+        {!primaryWorkspaceRoot ? (
           <p className="truncate">{t("contextPanel.empty.folderNotSet")}</p>
         ) : isLoading && !gitState ? (
           <div className="flex items-center gap-2 text-foreground">
@@ -115,7 +115,7 @@ export function WorkspaceWidget({
         ) : gitState?.isGitRepo ? (
           <div className="space-y-2">
             <WorkingContextPicker
-              currentProjectPath={primaryWorkingDir}
+              currentProjectPath={primaryWorkspaceRoot}
               gitState={gitState}
               activeContext={activeContext}
               onSelect={onContextChange}
@@ -123,7 +123,7 @@ export function WorkspaceWidget({
               onStashAndSwitch={onStashAndSwitch}
             />
             <WorkspaceActionsMenu
-              currentProjectPath={primaryWorkingDir}
+              currentProjectPath={primaryWorkspaceRoot}
               gitState={gitState}
               activeContext={activeContext}
               disabled={isFetching}
@@ -137,13 +137,13 @@ export function WorkspaceWidget({
         ) : (
           <div className="space-y-3">
             <p className="truncate text-foreground-subtle">
-              {shortenPath(primaryWorkingDir)}
+              {shortenPath(primaryWorkspaceRoot)}
             </p>
             <Button
               type="button"
               variant="ghost"
               size="xs"
-              onClick={() => void onInitRepo(primaryWorkingDir)}
+              onClick={() => void onInitRepo(primaryWorkspaceRoot)}
             >
               <IconGitBranch className="size-3" />
               {t("contextPanel.git.initRepo")}

--- a/ui/goose2/src/features/projects/lib/chatProjectContext.test.ts
+++ b/ui/goose2/src/features/projects/lib/chatProjectContext.test.ts
@@ -2,12 +2,12 @@ import { describe, expect, it } from "vitest";
 import {
   buildProjectSystemPrompt,
   composeSystemPrompt,
-  defaultArtifactsDir,
+  defaultGlobalArtifactRoot,
   getProjectArtifactRoots,
   getProjectFolderName,
   getProjectFolderOption,
-  resolveEffectiveWorkingDir,
-  resolveProjectWorkingDir,
+  resolveDefaultSessionCwd,
+  resolveProjectDefaultArtifactRoot,
 } from "./chatProjectContext";
 
 describe("chatProjectContext", () => {
@@ -112,57 +112,57 @@ describe("chatProjectContext", () => {
     ]);
   });
 
-  it("resolves the first working directory to an artifacts subfolder", () => {
+  it("resolves the first workspace root to the default artifact root", () => {
     expect(
-      resolveProjectWorkingDir({
+      resolveProjectDefaultArtifactRoot({
         workingDirs: ["/Users/wesb/dev/goose2", "/Users/wesb/dev/other"],
         artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
       }),
     ).toBe("/Users/wesb/dev/goose2/artifacts");
   });
 
-  it("falls back to the project artifacts dir when no working dirs exist", () => {
+  it("falls back to the stored project artifact root when no workspace roots exist", () => {
     expect(
-      resolveProjectWorkingDir({
+      resolveProjectDefaultArtifactRoot({
         workingDirs: [],
         artifactsDir: "/Users/wesb/.goose/projects/sample-project/artifacts",
       }),
     ).toBe("/Users/wesb/.goose/projects/sample-project/artifacts");
   });
 
-  describe("defaultArtifactsDir", () => {
+  describe("defaultGlobalArtifactRoot", () => {
     it("normalises path separators and appends .goose/artifacts", () => {
-      expect(defaultArtifactsDir("/Users/wesb")).toBe(
+      expect(defaultGlobalArtifactRoot("/Users/wesb")).toBe(
         "/Users/wesb/.goose/artifacts",
       );
     });
 
     it("normalises backslashes on Windows-style paths", () => {
-      expect(defaultArtifactsDir("C:\\Users\\wesb\\")).toBe(
+      expect(defaultGlobalArtifactRoot("C:\\Users\\wesb\\")).toBe(
         "C:/Users/wesb/.goose/artifacts",
       );
     });
 
     it("strips trailing slashes", () => {
-      expect(defaultArtifactsDir("/Users/wesb/")).toBe(
+      expect(defaultGlobalArtifactRoot("/Users/wesb/")).toBe(
         "/Users/wesb/.goose/artifacts",
       );
     });
   });
 
-  describe("resolveEffectiveWorkingDir", () => {
-    it("returns the project working dir without requiring homeDir", () => {
+  describe("resolveDefaultSessionCwd", () => {
+    it("returns the project default artifact root without requiring homeDir", () => {
       expect(
-        resolveEffectiveWorkingDir({
+        resolveDefaultSessionCwd({
           workingDirs: ["/Users/wesb/dev/goose2"],
           artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
         }),
       ).toBe("/Users/wesb/dev/goose2/artifacts");
     });
 
-    it("returns the project working dir when available", () => {
+    it("returns the project default artifact root when available", () => {
       expect(
-        resolveEffectiveWorkingDir(
+        resolveDefaultSessionCwd(
           {
             workingDirs: ["/Users/wesb/dev/goose2"],
             artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
@@ -174,7 +174,7 @@ describe("chatProjectContext", () => {
 
     it("returns undefined when a project exists but has no working dirs", () => {
       expect(
-        resolveEffectiveWorkingDir(
+        resolveDefaultSessionCwd(
           { workingDirs: [], artifactsDir: "" },
           "/Users/wesb",
         ),
@@ -182,13 +182,13 @@ describe("chatProjectContext", () => {
     });
 
     it("falls back to home artifacts dir when no project", () => {
-      expect(resolveEffectiveWorkingDir(null, "/Users/wesb")).toBe(
+      expect(resolveDefaultSessionCwd(null, "/Users/wesb")).toBe(
         "/Users/wesb/.goose/artifacts",
       );
     });
 
     it("does not resolve a non-project fallback without homeDir", () => {
-      expect(resolveEffectiveWorkingDir(null)).toBeUndefined();
+      expect(resolveDefaultSessionCwd(null)).toBeUndefined();
     });
   });
 });

--- a/ui/goose2/src/features/projects/lib/chatProjectContext.test.ts
+++ b/ui/goose2/src/features/projects/lib/chatProjectContext.test.ts
@@ -2,12 +2,9 @@ import { describe, expect, it } from "vitest";
 import {
   buildProjectSystemPrompt,
   composeSystemPrompt,
-  defaultGlobalArtifactRoot,
   getProjectArtifactRoots,
   getProjectFolderName,
   getProjectFolderOption,
-  resolveDefaultSessionCwd,
-  resolveProjectDefaultArtifactRoot,
 } from "./chatProjectContext";
 
 describe("chatProjectContext", () => {
@@ -110,85 +107,5 @@ describe("chatProjectContext", () => {
       "/Users/wesb/dev/goose2/artifacts",
       "/Users/wesb/dev/other/artifacts",
     ]);
-  });
-
-  it("resolves the first workspace root to the default artifact root", () => {
-    expect(
-      resolveProjectDefaultArtifactRoot({
-        workingDirs: ["/Users/wesb/dev/goose2", "/Users/wesb/dev/other"],
-        artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
-      }),
-    ).toBe("/Users/wesb/dev/goose2/artifacts");
-  });
-
-  it("falls back to the stored project artifact root when no workspace roots exist", () => {
-    expect(
-      resolveProjectDefaultArtifactRoot({
-        workingDirs: [],
-        artifactsDir: "/Users/wesb/.goose/projects/sample-project/artifacts",
-      }),
-    ).toBe("/Users/wesb/.goose/projects/sample-project/artifacts");
-  });
-
-  describe("defaultGlobalArtifactRoot", () => {
-    it("normalises path separators and appends .goose/artifacts", () => {
-      expect(defaultGlobalArtifactRoot("/Users/wesb")).toBe(
-        "/Users/wesb/.goose/artifacts",
-      );
-    });
-
-    it("normalises backslashes on Windows-style paths", () => {
-      expect(defaultGlobalArtifactRoot("C:\\Users\\wesb\\")).toBe(
-        "C:/Users/wesb/.goose/artifacts",
-      );
-    });
-
-    it("strips trailing slashes", () => {
-      expect(defaultGlobalArtifactRoot("/Users/wesb/")).toBe(
-        "/Users/wesb/.goose/artifacts",
-      );
-    });
-  });
-
-  describe("resolveDefaultSessionCwd", () => {
-    it("returns the project default artifact root without requiring homeDir", () => {
-      expect(
-        resolveDefaultSessionCwd({
-          workingDirs: ["/Users/wesb/dev/goose2"],
-          artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
-        }),
-      ).toBe("/Users/wesb/dev/goose2/artifacts");
-    });
-
-    it("returns the project default artifact root when available", () => {
-      expect(
-        resolveDefaultSessionCwd(
-          {
-            workingDirs: ["/Users/wesb/dev/goose2"],
-            artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
-          },
-          "/Users/wesb",
-        ),
-      ).toBe("/Users/wesb/dev/goose2/artifacts");
-    });
-
-    it("returns undefined when a project exists but has no working dirs", () => {
-      expect(
-        resolveDefaultSessionCwd(
-          { workingDirs: [], artifactsDir: "" },
-          "/Users/wesb",
-        ),
-      ).toBeUndefined();
-    });
-
-    it("falls back to home artifacts dir when no project", () => {
-      expect(resolveDefaultSessionCwd(null, "/Users/wesb")).toBe(
-        "/Users/wesb/.goose/artifacts",
-      );
-    });
-
-    it("does not resolve a non-project fallback without homeDir", () => {
-      expect(resolveDefaultSessionCwd(null)).toBeUndefined();
-    });
   });
 });

--- a/ui/goose2/src/features/projects/lib/chatProjectContext.ts
+++ b/ui/goose2/src/features/projects/lib/chatProjectContext.ts
@@ -6,6 +6,17 @@ export interface ProjectFolderOption {
   path?: string;
 }
 
+/**
+ * Path concepts in goose2:
+ * - workspaceRoot: raw project/worktree path from project.workingDirs
+ * - artifactRoot: default output path derived from a workspace root or stored on the project
+ * - sessionCwd: runtime cwd passed to ACP session preparation
+ *
+ * This module currently preserves existing behavior, where project-backed
+ * session cwd values are artifact-root oriented. Keep those concepts explicit
+ * in names even before the behavior moves to Rust.
+ */
+
 function trimValue(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
@@ -25,7 +36,7 @@ function appendArtifactsSegment(path: string): string {
   return `${path.replace(/[\\/]+$/, "")}/artifacts`;
 }
 
-function resolveProjectFolderPaths(
+function resolveProjectArtifactRoots(
   project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
 ): string[] {
   const workingDirs = (project?.workingDirs ?? [])
@@ -43,23 +54,23 @@ function resolveProjectFolderPaths(
 export function getProjectArtifactRoots(
   project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
 ): string[] {
-  return resolveProjectFolderPaths(project);
+  return resolveProjectArtifactRoots(project);
 }
 
 export function getProjectFolderOption(
   project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
 ): ProjectFolderOption[] {
-  return resolveProjectFolderPaths(project).map((d) => ({
+  return resolveProjectArtifactRoots(project).map((d) => ({
     id: d,
     name: getProjectFolderName(d),
     path: d,
   }));
 }
 
-export function resolveProjectWorkingDir(
+export function resolveProjectDefaultArtifactRoot(
   project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
 ): string | undefined {
-  return resolveProjectFolderPaths(project)[0];
+  return resolveProjectArtifactRoots(project)[0];
 }
 
 export function buildProjectSystemPrompt(
@@ -69,7 +80,7 @@ export function buildProjectSystemPrompt(
     return undefined;
   }
 
-  const artifactDir = resolveProjectWorkingDir(project);
+  const artifactDir = resolveProjectDefaultArtifactRoot(project);
   const settings: string[] = [`Project name: ${project.name}`];
   const description = trimValue(project.description);
   const workingDirs = (project.workingDirs ?? [])
@@ -124,7 +135,7 @@ export function buildProjectSystemPrompt(
  * Builds the default artifacts directory from a raw home-dir string.
  * Normalises path separators and trailing slashes before appending `.goose/artifacts`.
  */
-export function defaultArtifactsDir(homeDir: string): string {
+export function defaultGlobalArtifactRoot(homeDir: string): string {
   const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/+$/, "");
   return `${normalizedHome}/.goose/artifacts`;
 }
@@ -137,13 +148,13 @@ export function defaultArtifactsDir(homeDir: string): string {
  * When a project is provided but has no configured working dirs, returns
  * `undefined` so the caller can decide how to handle it.
  */
-export function resolveEffectiveWorkingDir(
+export function resolveDefaultSessionCwd(
   project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
   homeDir?: string,
 ): string | undefined {
-  const projectDir = resolveProjectWorkingDir(project);
-  if (projectDir) {
-    return projectDir;
+  const projectArtifactRoot = resolveProjectDefaultArtifactRoot(project);
+  if (projectArtifactRoot) {
+    return projectArtifactRoot;
   }
   if (project) {
     return undefined;
@@ -151,7 +162,7 @@ export function resolveEffectiveWorkingDir(
   if (!homeDir) {
     return undefined;
   }
-  return defaultArtifactsDir(homeDir);
+  return defaultGlobalArtifactRoot(homeDir);
 }
 
 export function composeSystemPrompt(

--- a/ui/goose2/src/features/projects/lib/chatProjectContext.ts
+++ b/ui/goose2/src/features/projects/lib/chatProjectContext.ts
@@ -1,6 +1,5 @@
 import type { ProjectInfo } from "../api/projects";
-import { resolveProjectDefaultArtifactRoot } from "./sessionCwdSelection";
-
+import { resolvePath } from "@/shared/api/pathResolver";
 export interface ProjectFolderOption {
   id: string;
   name: string;
@@ -45,6 +44,24 @@ export function getProjectArtifactRoots(
   project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
 ): string[] {
   return resolveProjectArtifactRoots(project);
+}
+
+export function resolveProjectDefaultArtifactRoot(
+  project: ProjectInfo | null | undefined,
+): string | undefined {
+  const workingDirs = (project?.workingDirs ?? [])
+    .map((directory) => trimValue(directory))
+    .filter((directory): directory is string => directory !== null);
+
+  if (workingDirs.length > 0) {
+    return appendArtifactsSegment(workingDirs[0]);
+  }
+
+  return trimValue(project?.artifactsDir) ?? undefined;
+}
+
+export async function defaultGlobalArtifactRoot(): Promise<string> {
+  return (await resolvePath({ parts: ["~", ".goose", "artifacts"] })).path;
 }
 
 export function getProjectFolderOption(

--- a/ui/goose2/src/features/projects/lib/chatProjectContext.ts
+++ b/ui/goose2/src/features/projects/lib/chatProjectContext.ts
@@ -1,21 +1,11 @@
 import type { ProjectInfo } from "../api/projects";
+import { resolveProjectDefaultArtifactRoot } from "./sessionCwdSelection";
 
 export interface ProjectFolderOption {
   id: string;
   name: string;
   path?: string;
 }
-
-/**
- * Path concepts in goose2:
- * - workspaceRoot: raw project/worktree path from project.workingDirs
- * - artifactRoot: default output path derived from a workspace root or stored on the project
- * - sessionCwd: runtime cwd passed to ACP session preparation
- *
- * This module currently preserves existing behavior, where project-backed
- * session cwd values are artifact-root oriented. Keep those concepts explicit
- * in names even before the behavior moves to Rust.
- */
 
 function trimValue(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
@@ -65,12 +55,6 @@ export function getProjectFolderOption(
     name: getProjectFolderName(d),
     path: d,
   }));
-}
-
-export function resolveProjectDefaultArtifactRoot(
-  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
-): string | undefined {
-  return resolveProjectArtifactRoots(project)[0];
 }
 
 export function buildProjectSystemPrompt(
@@ -129,40 +113,6 @@ export function buildProjectSystemPrompt(
   }
 
   return sections.join("\n\n");
-}
-
-/**
- * Builds the default artifacts directory from a raw home-dir string.
- * Normalises path separators and trailing slashes before appending `.goose/artifacts`.
- */
-export function defaultGlobalArtifactRoot(homeDir: string): string {
-  const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/+$/, "");
-  return `${normalizedHome}/.goose/artifacts`;
-}
-
-/**
- * Resolves the effective working directory for a session.
- * Uses the project's working dir if available, otherwise falls back to
- * `~/.goose/artifacts` using the provided home directory.
- *
- * When a project is provided but has no configured working dirs, returns
- * `undefined` so the caller can decide how to handle it.
- */
-export function resolveDefaultSessionCwd(
-  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
-  homeDir?: string,
-): string | undefined {
-  const projectArtifactRoot = resolveProjectDefaultArtifactRoot(project);
-  if (projectArtifactRoot) {
-    return projectArtifactRoot;
-  }
-  if (project) {
-    return undefined;
-  }
-  if (!homeDir) {
-    return undefined;
-  }
-  return defaultGlobalArtifactRoot(homeDir);
 }
 
 export function composeSystemPrompt(

--- a/ui/goose2/src/features/projects/lib/sessionCwdSelection.test.ts
+++ b/ui/goose2/src/features/projects/lib/sessionCwdSelection.test.ts
@@ -1,12 +1,20 @@
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { resolvePath } from "@/shared/api/pathResolver";
+import { resolveSessionCwd } from "./sessionCwdSelection";
 import {
-  buildSessionCwdParts,
   defaultGlobalArtifactRoot,
-  resolveDefaultSessionCwd,
   resolveProjectDefaultArtifactRoot,
-} from "./sessionCwdSelection";
+} from "./chatProjectContext";
+
+vi.mock("@/shared/api/pathResolver", () => ({
+  resolvePath: vi.fn(),
+}));
 
 describe("sessionCwdSelection", () => {
+  beforeEach(() => {
+    vi.mocked(resolvePath).mockReset();
+  });
+
   it("resolves the first workspace root to the default artifact root", () => {
     expect(
       resolveProjectDefaultArtifactRoot({
@@ -25,107 +33,45 @@ describe("sessionCwdSelection", () => {
     ).toBe("/Users/wesb/.goose/projects/sample-project/artifacts");
   });
 
+  it("returns undefined for a pathless project artifact root", () => {
+    expect(
+      resolveProjectDefaultArtifactRoot({
+        workingDirs: [],
+        artifactsDir: "   ",
+      }),
+    ).toBeUndefined();
+  });
+
+  it("falls back to global artifacts for a pathless project session cwd", async () => {
+    vi.mocked(resolvePath).mockResolvedValue({
+      path: "/Users/wesb/.goose/artifacts",
+    });
+
+    await expect(
+      resolveSessionCwd({
+        workingDirs: [],
+        artifactsDir: "   ",
+      }),
+    ).resolves.toBe("/Users/wesb/.goose/artifacts");
+
+    expect(resolvePath).toHaveBeenCalledWith({
+      parts: ["~", ".goose", "artifacts"],
+    });
+  });
+
   describe("defaultGlobalArtifactRoot", () => {
-    it("normalises path separators and appends .goose/artifacts", () => {
-      expect(defaultGlobalArtifactRoot("/Users/wesb")).toBe(
+    it("resolves the global artifact root through the path resolver", async () => {
+      vi.mocked(resolvePath).mockResolvedValue({
+        path: "/Users/wesb/.goose/artifacts",
+      });
+
+      await expect(defaultGlobalArtifactRoot()).resolves.toBe(
         "/Users/wesb/.goose/artifacts",
       );
-    });
 
-    it("normalises backslashes on Windows-style paths", () => {
-      expect(defaultGlobalArtifactRoot("C:\\Users\\wesb\\")).toBe(
-        "C:/Users/wesb/.goose/artifacts",
-      );
-    });
-
-    it("strips trailing slashes", () => {
-      expect(defaultGlobalArtifactRoot("/Users/wesb/")).toBe(
-        "/Users/wesb/.goose/artifacts",
-      );
-    });
-  });
-
-  describe("resolveDefaultSessionCwd", () => {
-    it("returns the project default artifact root without requiring homeDir", () => {
-      expect(
-        resolveDefaultSessionCwd({
-          workingDirs: ["/Users/wesb/dev/goose2"],
-          artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
-        }),
-      ).toBe("/Users/wesb/dev/goose2/artifacts");
-    });
-
-    it("returns the project default artifact root when available", () => {
-      expect(
-        resolveDefaultSessionCwd(
-          {
-            workingDirs: ["/Users/wesb/dev/goose2"],
-            artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
-          },
-          "/Users/wesb",
-        ),
-      ).toBe("/Users/wesb/dev/goose2/artifacts");
-    });
-
-    it("returns undefined when a project exists but has no working dirs", () => {
-      expect(
-        resolveDefaultSessionCwd(
-          { workingDirs: [], artifactsDir: "" },
-          "/Users/wesb",
-        ),
-      ).toBeUndefined();
-    });
-
-    it("falls back to home artifacts dir when no project", () => {
-      expect(resolveDefaultSessionCwd(null, "/Users/wesb")).toBe(
-        "/Users/wesb/.goose/artifacts",
-      );
-    });
-
-    it("does not resolve a non-project fallback without homeDir", () => {
-      expect(resolveDefaultSessionCwd(null)).toBeUndefined();
-    });
-  });
-
-  describe("buildSessionCwdParts", () => {
-    it("prefers the active workspace path when present", () => {
-      expect(
-        buildSessionCwdParts(
-          {
-            workingDirs: ["/Users/wesb/dev/goose2"],
-            artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
-          },
-          "/Users/wesb/dev/goose2-worktree",
-        ),
-      ).toEqual(["/Users/wesb/dev/goose2-worktree"]);
-    });
-
-    it("uses the first project workspace root plus artifacts for project defaults", () => {
-      expect(
-        buildSessionCwdParts({
-          workingDirs: ["/Users/wesb/dev/goose2"],
-          artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
-        }),
-      ).toEqual(["/Users/wesb/dev/goose2", "artifacts"]);
-    });
-
-    it("falls back to the stored project artifacts root when no workspace roots exist", () => {
-      expect(
-        buildSessionCwdParts({
-          workingDirs: [],
-          artifactsDir: "/Users/wesb/.goose/projects/sample-project/artifacts",
-        }),
-      ).toEqual(["/Users/wesb/.goose/projects/sample-project/artifacts"]);
-    });
-
-    it("returns the global fallback parts when no project exists", () => {
-      expect(buildSessionCwdParts(null)).toEqual(["~", ".goose", "artifacts"]);
-    });
-
-    it("returns undefined for a project with no usable runtime path", () => {
-      expect(
-        buildSessionCwdParts({ workingDirs: [], artifactsDir: "   " }),
-      ).toBeUndefined();
+      expect(resolvePath).toHaveBeenCalledWith({
+        parts: ["~", ".goose", "artifacts"],
+      });
     });
   });
 });

--- a/ui/goose2/src/features/projects/lib/sessionCwdSelection.test.ts
+++ b/ui/goose2/src/features/projects/lib/sessionCwdSelection.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSessionCwdParts,
+  defaultGlobalArtifactRoot,
+  resolveDefaultSessionCwd,
+  resolveProjectDefaultArtifactRoot,
+} from "./sessionCwdSelection";
+
+describe("sessionCwdSelection", () => {
+  it("resolves the first workspace root to the default artifact root", () => {
+    expect(
+      resolveProjectDefaultArtifactRoot({
+        workingDirs: ["/Users/wesb/dev/goose2", "/Users/wesb/dev/other"],
+        artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
+      }),
+    ).toBe("/Users/wesb/dev/goose2/artifacts");
+  });
+
+  it("falls back to the stored project artifact root when no workspace roots exist", () => {
+    expect(
+      resolveProjectDefaultArtifactRoot({
+        workingDirs: [],
+        artifactsDir: "/Users/wesb/.goose/projects/sample-project/artifacts",
+      }),
+    ).toBe("/Users/wesb/.goose/projects/sample-project/artifacts");
+  });
+
+  describe("defaultGlobalArtifactRoot", () => {
+    it("normalises path separators and appends .goose/artifacts", () => {
+      expect(defaultGlobalArtifactRoot("/Users/wesb")).toBe(
+        "/Users/wesb/.goose/artifacts",
+      );
+    });
+
+    it("normalises backslashes on Windows-style paths", () => {
+      expect(defaultGlobalArtifactRoot("C:\\Users\\wesb\\")).toBe(
+        "C:/Users/wesb/.goose/artifacts",
+      );
+    });
+
+    it("strips trailing slashes", () => {
+      expect(defaultGlobalArtifactRoot("/Users/wesb/")).toBe(
+        "/Users/wesb/.goose/artifacts",
+      );
+    });
+  });
+
+  describe("resolveDefaultSessionCwd", () => {
+    it("returns the project default artifact root without requiring homeDir", () => {
+      expect(
+        resolveDefaultSessionCwd({
+          workingDirs: ["/Users/wesb/dev/goose2"],
+          artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
+        }),
+      ).toBe("/Users/wesb/dev/goose2/artifacts");
+    });
+
+    it("returns the project default artifact root when available", () => {
+      expect(
+        resolveDefaultSessionCwd(
+          {
+            workingDirs: ["/Users/wesb/dev/goose2"],
+            artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
+          },
+          "/Users/wesb",
+        ),
+      ).toBe("/Users/wesb/dev/goose2/artifacts");
+    });
+
+    it("returns undefined when a project exists but has no working dirs", () => {
+      expect(
+        resolveDefaultSessionCwd(
+          { workingDirs: [], artifactsDir: "" },
+          "/Users/wesb",
+        ),
+      ).toBeUndefined();
+    });
+
+    it("falls back to home artifacts dir when no project", () => {
+      expect(resolveDefaultSessionCwd(null, "/Users/wesb")).toBe(
+        "/Users/wesb/.goose/artifacts",
+      );
+    });
+
+    it("does not resolve a non-project fallback without homeDir", () => {
+      expect(resolveDefaultSessionCwd(null)).toBeUndefined();
+    });
+  });
+
+  describe("buildSessionCwdParts", () => {
+    it("prefers the active workspace path when present", () => {
+      expect(
+        buildSessionCwdParts(
+          {
+            workingDirs: ["/Users/wesb/dev/goose2"],
+            artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
+          },
+          "/Users/wesb/dev/goose2-worktree",
+        ),
+      ).toEqual(["/Users/wesb/dev/goose2-worktree"]);
+    });
+
+    it("uses the first project workspace root plus artifacts for project defaults", () => {
+      expect(
+        buildSessionCwdParts({
+          workingDirs: ["/Users/wesb/dev/goose2"],
+          artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
+        }),
+      ).toEqual(["/Users/wesb/dev/goose2", "artifacts"]);
+    });
+
+    it("falls back to the stored project artifacts root when no workspace roots exist", () => {
+      expect(
+        buildSessionCwdParts({
+          workingDirs: [],
+          artifactsDir: "/Users/wesb/.goose/projects/sample-project/artifacts",
+        }),
+      ).toEqual(["/Users/wesb/.goose/projects/sample-project/artifacts"]);
+    });
+
+    it("returns the global fallback parts when no project exists", () => {
+      expect(buildSessionCwdParts(null)).toEqual(["~", ".goose", "artifacts"]);
+    });
+
+    it("returns undefined for a project with no usable runtime path", () => {
+      expect(
+        buildSessionCwdParts({ workingDirs: [], artifactsDir: "   " }),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/ui/goose2/src/features/projects/lib/sessionCwdSelection.test.ts
+++ b/ui/goose2/src/features/projects/lib/sessionCwdSelection.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { resolvePath } from "@/shared/api/pathResolver";
+import type { ProjectInfo } from "../api/projects";
 import { resolveSessionCwd } from "./sessionCwdSelection";
 import {
   defaultGlobalArtifactRoot,
@@ -10,6 +11,27 @@ vi.mock("@/shared/api/pathResolver", () => ({
   resolvePath: vi.fn(),
 }));
 
+function makeProject(overrides: Partial<ProjectInfo> = {}): ProjectInfo {
+  return {
+    id: "project-1",
+    name: "Project",
+    description: "",
+    prompt: "",
+    icon: "folder",
+    color: "#000000",
+    preferredProvider: null,
+    preferredModel: null,
+    workingDirs: [],
+    useWorktrees: false,
+    order: 0,
+    archivedAt: null,
+    createdAt: "2026-01-01T00:00:00.000Z",
+    updatedAt: "2026-01-01T00:00:00.000Z",
+    artifactsDir: "",
+    ...overrides,
+  };
+}
+
 describe("sessionCwdSelection", () => {
   beforeEach(() => {
     vi.mocked(resolvePath).mockReset();
@@ -17,28 +39,34 @@ describe("sessionCwdSelection", () => {
 
   it("resolves the first workspace root to the default artifact root", () => {
     expect(
-      resolveProjectDefaultArtifactRoot({
-        workingDirs: ["/Users/wesb/dev/goose2", "/Users/wesb/dev/other"],
-        artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
-      }),
+      resolveProjectDefaultArtifactRoot(
+        makeProject({
+          workingDirs: ["/Users/wesb/dev/goose2", "/Users/wesb/dev/other"],
+          artifactsDir: "/Users/wesb/.goose/projects/goose2/artifacts",
+        }),
+      ),
     ).toBe("/Users/wesb/dev/goose2/artifacts");
   });
 
   it("falls back to the stored project artifact root when no workspace roots exist", () => {
     expect(
-      resolveProjectDefaultArtifactRoot({
-        workingDirs: [],
-        artifactsDir: "/Users/wesb/.goose/projects/sample-project/artifacts",
-      }),
+      resolveProjectDefaultArtifactRoot(
+        makeProject({
+          workingDirs: [],
+          artifactsDir: "/Users/wesb/.goose/projects/sample-project/artifacts",
+        }),
+      ),
     ).toBe("/Users/wesb/.goose/projects/sample-project/artifacts");
   });
 
   it("returns undefined for a pathless project artifact root", () => {
     expect(
-      resolveProjectDefaultArtifactRoot({
-        workingDirs: [],
-        artifactsDir: "   ",
-      }),
+      resolveProjectDefaultArtifactRoot(
+        makeProject({
+          workingDirs: [],
+          artifactsDir: "   ",
+        }),
+      ),
     ).toBeUndefined();
   });
 
@@ -48,10 +76,12 @@ describe("sessionCwdSelection", () => {
     });
 
     await expect(
-      resolveSessionCwd({
-        workingDirs: [],
-        artifactsDir: "   ",
-      }),
+      resolveSessionCwd(
+        makeProject({
+          workingDirs: [],
+          artifactsDir: "   ",
+        }),
+      ),
     ).resolves.toBe("/Users/wesb/.goose/artifacts");
 
     expect(resolvePath).toHaveBeenCalledWith({

--- a/ui/goose2/src/features/projects/lib/sessionCwdSelection.ts
+++ b/ui/goose2/src/features/projects/lib/sessionCwdSelection.ts
@@ -1,0 +1,84 @@
+import type { ProjectInfo } from "../api/projects";
+import { resolveOptionalPath } from "@/shared/api/pathResolver";
+
+function trimValue(value: string | null | undefined): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+function appendArtifactsSegment(path: string): string {
+  return `${path.replace(/[\\/]+$/, "")}/artifacts`;
+}
+
+export function defaultGlobalArtifactRoot(homeDir: string): string {
+  const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/+$/, "");
+  return `${normalizedHome}/.goose/artifacts`;
+}
+
+export function resolveProjectDefaultArtifactRoot(
+  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
+): string | undefined {
+  const workingDirs = (project?.workingDirs ?? [])
+    .map((directory) => trimValue(directory))
+    .filter((directory): directory is string => directory !== null);
+
+  if (workingDirs.length > 0) {
+    return appendArtifactsSegment(workingDirs[0]);
+  }
+
+  return trimValue(project?.artifactsDir) ?? undefined;
+}
+
+export function resolveDefaultSessionCwd(
+  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
+  homeDir?: string,
+): string | undefined {
+  const projectArtifactRoot = resolveProjectDefaultArtifactRoot(project);
+  if (projectArtifactRoot) {
+    return projectArtifactRoot;
+  }
+  if (project) {
+    return undefined;
+  }
+  if (!homeDir) {
+    return undefined;
+  }
+  return defaultGlobalArtifactRoot(homeDir);
+}
+
+export function buildSessionCwdParts(
+  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
+  activeWorkspacePath?: string | null,
+): string[] | undefined {
+  const trimmedWorkspacePath = trimValue(activeWorkspacePath);
+  if (trimmedWorkspacePath) {
+    return [trimmedWorkspacePath];
+  }
+
+  const workingDirs = (project?.workingDirs ?? [])
+    .map((directory) => trimValue(directory))
+    .filter((directory): directory is string => directory !== null);
+  if (workingDirs.length > 0) {
+    return [workingDirs[0], "artifacts"];
+  }
+
+  const artifactRoot = trimValue(project?.artifactsDir);
+  if (artifactRoot) {
+    return [artifactRoot];
+  }
+
+  if (project) {
+    return undefined;
+  }
+
+  return ["~", ".goose", "artifacts"];
+}
+
+export async function resolveSessionCwd(
+  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
+  activeWorkspacePath?: string | null,
+): Promise<string | undefined> {
+  return resolveOptionalPath(
+    buildSessionCwdParts(project, activeWorkspacePath),
+  );
+}

--- a/ui/goose2/src/features/projects/lib/sessionCwdSelection.ts
+++ b/ui/goose2/src/features/projects/lib/sessionCwdSelection.ts
@@ -1,55 +1,15 @@
 import type { ProjectInfo } from "../api/projects";
-import { resolveOptionalPath } from "@/shared/api/pathResolver";
+import { resolvePath } from "@/shared/api/pathResolver";
 
 function trimValue(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   return trimmed ? trimmed : null;
 }
 
-function appendArtifactsSegment(path: string): string {
-  return `${path.replace(/[\\/]+$/, "")}/artifacts`;
-}
-
-export function defaultGlobalArtifactRoot(homeDir: string): string {
-  const normalizedHome = homeDir.replace(/\\/g, "/").replace(/\/+$/, "");
-  return `${normalizedHome}/.goose/artifacts`;
-}
-
-export function resolveProjectDefaultArtifactRoot(
-  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
-): string | undefined {
-  const workingDirs = (project?.workingDirs ?? [])
-    .map((directory) => trimValue(directory))
-    .filter((directory): directory is string => directory !== null);
-
-  if (workingDirs.length > 0) {
-    return appendArtifactsSegment(workingDirs[0]);
-  }
-
-  return trimValue(project?.artifactsDir) ?? undefined;
-}
-
-export function resolveDefaultSessionCwd(
-  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
-  homeDir?: string,
-): string | undefined {
-  const projectArtifactRoot = resolveProjectDefaultArtifactRoot(project);
-  if (projectArtifactRoot) {
-    return projectArtifactRoot;
-  }
-  if (project) {
-    return undefined;
-  }
-  if (!homeDir) {
-    return undefined;
-  }
-  return defaultGlobalArtifactRoot(homeDir);
-}
-
-export function buildSessionCwdParts(
-  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
+function buildSessionCwdParts(
+  project: ProjectInfo | null | undefined,
   activeWorkspacePath?: string | null,
-): string[] | undefined {
+): string[] {
   const trimmedWorkspacePath = trimValue(activeWorkspacePath);
   if (trimmedWorkspacePath) {
     return [trimmedWorkspacePath];
@@ -67,18 +27,16 @@ export function buildSessionCwdParts(
     return [artifactRoot];
   }
 
-  if (project) {
-    return undefined;
-  }
-
   return ["~", ".goose", "artifacts"];
 }
 
 export async function resolveSessionCwd(
-  project: Pick<ProjectInfo, "workingDirs" | "artifactsDir"> | null | undefined,
+  project: ProjectInfo | null | undefined,
   activeWorkspacePath?: string | null,
-): Promise<string | undefined> {
-  return resolveOptionalPath(
-    buildSessionCwdParts(project, activeWorkspacePath),
-  );
+): Promise<string> {
+  return (
+    await resolvePath({
+      parts: buildSessionCwdParts(project, activeWorkspacePath),
+    })
+  ).path;
 }

--- a/ui/goose2/src/shared/api/acp.ts
+++ b/ui/goose2/src/shared/api/acp.ts
@@ -21,7 +21,6 @@ export interface AcpSendMessageOptions {
 }
 
 export interface AcpPrepareSessionOptions {
-  workingDir?: string;
   personaId?: string;
 }
 
@@ -67,9 +66,9 @@ export async function acpSendMessage(
 export async function acpPrepareSession(
   sessionId: string,
   providerId: string,
+  workingDir: string,
   options: AcpPrepareSessionOptions = {},
 ): Promise<void> {
-  const workingDir = options.workingDir ?? "~/.goose/artifacts";
   await sessionTracker.prepareSession(
     sessionId,
     providerId,

--- a/ui/goose2/src/shared/api/index.ts
+++ b/ui/goose2/src/shared/api/index.ts
@@ -1,3 +1,4 @@
 export * from "./agents";
 export * from "./acp";
 export * from "./git";
+export * from "./pathResolver";

--- a/ui/goose2/src/shared/api/pathResolver.ts
+++ b/ui/goose2/src/shared/api/pathResolver.ts
@@ -5,7 +5,7 @@ export interface ResolvePathParams {
 }
 
 export interface ResolvedPath {
-  path?: string;
+  path: string;
 }
 
 export async function resolvePath({
@@ -14,14 +14,4 @@ export async function resolvePath({
   return invoke("resolve_path", {
     request: { parts },
   });
-}
-
-export async function resolveOptionalPath(
-  parts?: string[] | null,
-): Promise<string | undefined> {
-  if (!parts) {
-    return undefined;
-  }
-
-  return (await resolvePath({ parts })).path;
 }

--- a/ui/goose2/src/shared/api/pathResolver.ts
+++ b/ui/goose2/src/shared/api/pathResolver.ts
@@ -1,0 +1,27 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface ResolvePathParams {
+  parts: string[];
+}
+
+export interface ResolvedPath {
+  path?: string;
+}
+
+export async function resolvePath({
+  parts,
+}: ResolvePathParams): Promise<ResolvedPath> {
+  return invoke("resolve_path", {
+    request: { parts },
+  });
+}
+
+export async function resolveOptionalPath(
+  parts?: string[] | null,
+): Promise<string | undefined> {
+  if (!parts) {
+    return undefined;
+  }
+
+  return (await resolvePath({ parts })).path;
+}

--- a/ui/goose2/src/test/mocks/goose-sdk.ts
+++ b/ui/goose2/src/test/mocks/goose-sdk.ts
@@ -1,7 +1,5 @@
 export class GooseClient {
   closed = Promise.resolve();
 
-  constructor(..._args: unknown[]) {}
-
   async initialize(..._args: unknown[]): Promise<void> {}
 }


### PR DESCRIPTION
## Summary

This PR cleans up ui/goose2 ACP session working directory handling.

### Changes

- Renamed path-related variables and state so their purpose is clearer.

- Introduced `sessionCwdSelection.ts` to centralize ACP session working directory resolution.

- Added a Tauri-backed path resolver so path joining and ~ expansion are centralized instead of built ad hoc in ts.
 
- Cleaned up the ACP boundary so acpPrepareSession now requires a real workingDir.

### Discussion
I intentionally kept the Tauri backend thin in this PR. The backend only handles low-level path resolution, while frontend still decides which path should be used for the ACP session working directory. This gives us one place for OS-specific path handling like joining segments and expanding ~, without moving app concept (eg project) into the Tauri backend.

I also thought about pushing more of this into goose serve or even Goose core. But it becomes a bigger design question,  we need to decide whether Goose core should know about project-related concepts , and if so, how the domain like project, workspace, artifact root, and session working directory should be represented (eg domain design)

### Testing
<!-- How have this change been tested? Unit/integration tests? Manual testing? -->

### Related Issues
Relates to #ISSUE_ID  
Discussion: LINK (if any)


### Screenshots/Demos (for UX changes)
Before:  

After:   

